### PR TITLE
[Python] Remove duplicate `crates.io` patching

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -57,12 +57,12 @@ jobs:
         shell: bash
         run: cp ../LICENSE LICENSE
 
-      - name: Patch Cargo.toml to use local Rust SDK
-        if: inputs.use_local_sdk
-        working-directory: python/rust
-        shell: bash
-        run: |
-          printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "../../rust/sdk" }\n' >> Cargo.toml
+      # - name: Patch Cargo.toml to use local Rust SDK
+      #   if: inputs.use_local_sdk
+      #   working-directory: python/rust
+      #   shell: bash
+      #   run: |
+      #     printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "../../rust/sdk" }\n' >> Cargo.toml
 
       - name: Run tests (Linux)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previous Python PR to bump version to 1.0.2 added a `[patch.crates-io]` to point to local Rust SDK. We also had this in `ci-python.yml` for cross-SDK tests. Here we are commenting out the `ci-python.yml` to avoid duplicate key collision in `Cargo.toml`.

## How is this tested?

CI