### PR TITLE
[Typescript] Fix `package-lock.json` sync with `package.json`

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -22,11 +22,9 @@
         "node": ">= 16"
       },
       "optionalDependencies": {
-        "@databricks/zerobus-ingest-sdk-darwin-arm64": "0.3.0",
-        "@databricks/zerobus-ingest-sdk-darwin-x64": "0.3.0",
-        "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "0.3.0",
-        "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "0.3.0",
-        "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "0.3.0"
+        "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.0.2",
+        "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.0.2",
+        "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.0.2"
       },
       "peerDependencies": {
         "apache-arrow": "^56.0.0",
@@ -86,21 +84,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@databricks/zerobus-ingest-sdk-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@databricks/zerobus-ingest-sdk-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@databricks/zerobus-ingest-sdk-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@databricks/zerobus-ingest-sdk-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@databricks/zerobus-ingest-sdk-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -2005,6 +1988,18 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
+    },
+    "node_modules/@databricks/zerobus-ingest-sdk-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "optional": true
+    },
+    "node_modules/@databricks/zerobus-ingest-sdk-linux-x64-gnu": {
+      "version": "1.0.2",
+      "optional": true
+    },
+    "node_modules/@databricks/zerobus-ingest-sdk-win32-x64-msvc": {
+      "version": "1.0.2",
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The v1.0.2 PR added `optionalDependencies` to `package.json` but the `package-lock.json` wasn't updated to match. This causes `npm ci` to fail with `EUSAGE` on all TypeScript CI jobs.

- Update optionalDependencies versions from 0.3.0 to 1.0.2
- Remove stale darwin platform entries (we don't build darwin targets)
- Remove empty node_modules/placeholder entries (no version/integrity)

## How is this tested?

CI — `npm ci` will pass once the lock file matches package.json.