### PR TITLE
[TypeScript] Release v1.0.2 - platform-specific binary packages

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -67,9 +67,19 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Upload artifact
+      - name: Upload native binding
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bindings-${{ matrix.target }}
           path: 'typescript/*.node'
+          if-no-files-found: error
+
+      - name: Upload JS/TS entry points
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: js-binding
+          path: |
+            typescript/index.js
+            typescript/index.d.ts
           if-no-files-found: error

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## Release v1.0.2
+
+### Bug Fixes
+
+- Split platform-specific native binaries into separate npm packages (`@databricks/zerobus-ingest-sdk-linux-x64-gnu`, `-linux-arm64-gnu`, `-win32-x64-msvc`). npm now auto-installs only the binary matching the user's OS/arch via `optionalDependencies`, reducing download size from ~15MB to ~5MB.
+
 ## Release v1.0.1
 
 ### Bug Fixes

--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-sdk-ts"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-sdk-ts"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Databricks"]
 edition = "2021"
 license = "Apache-2.0"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/zerobus-ingest-sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -1313,7 +1313,7 @@
       }
     },
     "node_modules/levn": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
@@ -1466,7 +1466,7 @@
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TypeScript/Node.js SDK for streaming data ingestion into Databricks Delta tables using Zerobus",
   "main": "index.js",
   "types": "index.d.ts",
@@ -65,6 +65,11 @@
     "example:proto:batch": "tsx examples/proto/batch.ts",
     "example:arrow:single": "tsx examples/arrow/single.ts",
     "example:arrow:batch": "tsx examples/arrow/batch.ts"
+  },
+  "optionalDependencies": {
+    "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.0.2",
+    "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.0.2",
+    "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.0.2"
   },
   "peerDependencies": {
     "protobufjs": "^7.0.0",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Version `1.0.1` shipped all native binaries (~15MB) bundled in the main package as a stopgap. Now that the platform packages exist on NPM, this release adds `optionalDependencies` so `npm` auto-installs only the binary matching the user's OS/arch (~5MB).

- Bump version to `1.0.2`
- Add `optionalDependencies` for `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`
- Update `CHANGELOG.md`

## How is this tested?

N/A