### PR TITLE
Windows support for tls certificates

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2021"
 prost = "0.13.3"
 prost-types = "0.13.3"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+rustls-platform-verifier = "0.5"
 serde_json = "1.0"    
 thiserror = "1.0"
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-retry = "0.3"
 tokio-stream = "0.1.16"
-tonic = { version = "0.12.3", features = ["tls"] }
+tonic = { version = "0.12.3", features = ["tls","transport"] }
 tracing = "0.1.41"
 
 [build-dependencies]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -260,7 +260,11 @@ impl ZerobusSdk {
         let tls_config = {
             #[cfg(target_os = "windows")]
             {
-                ClientTlsConfig::new()
+                let mut root_config = rustls::ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_platform_verifier()
+                    .with_no_client_auth();
+                ClientTlsConfig::new().rustls_client_config(root_config)
             }
 
             #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, we read tls certificates only for macos and linux. Now we added support for windows too.

## How is this tested?

Not tested.