### PR TITLE
[Rust] Release v1.2.0

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,8 +1,39 @@
 # Version changelog
 
-## Release v1.0.1
+## Release v1.2.0
 
 ### Major Changes
+
+- **License: Migrated from the Databricks License to the Apache License 2.0**
+
+### New Features and Improvements
+
+- Added the `schema` module with `descriptor_from_uc_columns` /
+  `descriptor_from_uc_schema`, which convert a Unity Catalog table schema
+  (including nested `STRUCT`, `ARRAY`, and `MAP` columns via `type_json`) into
+  a `prost_types::DescriptorProto` that can be passed to
+  `TableProperties::descriptor_proto`. Enables building descriptors at runtime
+  without pre-generating `.proto` files.
+
+### Internal Changes
+
+- The `generate_files` CLI tool now delegates schema → descriptor conversion
+  to the SDK's new `schema` module instead of its own hand-rolled DDL-string
+  parser, and renders the resulting `DescriptorProto` back to proto2 text.
+
+### Breaking Changes
+
+- `generate_files`: the emitted `.proto` files have changed shape for
+  non-trivial schemas. Consumers regenerating existing files should expect:
+  - Field numbers now follow Unity Catalog's `position + 1` (so gaps from
+    `DROP COLUMN` under Delta column-mapping are preserved) instead of the
+    previous 1,2,3… sequential numbering with a 19000-range skip.
+  - Nested struct messages use path-based names (e.g. `OuterInner` instead of
+    `Inner`) and are emitted hierarchically inside their parent message.
+  - Struct field nullability now honors Unity Catalog's `nullable` flag
+    instead of being forced to `optional`.
+
+## Release v1.1.0
 
 ### New Features and Improvements
 
@@ -11,17 +42,6 @@
 ### Bug Fixes
 
 - Fixed proto generation tool to skip reserved field numbers 19000-19999 for tables with more than 19000 columns
-
-### Documentation
-
-### Internal Changes
-
-### Breaking Changes
-
-### Deprecations
-
-### API Changes
-
 
 ## Release v1.0.1
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arrow-array",
  "arrow-flight",
@@ -670,7 +670,7 @@ name = "example_json_batch"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "serde",
  "tokio",
 ]
@@ -680,7 +680,7 @@ name = "example_json_single"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "serde",
  "tokio",
 ]
@@ -690,7 +690,7 @@ name = "example_proto_batch"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "prost 0.13.5",
  "prost-build 0.12.6",
  "prost-reflect",
@@ -706,7 +706,7 @@ name = "example_proto_single"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "prost 0.13.5",
  "prost-build 0.12.6",
  "prost-reflect",
@@ -2537,7 +2537,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bytes",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "futures",
  "prost 0.13.5",
  "prost-reflect",
@@ -2834,7 +2834,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "databricks-zerobus-ingest-sdk 1.1.0",
+ "databricks-zerobus-ingest-sdk 1.2.0",
  "prost-types 0.13.5",
  "protoc-bin-vendored",
  "reqwest",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,19 +1,10 @@
 # NEXT CHANGELOG
 
-## Release v1.2.0
+## Release v1.3.0
 
 ### Major Changes
 
-- **License: Migrated from the Databricks License to the Apache License 2.0**
-
 ### New Features and Improvements
-
-- Added the `schema` module with `descriptor_from_uc_columns` /
-  `descriptor_from_uc_schema`, which convert a Unity Catalog table schema
-  (including nested `STRUCT`, `ARRAY`, and `MAP` columns via `type_json`) into
-  a `prost_types::DescriptorProto` that can be passed to
-  `TableProperties::descriptor_proto`. Enables building descriptors at runtime
-  without pre-generating `.proto` files.
 
 ### Bug Fixes
 
@@ -21,23 +12,8 @@
 
 ### Internal Changes
 
-- The `generate_files` CLI tool now delegates schema → descriptor conversion
-  to the SDK's new `schema` module instead of its own hand-rolled DDL-string
-  parser, and renders the resulting `DescriptorProto` back to proto2 text.
-
 ### Breaking Changes
-
-- `generate_files`: the emitted `.proto` files have changed shape for
-  non-trivial schemas. Consumers regenerating existing files should expect:
-  - Field numbers now follow Unity Catalog's `position + 1` (so gaps from
-    `DROP COLUMN` under Delta column-mapping are preserved) instead of the
-    previous 1,2,3… sequential numbering with a 19000-range skip.
-  - Nested struct messages use path-based names (e.g. `OuterInner` instead of
-    `Inner`) and are emitted hierarchically inside their parent message.
-  - Struct field nullability now honors Unity Catalog's `nullable` flag
-    instead of being forced to `optional`.
 
 ### Deprecations
 
 ### API Changes
-

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prepare Rust SDK v1.2.0 release.

- Bump crate version from `1.1.0` to `1.2.0`
- Move `v1.2.0` release notes from `NEXT_CHANGELOG.md` into `CHANGELOG.md`
- Add missing `v1.1.0` release notes to `CHANGELOG.md` (were never moved during the `v1.1.0` release)
- Remove duplicate `v1.0.1` changelog entry
- Reset `NEXT_CHANGELOG.md` for `v1.3.0`

Changes in `v.1.2.0`:

- License change: `Databricks License` to `Apache License 2.0`
- New `schema` module: `descriptor_from_uc_columns` / `descriptor_from_uc_schema` for converting Unity Catalog table schemas into `DescriptorProto` at runtime, without pre-generating `.proto` files
- Breaking (`generate_files` tool only): emitted `.proto` files now preserve UC field positions, use path-based nested message names, and honor the `nullable` flag

## How is this tested?

n/a — version bump and changelog only.