### PR TITLE
[Java] Add configurable IPC compression for Arrow streams

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -11,7 +11,8 @@
 - **Arrow Flight Support (Experimental)**: Added support for ingesting Apache Arrow `VectorSchemaRoot` batches via Arrow Flight protocol
   - **Note**: Arrow Flight is not yet supported by default from the Zerobus server side.
   - New `ZerobusArrowStream` class with `ingestBatch()`, `waitForOffset()`, `flush()`, `close()`, `getUnackedBatches()` methods
-  - New `ArrowStreamConfigurationOptions` for configuring Arrow streams (max inflight batches, recovery, timeouts)
+  - New `ArrowStreamConfigurationOptions` for configuring Arrow streams (max inflight batches, recovery, timeouts, IPC compression)
+  - Configurable IPC compression via `ArrowStreamConfigurationOptions.setIpcCompression()` (supports `LZ4_FRAME` and `ZSTD`)
   - New `createArrowStream()` and `recreateArrowStream()` methods on `ZerobusSdk`
   - Accepts `VectorSchemaRoot` directly via `ingestBatch()` (IPC serialization handled internally)
   - Arrow is opt-in: add `arrow-vector` and `arrow-memory-netty` as dependencies (provided scope, `>= 15.0.0`)
@@ -39,6 +40,7 @@
 - Added `createArrowStream(String tableName, Schema schema, String clientId, String clientSecret, ArrowStreamConfigurationOptions options)` to `ZerobusSdk`
 - Added `recreateArrowStream(ZerobusArrowStream closedStream)` to `ZerobusSdk`
 - Added `ZerobusArrowStream` class with methods: `ingestBatch()`, `waitForOffset()`, `flush()`, `close()`, `getUnackedBatches()`, `isClosed()`, `getTableName()`, `getOptions()`
-- Added `ArrowStreamConfigurationOptions` class with fields: `maxInflightBatches`, `recovery`, `recoveryTimeoutMs`, `recoveryBackoffMs`, `recoveryRetries`, `serverLackOfAckTimeoutMs`, `flushTimeoutMs`, `connectionTimeoutMs`
+- Added `ArrowStreamConfigurationOptions` class with fields: `maxInflightBatches`, `recovery`, `recoveryTimeoutMs`, `recoveryBackoffMs`, `recoveryRetries`, `serverLackOfAckTimeoutMs`, `flushTimeoutMs`, `connectionTimeoutMs`, `ipcCompression`
+- Added `IPCCompressionType` enum with values: `NONE`, `LZ4_FRAME`, `ZSTD`
 - Added optional dependency: `org.apache.arrow:arrow-vector >= 15.0.0` (provided scope)
 

--- a/java/examples/arrow/ArrowIngestionExample.java
+++ b/java/examples/arrow/ArrowIngestionExample.java
@@ -123,11 +123,13 @@ public class ArrowIngestionExample {
                 .setFlushTimeoutMs(600000)
                 .setRecovery(true)
                 .setRecoveryRetries(5)
+                .setIpcCompression(IPCCompressionType.LZ4_FRAME)
                 .build();
         System.out.println(
             "  maxInflightBatches: " + customOptions.maxInflightBatches());
         System.out.println("  flushTimeoutMs: " + customOptions.flushTimeoutMs());
         System.out.println("  recoveryRetries: " + customOptions.recoveryRetries());
+        System.out.println("  ipcCompression: " + customOptions.ipcCompression());
 
       } finally {
         stream.close();

--- a/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
+++ b/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
@@ -29,6 +29,7 @@ public class ArrowStreamConfigurationOptions {
   private long serverLackOfAckTimeoutMs = 60000;
   private long flushTimeoutMs = 300000;
   private long connectionTimeoutMs = 30000;
+  private IPCCompressionType ipcCompression = IPCCompressionType.NONE;
 
   private ArrowStreamConfigurationOptions() {}
 
@@ -40,7 +41,8 @@ public class ArrowStreamConfigurationOptions {
       int recoveryRetries,
       long serverLackOfAckTimeoutMs,
       long flushTimeoutMs,
-      long connectionTimeoutMs) {
+      long connectionTimeoutMs,
+      IPCCompressionType ipcCompression) {
     this.maxInflightBatches = maxInflightBatches;
     this.recovery = recovery;
     this.recoveryTimeoutMs = recoveryTimeoutMs;
@@ -49,6 +51,7 @@ public class ArrowStreamConfigurationOptions {
     this.serverLackOfAckTimeoutMs = serverLackOfAckTimeoutMs;
     this.flushTimeoutMs = flushTimeoutMs;
     this.connectionTimeoutMs = connectionTimeoutMs;
+    this.ipcCompression = ipcCompression;
   }
 
   /**
@@ -130,6 +133,18 @@ public class ArrowStreamConfigurationOptions {
   }
 
   /**
+   * Returns the IPC compression type for Arrow Flight payloads.
+   *
+   * <p>When set to a value other than {@link IPCCompressionType#NONE}, each Arrow record batch is
+   * compressed before transmission, reducing network bandwidth at the cost of CPU.
+   *
+   * @return the IPC compression type
+   */
+  public IPCCompressionType ipcCompression() {
+    return this.ipcCompression;
+  }
+
+  /**
    * Returns the default Arrow stream configuration options.
    *
    * <p>Default values:
@@ -143,6 +158,7 @@ public class ArrowStreamConfigurationOptions {
    *   <li>serverLackOfAckTimeoutMs: 60000
    *   <li>flushTimeoutMs: 300000
    *   <li>connectionTimeoutMs: 30000
+   *   <li>ipcCompression: {@link IPCCompressionType#NONE}
    * </ul>
    *
    * @return the default Arrow stream configuration options
@@ -177,6 +193,7 @@ public class ArrowStreamConfigurationOptions {
     private long serverLackOfAckTimeoutMs = defaults.serverLackOfAckTimeoutMs;
     private long flushTimeoutMs = defaults.flushTimeoutMs;
     private long connectionTimeoutMs = defaults.connectionTimeoutMs;
+    private IPCCompressionType ipcCompression = defaults.ipcCompression;
 
     private ArrowStreamConfigurationOptionsBuilder() {}
 
@@ -270,6 +287,26 @@ public class ArrowStreamConfigurationOptions {
     }
 
     /**
+     * Sets the IPC compression type for Arrow Flight payloads.
+     *
+     * <p>Compression reduces network bandwidth at the cost of CPU. Supported codecs:
+     *
+     * <ul>
+     *   <li>{@link IPCCompressionType#NONE} - No compression (default)
+     *   <li>{@link IPCCompressionType#LZ4_FRAME} - LZ4 frame compression
+     *   <li>{@link IPCCompressionType#ZSTD} - Zstandard compression
+     * </ul>
+     *
+     * @param ipcCompression the compression type to use
+     * @return this builder for method chaining
+     */
+    public ArrowStreamConfigurationOptionsBuilder setIpcCompression(
+        IPCCompressionType ipcCompression) {
+      this.ipcCompression = ipcCompression;
+      return this;
+    }
+
+    /**
      * Builds a new ArrowStreamConfigurationOptions instance.
      *
      * @return a new ArrowStreamConfigurationOptions with the configured settings
@@ -283,7 +320,8 @@ public class ArrowStreamConfigurationOptions {
           this.recoveryRetries,
           this.serverLackOfAckTimeoutMs,
           this.flushTimeoutMs,
-          this.connectionTimeoutMs);
+          this.connectionTimeoutMs,
+          this.ipcCompression);
     }
   }
 }

--- a/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
+++ b/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
@@ -302,7 +302,7 @@ public class ArrowStreamConfigurationOptions {
      */
     public ArrowStreamConfigurationOptionsBuilder setIpcCompression(
         IPCCompressionType ipcCompression) {
-      this.ipcCompression = ipcCompression;
+      this.ipcCompression = ipcCompression != null ? ipcCompression : IPCCompressionType.NONE;
       return this;
     }
 

--- a/java/src/main/java/com/databricks/zerobus/IPCCompressionType.java
+++ b/java/src/main/java/com/databricks/zerobus/IPCCompressionType.java
@@ -3,9 +3,9 @@ package com.databricks.zerobus;
 /**
  * Compression type for Arrow IPC messages.
  *
- * <p>When set on {@link ArrowStreamConfigurationOptions}, the SDK compresses each Arrow record batch
- * before transmitting it over the Arrow Flight connection. This can significantly reduce network
- * bandwidth at the cost of additional CPU usage.
+ * <p>When set on {@link ArrowStreamConfigurationOptions}, the SDK compresses each Arrow record
+ * batch before transmitting it over the Arrow Flight connection. This can significantly reduce
+ * network bandwidth at the cost of additional CPU usage.
  *
  * <p>Supported codecs:
  *

--- a/java/src/main/java/com/databricks/zerobus/IPCCompressionType.java
+++ b/java/src/main/java/com/databricks/zerobus/IPCCompressionType.java
@@ -1,0 +1,29 @@
+package com.databricks.zerobus;
+
+/**
+ * Compression type for Arrow IPC messages.
+ *
+ * <p>When set on {@link ArrowStreamConfigurationOptions}, the SDK compresses each Arrow record batch
+ * before transmitting it over the Arrow Flight connection. This can significantly reduce network
+ * bandwidth at the cost of additional CPU usage.
+ *
+ * <p>Supported codecs:
+ *
+ * <ul>
+ *   <li>{@link #NONE} - No compression (default)
+ *   <li>{@link #LZ4_FRAME} - LZ4 frame compression (fast, moderate ratio)
+ *   <li>{@link #ZSTD} - Zstandard compression (slower, better ratio)
+ * </ul>
+ *
+ * @see ArrowStreamConfigurationOptions.ArrowStreamConfigurationOptionsBuilder#setIpcCompression
+ */
+public enum IPCCompressionType {
+  /** No compression. This is the default. */
+  NONE,
+
+  /** LZ4 frame compression. Offers fast compression with a moderate compression ratio. */
+  LZ4_FRAME,
+
+  /** Zstandard compression. Offers slower compression with a better compression ratio. */
+  ZSTD
+}

--- a/java/src/test/java/com/databricks/zerobus/ArrowIntegrationTest.java
+++ b/java/src/test/java/com/databricks/zerobus/ArrowIntegrationTest.java
@@ -600,6 +600,92 @@ public class ArrowIntegrationTest {
   }
 
   // ===================================================================================
+  // Test 13: Arrow stream - LZ4 compression
+  // ===================================================================================
+
+  @Test
+  @Order(13)
+  @DisplayName("Arrow stream - LZ4 compression")
+  void testArrowLz4Compression() throws Exception {
+    ArrowStreamConfigurationOptions options =
+        ArrowStreamConfigurationOptions.builder()
+            .setIpcCompression(IPCCompressionType.LZ4_FRAME)
+            .build();
+
+    try (ZerobusSdk sdk = new ZerobusSdk(serverEndpoint, workspaceUrl);
+        BufferAllocator allocator = new RootAllocator()) {
+      ZerobusArrowStream stream =
+          sdk.createArrowStream(tableName, SCHEMA, clientId, clientSecret, options).join();
+
+      try {
+        try (VectorSchemaRoot batch = VectorSchemaRoot.create(SCHEMA, allocator)) {
+          fillBatch(batch, "test-arrow-lz4", 5);
+
+          long offset = stream.ingestBatch(batch).get();
+          stream.waitForOffset(offset);
+        }
+
+        assertEquals(IPCCompressionType.LZ4_FRAME, stream.getOptions().ipcCompression());
+        System.out.println("Arrow LZ4 compression: 5 rows ingested");
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  // ===================================================================================
+  // Test 14: Arrow stream - ZSTD compression
+  // ===================================================================================
+
+  @Test
+  @Order(14)
+  @DisplayName("Arrow stream - ZSTD compression")
+  void testArrowZstdCompression() throws Exception {
+    ArrowStreamConfigurationOptions options =
+        ArrowStreamConfigurationOptions.builder()
+            .setIpcCompression(IPCCompressionType.ZSTD)
+            .build();
+
+    try (ZerobusSdk sdk = new ZerobusSdk(serverEndpoint, workspaceUrl);
+        BufferAllocator allocator = new RootAllocator()) {
+      ZerobusArrowStream stream =
+          sdk.createArrowStream(tableName, SCHEMA, clientId, clientSecret, options).join();
+
+      try {
+        try (VectorSchemaRoot batch = VectorSchemaRoot.create(SCHEMA, allocator)) {
+          fillBatch(batch, "test-arrow-zstd", 5);
+
+          long offset = stream.ingestBatch(batch).get();
+          stream.waitForOffset(offset);
+        }
+
+        assertEquals(IPCCompressionType.ZSTD, stream.getOptions().ipcCompression());
+        System.out.println("Arrow ZSTD compression: 5 rows ingested");
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  // ===================================================================================
+  // Test 15: Arrow stream - default compression is NONE
+  // ===================================================================================
+
+  @Test
+  @Order(15)
+  @DisplayName("Arrow stream - default compression is NONE")
+  void testArrowDefaultCompressionIsNone() {
+    ArrowStreamConfigurationOptions defaultOptions = ArrowStreamConfigurationOptions.getDefault();
+    assertEquals(IPCCompressionType.NONE, defaultOptions.ipcCompression());
+
+    ArrowStreamConfigurationOptions builtOptions =
+        ArrowStreamConfigurationOptions.builder().build();
+    assertEquals(IPCCompressionType.NONE, builtOptions.ipcCompression());
+
+    System.out.println("Arrow default compression: NONE verified");
+  }
+
+  // ===================================================================================
   // Helper
   // ===================================================================================
 

--- a/rust/jni/src/options.rs
+++ b/rust/jni/src/options.rs
@@ -158,8 +158,7 @@ pub fn extract_arrow_stream_options(
         .call_method(options, "connectionTimeoutMs", "()J", &[])?
         .j()? as u64;
 
-    // Extract IPC compression type from the Java enum via ordinal().
-    // IPCCompressionType: NONE=0, LZ4_FRAME=1, ZSTD=2
+    // Extract IPC compression type from the Java enum via name().
     let compression_enum = env
         .call_method(
             options,
@@ -168,13 +167,14 @@ pub fn extract_arrow_stream_options(
             &[],
         )?
         .l()?;
-    let compression_ordinal = env
-        .call_method(&compression_enum, "ordinal", "()I", &[])?
-        .i()?;
-    let ipc_compression = match compression_ordinal {
-        1 => Some(CompressionType::LZ4_FRAME),
-        2 => Some(CompressionType::ZSTD),
-        _ => None, // 0 (NONE) or any unknown value
+    let compression_jstring = env
+        .call_method(&compression_enum, "name", "()Ljava/lang/String;", &[])?
+        .l()?;
+    let compression_name: String = env.get_string((&compression_jstring).into())?.into();
+    let ipc_compression = match compression_name.as_str() {
+        "LZ4_FRAME" => Some(CompressionType::LZ4_FRAME),
+        "ZSTD" => Some(CompressionType::ZSTD),
+        _ => None, // "NONE" or any unknown value
     };
 
     Ok(ArrowStreamConfigurationOptions {

--- a/rust/jni/src/options.rs
+++ b/rust/jni/src/options.rs
@@ -4,6 +4,7 @@
 //! objects to Rust StreamConfigurationOptions structs.
 
 use crate::callbacks::JavaAckCallback;
+use arrow_ipc::CompressionType;
 use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType;
 use databricks_zerobus_ingest_sdk::{
     AckCallback, ArrowStreamConfigurationOptions, StreamConfigurationOptions,
@@ -157,6 +158,25 @@ pub fn extract_arrow_stream_options(
         .call_method(options, "connectionTimeoutMs", "()J", &[])?
         .j()? as u64;
 
+    // Extract IPC compression type from the Java enum via ordinal().
+    // IPCCompressionType: NONE=0, LZ4_FRAME=1, ZSTD=2
+    let compression_enum = env
+        .call_method(
+            options,
+            "ipcCompression",
+            "()Lcom/databricks/zerobus/IPCCompressionType;",
+            &[],
+        )?
+        .l()?;
+    let compression_ordinal = env
+        .call_method(&compression_enum, "ordinal", "()I", &[])?
+        .i()?;
+    let ipc_compression = match compression_ordinal {
+        1 => Some(CompressionType::LZ4_FRAME),
+        2 => Some(CompressionType::ZSTD),
+        _ => None, // 0 (NONE) or any unknown value
+    };
+
     Ok(ArrowStreamConfigurationOptions {
         max_inflight_batches,
         recovery,
@@ -166,7 +186,7 @@ pub fn extract_arrow_stream_options(
         server_lack_of_ack_timeout_ms,
         flush_timeout_ms,
         connection_timeout_ms,
-        ipc_compression: None, // Default, could be extended later
+        ipc_compression,
     })
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Adds `IPCCompressionType` enum (`NONE`, `LZ4_FRAME`, `ZSTD`) to configure Arrow IPC compression
- Adds `ipcCompression` field to `ArrowStreamConfigurationOptions` with builder support
- Updates Rust JNI bridge to read the Java enum and map it to `arrow_ipc::CompressionType`

## How is this tested?

Added integration tests + ran the sample client with all kinds of compressions