### PR TITLE
[TypeScript] Release v1.0.1 — fix npm packaging

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## Release v1.0.1
+
+### Bug Fixes
+
+- Fixed npm packaging: v1.0.0 was published without the napi-rs generated `index.js` loader and `index.d.ts` type declarations, causing `MODULE_NOT_FOUND` on `require('@databricks/zerobus-ingest-sdk')`. The platform-specific native binary packages (e.g. `@databricks/zerobus-ingest-sdk-linux-x64-gnu`) were also missing from npm. This release includes all generated files and platform packages.
+
 ## Release v1.0.0
 
 GA release of the Databricks Zerobus Ingest SDK for TypeScript.

--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-sdk-ts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-sdk-ts"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Databricks"]
 edition = "2021"
 license = "Apache-2.0"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "0.3.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/zerobus-ingest-sdk",
-      "version": "0.3.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -1313,7 +1313,7 @@
       }
     },
     "node_modules/levn": {
-      "version": "0.3.0",
+      "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript/Node.js SDK for streaming data ingestion into Databricks Delta tables using Zerobus",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## What changes are proposed in this pull request?

v1.0.0 was published without the napi-rs generated `index.js` loader, `index.d.ts`
type declarations, and platform-specific native binary packages
(e.g. `@databricks/zerobus-ingest-sdk-linux-x64-gnu`). This caused
`MODULE_NOT_FOUND` on `require('@databricks/zerobus-ingest-sdk')` and
installation failures with yarn/npm.

## How is this tested?

n/a — version bump and changelog only. The actual fix is in the release
workflow which correctly runs `napi prepublish` and publishes platform packages.