### PR TITLE
Removing some `unwrap` calls from production code

### DIFF
--- a/sdk/src/default_token_factory.rs
+++ b/sdk/src/default_token_factory.rs
@@ -31,7 +31,7 @@ impl DefaultTokenFactory {
         client_secret: &str,
         workspace_id: &str,
     ) -> ZerobusResult<String> {
-        let (catalog, schema, table) = Self::parse_table_name(table_name).unwrap();
+        let (catalog, schema, table) = Self::parse_table_name(table_name)?;
 
         let uc_endpoint = uc_endpoint.to_string();
         let databricks_client_id = client_id.to_string();
@@ -122,21 +122,91 @@ impl DefaultTokenFactory {
     ///
     /// # Errors
     ///
-    /// * `InvalidUCTokenError` - If the table name is missing catalog, schema, or table components
+    /// * `InvalidTableName` - If the table name doesn't have exactly 3 non-empty parts.
     #[allow(clippy::result_large_err)]
     fn parse_table_name(table_name: &str) -> Result<(String, String, String), ZerobusError> {
-        let mut parts = table_name.splitn(3, '.');
+        let parts: Vec<&str> = table_name.split('.').collect();
 
-        let catalog = parts.next().ok_or_else(|| {
-            ZerobusError::InvalidUCTokenError("Missing catalog in table name".to_string())
-        })?;
-        let schema = parts.next().ok_or_else(|| {
-            ZerobusError::InvalidUCTokenError("Missing schema in table name".to_string())
-        })?;
-        let table = parts.next().ok_or_else(|| {
-            ZerobusError::InvalidUCTokenError("Missing table in table name".to_string())
-        })?;
+        if parts.len() != 3 {
+            return Err(ZerobusError::InvalidTableName(format!(
+                "Table name must have exactly 3 parts (catalog.schema.table), found {} parts",
+                parts.len()
+            )));
+        }
+
+        let catalog = parts[0];
+        let schema = parts[1];
+        let table = parts[2];
+
+        if catalog.is_empty() {
+            return Err(ZerobusError::InvalidTableName(
+                "Catalog name cannot be empty".to_string(),
+            ));
+        }
+        if schema.is_empty() {
+            return Err(ZerobusError::InvalidTableName(
+                "Schema name cannot be empty".to_string(),
+            ));
+        }
+        if table.is_empty() {
+            return Err(ZerobusError::InvalidTableName(
+                "Table name cannot be empty".to_string(),
+            ));
+        }
 
         Ok((catalog.to_string(), schema.to_string(), table.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_table_name_valid() {
+        let result = DefaultTokenFactory::parse_table_name("catalog_1.schema_2.table_3");
+        assert!(result.is_ok());
+        let (catalog, schema, table) = result.unwrap();
+        assert_eq!(catalog, "catalog_1");
+        assert_eq!(schema, "schema_2");
+        assert_eq!(table, "table_3");
+    }
+
+    #[test]
+    fn test_parse_table_name_invalid() {
+        let invalid_cases = vec![
+            ("catalog.schema.table.extra", "exactly 3 parts"),
+            ("catalog.schema.table.with.dots", "exactly 3 parts"),
+            ("catalog", "exactly 3 parts"),
+            ("catalog.schema", "exactly 3 parts"),
+            ("", "exactly 3 parts"),
+            (".schema.table", "Catalog name cannot be empty"),
+            ("catalog..table", "Schema name cannot be empty"),
+            ("catalog.schema.", "Table name cannot be empty"),
+            ("..", "Catalog name cannot be empty"),
+            ("..table", "Catalog name cannot be empty"),
+            ("catalog..", "Schema name cannot be empty"),
+        ];
+
+        for (input, expected_error) in invalid_cases {
+            let result = DefaultTokenFactory::parse_table_name(input);
+            assert!(
+                result.is_err(),
+                "Expected '{}' to be invalid, but it was parsed successfully",
+                input
+            );
+            match result {
+                Err(ZerobusError::InvalidTableName(msg)) => {
+                    assert!(
+                        msg.contains(expected_error),
+                        "For input '{}', expected error to contain '{}', but got: '{}'",
+                        input,
+                        expected_error,
+                        msg
+                    );
+                }
+                _ => panic!("Expected InvalidTableName error for '{}'", input),
+            }
+        }
     }
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -15,8 +15,8 @@ pub enum ZerobusError {
     /// Returned when the specified Zerobus endpoint is in invalid format.
     #[error("The specified Zerobus endpoint is in invalid format: {0}.")]
     InvalidZerobusEndpointError(String),
-    /// Returned when the specified Unity Catalog table is invalid.
-    #[error("Specified UC table is invalid: {0}.")]
+    /// Returned when the specified Unity Catalog table name is invalid.
+    #[error("Specified UC table name is invalid: {0}.")]
     InvalidTableName(String),
     /// Returned when the specified Unity Catalog endpoint is in invalid format.
     #[error("Specified UC endpoint is in invalid format: {0}.")]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -845,8 +845,7 @@ impl ZerobusStream {
             };
 
             // 5. Handle errors.
-            if result.is_err() {
-                let error = result.err().unwrap();
+            if let Err(error) = result {
                 error!(stream_id = %stream_id, "Stream failure detected: {}", error);
                 let error = match &error {
                     // Mapping this to pass certain e2e tests.
@@ -898,7 +897,7 @@ impl ZerobusStream {
             match key {
                 "x-databricks-zerobus-table-name" => {
                     let table_name = MetadataValue::try_from(value.as_str())
-                        .map_err(|_| ZerobusError::InvalidTableName(key.to_string()))?;
+                        .map_err(|e| ZerobusError::InvalidTableName(e.to_string()))?;
                     stream_metadata.insert("x-databricks-zerobus-table-name", table_name);
                 }
                 "authorization" => {
@@ -928,7 +927,11 @@ impl ZerobusStream {
                 table_properties
                     .descriptor_proto
                     .as_ref()
-                    .unwrap()
+                    .ok_or_else(|| {
+                        ZerobusError::InvalidArgument(
+                            "Descriptor proto is required for Proto record type".to_string(),
+                        )
+                    })?
                     .encode_to_vec(),
             )
         } else {
@@ -1532,5 +1535,111 @@ impl ZerobusStream {
             "Cannot get unacked records from an active stream. Stream must be closed first."
                 .to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_into_request_payload_single_proto_record() {
+        let record = vec![1, 2, 3];
+        let batch = EncodedBatch::Proto(smallvec![record.clone()]);
+        let payload = batch.into_request_payload(42);
+
+        match payload {
+            RequestPayload::IngestRecord(req) => {
+                assert_eq!(req.offset_id, Some(42));
+                match req.record {
+                    Some(IngestRequestRecord::ProtoEncodedRecord(data)) => {
+                        assert_eq!(data, record);
+                    }
+                    _ => panic!("Expected ProtoEncodedRecord"),
+                }
+            }
+            _ => panic!("Expected IngestRecord payload"),
+        }
+    }
+
+    #[test]
+    fn test_into_request_payload_single_json_record() {
+        let record = r#"{"id": 1}"#.to_string();
+        let batch = EncodedBatch::Json(smallvec![record.clone()]);
+        let payload = batch.into_request_payload(123);
+
+        match payload {
+            RequestPayload::IngestRecord(req) => {
+                assert_eq!(req.offset_id, Some(123));
+                match req.record {
+                    Some(IngestRequestRecord::JsonRecord(data)) => {
+                        assert_eq!(data, record);
+                    }
+                    _ => panic!("Expected JsonRecord"),
+                }
+            }
+            _ => panic!("Expected IngestRecord payload"),
+        }
+    }
+
+    #[test]
+    fn test_into_request_payload_batch_proto() {
+        let records = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let batch = EncodedBatch::Proto(SmallVec::from_vec(records.clone()));
+        let payload = batch.into_request_payload(99);
+
+        match payload {
+            RequestPayload::IngestRecordBatch(req) => {
+                assert_eq!(req.offset_id, Some(99));
+                match req.batch {
+                    Some(IngestRequestBatch::ProtoEncodedBatch(proto_batch)) => {
+                        assert_eq!(proto_batch.records, records);
+                    }
+                    _ => panic!("Expected ProtoEncodedBatch"),
+                }
+            }
+            _ => panic!("Expected IngestRecordBatch payload"),
+        }
+    }
+
+    #[test]
+    fn test_into_request_payload_batch_json() {
+        let records = vec![r#"{"id": 1}"#.to_string(), r#"{"id": 2}"#.to_string()];
+        let batch = EncodedBatch::Json(SmallVec::from_vec(records.clone()));
+        let payload = batch.into_request_payload(77);
+
+        match payload {
+            RequestPayload::IngestRecordBatch(req) => {
+                assert_eq!(req.offset_id, Some(77));
+                match req.batch {
+                    Some(IngestRequestBatch::JsonBatch(json_batch)) => {
+                        assert_eq!(json_batch.records, records);
+                    }
+                    _ => panic!("Expected JsonBatch"),
+                }
+            }
+            _ => panic!("Expected IngestRecordBatch payload"),
+        }
+    }
+
+    #[test]
+    fn test_encoded_batch_get_record_count() {
+        let proto_batch = EncodedBatch::Proto(smallvec![vec![1], vec![2], vec![3]]);
+        assert_eq!(proto_batch.get_record_count(), 3);
+
+        let json_batch = EncodedBatch::Json(smallvec!["a".to_string(), "b".to_string()]);
+        assert_eq!(json_batch.get_record_count(), 2);
+
+        let empty_batch = EncodedBatch::Proto(smallvec![]);
+        assert_eq!(empty_batch.get_record_count(), 0);
+    }
+
+    #[test]
+    fn test_encoded_batch_is_empty() {
+        let non_empty = EncodedBatch::Proto(smallvec![vec![1]]);
+        assert!(!non_empty.is_empty());
+
+        let empty = EncodedBatch::Json(smallvec![]);
+        assert!(empty.is_empty());
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Switching some `unwrap` calls to propagating errors in production code:

- `lib.rs:930` - Changed `descriptor_proto.unwrap()` to proper error propagation with `ok_or_else()`
- `lib.rs:846` - Changed `result.err().unwrap()` to idiomatic `if let Err(error) = result`
- `default_token_factory:34` - Changed to propagate error from `parse_table_name`

Stricter `parse_table_name` validation:

- Changed from `splitn(3, '.')` to `split('.')` to enforce exactly 3 parts
- Added validation that catalog, schema, and table names are non-empty
- Improved error messages with specific context

## How is this tested?

Tests added to `lib.rs` for `into_request_payload`:

1. `test_into_request_payload_single_proto_record` - Validates single proto record creates IngestRecord payload
2. `test_into_request_payload_single_json_record` - Validates single JSON record creates IngestRecord payload
3. `test_into_request_payload_batch_proto` - Validates multiple proto records create IngestRecordBatch payload
4. `test_into_request_payload_batch_json` - Validates multiple JSON records create IngestRecordBatch payload
5. `test_encoded_batch_get_record_count` - Tests record counting for proto, JSON, and empty batches
6. `test_encoded_batch_is_empty` - Tests empty batch detection

Tests added to `default_token_factory.rs` for `parse_table_name`:

1. `test_parse_table_name_valid`:

```
"catalog_1.schema_2.table_3" → ("catalog_1", "schema_2", "table_3")
```

2. `test_parse_table_name_invalid`:

| Input                            | Expected Error                 |
|----------------------------------|--------------------------------|
| "catalog.schema.table.extra"     | "exactly 3 parts"              |
| "catalog.schema.table.with.dots" | "exactly 3 parts"              |
| "catalog"                        | "exactly 3 parts"              |
| "catalog.schema"                 | "exactly 3 parts"              |
| ""                               | "exactly 3 parts"              |
| ".schema.table"                  | "Catalog name cannot be empty" |
| "catalog..table"                 | "Schema name cannot be empty"  |
| "catalog.schema."                | "Table name cannot be empty"   |
| ".."                             | "Catalog name cannot be empty" |
| "..table"                        | "Catalog name cannot be empty" |
| "catalog.."                      | "Schema name cannot be empty"  |