### PR TITLE
[Java] Release hotfix version 1.1.1

### DIFF
--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## Release v1.1.1
+
+### Bug Fixes
+
+- Fixed `isClosed()` returning `false` after the stream internally closed due to non-retryable errors (e.g. server rejection, auth failure). The JNI layer now checks both the wrapper state and the Rust stream's internal closed flag. Affects both proto/JSON streams and Arrow streams.
+
 ## Release v1.1.0
 
 ### Major Changes

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.databricks</groupId>
   <artifactId>zerobus-ingest-sdk</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
   <name>Zerobus Ingest SDK for Java</name>
   <description>Databricks Zerobus Ingest SDK for Java - Direct ingestion to Delta tables via native Rust SDK</description>

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-jni"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/rust/jni/Cargo.toml
+++ b/rust/jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-jni"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"

--- a/rust/jni/src/arrow_stream.rs
+++ b/rust/jni/src/arrow_stream.rs
@@ -256,10 +256,13 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusArrowStream_nativeIsCl
     // Get stream handle
     let stream_handle = unsafe { NativeArrowStreamHandle::borrow_from_raw(handle) };
 
-    // Block on the async operation
+    // Check both: wrapper cleared (nativeClose called) or stream internally closed (error/shutdown)
     let is_closed = block_on(async {
         let guard = stream_handle.stream.lock().await;
-        guard.is_none()
+        match guard.as_ref() {
+            None => true,
+            Some(stream) => stream.is_closed(),
+        }
     });
 
     if is_closed {

--- a/rust/jni/src/stream.rs
+++ b/rust/jni/src/stream.rs
@@ -418,10 +418,13 @@ pub extern "system" fn Java_com_databricks_zerobus_BaseZerobusStream_nativeIsClo
     // Get stream handle
     let stream_handle = unsafe { NativeStreamHandle::borrow_from_raw(handle) };
 
-    // Block on the async operation
+    // Check both: wrapper cleared (nativeClose called) or stream internally closed (error/shutdown)
     let is_closed = block_on(async {
         let guard = stream_handle.stream.lock().await;
-        guard.is_none()
+        match guard.as_ref() {
+            None => true,
+            Some(stream) => stream.is_closed(),
+        }
     });
 
     if is_closed {


### PR DESCRIPTION
## What changes are proposed in this pull request?

The JNI `nativeIsClosed` implementation only checked whether the stream wrapper
was explicitly closed (via `nativeClose`), but did not check the Rust stream's
internal `is_closed` flag. This meant `isClosed()` returned `false` even after
the stream internally shut down due to non-retryable errors.

The fix checks both conditions, wrapper cleared or stream internally closed.

- Bump Java SDK version from 1.1.0 to 1.1.1
- Bump JNI crate version from 1.1.0 to 1.1.1

## How is this tested?

Compiled and verified via `cargo check -p zerobus-jni`.