### PR TITLE
Fix ffi and jni release paths in README

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1026,7 +1026,7 @@ cargo build -p zerobus-ffi --release
 # ffi/zerobus.h                        (C header file)
 ```
 
-Pre-built binaries for all platforms are available in [GitHub Releases](https://github.com/databricks/zerobus-sdk/releases) with tags `ffi-vX.X.X`.
+Pre-built binaries for all platforms are available in [GitHub Releases](https://github.com/databricks/zerobus-sdk/releases) with tags `ffi/vX.X.X`.
 
 ### JNI (`jni/`)
 
@@ -1042,7 +1042,7 @@ cargo build -p zerobus-jni --release
 # target/release/zerobus_jni.dll       (Windows)
 ```
 
-Pre-built binaries are available in [GitHub Releases](https://github.com/databricks/zerobus-sdk/releases) with tags `jni-vX.X.X`.
+Pre-built binaries are available in [GitHub Releases](https://github.com/databricks/zerobus-sdk/releases) with tags `jni/vX.X.X`.
 
 ## Building from Source
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Readme had download links written as `ffi-vX.X.X` and `jni-vX.X.X` while the tags were published with `/`.

## How is this tested?
n/a