### PR TITLE
[Rust] Add stream builder API

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -17,6 +17,10 @@
   hop does a TLS handshake using the system trust store; the CONNECT tunnel
   still carries raw TCP so tonic applies end-to-end TLS to the target endpoint
   on top.
+- **`StreamBuilder` API**: New fluent builder for creating ingestion streams.
+  Setters can be called in any order; the builder validates at `build()` time
+  that both authentication and format have been configured.
+
 
 ### Bug Fixes
 
@@ -28,7 +32,14 @@
 
 ### Deprecations
 
+- **`ZerobusSdk::create_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).json().build().await` instead
+- **`ZerobusSdk::create_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).json().build().await` instead
+- **`ZerobusSdk::create_arrow_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).arrow(schema).build_arrow().await` instead
+- **`ZerobusSdk::create_arrow_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).arrow(schema).build_arrow().await` instead
+
 ### API Changes
 
-- New public exports: `ProxyConnector`, `ConnectorFactory`.
+- New public exports: `ProxyConnector`, `ConnectorFactory`, `StreamBuilder`.
 - New builder method: `ZerobusSdkBuilder::connector_factory`.
+- New entry point: `ZerobusSdk::stream_builder()`.
+- Changed `ZerobusSdk` fields `workspace_id` and `tls_config` to `pub(crate)` visibility (no public API impact).

--- a/rust/README.md
+++ b/rust/README.md
@@ -688,14 +688,18 @@ match stream.close().await {
 **Example:**
 
 ```rust
-let options = StreamConfigurationOptions {
-    max_inflight_requests: 50000,
-    recovery: true,
-    recovery_timeout_ms: 20000,
-    recovery_retries: 5,
-    flush_timeout_ms: 600000,
-    ..Default::default()
-};
+let stream = sdk
+    .stream_builder()
+    .table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .json()
+    .max_inflight_requests(50_000)
+    .recovery(true)
+    .recovery_timeout_ms(20_000)
+    .recovery_retries(5)
+    .flush_timeout_ms(600_000)
+    .build()
+    .await?;
 ```
 
 ## Error Handling
@@ -902,43 +906,9 @@ Returns unacknowledged records grouped by batch, preserving the original batch s
 
 Only call after stream failure.
 
-### `TableProperties`
+### `StreamBuilder`
 
-Configuration for the target table.
-
-**Fields:**
-```rust
-pub struct TableProperties {
-    pub table_name: String,
-    pub descriptor_proto: Option<prost_types::DescriptorProto>,
-}
-```
-
-- `table_name` - Full table name (e.g., "catalog.schema.table")
-- `descriptor_proto` - Optional Protocol buffer descriptor loaded from generated files (required for Proto record type, None for JSON)
-
-### `StreamConfigurationOptions`
-
-Stream behavior configuration.
-
-**Fields:**
-```rust
-pub struct StreamConfigurationOptions {
-    pub max_inflight_requests: usize,
-    pub recovery: bool,
-    pub recovery_timeout_ms: u64,
-    pub recovery_backoff_ms: u64,
-    pub recovery_retries: u32,
-    pub server_lack_of_ack_timeout_ms: u64,
-    pub flush_timeout_ms: u64,
-    pub record_type: RecordType,
-    pub stream_paused_max_wait_time_ms: Option<u64>,
-    pub ack_callback: Option<Arc<dyn AckCallback>>,
-    pub callback_max_wait_time_ms: Option<u64>
-}
-```
-
-See [Configuration Options](#configuration-options) for details.
+Configure stream parameters via fluent setters; all configuration goes through the builder. See [Create a Stream](#4-create-a-stream) for usage and [Configuration Options](#configuration-options) for the full list of available setters and their defaults.
 
 ### `AckCallback`
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -42,7 +42,6 @@ The Zerobus Rust SDK provides a robust, async-first interface for ingesting larg
 - **High Throughput** - Configurable inflight record limits for optimal performance
 - **Batch Ingestion** - Ingest multiple records at once with all-or-nothing semantics for maximum throughput
 - **Flexible Serialization** - Support for both JSON (simple) and Protocol Buffers (type-safe) data formats
-- **Stream Builder** - Fluent builder API for configuring and creating ingestion streams
 - **Type Safety** - Protocol Buffers ensure schema validation at compile time
 - **Schema Generation** - CLI tool to generate protobuf schemas from Unity Catalog tables
 - **Flexible Configuration** - Fine-tune timeouts, retries, and recovery behavior
@@ -590,15 +589,15 @@ impl AckCallback for MyCallback {
 let mut stream = sdk
     .stream_builder().table("catalog.schema.orders")
     .oauth(client_id, client_secret)
-    .json()
+    .compiled_proto(descriptor_proto)
     .max_inflight_requests(10_000)
     .ack_callback(Arc::new(MyCallback))
     .build()
     .await?;
 
 for i in 0..1000 {
-    let record = serde_json::json!({"id": i, "name": format!("order-{}", i)});
-    stream.ingest_record_offset(record.to_string()).await?;
+    let record = YourMessage { id: Some(i), /* ... */ };
+    stream.ingest_record_offset(ProtoMessage(record)).await?;
     // Callback fires when this record is acknowledged
 }
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -42,6 +42,7 @@ The Zerobus Rust SDK provides a robust, async-first interface for ingesting larg
 - **High Throughput** - Configurable inflight record limits for optimal performance
 - **Batch Ingestion** - Ingest multiple records at once with all-or-nothing semantics for maximum throughput
 - **Flexible Serialization** - Support for both JSON (simple) and Protocol Buffers (type-safe) data formats
+- **Stream Builder** - Fluent builder API for configuring and creating ingestion streams
 - **Type Safety** - Protocol Buffers ensure schema validation at compile time
 - **Schema Generation** - CLI tool to generate protobuf schemas from Unity Catalog tables
 - **Flexible Configuration** - Fine-tune timeouts, retries, and recovery behavior
@@ -189,7 +190,7 @@ zerobus_rust_sdk/
 +-----------------+
 |    Your App     |
 +-----------------+
-        | 1. create_stream()
+        | 1. stream_builder().build()
         v
 +-----------------+
 |   ZerobusSdk    |
@@ -270,13 +271,14 @@ impl HeadersProvider for MyCustomAuthProvider {
     }
 }
 
-async fn example(sdk: ZerobusSdk, table_properties: TableProperties) -> ZerobusResult<()> {
+async fn example(sdk: ZerobusSdk) -> ZerobusResult<()> {
     let custom_provider = Arc::new(MyCustomAuthProvider {});
-    let stream = sdk.create_stream_with_headers_provider(
-        table_properties,
-        custom_provider,
-        None,
-    ).await?;
+    let stream = sdk
+        .stream_builder().table("catalog.schema.table")
+        .headers_provider(custom_provider)
+        .json()
+        .build()
+        .await?;
     Ok(())
 }
 ```
@@ -397,7 +399,24 @@ See [`examples/README.md`](https://github.com/databricks/zerobus-sdk/blob/main/r
 
 ### 4. Create a Stream
 
-Configure table properties and stream options:
+Use the `stream_builder()` API to create a stream:
+
+#### JSON Stream
+
+```rust
+let mut stream = sdk
+    .stream_builder().table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .json()
+    .max_inflight_requests(10_000)
+    .recovery_timeout_ms(15_000)
+    .recovery_backoff_ms(2_000)
+    .recovery_retries(4)
+    .build()
+    .await?;
+```
+
+#### Protocol Buffers Stream
 
 ```rust
 use std::fs;
@@ -424,27 +443,19 @@ let descriptor_proto = load_descriptor(
     "table_Orders",
 );
 
-let table_properties = TableProperties {
-    table_name: "catalog.schema.orders".to_string(),
-    descriptor_proto,
-};
-
-let options = StreamConfigurationOptions {
-    max_inflight_requests: 10000,
-    recovery: true,
-    recovery_timeout_ms: 15000,
-    recovery_backoff_ms: 2000,
-    recovery_retries: 4,
-    ..Default::default()
-};
-
-let mut stream = sdk.create_stream(
-    table_properties,
-    client_id,
-    client_secret,
-    Some(options),
-).await?;
+let mut stream = sdk
+    .stream_builder().table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .compiled_proto(descriptor_proto)
+    .max_inflight_requests(10_000)
+    .recovery_timeout_ms(15_000)
+    .recovery_backoff_ms(2_000)
+    .recovery_retries(4)
+    .build()
+    .await?;
 ```
+
+Setters can be called in any order. The builder validates at `build()` time that both authentication and format have been configured.
 
 ### 5. Ingest Data
 
@@ -576,22 +587,18 @@ impl AckCallback for MyCallback {
 }
 
 // Configure stream with callback
-let options = StreamConfigurationOptions {
-    max_inflight_requests: 10000,
-    ack_callback: Some(Arc::new(MyCallback)),
-    ..Default::default()
-};
-
-let mut stream = sdk.create_stream(
-    table_properties,
-    client_id,
-    client_secret,
-    Some(options),
-).await?;
+let mut stream = sdk
+    .stream_builder().table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .json()
+    .max_inflight_requests(10_000)
+    .ack_callback(Arc::new(MyCallback))
+    .build()
+    .await?;
 
 for i in 0..1000 {
-    let record = YourMessage { id: Some(i), /* ... */ };
-    stream.ingest_record_offset(record.encode_to_vec()).await?;
+    let record = serde_json::json!({"id": i, "name": format!("order-{}", i)});
+    stream.ingest_record_offset(record.to_string()).await?;
     // Callback fires when this record is acknowledged
 }
 
@@ -753,18 +760,18 @@ let sdk = ZerobusSdk::builder()
     .unity_catalog_url(uc_endpoint)
     .build()?;
 
-let mut stream = sdk.create_stream(
-    table_properties.clone(),
-    client_id.clone(),
-    client_secret.clone(),
-    Some(options),
-).await?;
+let mut stream = sdk
+    .stream_builder().table("catalog.schema.table")
+    .oauth(client_id, client_secret)
+    .json()
+    .build()
+    .await?;
 
 // Ingest data...
 match stream.close().await {
     Err(_) => {
         // Stream failed, recreate with unacked records
-        stream = sdk.recreate_stream(stream).await?;
+        stream = sdk.recreate_stream(&stream).await?;
     }
     Ok(_) => println!("Closed successfully"),
 }
@@ -816,33 +823,19 @@ let sdk = ZerobusSdk::builder()
 ```
 
 **Methods:**
+
 ```rust
-pub async fn create_stream(
-    &self,
-    table_properties: TableProperties,
-    client_id: String,
-    client_secret: String,
-    options: Option<StreamConfigurationOptions>,
-) -> ZerobusResult<ZerobusStream>
+pub fn stream_builder(&self) -> StreamBuilder<'_>
 ```
+Returns a fluent builder for creating ingestion streams. All setters can be called in any order. Call `validate()` to check the configuration without opening a stream, or `build()` / `build_arrow()` to open the stream. See [Create a Stream](#4-create-a-stream) for usage.
 
 ```rust
 pub async fn recreate_stream(
     &self,
-    stream: ZerobusStream
+    stream: &ZerobusStream
 ) -> ZerobusResult<ZerobusStream>
 ```
 Recreates a failed stream, preserving and re-ingesting unacknowledged records.
-
-```rust
-pub async fn create_stream_with_headers_provider(
-    &self,
-    table_properties: TableProperties,
-    headers_provider: Arc<dyn HeadersProvider>,
-    options: Option<StreamConfigurationOptions>,
-) -> ZerobusResult<ZerobusStream>
-```
-Creates a stream with a custom headers provider for advanced authentication.
 
 ### `ZerobusStream`
 

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -95,20 +95,24 @@ All examples follow the same general flow:
 ### 1. Initialize SDK
 
 ```rust
-let sdk = ZerobusSdk::new(
-    SERVER_ENDPOINT.to_string(),
-    DATABRICKS_WORKSPACE_URL.to_string(),
-)?;
+let sdk = ZerobusSdk::builder()
+    .endpoint(SERVER_ENDPOINT)
+    .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
+    .build()?;
 ```
 
-### 2. Configure Table Properties
+### 2. Create Stream
 
 **JSON:**
 ```rust
-let table_properties = TableProperties {
-    table_name: TABLE_NAME.to_string(),
-    descriptor_proto: None,  // Not needed for JSON
-};
+let mut stream = sdk
+    .stream_builder()
+    .table(TABLE_NAME)
+    .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+    .json()
+    .max_inflight_requests(100)
+    .build()
+    .await?;
 ```
 
 **Protocol Buffers:**
@@ -118,41 +122,25 @@ let descriptor_proto = load_descriptor_proto(
     "orders.proto",
     "table_Orders"
 );
-let table_properties = TableProperties {
-    table_name: TABLE_NAME.to_string(),
-    descriptor_proto: Some(descriptor_proto),
-};
+
+let mut stream = sdk
+    .stream_builder()
+    .table(TABLE_NAME)
+    .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+    .compiled_proto(descriptor_proto)
+    .max_inflight_requests(100)
+    .build()
+    .await?;
 ```
 
-### 3. Configure Stream Options
-
-```rust
-let options = StreamConfigurationOptions {
-    max_inflight_requests: 100,
-    record_type: RecordType::Json,  // Or RecordType::Proto (default)
-    ..Default::default()
-};
-```
-
-### 4. Create Stream
-
-```rust
-let mut stream = sdk.create_stream(
-    table_properties,
-    DATABRICKS_CLIENT_ID.to_string(),
-    DATABRICKS_CLIENT_SECRET.to_string(),
-    Some(options),
-).await?;
-```
-
-### 5. Ingest and Acknowledge
+### 3. Ingest and Acknowledge
 
 ```rust
 let offset = stream.ingest_record_offset(data).await?;
 stream.wait_for_offset(offset).await?;
 ```
 
-### 6. Close Stream
+### 4. Close Stream
 
 ```rust
 stream.close().await?;

--- a/rust/examples/json/README.md
+++ b/rust/examples/json/README.md
@@ -116,12 +116,15 @@ let ack = stream.ingest_record(json).await?;
 let offset = ack.await?;
 ```
 
-**Key configuration for JSON:**
+**Building a JSON stream:**
 ```rust
-let stream_configuration_options = StreamConfigurationOptions {
-    record_type: RecordType::Json,  // Important!
-    ..Default::default()
-};
+let stream = sdk
+    .stream_builder()
+    .table(TABLE_NAME)
+    .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+    .json()
+    .build()
+    .await?;
 ```
 
 ## Batch Example

--- a/rust/examples/json/batch/src/main.rs
+++ b/rust/examples/json/batch/src/main.rs
@@ -1,9 +1,6 @@
 use std::error::Error;
 
-use databricks_zerobus_ingest_sdk::{
-    databricks::zerobus::RecordType, JsonString, JsonValue, StreamConfigurationOptions,
-    TableProperties, ZerobusSdk, ZerobusStream,
-};
+use databricks_zerobus_ingest_sdk::{JsonString, JsonValue, ZerobusSdk, ZerobusStream};
 use serde::Serialize;
 
 /// Order struct that can be automatically serialized to JSON using JsonValue wrapper.
@@ -36,28 +33,18 @@ const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.da
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let table_properties = TableProperties {
-        table_name: TABLE_NAME.to_string(),
-        // Not needed for JSON.
-        descriptor_proto: None,
-    };
-    let stream_configuration_options = StreamConfigurationOptions {
-        max_inflight_requests: 100,
-        record_type: RecordType::Json,
-        ..Default::default()
-    };
     let sdk_handle = ZerobusSdk::builder()
         .endpoint(SERVER_ENDPOINT)
         .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
         .build()?;
 
     let mut stream = sdk_handle
-        .create_stream(
-            table_properties.clone(),
-            DATABRICKS_CLIENT_ID.to_string(),
-            DATABRICKS_CLIENT_SECRET.to_string(),
-            Some(stream_configuration_options),
-        )
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .json()
+        .max_inflight_requests(100)
+        .build()
         .await?;
 
     ingest_with_offset_api(&mut stream).await?;

--- a/rust/examples/json/single/src/main.rs
+++ b/rust/examples/json/single/src/main.rs
@@ -1,9 +1,6 @@
 use std::error::Error;
 
-use databricks_zerobus_ingest_sdk::{
-    databricks::zerobus::RecordType, JsonString, JsonValue, StreamConfigurationOptions,
-    TableProperties, ZerobusSdk, ZerobusStream,
-};
+use databricks_zerobus_ingest_sdk::{JsonString, JsonValue, ZerobusSdk, ZerobusStream};
 use serde::Serialize;
 
 /// Order struct that can be automatically serialized to JSON using JsonValue wrapper.
@@ -36,28 +33,18 @@ const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.da
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let table_properties = TableProperties {
-        table_name: TABLE_NAME.to_string(),
-        // Not needed for JSON.
-        descriptor_proto: None,
-    };
-    let stream_configuration_options = StreamConfigurationOptions {
-        max_inflight_requests: 100,
-        record_type: RecordType::Json,
-        ..Default::default()
-    };
     let sdk_handle = ZerobusSdk::builder()
         .endpoint(SERVER_ENDPOINT)
         .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
         .build()?;
 
     let mut stream = sdk_handle
-        .create_stream(
-            table_properties.clone(),
-            DATABRICKS_CLIENT_ID.to_string(),
-            DATABRICKS_CLIENT_SECRET.to_string(),
-            Some(stream_configuration_options),
-        )
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .json()
+        .max_inflight_requests(100)
+        .build()
         .await?;
 
     ingest_with_offset_api(&mut stream).await?;

--- a/rust/examples/proto/README.md
+++ b/rust/examples/proto/README.md
@@ -118,7 +118,7 @@ let ack = stream.ingest_record(bytes).await?;
 let offset = ack.await?;
 ```
 
-**Key configuration for Protocol Buffers:**
+**Building a Protocol Buffers stream:**
 ```rust
 // Load descriptor from generated files
 let descriptor_proto = load_descriptor_proto(
@@ -127,15 +127,13 @@ let descriptor_proto = load_descriptor_proto(
     "table_Orders"
 );
 
-let table_properties = TableProperties {
-    table_name: TABLE_NAME.to_string(),
-    descriptor_proto: Some(descriptor_proto),  // Required for Proto
-};
-
-let stream_configuration_options = StreamConfigurationOptions {
-    // RecordType::Proto is the default, no need to set explicitly
-    ..Default::default()
-};
+let stream = sdk
+    .stream_builder()
+    .table(TABLE_NAME)
+    .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+    .compiled_proto(descriptor_proto)
+    .build()
+    .await?;
 ```
 
 ## Batch Example

--- a/rust/examples/proto/batch/src/main.rs
+++ b/rust/examples/proto/batch/src/main.rs
@@ -4,10 +4,7 @@ use std::fs;
 use prost::Message;
 use prost_reflect::prost_types;
 
-use databricks_zerobus_ingest_sdk::{
-    ProtoBytes, ProtoMessage, StreamConfigurationOptions, TableProperties, ZerobusSdk,
-    ZerobusStream,
-};
+use databricks_zerobus_ingest_sdk::{ProtoBytes, ProtoMessage, ZerobusSdk, ZerobusStream};
 
 pub mod orders {
     include!("../output/orders.rs");
@@ -33,27 +30,18 @@ const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.da
 async fn main() -> Result<(), Box<dyn Error>> {
     let descriptor_proto =
         load_descriptor_proto("output/orders.descriptor", "orders.proto", "table_Orders");
-    let table_properties = TableProperties {
-        table_name: TABLE_NAME.to_string(),
-        descriptor_proto: Some(descriptor_proto),
-    };
-    let stream_configuration_options = StreamConfigurationOptions {
-        max_inflight_requests: 100,
-        // RecordType::Proto is the default.
-        ..Default::default()
-    };
     let sdk_handle = ZerobusSdk::builder()
         .endpoint(SERVER_ENDPOINT)
         .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
         .build()?;
 
     let mut stream = sdk_handle
-        .create_stream(
-            table_properties.clone(),
-            DATABRICKS_CLIENT_ID.to_string(),
-            DATABRICKS_CLIENT_SECRET.to_string(),
-            Some(stream_configuration_options),
-        )
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .compiled_proto(descriptor_proto)
+        .max_inflight_requests(100)
+        .build()
         .await?;
 
     ingest_with_offset_api(&mut stream).await?;

--- a/rust/examples/proto/single/src/main.rs
+++ b/rust/examples/proto/single/src/main.rs
@@ -4,10 +4,7 @@ use std::fs;
 use prost::Message;
 use prost_reflect::prost_types;
 
-use databricks_zerobus_ingest_sdk::{
-    ProtoBytes, ProtoMessage, StreamConfigurationOptions, TableProperties, ZerobusSdk,
-    ZerobusStream,
-};
+use databricks_zerobus_ingest_sdk::{ProtoBytes, ProtoMessage, ZerobusSdk, ZerobusStream};
 
 pub mod orders {
     include!("../output/orders.rs");
@@ -33,27 +30,18 @@ const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.da
 async fn main() -> Result<(), Box<dyn Error>> {
     let descriptor_proto =
         load_descriptor_proto("output/orders.descriptor", "orders.proto", "table_Orders");
-    let table_properties = TableProperties {
-        table_name: TABLE_NAME.to_string(),
-        descriptor_proto: Some(descriptor_proto),
-    };
-    let stream_configuration_options = StreamConfigurationOptions {
-        max_inflight_requests: 100,
-        // RecordType::Proto is the default.
-        ..Default::default()
-    };
     let sdk_handle = ZerobusSdk::builder()
         .endpoint(SERVER_ENDPOINT)
         .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
         .build()?;
 
     let mut stream = sdk_handle
-        .create_stream(
-            table_properties.clone(),
-            DATABRICKS_CLIENT_ID.to_string(),
-            DATABRICKS_CLIENT_SECRET.to_string(),
-            Some(stream_configuration_options),
-        )
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .compiled_proto(descriptor_proto)
+        .max_inflight_requests(100)
+        .build()
         .await?;
 
     ingest_with_offset_api(&mut stream).await?;

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -163,6 +163,7 @@ fn record_batch_to_ipc_bytes(batch: &RecordBatch) -> ZerobusResult<Vec<u8>> {
 /// `schema_ipc_bytes` must point to Arrow IPC stream bytes encoding only the schema
 /// (write an empty IPC stream with just the schema message).
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "C" fn zerobus_sdk_create_arrow_stream(
     sdk: *mut CZerobusSdk,
     table_name: *const c_char,
@@ -233,6 +234,7 @@ pub extern "C" fn zerobus_sdk_create_arrow_stream(
 ///
 /// `schema_ipc_bytes` must point to Arrow IPC stream bytes encoding only the schema.
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "C" fn zerobus_sdk_create_arrow_stream_with_headers_provider(
     sdk: *mut CZerobusSdk,
     table_name: *const c_char,
@@ -1025,6 +1027,7 @@ pub extern "C" fn zerobus_sdk_set_use_tls(sdk: *mut CZerobusSdk, _use_tls: bool)
 /// Create a stream with OAuth authentication
 /// descriptor_proto_bytes: protobuf-encoded DescriptorProto (can be NULL for JSON streams)
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "C" fn zerobus_sdk_create_stream(
     sdk: *mut CZerobusSdk,
     table_name: *const c_char,
@@ -1098,6 +1101,7 @@ pub extern "C" fn zerobus_sdk_create_stream(
 /// Create a stream with a custom headers provider callback
 /// This allows you to provide custom authentication headers via a Go callback function
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider(
     sdk: *mut CZerobusSdk,
     table_name: *const c_char,

--- a/rust/jni/src/sdk.rs
+++ b/rust/jni/src/sdk.rs
@@ -126,6 +126,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeDestroy<'loc
 /// );
 /// ```
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreateStream<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject<'local>,
@@ -346,6 +347,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeRecreateStre
 /// );
 /// ```
 #[no_mangle]
+#[allow(deprecated)]
 pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreateArrowStream<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject<'local>,

--- a/rust/sdk/src/arrow_configuration.rs
+++ b/rust/sdk/src/arrow_configuration.rs
@@ -11,17 +11,19 @@ use arrow_ipc::CompressionType;
 /// These options control the behavior of Arrow Flight ingestion streams, including
 /// backpressure limits, timeout settings, and recovery policies.
 ///
-/// # Examples
+/// **Do not construct this directly.** Configure Arrow streams via the builder API:
 ///
-/// ```
-/// use databricks_zerobus_ingest_sdk::ArrowStreamConfigurationOptions;
-///
-/// let options = ArrowStreamConfigurationOptions {
-///     max_inflight_batches: 100,
-///     server_lack_of_ack_timeout_ms: 30_000,
-///     recovery: true,
-///     ..Default::default()
-/// };
+/// ```rust,ignore
+/// let stream = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .oauth("client-id", "client-secret")
+///     .arrow(schema)
+///     .max_inflight_batches(100)
+///     .server_lack_of_ack_timeout_ms(30_000)
+///     .recovery(true)
+///     .build_arrow()
+///     .await?;
 /// ```
 #[derive(Clone, Debug)]
 pub struct ArrowStreamConfigurationOptions {

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -64,8 +64,8 @@ impl ArrowPayload {
 
 /// Properties for an Arrow Flight ingestion table.
 ///
-/// Unlike `TableProperties` which requires a protobuf descriptor, Arrow Flight
-/// streams derive the schema from the first RecordBatch sent.
+/// **Do not construct this directly.** Configure Arrow streams via the builder API:
+/// `sdk.stream_builder().table("catalog.schema.table").arrow(schema)`.
 #[derive(Debug, Clone)]
 pub struct ArrowTableProperties {
     /// The fully qualified table name (e.g., "catalog.schema.table").

--- a/rust/sdk/src/builder/mod.rs
+++ b/rust/sdk/src/builder/mod.rs
@@ -1,9 +1,11 @@
-//! Builder API for creating Zerobus SDK instances.
+//! Builder API for creating Zerobus SDK instances and ingestion streams.
 //!
-//! This module provides a fluent builder pattern for configuring and creating
-//! SDK instances.
+//! This module provides fluent builder patterns for configuring and creating
+//! SDK instances and streams.
 //!
 //! # Examples
+//!
+//! ## SDK Builder
 //!
 //! ```no_run
 //! use databricks_zerobus_ingest_sdk::ZerobusSdkBuilder;
@@ -14,7 +16,21 @@
 //!     .build()?;
 //! # Ok::<(), databricks_zerobus_ingest_sdk::ZerobusError>(())
 //! ```
+//!
+//! ## Stream Builder
+//!
+//! ```rust,ignore
+//! let stream = sdk
+//!     .stream_builder()
+//!     .table("catalog.schema.table")
+//!     .oauth("client-id", "client-secret")
+//!     .json()
+//!     .build()
+//!     .await?;
+//! ```
 
 mod sdk_builder;
+mod stream_builder;
 
 pub use sdk_builder::ZerobusSdkBuilder;
+pub use stream_builder::StreamBuilder;

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -1,0 +1,653 @@
+//! Fluent builder for creating Zerobus ingestion streams.
+//!
+//! All setters can be called in any order. The builder validates at
+//! `build()` time that table name, authentication, and format have been
+//! configured. You can also call `validate()` to check the builder state
+//! without opening a stream.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! let stream = sdk
+//!     .stream_builder()
+//!     .table("catalog.schema.table")
+//!     .oauth("client-id", "client-secret")
+//!     .json()
+//!     .max_inflight_requests(500_000)
+//!     .build()
+//!     .await?;
+//! ```
+
+use std::fmt;
+use std::sync::Arc;
+
+use crate::callbacks::AckCallback;
+use crate::databricks::zerobus::RecordType;
+use crate::headers_provider::{HeadersProvider, OAuthHeadersProvider};
+use crate::stream_configuration::StreamConfigurationOptions;
+use crate::{TableProperties, ZerobusError, ZerobusResult, ZerobusSdk, ZerobusStream};
+
+#[cfg(feature = "arrow-flight")]
+use crate::arrow_configuration::ArrowStreamConfigurationOptions;
+#[cfg(feature = "arrow-flight")]
+use crate::arrow_stream::{ArrowSchema, ArrowTableProperties, ZerobusArrowStream};
+
+/// Internal representation of the authentication configuration.
+enum AuthConfig {
+    OAuth {
+        client_id: String,
+        client_secret: String,
+    },
+    HeadersProvider(Arc<dyn HeadersProvider>),
+}
+
+/// Which record format was selected.
+enum FormatConfig {
+    Json,
+    CompiledProto(Box<prost_types::DescriptorProto>),
+    #[cfg(feature = "arrow-flight")]
+    Arrow(Arc<ArrowSchema>),
+}
+
+/// A fluent builder for creating Zerobus ingestion streams.
+///
+/// All setters can be called in any order. The builder validates at
+/// `build()` time that table name, authentication, and format have been
+/// configured. Use [`validate()`](Self::validate) to check the builder
+/// state without opening a stream.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // JSON stream with OAuth
+/// let stream = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .oauth("client-id", "client-secret")
+///     .json()
+///     .build()
+///     .await?;
+///
+/// // Proto stream with custom headers
+/// let stream = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .headers_provider(my_provider)
+///     .compiled_proto(descriptor)
+///     .max_inflight_requests(500_000)
+///     .build()
+///     .await?;
+///
+/// // Validate without opening a stream
+/// let builder = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .oauth("client-id", "client-secret")
+///     .json();
+/// builder.validate()?;
+/// let stream = builder.build().await?;
+/// ```
+#[must_use = "a StreamBuilder does nothing until `.build()` is called"]
+pub struct StreamBuilder<'a> {
+    sdk: &'a ZerobusSdk,
+    table_name: String,
+    auth: Option<AuthConfig>,
+    format: Option<FormatConfig>,
+    grpc_config: StreamConfigurationOptions,
+    #[cfg(feature = "arrow-flight")]
+    arrow_config: ArrowStreamConfigurationOptions,
+}
+
+impl fmt::Debug for StreamBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let auth_kind = match &self.auth {
+            Some(AuthConfig::OAuth { .. }) => "OAuth",
+            Some(AuthConfig::HeadersProvider(_)) => "HeadersProvider",
+            None => "None",
+        };
+        let format_kind = match &self.format {
+            Some(FormatConfig::Json) => "Json",
+            Some(FormatConfig::CompiledProto(_)) => "CompiledProto",
+            #[cfg(feature = "arrow-flight")]
+            Some(FormatConfig::Arrow(_)) => "Arrow",
+            None => "None",
+        };
+        f.debug_struct("StreamBuilder")
+            .field("table_name", &self.table_name)
+            .field("auth", &auth_kind)
+            .field("format", &format_kind)
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(clippy::result_large_err)]
+impl<'a> StreamBuilder<'a> {
+    pub(crate) fn new(sdk: &'a ZerobusSdk) -> Self {
+        Self {
+            sdk,
+            table_name: String::new(),
+            auth: None,
+            format: None,
+            grpc_config: StreamConfigurationOptions::default(),
+            #[cfg(feature = "arrow-flight")]
+            arrow_config: ArrowStreamConfigurationOptions::default(),
+        }
+    }
+
+    /// Set the fully-qualified Unity Catalog table name (e.g., `"catalog.schema.table"`).
+    pub fn table(mut self, table_name: impl Into<String>) -> Self {
+        self.table_name = table_name.into();
+        self
+    }
+
+    /// Authenticate with OAuth client credentials.
+    pub fn oauth(mut self, client_id: impl Into<String>, client_secret: impl Into<String>) -> Self {
+        self.auth = Some(AuthConfig::OAuth {
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+        });
+        self
+    }
+
+    /// Authenticate with a custom headers provider.
+    pub fn headers_provider(mut self, provider: Arc<dyn HeadersProvider>) -> Self {
+        self.auth = Some(AuthConfig::HeadersProvider(provider));
+        self
+    }
+
+    /// Select JSON record format.
+    pub fn json(mut self) -> Self {
+        self.format = Some(FormatConfig::Json);
+        self
+    }
+
+    /// Select compiled protobuf record format.
+    pub fn compiled_proto(mut self, descriptor: prost_types::DescriptorProto) -> Self {
+        self.format = Some(FormatConfig::CompiledProto(Box::new(descriptor)));
+        self
+    }
+
+    /// Select Arrow Flight record format.
+    #[cfg(feature = "arrow-flight")]
+    pub fn arrow(mut self, schema: Arc<ArrowSchema>) -> Self {
+        self.format = Some(FormatConfig::Arrow(schema));
+        self
+    }
+
+    /// Enable or disable automatic stream recovery.
+    pub fn recovery(mut self, enabled: bool) -> Self {
+        self.grpc_config.recovery = enabled;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.recovery = enabled;
+        }
+        self
+    }
+
+    /// Set the timeout in milliseconds for each recovery attempt.
+    pub fn recovery_timeout_ms(mut self, ms: u64) -> Self {
+        self.grpc_config.recovery_timeout_ms = ms;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.recovery_timeout_ms = ms;
+        }
+        self
+    }
+
+    /// Set the backoff time in milliseconds between recovery retries.
+    pub fn recovery_backoff_ms(mut self, ms: u64) -> Self {
+        self.grpc_config.recovery_backoff_ms = ms;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.recovery_backoff_ms = ms;
+        }
+        self
+    }
+
+    /// Set the maximum number of recovery retry attempts.
+    pub fn recovery_retries(mut self, n: u32) -> Self {
+        self.grpc_config.recovery_retries = n;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.recovery_retries = n;
+        }
+        self
+    }
+
+    /// Set the timeout in milliseconds for server acknowledgement.
+    pub fn server_lack_of_ack_timeout_ms(mut self, ms: u64) -> Self {
+        self.grpc_config.server_lack_of_ack_timeout_ms = ms;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.server_lack_of_ack_timeout_ms = ms;
+        }
+        self
+    }
+
+    /// Set the timeout in milliseconds for flush operations.
+    pub fn flush_timeout_ms(mut self, ms: u64) -> Self {
+        self.grpc_config.flush_timeout_ms = ms;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.flush_timeout_ms = ms;
+        }
+        self
+    }
+
+    /// Set the maximum number of in-flight requests (gRPC streams only).
+    pub fn max_inflight_requests(mut self, n: usize) -> Self {
+        self.grpc_config.max_inflight_requests = n;
+        self
+    }
+
+    /// Set the maximum wait time during graceful stream pause (gRPC streams only).
+    pub fn stream_paused_max_wait_time_ms(mut self, ms: Option<u64>) -> Self {
+        self.grpc_config.stream_paused_max_wait_time_ms = ms;
+        self
+    }
+
+    /// Set the acknowledgment callback (gRPC streams only).
+    pub fn ack_callback(mut self, callback: Arc<dyn AckCallback>) -> Self {
+        self.grpc_config.ack_callback = Some(callback);
+        self
+    }
+
+    /// Set the maximum wait time for callbacks after stream close (gRPC streams only).
+    pub fn callback_max_wait_time_ms(mut self, ms: Option<u64>) -> Self {
+        self.grpc_config.callback_max_wait_time_ms = ms;
+        self
+    }
+
+    /// Set the maximum number of in-flight Arrow batches (Arrow streams only).
+    #[cfg(feature = "arrow-flight")]
+    pub fn max_inflight_batches(mut self, n: usize) -> Self {
+        self.arrow_config.max_inflight_batches = n;
+        self
+    }
+
+    /// Set the connection timeout in milliseconds for Arrow Flight (Arrow streams only).
+    #[cfg(feature = "arrow-flight")]
+    pub fn connection_timeout_ms(mut self, ms: u64) -> Self {
+        self.arrow_config.connection_timeout_ms = ms;
+        self
+    }
+
+    /// Set the Arrow IPC compression type (Arrow streams only).
+    #[cfg(feature = "arrow-flight")]
+    pub fn ipc_compression(mut self, compression: Option<arrow_ipc::CompressionType>) -> Self {
+        self.arrow_config.ipc_compression = compression;
+        self
+    }
+
+    /// Validate that the builder has all required fields configured.
+    ///
+    /// Returns `Ok(())` if table name, authentication, and format are all set.
+    /// This performs the same checks as `build()` without actually opening
+    /// a stream — useful for fail-fast validation during startup or config
+    /// parsing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let builder = sdk
+    ///     .stream_builder()
+    ///     .table("catalog.schema.table")
+    ///     .oauth("client-id", "client-secret")
+    ///     .json();
+    ///
+    /// // Check configuration before opening the stream
+    /// builder.validate()?;
+    /// let stream = builder.build().await?;
+    /// ```
+    pub fn validate(&self) -> ZerobusResult<()> {
+        if self.table_name.is_empty() {
+            return Err(ZerobusError::InvalidArgument(
+                "table name is required: call .table()".into(),
+            ));
+        }
+        if self.auth.is_none() {
+            return Err(ZerobusError::InvalidArgument(
+                "authentication is required: call .oauth() or .headers_provider()".into(),
+            ));
+        }
+        if self.format.is_none() {
+            return Err(ZerobusError::InvalidArgument(
+                "record format is required: call .json(), .compiled_proto(), or .arrow()".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Resolve the headers provider from the stored auth config.
+    fn resolve_headers_provider(&self) -> ZerobusResult<Arc<dyn HeadersProvider>> {
+        match self.auth.as_ref() {
+            Some(AuthConfig::OAuth {
+                client_id,
+                client_secret,
+            }) => Ok(Arc::new(OAuthHeadersProvider::new(
+                client_id.clone(),
+                client_secret.clone(),
+                self.table_name.clone(),
+                self.sdk.workspace_id.clone(),
+                self.sdk.unity_catalog_url.clone(),
+            ))),
+            Some(AuthConfig::HeadersProvider(p)) => Ok(Arc::clone(p)),
+            None => Err(ZerobusError::InvalidArgument(
+                "authentication is required: call .oauth() or .headers_provider()".into(),
+            )),
+        }
+    }
+
+    /// Build and open a gRPC ingestion stream (JSON or compiled protobuf).
+    ///
+    /// Returns an error if table name, authentication, or format has not been set,
+    /// or if an Arrow format was selected (use `build_arrow()` instead).
+    pub async fn build(mut self) -> ZerobusResult<ZerobusStream> {
+        self.validate()?;
+        let headers_provider = self.resolve_headers_provider()?;
+
+        let (record_type, descriptor_proto) = match self.format {
+            Some(FormatConfig::Json) => (RecordType::Json, None),
+            Some(FormatConfig::CompiledProto(desc)) => (RecordType::Proto, Some(*desc)),
+            #[cfg(feature = "arrow-flight")]
+            Some(FormatConfig::Arrow(_)) => {
+                return Err(ZerobusError::InvalidArgument(
+                    "Arrow format requires .build_arrow() instead of .build()".into(),
+                ));
+            }
+            None => {
+                return Err(ZerobusError::InvalidArgument(
+                    "record format is required: call .json() or .compiled_proto() before .build()"
+                        .into(),
+                ));
+            }
+        };
+
+        self.grpc_config.record_type = record_type;
+        let table_properties = TableProperties {
+            table_name: self.table_name,
+            descriptor_proto,
+        };
+
+        let channel = self.sdk.get_or_create_channel_zerobus_client().await?;
+        ZerobusStream::new_stream(
+            channel,
+            table_properties,
+            headers_provider,
+            self.grpc_config,
+        )
+        .await
+    }
+
+    /// Build and open an Arrow Flight ingestion stream.
+    ///
+    /// Returns an error if table name, authentication, or format has not been set,
+    /// or if a non-Arrow format was selected (use `build()` instead).
+    #[cfg(feature = "arrow-flight")]
+    pub async fn build_arrow(self) -> ZerobusResult<ZerobusArrowStream> {
+        self.validate()?;
+        let headers_provider = self.resolve_headers_provider()?;
+
+        let schema = match self.format {
+            Some(FormatConfig::Arrow(schema)) => schema,
+            Some(_) => {
+                return Err(ZerobusError::InvalidArgument(
+                    "non-Arrow format requires .build() instead of .build_arrow()".into(),
+                ));
+            }
+            None => {
+                return Err(ZerobusError::InvalidArgument(
+                    "record format is required: call .arrow() before .build_arrow()".into(),
+                ));
+            }
+        };
+
+        let table_properties = ArrowTableProperties {
+            table_name: self.table_name,
+            schema,
+        };
+
+        ZerobusArrowStream::new(
+            &self.sdk.zerobus_endpoint,
+            Arc::clone(&self.sdk.tls_config),
+            table_properties,
+            headers_provider,
+            self.arrow_config,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn test_sdk() -> ZerobusSdk {
+        ZerobusSdk::new_with_config(
+            "http://localhost:1234".to_string(),
+            "http://localhost:5678".to_string(),
+            "test-workspace".to_string(),
+            Arc::new(crate::tls_config::SecureTlsConfig::new()),
+            None,
+        )
+    }
+
+    #[test]
+    fn json_oauth_builder() {
+        let sdk = test_sdk();
+        let _builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .oauth("cid", "csec")
+            .json()
+            .max_inflight_requests(100);
+    }
+
+    #[test]
+    fn compiled_proto_headers_provider() {
+        struct StubProvider;
+        #[async_trait::async_trait]
+        impl HeadersProvider for StubProvider {
+            async fn get_headers(&self) -> crate::ZerobusResult<HashMap<&'static str, String>> {
+                Ok(HashMap::new())
+            }
+        }
+
+        let sdk = test_sdk();
+        let provider: Arc<dyn HeadersProvider> = Arc::new(StubProvider);
+        let _builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .headers_provider(provider)
+            .compiled_proto(prost_types::DescriptorProto::default());
+    }
+
+    #[test]
+    fn any_order_format_before_auth() {
+        let sdk = test_sdk();
+        let _builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .json()
+            .oauth("cid", "csec")
+            .max_inflight_requests(100);
+    }
+
+    #[test]
+    fn any_order_config_before_format() {
+        let sdk = test_sdk();
+        let _builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .max_inflight_requests(100)
+            .recovery(false)
+            .oauth("cid", "csec")
+            .json();
+    }
+
+    #[test]
+    fn config_setters_chain() {
+        let sdk = test_sdk();
+        let _builder = sdk
+            .stream_builder()
+            .table("t")
+            .oauth("a", "b")
+            .json()
+            .recovery(false)
+            .recovery_timeout_ms(10_000)
+            .recovery_backoff_ms(1_000)
+            .recovery_retries(3)
+            .server_lack_of_ack_timeout_ms(30_000)
+            .flush_timeout_ms(60_000)
+            .max_inflight_requests(500)
+            .stream_paused_max_wait_time_ms(Some(5_000))
+            .callback_max_wait_time_ms(None);
+    }
+
+    #[test]
+    fn default_config_without_setters() {
+        let sdk = test_sdk();
+        let builder = sdk.stream_builder().table("t").oauth("a", "b").json();
+        assert_eq!(builder.grpc_config.max_inflight_requests, 1_000_000);
+        assert!(builder.grpc_config.recovery);
+    }
+
+    #[tokio::test]
+    async fn build_without_auth_returns_error() {
+        let sdk = test_sdk();
+        let result = sdk.stream_builder().table("t").json().build().await;
+        match result {
+            Err(ZerobusError::InvalidArgument(msg)) => {
+                assert!(msg.contains("authentication is required"));
+            }
+            _ => panic!("expected InvalidArgument error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_without_table_returns_error() {
+        let sdk = test_sdk();
+        let result = sdk.stream_builder().oauth("a", "b").json().build().await;
+        match result {
+            Err(ZerobusError::InvalidArgument(msg)) => {
+                assert!(msg.contains("table name is required"));
+            }
+            _ => panic!("expected InvalidArgument error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_without_format_returns_error() {
+        let sdk = test_sdk();
+        let result = sdk
+            .stream_builder()
+            .table("t")
+            .oauth("a", "b")
+            .build()
+            .await;
+        match result {
+            Err(ZerobusError::InvalidArgument(msg)) => {
+                assert!(msg.contains("record format is required"));
+            }
+            _ => panic!("expected InvalidArgument error"),
+        }
+    }
+
+    #[test]
+    fn debug_impl_works() {
+        let sdk = test_sdk();
+        let builder = sdk.stream_builder().table("t").oauth("a", "b").json();
+        let debug_str = format!("{:?}", builder);
+        assert!(debug_str.contains("StreamBuilder"));
+        assert!(debug_str.contains("OAuth"));
+        assert!(debug_str.contains("Json"));
+    }
+
+    #[tokio::test]
+    async fn resolve_headers_provider_with_custom_provider() {
+        struct TestProvider;
+
+        #[async_trait::async_trait]
+        impl HeadersProvider for TestProvider {
+            async fn get_headers(&self) -> crate::ZerobusResult<HashMap<&'static str, String>> {
+                let mut h = HashMap::new();
+                h.insert("x-test", "value".to_string());
+                Ok(h)
+            }
+        }
+
+        let sdk = test_sdk();
+        let builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .headers_provider(Arc::new(TestProvider))
+            .json();
+
+        let provider = builder.resolve_headers_provider().unwrap();
+        let headers = provider.get_headers().await.unwrap();
+        assert_eq!(headers.get("x-test").unwrap(), "value");
+    }
+
+    #[tokio::test]
+    async fn resolve_headers_provider_with_oauth() {
+        let sdk = test_sdk();
+        let builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .oauth("my-client-id", "my-secret")
+            .json();
+
+        let _provider = builder.resolve_headers_provider().unwrap();
+    }
+
+    #[cfg(feature = "arrow-flight")]
+    #[test]
+    fn arrow_builder() {
+        use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+        let sdk = test_sdk();
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let _builder = sdk
+            .stream_builder()
+            .table("t")
+            .oauth("a", "b")
+            .arrow(schema)
+            .max_inflight_batches(500)
+            .connection_timeout_ms(10_000);
+    }
+
+    #[cfg(feature = "arrow-flight")]
+    #[test]
+    fn shared_setters_write_to_arrow_config() {
+        use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+        let sdk = test_sdk();
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let builder = sdk
+            .stream_builder()
+            .table("t")
+            .oauth("a", "b")
+            .arrow(schema)
+            .recovery(false)
+            .recovery_timeout_ms(5_000)
+            .recovery_backoff_ms(500)
+            .recovery_retries(2)
+            .server_lack_of_ack_timeout_ms(10_000)
+            .flush_timeout_ms(20_000);
+        assert!(!builder.arrow_config.recovery);
+        assert_eq!(builder.arrow_config.recovery_timeout_ms, 5_000);
+        assert_eq!(builder.arrow_config.recovery_backoff_ms, 500);
+        assert_eq!(builder.arrow_config.recovery_retries, 2);
+        assert_eq!(builder.arrow_config.server_lack_of_ack_timeout_ms, 10_000);
+        assert_eq!(builder.arrow_config.flush_timeout_ms, 20_000);
+    }
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -5,16 +5,23 @@
 //! ## Quick Start
 //!
 //! ```rust,ignore
-//! use databricks_zerobus_ingest_sdk::{ZerobusSdk, TableProperties, ProtoMessage};
+//! use databricks_zerobus_ingest_sdk::{ZerobusSdk, JsonValue};
 //!
 //! let sdk = ZerobusSdk::builder()
 //!     .endpoint(zerobus_endpoint)
 //!     .unity_catalog_url(uc_endpoint)
 //!     .build()?;
-//! let stream = sdk.create_stream(table_properties, client_id, client_secret, None).await?;
+//!
+//! let stream = sdk
+//!     .stream_builder()
+//!     .table("catalog.schema.table")
+//!     .oauth(client_id, client_secret)
+//!     .json()
+//!     .build()
+//!     .await?;
 //!
 //! // Ingest a record and wait for acknowledgment
-//! let offset = stream.ingest_record_offset(ProtoMessage(my_message)).await?;
+//! let offset = stream.ingest_record_offset(JsonValue(my_record)).await?;
 //! stream.wait_for_offset(offset).await?;
 //!
 //! stream.close().await?;
@@ -82,7 +89,7 @@ pub use arrow_configuration::ArrowStreamConfigurationOptions;
 pub use arrow_stream::{
     ArrowSchema, ArrowTableProperties, DataType, Field, RecordBatch, ZerobusArrowStream,
 };
-pub use builder::ZerobusSdkBuilder;
+pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
 pub use errors::ZerobusError;
@@ -269,8 +276,8 @@ pub struct ZerobusSdk {
     pub use_tls: bool,
     pub unity_catalog_url: String,
     shared_channel: tokio::sync::Mutex<Option<ZerobusClient<Channel>>>,
-    workspace_id: String,
-    tls_config: Arc<dyn TlsConfig>,
+    pub(crate) workspace_id: String,
+    pub(crate) tls_config: Arc<dyn TlsConfig>,
     connector_factory: Option<ConnectorFactory>,
 }
 
@@ -292,6 +299,39 @@ impl ZerobusSdk {
     /// ```
     pub fn builder() -> ZerobusSdkBuilder {
         ZerobusSdkBuilder::new()
+    }
+
+    /// Creates a new stream builder for configuring an ingestion stream.
+    ///
+    /// All setters can be called in any order. The builder validates at
+    /// `build()` time that table name, authentication, and format have
+    /// been configured. Use [`StreamBuilder::validate()`] to check the
+    /// configuration without opening a stream.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // JSON stream with OAuth
+    /// let stream = sdk
+    ///     .stream_builder()
+    ///     .table("catalog.schema.table")
+    ///     .oauth("client-id", "client-secret")
+    ///     .json()
+    ///     .build()
+    ///     .await?;
+    ///
+    /// // Proto stream with custom headers
+    /// let stream = sdk
+    ///     .stream_builder()
+    ///     .table("catalog.schema.table")
+    ///     .headers_provider(my_provider)
+    ///     .compiled_proto(descriptor)
+    ///     .max_inflight_requests(500_000)
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub fn stream_builder(&self) -> StreamBuilder<'_> {
+        StreamBuilder::new(self)
     }
 
     /// Creates a new Zerobus SDK instance.
@@ -420,6 +460,11 @@ impl ZerobusSdk {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        since = "1.3.0",
+        note = "Use `sdk.stream_builder().table(table_name).oauth(id, secret).json().build().await` or `.compiled_proto(desc)` instead"
+    )]
+    #[allow(deprecated)]
     #[instrument(level = "debug", skip_all)]
     pub async fn create_stream(
         &self,
@@ -493,6 +538,11 @@ impl ZerobusSdk {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        since = "1.3.0",
+        note = "Use `sdk.stream_builder().table(table_name).headers_provider(p).json().build().await` instead"
+    )]
+    #[allow(deprecated)]
     #[instrument(level = "debug", skip_all)]
     pub async fn create_stream_with_headers_provider(
         &self,
@@ -530,6 +580,7 @@ impl ZerobusSdk {
             options,
         )
         .await;
+
         match stream {
             Ok(stream) => {
                 if let Some(stream_id) = stream.stream_id.as_ref() {
@@ -583,18 +634,35 @@ impl ZerobusSdk {
     #[instrument(level = "debug", skip_all)]
     pub async fn recreate_stream(&self, stream: &ZerobusStream) -> ZerobusResult<ZerobusStream> {
         let batches = stream.get_unacked_batches().await?;
-        let new_stream = self
-            .create_stream_with_headers_provider(
-                stream.table_properties.clone(),
-                Arc::clone(&stream.headers_provider),
-                Some(stream.options.clone()),
-            )
-            .await?;
-        for batch in batches {
-            let ack = new_stream.ingest_internal(batch).await?;
-            tokio::spawn(ack);
+        let channel = self.get_or_create_channel_zerobus_client().await?;
+        let new_stream = ZerobusStream::new_stream(
+            channel,
+            stream.table_properties.clone(),
+            Arc::clone(&stream.headers_provider),
+            stream.options.clone(),
+        )
+        .await;
+
+        match new_stream {
+            Ok(new_stream) => {
+                if let Some(stream_id) = new_stream.stream_id.as_ref() {
+                    info!(stream_id = %stream_id, "Successfully recreated ephemeral stream");
+                } else {
+                    error!("Successfully recreated a stream but stream_id is None");
+                }
+
+                for batch in batches {
+                    let ack = new_stream.ingest_internal(batch).await?;
+                    tokio::spawn(ack);
+                }
+
+                Ok(new_stream)
+            }
+            Err(e) => {
+                error!("Stream recreation failed with error: {}", e);
+                Err(e)
+            }
         }
-        return Ok(new_stream);
     }
 
     /// Creates a new Arrow Flight ingestion stream to a Unity Catalog table.
@@ -648,6 +716,11 @@ impl ZerobusSdk {
     /// # }
     /// ```
     #[cfg(feature = "arrow-flight")]
+    #[deprecated(
+        since = "1.3.0",
+        note = "Use `sdk.stream_builder().table(table_name).oauth(id, secret).arrow(schema).build().await` instead"
+    )]
+    #[allow(deprecated)]
     #[instrument(level = "debug", skip_all)]
     pub async fn create_arrow_stream(
         &self,
@@ -727,6 +800,11 @@ impl ZerobusSdk {
     /// # }
     /// ```
     #[cfg(feature = "arrow-flight")]
+    #[deprecated(
+        since = "1.3.0",
+        note = "Use `sdk.stream_builder().table(table_name).headers_provider(p).arrow(schema).build().await` instead"
+    )]
+    #[allow(deprecated)]
     #[instrument(level = "debug", skip_all)]
     pub async fn create_arrow_stream_with_headers_provider(
         &self,
@@ -814,31 +892,41 @@ impl ZerobusSdk {
     ) -> ZerobusResult<ZerobusArrowStream> {
         let batches = stream.get_unacked_batches().await?;
 
-        let new_stream = self
-            .create_arrow_stream_with_headers_provider(
-                stream.table_properties().clone(),
-                stream.headers_provider(),
-                Some(stream.options().clone()),
-            )
-            .await?;
+        let new_stream = ZerobusArrowStream::new(
+            &self.zerobus_endpoint,
+            Arc::clone(&self.tls_config),
+            stream.table_properties().clone(),
+            stream.headers_provider(),
+            stream.options().clone(),
+        )
+        .await;
 
-        // Replay unacked batches.
-        for batch in batches {
-            let _offset = new_stream.ingest_batch(batch).await?;
+        match new_stream {
+            Ok(new_stream) => {
+                info!(
+                    table_name = %new_stream.table_name(),
+                    "Successfully recreated Arrow Flight stream"
+                );
+
+                for batch in batches {
+                    let _offset = new_stream.ingest_batch(batch).await?;
+                }
+
+                Ok(new_stream)
+            }
+            Err(e) => {
+                error!("Arrow Flight stream recreation failed: {}", e);
+                Err(e)
+            }
         }
-
-        info!(
-            table_name = %new_stream.table_name(),
-            "Successfully recreated Arrow Flight stream"
-        );
-
-        Ok(new_stream)
     }
 
     /// Gets or creates the shared Channel for all streams.
     /// The first call creates the Channel, subsequent calls clone it.
     /// All clones share the same underlying TCP connection via HTTP/2 multiplexing.
-    async fn get_or_create_channel_zerobus_client(&self) -> ZerobusResult<ZerobusClient<Channel>> {
+    pub(crate) async fn get_or_create_channel_zerobus_client(
+        &self,
+    ) -> ZerobusResult<ZerobusClient<Channel>> {
         let mut guard = self.shared_channel.lock().await;
 
         if guard.is_none() {
@@ -880,7 +968,7 @@ impl ZerobusSdk {
 impl ZerobusStream {
     /// Creates a new ephemeral stream for ingesting records.
     #[instrument(level = "debug", skip_all)]
-    async fn new_stream(
+    pub(crate) async fn new_stream(
         channel: ZerobusClient<Channel>,
         table_properties: TableProperties,
         headers_provider: Arc<dyn HeadersProvider>,

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -120,8 +120,8 @@ pub enum StreamType {
 
 /// The properties of the table to ingest to.
 ///
-/// Used when creating streams via `ZerobusSdk::create_stream()` to specify
-/// which table to write to and the schema of records being ingested.
+/// Configure the table via the builder API:
+/// `sdk.stream_builder().table("catalog.schema.table").compiled_proto(descriptor)`.
 ///
 /// # Common errors:
 /// -`InvalidTableName`: table_name contains invalid characters or doesn't exist
@@ -163,8 +163,8 @@ enum CallbackMessage {
 ///
 /// # Lifecycle
 ///
-/// 1. Create a stream via `ZerobusSdk::create_stream()`
-/// 2. Ingest records with `ingest_record()` and await acknowledgments
+/// 1. Create a stream via `ZerobusSdk::stream_builder()`
+/// 2. Ingest records with `ingest_record_offset()` and `wait_for_offset()` for acknowledgments
 /// 3. Optionally call `flush()` to ensure all records are persisted
 /// 4. Close the stream with `close()` to release resources
 ///
@@ -228,43 +228,28 @@ pub struct ZerobusStream {
 
 /// The main interface for interacting with the Zerobus API.
 /// # Examples
-/// ```no_run
-/// # use std::error::Error;
-/// # use std::sync::Arc;
-/// # use databricks_zerobus_ingest_sdk::{ZerobusSdk, StreamConfigurationOptions, TableProperties, ZerobusError, ZerobusResult};
-/// #
-/// # async fn write_single_row(row: impl prost::Message) -> Result<(), ZerobusError> {
-///
+/// ```rust,ignore
 /// // Create SDK using the builder
 /// let sdk = ZerobusSdk::builder()
 ///     .endpoint("https://your-workspace.zerobus.region.cloud.databricks.com")
 ///     .unity_catalog_url("https://your-workspace.cloud.databricks.com")
 ///     .build()?;
 ///
-/// // Define the arguments for the ephemeral stream.
-/// let table_properties = TableProperties {
-///     table_name: "test_table".to_string(),
-///     descriptor_proto: Default::default(),
-/// };
-/// let options = StreamConfigurationOptions {
-///     max_inflight_requests: 100,
-///     ..Default::default()
-/// };
-/// let client_id = "your-client-id".to_string();
-/// let client_secret = "your-client-secret".to_string();
-///
-/// // Create a stream
-/// let stream = sdk.create_stream(table_properties, client_id, client_secret, Some(options)).await?;
+/// // Create a stream via the stream builder
+/// let stream = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .oauth("client-id", "client-secret")
+///     .compiled_proto(descriptor_proto)
+///     .max_inflight_requests(100)
+///     .build()
+///     .await?;
 ///
 /// // Ingest a single record
-/// let offset_id = stream.ingest_record_offset(row.encode_to_vec()).await?;
-/// println!("Record sent with offset Id: {}", offset_id);
+/// let offset_id = stream.ingest_record_offset(ProtoMessage(row)).await?;
 ///
 /// // Wait for acknowledgment
 /// stream.wait_for_offset(offset_id).await?;
-/// println!("Record acknowledged with offset Id: {}", offset_id);
-/// # Ok(())
-/// # }
 /// ```
 pub struct ZerobusSdk {
     pub zerobus_endpoint: String,

--- a/rust/sdk/src/stream_configuration.rs
+++ b/rust/sdk/src/stream_configuration.rs
@@ -9,18 +9,20 @@ use crate::stream_options::defaults;
 /// These options control the behavior of ingestion streams, including memory limits,
 /// recovery policies, and timeout settings.
 ///
-/// # Examples
+/// **Do not construct this directly.** Configure streams via the builder API:
 ///
-/// ```
-/// use databricks_zerobus_ingest_sdk::StreamConfigurationOptions;
-///
-/// let options = StreamConfigurationOptions {
-///     max_inflight_requests: 1_000_000,
-///     recovery: true,
-///     recovery_timeout_ms: 20_000,
-///     recovery_retries: 5,
-///     ..Default::default()
-/// };
+/// ```rust,ignore
+/// let stream = sdk
+///     .stream_builder()
+///     .table("catalog.schema.table")
+///     .oauth("client-id", "client-secret")
+///     .json()
+///     .max_inflight_requests(1_000_000)
+///     .recovery(true)
+///     .recovery_timeout_ms(20_000)
+///     .recovery_retries(5)
+///     .build()
+///     .await?;
 /// ```
 #[derive(Clone)]
 pub struct StreamConfigurationOptions {
@@ -114,9 +116,9 @@ pub struct StreamConfigurationOptions {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,ignore
     /// use std::sync::Arc;
-    /// use databricks_zerobus_ingest_sdk::{AckCallback, StreamConfigurationOptions, OffsetId};
+    /// use databricks_zerobus_ingest_sdk::{AckCallback, OffsetId};
     ///
     /// struct MyCallback;
     ///
@@ -130,10 +132,14 @@ pub struct StreamConfigurationOptions {
     ///     }
     /// }
     ///
-    /// let options = StreamConfigurationOptions {
-    ///     ack_callback: Some(Arc::new(MyCallback)),
-    ///     ..Default::default()
-    /// };
+    /// let stream = sdk
+    ///     .stream_builder()
+    ///     .table("catalog.schema.table")
+    ///     .oauth("client-id", "client-secret")
+    ///     .json()
+    ///     .ack_callback(Arc::new(MyCallback))
+    ///     .build()
+    ///     .await?;
     /// ```
     pub ack_callback: Option<Arc<dyn AckCallback>>,
 

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod mock_arrow_flight;
 mod utils;
 

--- a/rust/tests/src/proxy_tests.rs
+++ b/rust/tests/src/proxy_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod mock_grpc;
 mod utils;
 

--- a/rust/tests/src/rust_tests.rs
+++ b/rust/tests/src/rust_tests.rs
@@ -5295,3 +5295,164 @@ mod callback_tests {
         Ok(())
     }
 }
+
+mod stream_builder_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_builder_json_stream_creation() -> Result<(), Box<dyn std::error::Error>> {
+        setup_tracing();
+
+        let (mock_server, server_url) = start_mock_server().await?;
+
+        mock_server
+            .inject_responses(
+                TABLE_NAME,
+                vec![MockResponse::CreateStream {
+                    stream_id: "builder_json_stream".to_string(),
+                    delay_ms: 0,
+                }],
+            )
+            .await;
+
+        let sdk = ZerobusSdk::builder()
+            .endpoint(server_url)
+            .unity_catalog_url("https://mock-uc.com")
+            .tls_config(Arc::new(NoTlsConfig))
+            .build()?;
+
+        let mut stream = sdk
+            .stream_builder()
+            .table(TABLE_NAME)
+            .headers_provider(Arc::new(TestHeadersProvider::default()))
+            .json()
+            .max_inflight_requests(100)
+            .recovery(false)
+            .build()
+            .await?;
+
+        assert_eq!(stream.stream_type, StreamType::Ephemeral);
+        stream.close().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_builder_proto_stream_creation() -> Result<(), Box<dyn std::error::Error>> {
+        setup_tracing();
+
+        let (mock_server, server_url) = start_mock_server().await?;
+
+        mock_server
+            .inject_responses(
+                TABLE_NAME,
+                vec![MockResponse::CreateStream {
+                    stream_id: "builder_proto_stream".to_string(),
+                    delay_ms: 0,
+                }],
+            )
+            .await;
+
+        let sdk = ZerobusSdk::builder()
+            .endpoint(server_url)
+            .unity_catalog_url("https://mock-uc.com")
+            .tls_config(Arc::new(NoTlsConfig))
+            .build()?;
+
+        let descriptor = create_test_descriptor_proto().unwrap();
+        let mut stream = sdk
+            .stream_builder()
+            .table(TABLE_NAME)
+            .headers_provider(Arc::new(TestHeadersProvider::default()))
+            .compiled_proto(descriptor)
+            .max_inflight_requests(100)
+            .recovery(false)
+            .build()
+            .await?;
+
+        assert_eq!(stream.stream_type, StreamType::Ephemeral);
+        stream.close().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_builder_json_ingest_and_ack() -> Result<(), Box<dyn std::error::Error>> {
+        setup_tracing();
+
+        let (mock_server, server_url) = start_mock_server().await?;
+
+        mock_server
+            .inject_responses(
+                TABLE_NAME,
+                vec![
+                    MockResponse::CreateStream {
+                        stream_id: "builder_ingest_stream".to_string(),
+                        delay_ms: 0,
+                    },
+                    MockResponse::RecordAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: 0,
+                    },
+                ],
+            )
+            .await;
+
+        let sdk = ZerobusSdk::builder()
+            .endpoint(server_url)
+            .unity_catalog_url("https://mock-uc.com")
+            .tls_config(Arc::new(NoTlsConfig))
+            .build()?;
+
+        let mut stream = sdk
+            .stream_builder()
+            .table(TABLE_NAME)
+            .headers_provider(Arc::new(TestHeadersProvider::default()))
+            .json()
+            .recovery(false)
+            .build()
+            .await?;
+
+        let offset = stream
+            .ingest_record_offset(r#"{"id": 1, "message": "hello"}"#.to_string())
+            .await?;
+        stream.wait_for_offset(offset).await?;
+        stream.close().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_builder_validate_catches_missing_fields() {
+        let sdk = ZerobusSdk::builder()
+            .endpoint("http://localhost:1234")
+            .tls_config(Arc::new(NoTlsConfig))
+            .build()
+            .unwrap();
+
+        // Missing everything
+        let result = sdk.stream_builder().validate();
+        assert!(result.is_err());
+
+        // Missing auth and format
+        let result = sdk.stream_builder().table(TABLE_NAME).validate();
+        assert!(result.is_err());
+
+        // Missing format
+        let result = sdk
+            .stream_builder()
+            .table(TABLE_NAME)
+            .headers_provider(Arc::new(TestHeadersProvider::default()))
+            .validate();
+        assert!(result.is_err());
+
+        // All set — should pass
+        let result = sdk
+            .stream_builder()
+            .table(TABLE_NAME)
+            .headers_provider(Arc::new(TestHeadersProvider::default()))
+            .json()
+            .validate();
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a `StreamBuilder` API to the Rust SDK that replaces the existing `create_stream*` family of methods with a fluent builder.

All setters can be called in any order. The builder validates at `build()` time that table name, authentication, and format have been configured.

```rust
let stream = sdk
    .stream_builder()
    .table("catalog.schema.table")
    .oauth("client-id", "client-secret")
    .json()
    .max_inflight_requests(500_000)
    .build()
    .await?;
```

Motivation:
- The current `create_stream` API is a wide parameter list where adding or removing arguments is a breaking change.
- The builder gives us a stable public surface where individual setters can be added/removed/deprecated independently.
- This is the first step toward providing similar builder APIs in the wrapper SDKs (Python, Java, Go, TypeScript), each idiomatic for their language.

Design decisions:
- No typestate, no generics — simple `StreamBuilder<'a>` with runtime validation at `build()`. Same pattern as `ZerobusSdkBuilder`. Keeps the public API surface small (one exported type) and allows setters in any order.
- `table_name` is a setter (`.table()`) not a constructor parameter, consistent with all other configuration.
- `build()` for gRPC streams (JSON/Proto), `build_arrow()` for Arrow streams — separate methods because the return types differ (`ZerobusStream` vs `ZerobusArrowStream`).
- `validate()` lets users check configuration without opening a stream, useful for fail-fast during startup.
- `#[must_use]` on `StreamBuilder` warns if a builder is created but never built.
- Deprecated methods are kept functional for backward compatibility and for wrapper SDKs that still depend on them.

## How is this tested?

1. 12 unit tests in `stream_builder.rs`.
2. 4 integration tests in `rust/tests/src/rust_tests.rs`.
3. CI.

## Follow-up items

These are scoped out of this PR and tracked for subsequent work.

1. Add `NoOpHeadersProvider` and `.no_auth()` builder method for local testing.

2. Add public getter methods on `ZerobusStream` and `ZerobusSdk` for fields that are currently public, prepares users for field privatization in version 2.0.0.

3. Unify `StreamConfigurationOptions` and `ArrowStreamConfigurationOptions` shared fields into a common config struct. Currently each shared setter dual-writes to both config structs.

4. Unify `ZerobusStream` and `ZerobusArrowStream` into a single stream type so `build()` can return one type regardless of format.

5. Add idiomatic stream builder APIs to wrapper SDKs (Python, Java, Go, TypeScript). Each language should use its own idiomatic pattern (kwargs in Python, traditional builder in Java, functional options in Go, options object in TypeScript).

6. Rust 2.0 breaking changes: privatize all public fields on `ZerobusStream`, `ZerobusSdk`, `StreamConfigurationOptions`, `ArrowStreamConfigurationOptions`, `TableProperties` (add getters). Remove deprecated `create_stream*` methods, `ZerobusSdk::new()`, `use_tls`, `ingest_record`/`ingest_records` (non-offset variants), and `record_type` from config.
