### PR TITLE
Add `gate` CI job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,18 @@ on:
     types: [checks_requested]
 
 jobs:
+  gate:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    needs: [changes, rust]
+    if: always()
+    steps:
+      - run: |
+          if [[ "${{ needs.rust.result }}" == "failure" ]]; then
+            exit 1
+          fi
+
   changes:
     runs-on:
       group: databricks-protected-runner-group
@@ -21,6 +33,7 @@ jobs:
           filters: |
             rust:
               - 'rust/**'
+              - '.github/workflows/ci-rust.yml'
 
   rust:
     needs: changes


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Adds a `gate` job to `push.yml` that aggregates results from all SDK CI jobs to act as the single required job for `main` branch protection
- The gate job always runs (`if: always()`) and only fails if a triggered SDK job actually fails — skipped jobs are treated as passing
- Adds `.github/workflows/ci-rust.yml` to the Rust path filter so CI workflow changes also trigger Rust checks

## How is this tested?

N/A