### PR TITLE
Bump `tonic` version from `0.13.0` to `0.14.0`

### DIFF
--- a/examples/proto/batch/Cargo.toml
+++ b/examples/proto/batch/Cargo.toml
@@ -6,12 +6,11 @@ publish = false
 
 [dependencies]
 databricks-zerobus-ingest-sdk = { path = "../../../sdk" }
-tonic-build = "0.13.1"
-prost = "0.13.3"
-prost-build = "0.12"
-prost-reflect = "0.14.2"
+tonic-prost-build = "0.14"
+prost = "0.14"
+prost-reflect = "0.16"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.16"
-tonic = { version = "0.12.3", features = ["tls"] }
+tonic = "0.14"
 tracing = "0.1.41"
 chrono = "0.4"

--- a/examples/proto/single/Cargo.toml
+++ b/examples/proto/single/Cargo.toml
@@ -6,12 +6,11 @@ publish = false
 
 [dependencies]
 databricks-zerobus-ingest-sdk = { path = "../../../sdk" }
-tonic-build = "0.13.1"
-prost = "0.13.3"
-prost-build = "0.12"
-prost-reflect = "0.14.2"
+tonic-prost-build = "0.14"
+prost = "0.14"
+prost-reflect = "0.16"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.16"
-tonic = { version = "0.12.3", features = ["tls"] }
+tonic = "0.14"
 tracing = "0.1.41"
 chrono = "0.4"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -16,8 +16,8 @@ databricks-zerobus-ingest-sdk = { path = "../sdk" }
 # FFI helpers
 tokio = { version = "1.42", features = ["rt", "rt-multi-thread"] }
 once_cell = "1.19"
-prost = "0.13.3"
-prost-types = "0.13.3"
+prost = "0.14"
+prost-types = "0.14"
 async-trait = "0.1"
 libc = "0.2"
 

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -17,15 +17,15 @@ name = "zerobus_jni"
 databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["arrow-flight"] }
 jni = "0.21"
 tokio = { version = "1.42", features = ["rt-multi-thread", "sync"] }
-prost = "0.13"
-prost-types = "0.13"
+prost = "0.14"
+prost-types = "0.14"
 thiserror = "1.0"
 tracing = "0.1"
 
 # Arrow dependencies (re-exported from SDK)
-arrow-array = "56.2.0"
-arrow-schema = "56.2.0"
-arrow-ipc = { version = "56.2.0", features = ["lz4", "zstd"] }
+arrow-array = "57"
+arrow-schema = "57"
+arrow-ipc = { version = "57", features = ["lz4", "zstd"] }
 
 [features]
 default = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/databricks-zerobus-ingest-sdk"
 
 [dependencies]
 async-trait = "0.1"
-prost = "0.13.3"
-prost-types = "0.13.3"
+prost = "0.14"
+prost-types = "0.14"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -24,19 +24,20 @@ tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "fs", "sy
 tokio-retry = "0.3"
 tokio-stream = "0.1.16"
 tokio-util = { version = "0.7.17", features = ["rt"] }
-tonic = { version = "0.13", features = ["tls-native-roots", "transport"] }
+tonic = { version = "0.14", features = ["tls-native-roots", "transport"] }
+tonic-prost = "0.14"
 tracing = "0.1.41"
 smallvec = "1.15.1"
 
 # Arrow Flight dependencies
-arrow-flight = { version = "56.2.0", default-features = false, optional = true }
-arrow-array = { version = "56.2.0", default-features = false, optional = true }
-arrow-schema = { version = "56.2.0", default-features = false, optional = true }
-arrow-ipc = { version = "56.2.0", default-features = false, optional = true, features = ["lz4","zstd"] }
+arrow-flight = { version = "57", default-features = false, optional = true }
+arrow-array = { version = "57", default-features = false, optional = true }
+arrow-schema = { version = "57", default-features = false, optional = true }
+arrow-ipc = { version = "57", default-features = false, optional = true, features = ["lz4","zstd"] }
 futures = { version = "0.3", optional = true }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"
 protoc-bin-vendored = "3.0.0"
 
 [features]

--- a/sdk/build.rs
+++ b/sdk/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
-    tonic_build::compile_protos("zerobus_service.proto")
+    tonic_prost_build::compile_protos("zerobus_service.proto")
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,24 +10,25 @@ path = "src/rust_tests.rs"
 
 [dependencies]
 async-trait = "0.1"
-prost = "0.13.3"
-prost-reflect = "0.14"
-prost-types = "0.13.3"
+prost = "0.14"
+prost-reflect = "0.16"
+prost-types = "0.14"
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1.16", features = ["net"] }
-tonic = { version = "0.13", features = ["tls-native-roots", "transport"] }
+tonic = { version = "0.14", features = ["tls-native-roots", "transport"] }
+tonic-prost = "0.14"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "arrow-flight"] }
 
 # Arrow Flight test dependencies
-arrow-flight = { version = "56.2.0", default-features = false }
-arrow-array = { version = "56.2.0", default-features = false }
-arrow-schema = { version = "56.2.0", default-features = false }
+arrow-flight = { version = "57", default-features = false }
+arrow-array = { version = "57", default-features = false }
+arrow-schema = { version = "57", default-features = false }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"
 protoc-bin-vendored = "3.0.0"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
         .compile_protos(&["../sdk/zerobus_service.proto"], &["../sdk"])?;

--- a/tools/generate_files/Cargo.toml
+++ b/tools/generate_files/Cargo.toml
@@ -14,10 +14,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 urlencoding = "2"
-tonic-build = "0.12.3"
+tonic-prost-build = "0.14"
 tempfile = "3.21.0"
-prost = "0.12"
-tonic = "0.12"
+prost = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
 
 [build-dependencies]
 protoc-bin-vendored = "3"

--- a/tools/generate_files/src/generate.rs
+++ b/tools/generate_files/src/generate.rs
@@ -437,7 +437,7 @@ pub fn generate_rust_and_descriptor(
         .context("bad filename")?;
     let desc_file = output_dir.join(format!("{}.descriptor", file_name));
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .out_dir(output_dir)
         .file_descriptor_set_path(&desc_file)
         .compile_protos(


### PR DESCRIPTION
## Summary

Bump tonic to 0.14, prost to 0.14, arrow to 57, and related dependencies across the workspace.

### Dependency Changes

| Crate | Old | New |
| --- | --- | --- |
| `tonic` | 0.12/0.13 | 0.14 |
| `tonic-prost` | (new) | 0.14 |
| `tonic-build` | 0.12/0.13 | removed |
| `tonic-prost-build` | (new) | 0.14 |
| `prost` | 0.12/0.13 | 0.14 |
| `prost-types` | 0.13 | 0.14 |
| `prost-reflect` | 0.14 | 0.16 |
| `prost-build` | 0.12 | removed |
| `arrow-flight` | 56.2.0 | 57 |
| `arrow-array` | 56.2.0 | 57 |
| `arrow-schema` | 56.2.0 | 57 |
| `arrow-ipc` | 56.2.0 | 57 |

### Files Changed

**Cargo.toml dependency bumps (8 files):**
- `sdk/Cargo.toml` - tonic, prost, arrow-*, added tonic-prost, replaced tonic-build with tonic-prost-build
- `tests/Cargo.toml` - same as sdk, plus prost-reflect bump
- `ffi/Cargo.toml` - prost, prost-types
- `jni/Cargo.toml` - prost, prost-types, arrow-*
- `examples/proto/single/Cargo.toml` - tonic, prost, prost-reflect, replaced tonic-build/prost-build with tonic-prost-build, removed nonexistent `tls` feature
- `examples/proto/batch/Cargo.toml` - same as single
- `tools/generate_files/Cargo.toml` - tonic, prost, replaced tonic-build with tonic-prost-build, added tonic-prost

**Build scripts and source (3 files):**
- `sdk/build.rs` - `tonic_build::compile_protos()` to `tonic_prost_build::compile_protos()`
- `tests/build.rs` - `tonic_build::configure()` to `tonic_prost_build::configure()`
- `tools/generate_files/src/generate.rs` - `tonic_build::configure()` to `tonic_prost_build::configure()`

No arrow-flight API changes were needed. All core APIs (`FlightClient`, `FlightDataEncoderBuilder`, `FlightError::Tonic`, `FlightServiceServer`, `PutResult`, `IpcWriteOptions`) are unchanged between arrow-flight 56 and 57.

---

## Breaking Changes for SDK Clients

### Required Dependency Updates

Clients must update their own dependencies to match:

| Dependency | Old | New |
| --- | --- | --- |
| `prost` | 0.13 | 0.14 |
| `prost-types` | 0.13 | 0.14 |
| `tonic` | 0.13 | 0.14 |
| `arrow-flight` | 56 | 57 |
| `arrow-array` | 56 | 57 |
| `arrow-schema` | 56 | 57 |
| `arrow-ipc` | 56 | 57 |

Mixing versions will result in "two different versions of crate" type errors at compile time.

---

### prost 0.13 to 0.14

- **`Debug` removed as supertrait of `Message`**. Code with generic bounds like `T: prost::Message` that previously relied on the implicit `Debug` bound must now use `T: prost::Message + Debug` explicitly.
- **`Eq` and `Hash` are now auto-derived** on generated message types when all fields support them. Any manual `impl Eq` or `impl Hash` for SDK-generated protobuf types will conflict and must be removed.
- **Repeated boxed fields changed**: `Vec<Box<T>>` is now `Vec<T>` for repeated fields marked as boxed. Code indexing into these fields may need adjustment.
- **MSRV raised to 1.82**.

### tonic 0.13 to 0.14

- **`Status` internals are now boxed**. Code that destructures or pattern-matches on `tonic::Status` fields may need updates.
- **Source error now included in `Status::Display`**. Log output and error messages involving `tonic::Status` will contain more detail, which may affect log parsing or error string matching.
- **Generic `tls` feature removed**. Clients enabling `tonic/tls` must switch to a specific backend: `tls-native-roots`, `tls-ring`, `tls-aws-lc`, or `tls-webpki-roots`.
- **`tonic-prost` is a new runtime dependency**. Projects with their own `.proto` codegen need `tonic-prost` (runtime) and `tonic-prost-build` (build-time) instead of `tonic-build`.

### arrow 56 to 57

- **MSRV raised to 1.85** (Rust 2024 edition).
- **`DataType` display formatting changed** for `RunEndEncoded`, `Map`, `ListView`, `LargeListView`, and `Union` types. Code that parses or compares `Display` output of these types will need updates.
- **`Array` trait marked `unsafe` to implement** (as of 57.3.0). Custom `Array` implementations must add `unsafe`.

### prost-reflect 0.14 to 0.16

- Only relevant if clients use `prost-reflect` directly alongside the SDK. The 0.16 release updates its internal prost dependency to 0.14 -- no API changes beyond that.
