### PR TITLE
[All] Graceful close on arrow streams

### DIFF
--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: When the server signals an impending close, the client pauses sends, drains in-flight acks within a bounded wait, then recovers; graceful-close recoveries do not count toward `RecoveryRetries`.
+- **Arrow Flight — graceful stream close**: When the server signals an impending close, the client pauses sends, drains in-flight acks within a bounded wait, then recovers.
 - **`ArrowStreamConfigurationOptions.StreamPausedMaxWaitTimeMs`**: Optional `*uint64` limiting how long to wait (ms) while paused (`nil` = full server duration, `0` = immediate recovery).
 
 ### Deprecations

--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### New Features and Improvements
 
+- **Arrow Flight — graceful stream close**: When the server signals an impending close, the client pauses sends, drains in-flight acks within a bounded wait, then recovers; graceful-close recoveries do not count toward `RecoveryRetries`.
+- **`ArrowStreamConfigurationOptions.StreamPausedMaxWaitTimeMs`**: Optional `*uint64` limiting how long to wait (ms) while paused (`nil` = full server duration, `0` = immediate recovery).
+
 ### Deprecations
 
 ### Bug Fixes

--- a/go/arrow_ffi.go
+++ b/go/arrow_ffi.go
@@ -52,6 +52,7 @@ typedef struct CArrowStreamConfigurationOptions {
     uint64_t  flush_timeout_ms;
     uint64_t  connection_timeout_ms;
     int32_t   ipc_compression;
+    int64_t   stream_paused_max_wait_time_ms;
 } CArrowStreamConfigurationOptions;
 
 // Array of Arrow IPC-encoded batches returned by get_unacked_batches.
@@ -201,16 +202,23 @@ func convertArrowConfigToC(opts *ArrowStreamConfigurationOptions) C.CArrowStream
 		ipcCompression = -1
 	}
 
+	// Map Go stream_paused_max_wait_time_ms: nil → -1 (wait full server duration).
+	var streamPausedMaxWait int64 = -1
+	if opts.StreamPausedMaxWaitTimeMs != nil {
+		streamPausedMaxWait = int64(*opts.StreamPausedMaxWaitTimeMs)
+	}
+
 	return C.CArrowStreamConfigurationOptions{
-		max_inflight_batches:          C.uintptr_t(maxInflight),
-		recovery:                      C.bool(recovery),
-		recovery_timeout_ms:           C.uint64_t(recoveryTimeout),
-		recovery_backoff_ms:           C.uint64_t(recoveryBackoff),
-		recovery_retries:              C.uint32_t(recoveryRetries),
-		server_lack_of_ack_timeout_ms: C.uint64_t(serverAckTimeout),
-		flush_timeout_ms:              C.uint64_t(flushTimeout),
-		connection_timeout_ms:         C.uint64_t(connTimeout),
-		ipc_compression:               C.int32_t(ipcCompression),
+		max_inflight_batches:            C.uintptr_t(maxInflight),
+		recovery:                        C.bool(recovery),
+		recovery_timeout_ms:             C.uint64_t(recoveryTimeout),
+		recovery_backoff_ms:             C.uint64_t(recoveryBackoff),
+		recovery_retries:                C.uint32_t(recoveryRetries),
+		server_lack_of_ack_timeout_ms:   C.uint64_t(serverAckTimeout),
+		flush_timeout_ms:                C.uint64_t(flushTimeout),
+		connection_timeout_ms:           C.uint64_t(connTimeout),
+		ipc_compression:                 C.int32_t(ipcCompression),
+		stream_paused_max_wait_time_ms:  C.int64_t(streamPausedMaxWait),
 	}
 }
 

--- a/go/arrow_ffi.go
+++ b/go/arrow_ffi.go
@@ -209,16 +209,16 @@ func convertArrowConfigToC(opts *ArrowStreamConfigurationOptions) C.CArrowStream
 	}
 
 	return C.CArrowStreamConfigurationOptions{
-		max_inflight_batches:            C.uintptr_t(maxInflight),
-		recovery:                        C.bool(recovery),
-		recovery_timeout_ms:             C.uint64_t(recoveryTimeout),
-		recovery_backoff_ms:             C.uint64_t(recoveryBackoff),
-		recovery_retries:                C.uint32_t(recoveryRetries),
-		server_lack_of_ack_timeout_ms:   C.uint64_t(serverAckTimeout),
-		flush_timeout_ms:                C.uint64_t(flushTimeout),
-		connection_timeout_ms:           C.uint64_t(connTimeout),
-		ipc_compression:                 C.int32_t(ipcCompression),
-		stream_paused_max_wait_time_ms:  C.int64_t(streamPausedMaxWait),
+		max_inflight_batches:           C.uintptr_t(maxInflight),
+		recovery:                       C.bool(recovery),
+		recovery_timeout_ms:            C.uint64_t(recoveryTimeout),
+		recovery_backoff_ms:            C.uint64_t(recoveryBackoff),
+		recovery_retries:               C.uint32_t(recoveryRetries),
+		server_lack_of_ack_timeout_ms:  C.uint64_t(serverAckTimeout),
+		flush_timeout_ms:               C.uint64_t(flushTimeout),
+		connection_timeout_ms:          C.uint64_t(connTimeout),
+		ipc_compression:                C.int32_t(ipcCompression),
+		stream_paused_max_wait_time_ms: C.int64_t(streamPausedMaxWait),
 	}
 }
 

--- a/go/arrow_stream.go
+++ b/go/arrow_stream.go
@@ -76,6 +76,11 @@ type ArrowStreamConfigurationOptions struct {
 	// Arrow IPC compression codec.
 	// Default: IPCCompressionNone
 	IPCCompression IPCCompressionType
+
+	// Maximum time in milliseconds to wait during graceful stream close.
+	// nil = wait full server duration, 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+	// Default: nil (wait full server duration)
+	StreamPausedMaxWaitTimeMs *uint64
 }
 
 // DefaultArrowStreamConfigurationOptions returns default configuration for Arrow streams

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### New Features and Improvements
 
+- **Arrow Flight — graceful stream close**: On server signaled close, the client stops sending new batches, drains in-flight acknowledgments within a bounded wait, then recovers; recoveries driven only by graceful close do not count against `recoveryRetries`.
+- **`ArrowStreamConfigurationOptions`**: Added `streamPausedMaxWaitTimeMs` for the maximum time (milliseconds) to wait in the paused state during graceful close (`null` = full server duration, `0` = immediate recovery).
+
 ### Bug Fixes
 
 ### Documentation

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New Features and Improvements
 
 - **Arrow Flight — graceful stream close**: On server signaled close, the client stops sending new batches, drains in-flight acknowledgments within a bounded wait, then recovers.
-- **`ArrowStreamConfigurationOptions`**: Added `streamPausedMaxWaitTimeMs` for the maximum time (milliseconds) to wait in the paused state during graceful close (`null` = full server duration, `0` = immediate recovery).
+- **`ArrowStreamConfigurationOptions`**: Added `streamPausedMaxWaitTimeMs` for the maximum time (milliseconds) to wait in the paused state during graceful close (`-1` = full server duration, `0` = immediate recovery).
 
 ### Bug Fixes
 

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: On server signaled close, the client stops sending new batches, drains in-flight acknowledgments within a bounded wait, then recovers; recoveries driven only by graceful close do not count against `recoveryRetries`.
+- **Arrow Flight — graceful stream close**: On server signaled close, the client stops sending new batches, drains in-flight acknowledgments within a bounded wait, then recovers.
 - **`ArrowStreamConfigurationOptions`**: Added `streamPausedMaxWaitTimeMs` for the maximum time (milliseconds) to wait in the paused state during graceful close (`null` = full server duration, `0` = immediate recovery).
 
 ### Bug Fixes

--- a/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
+++ b/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
@@ -151,7 +151,7 @@ public class ArrowStreamConfigurationOptions {
    * Returns the maximum time in milliseconds to wait during graceful stream close.
    *
    * <p>When the server sends a close stream signal, the SDK enters a "paused" state where it stops
-   * accepting new batches but continues processing acknowledgments for in-flight batches.
+   * sending new batches but continues processing acknowledgments for in-flight batches.
    *
    * <p>Values: -1 = wait full server duration (default), 0 = immediate recovery, &gt;0 = wait up to
    * min(this, server_duration) milliseconds.

--- a/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
+++ b/java/src/main/java/com/databricks/zerobus/ArrowStreamConfigurationOptions.java
@@ -30,6 +30,7 @@ public class ArrowStreamConfigurationOptions {
   private long flushTimeoutMs = 300000;
   private long connectionTimeoutMs = 30000;
   private IPCCompressionType ipcCompression = IPCCompressionType.NONE;
+  private long streamPausedMaxWaitTimeMs = -1;
 
   private ArrowStreamConfigurationOptions() {}
 
@@ -42,7 +43,8 @@ public class ArrowStreamConfigurationOptions {
       long serverLackOfAckTimeoutMs,
       long flushTimeoutMs,
       long connectionTimeoutMs,
-      IPCCompressionType ipcCompression) {
+      IPCCompressionType ipcCompression,
+      long streamPausedMaxWaitTimeMs) {
     this.maxInflightBatches = maxInflightBatches;
     this.recovery = recovery;
     this.recoveryTimeoutMs = recoveryTimeoutMs;
@@ -52,6 +54,7 @@ public class ArrowStreamConfigurationOptions {
     this.flushTimeoutMs = flushTimeoutMs;
     this.connectionTimeoutMs = connectionTimeoutMs;
     this.ipcCompression = ipcCompression;
+    this.streamPausedMaxWaitTimeMs = streamPausedMaxWaitTimeMs;
   }
 
   /**
@@ -145,6 +148,21 @@ public class ArrowStreamConfigurationOptions {
   }
 
   /**
+   * Returns the maximum time in milliseconds to wait during graceful stream close.
+   *
+   * <p>When the server sends a close stream signal, the SDK enters a "paused" state where it stops
+   * accepting new batches but continues processing acknowledgments for in-flight batches.
+   *
+   * <p>Values: -1 = wait full server duration (default), 0 = immediate recovery, &gt;0 = wait up to
+   * min(this, server_duration) milliseconds.
+   *
+   * @return the stream paused max wait time in milliseconds, or -1 for full server duration
+   */
+  public long streamPausedMaxWaitTimeMs() {
+    return this.streamPausedMaxWaitTimeMs;
+  }
+
+  /**
    * Returns the default Arrow stream configuration options.
    *
    * <p>Default values:
@@ -159,6 +177,7 @@ public class ArrowStreamConfigurationOptions {
    *   <li>flushTimeoutMs: 300000
    *   <li>connectionTimeoutMs: 30000
    *   <li>ipcCompression: {@link IPCCompressionType#NONE}
+   *   <li>streamPausedMaxWaitTimeMs: -1 (wait full server duration)
    * </ul>
    *
    * @return the default Arrow stream configuration options
@@ -194,6 +213,7 @@ public class ArrowStreamConfigurationOptions {
     private long flushTimeoutMs = defaults.flushTimeoutMs;
     private long connectionTimeoutMs = defaults.connectionTimeoutMs;
     private IPCCompressionType ipcCompression = defaults.ipcCompression;
+    private long streamPausedMaxWaitTimeMs = defaults.streamPausedMaxWaitTimeMs;
 
     private ArrowStreamConfigurationOptionsBuilder() {}
 
@@ -307,6 +327,21 @@ public class ArrowStreamConfigurationOptions {
     }
 
     /**
+     * Sets the maximum time in milliseconds to wait during graceful stream close.
+     *
+     * <p>Values: -1 = wait full server duration (default), 0 = immediate recovery, &gt;0 = wait up
+     * to min(this, server_duration) milliseconds.
+     *
+     * @param streamPausedMaxWaitTimeMs the max wait time, or -1 for full server duration
+     * @return this builder for method chaining
+     */
+    public ArrowStreamConfigurationOptionsBuilder setStreamPausedMaxWaitTimeMs(
+        long streamPausedMaxWaitTimeMs) {
+      this.streamPausedMaxWaitTimeMs = streamPausedMaxWaitTimeMs;
+      return this;
+    }
+
+    /**
      * Builds a new ArrowStreamConfigurationOptions instance.
      *
      * @return a new ArrowStreamConfigurationOptions with the configured settings
@@ -321,7 +356,8 @@ public class ArrowStreamConfigurationOptions {
           this.serverLackOfAckTimeoutMs,
           this.flushTimeoutMs,
           this.connectionTimeoutMs,
-          this.ipcCompression);
+          this.ipcCompression,
+          this.streamPausedMaxWaitTimeMs);
     }
   }
 }

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: On server signaled close, the client pauses sending, drains in-flight acks within a bounded wait, then recovers; those recoveries do not consume the `recovery_retries` budget.
+- **Arrow Flight — graceful stream close**: On server signaled close, the client pauses sending, drains in-flight acks within a bounded wait, then recovers.
 - **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional milliseconds cap for the paused wait (`None` = full server duration, `0` = immediate recovery).
 
 ### Bug Fixes

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### New Features and Improvements
 
+- **Arrow Flight — graceful stream close**: On server signaled close, the client pauses sending, drains in-flight acks within a bounded wait, then recovers; those recoveries do not consume the `recovery_retries` budget.
+- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional milliseconds cap for the paused wait (`None` = full server duration, `0` = immediate recovery).
+
 ### Bug Fixes
 
 ### Documentation

--- a/python/rust/src/arrow.rs
+++ b/python/rust/src/arrow.rs
@@ -136,6 +136,11 @@ pub struct ArrowStreamConfigurationOptions {
     /// IPC compression codec. Default: IPCCompression.NONE
     #[pyo3(get, set)]
     pub ipc_compression: IPCCompression,
+
+    /// Maximum time in milliseconds to wait during graceful stream close.
+    /// None = wait full server duration, 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+    #[pyo3(get, set)]
+    pub stream_paused_max_wait_time_ms: Option<i64>,
 }
 
 impl Default for ArrowStreamConfigurationOptions {
@@ -151,6 +156,9 @@ impl Default for ArrowStreamConfigurationOptions {
             flush_timeout_ms: rust_default.flush_timeout_ms as i64,
             connection_timeout_ms: rust_default.connection_timeout_ms as i64,
             ipc_compression: IPCCompression::Uncompressed,
+            stream_paused_max_wait_time_ms: rust_default
+                .stream_paused_max_wait_time_ms
+                .map(|v| v as i64),
         }
     }
 }
@@ -179,6 +187,9 @@ impl ArrowStreamConfigurationOptions {
                     "ipc_compression" => {
                         options.ipc_compression = value.extract()?;
                     }
+                    "stream_paused_max_wait_time_ms" => {
+                        options.stream_paused_max_wait_time_ms = value.extract()?
+                    }
                     _ => {
                         return Err(pyo3::exceptions::PyValueError::new_err(format!(
                             "Unknown configuration option: {}",
@@ -197,7 +208,8 @@ impl ArrowStreamConfigurationOptions {
             "ArrowStreamConfigurationOptions(max_inflight_batches={}, recovery={}, \
              recovery_timeout_ms={}, recovery_backoff_ms={}, recovery_retries={}, \
              server_lack_of_ack_timeout_ms={}, flush_timeout_ms={}, connection_timeout_ms={}, \
-             ipc_compression={})",
+             ipc_compression={}, \
+             stream_paused_max_wait_time_ms={:?})",
             self.max_inflight_batches,
             self.recovery,
             self.recovery_timeout_ms,
@@ -207,6 +219,7 @@ impl ArrowStreamConfigurationOptions {
             self.flush_timeout_ms,
             self.connection_timeout_ms,
             self.ipc_compression.__repr__(),
+            self.stream_paused_max_wait_time_ms,
         )
     }
 }
@@ -263,6 +276,9 @@ impl ArrowStreamConfigurationOptions {
             flush_timeout_ms: self.flush_timeout_ms as u64,
             connection_timeout_ms: self.connection_timeout_ms as u64,
             ipc_compression,
+            stream_paused_max_wait_time_ms: self
+                .stream_paused_max_wait_time_ms
+                .map(|v| v as u64),
         })
     }
 }

--- a/python/rust/src/arrow.rs
+++ b/python/rust/src/arrow.rs
@@ -276,9 +276,7 @@ impl ArrowStreamConfigurationOptions {
             flush_timeout_ms: self.flush_timeout_ms as u64,
             connection_timeout_ms: self.connection_timeout_ms as u64,
             ipc_compression,
-            stream_paused_max_wait_time_ms: self
-                .stream_paused_max_wait_time_ms
-                .map(|v| v as u64),
+            stream_paused_max_wait_time_ms: self.stream_paused_max_wait_time_ms.map(|v| v as u64),
         })
     }
 }

--- a/python/rust/src/arrow.rs
+++ b/python/rust/src/arrow.rs
@@ -261,6 +261,13 @@ impl ArrowStreamConfigurationOptions {
                 "connection_timeout_ms must be non-negative",
             ));
         }
+        if let Some(v) = self.stream_paused_max_wait_time_ms {
+            if v < 0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "stream_paused_max_wait_time_ms must be non-negative",
+                ));
+            }
+        }
         let ipc_compression = match self.ipc_compression {
             IPCCompression::Uncompressed => None,
             IPCCompression::LZ4Frame => Some(arrow_ipc::CompressionType::LZ4_FRAME),

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers. Recoveries triggered only by this graceful-close path do **not** count against the `recovery_retries` budget.
+- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers.
 - **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (milliseconds) on how long to wait during that paused phase (`None` = use full server duration, `Some(0)` = recover immediately, `Some(x)` = wait up to `min(x, server_duration)`).
 - Added `ZerobusSdkBuilder::connector_factory` for programmatic proxy
   configuration. Callers can install a `ConnectorFactory` (a

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers. Recoveries triggered only by this graceful-close path do **not** count against the `recovery_retries` budget.
+- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (milliseconds) on how long to wait during that paused phase (`None` = use full server duration, `Some(0)` = recover immediately, `Some(x)` = wait up to `min(x, server_duration)`).
 - Added `ZerobusSdkBuilder::connector_factory` for programmatic proxy
   configuration. Callers can install a `ConnectorFactory` (a
   `Fn(&str) -> Option<ProxyConnector>` closure) that fully overrides the
@@ -26,6 +28,7 @@
 
 - **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
 - After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
+- **`StreamBuilder::stream_paused_max_wait_time_ms`**: Now updates Arrow stream settings (`arrow_config`) as well as JSON/proto gRPC settings, so `.build_arrow()` respects this option (previously only JSON/proto streams saw the value).
 
 ### Documentation
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+- **Arrow stream options (C API)**: `CArrowStreamConfigurationOptions.stream_paused_max_wait_time_ms` (`int64_t`) configures graceful-close paused wait: `-1` = None (full server duration), `0` = immediate recovery, `>0` = capped wait (see `zerobus.h` comments).
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -56,6 +56,9 @@ pub struct CArrowStreamConfigurationOptions {
     pub connection_timeout_ms: u64,
     /// -1 = None, 0 = LZ4_FRAME, 1 = ZSTD
     pub ipc_compression: i32,
+    /// Maximum time in milliseconds to wait during graceful stream close.
+    /// -1 = None (wait full server duration), 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+    pub stream_paused_max_wait_time_ms: i64,
 }
 
 impl From<CArrowStreamConfigurationOptions> for ArrowStreamConfigurationOptions {
@@ -64,6 +67,10 @@ impl From<CArrowStreamConfigurationOptions> for ArrowStreamConfigurationOptions 
             0 => Some(CompressionType::LZ4_FRAME),
             1 => Some(CompressionType::ZSTD),
             _ => None,
+        };
+        let stream_paused_max_wait_time_ms = match c_opts.stream_paused_max_wait_time_ms {
+            n if n < 0 => None,
+            n => Some(n as u64),
         };
         ArrowStreamConfigurationOptions {
             max_inflight_batches: c_opts.max_inflight_batches,
@@ -75,6 +82,7 @@ impl From<CArrowStreamConfigurationOptions> for ArrowStreamConfigurationOptions 
             flush_timeout_ms: c_opts.flush_timeout_ms,
             connection_timeout_ms: c_opts.connection_timeout_ms,
             ipc_compression,
+            stream_paused_max_wait_time_ms,
         }
     }
 }
@@ -588,6 +596,10 @@ pub extern "C" fn zerobus_arrow_get_default_config() -> CArrowStreamConfiguratio
         Some(ct) if ct == CompressionType::ZSTD => 1,
         _ => -1,
     };
+    let stream_paused_max_wait_time_ms = match d.stream_paused_max_wait_time_ms {
+        None => -1,
+        Some(n) => n as i64,
+    };
     CArrowStreamConfigurationOptions {
         max_inflight_batches: d.max_inflight_batches,
         recovery: d.recovery,
@@ -598,6 +610,7 @@ pub extern "C" fn zerobus_arrow_get_default_config() -> CArrowStreamConfiguratio
         flush_timeout_ms: d.flush_timeout_ms,
         connection_timeout_ms: d.connection_timeout_ms,
         ipc_compression,
+        stream_paused_max_wait_time_ms,
     }
 }
 

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -47,6 +47,11 @@ typedef struct CArrowStreamConfigurationOptions {
    * -1 = None, 0 = LZ4_FRAME, 1 = ZSTD
    */
   int32_t ipc_compression;
+  /**
+   * Maximum time in milliseconds to wait during graceful stream close.
+   * -1 = None (wait full server duration), 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+   */
+  int64_t stream_paused_max_wait_time_ms;
 } CArrowStreamConfigurationOptions;
 
 typedef struct CResult {

--- a/rust/jni/src/options.rs
+++ b/rust/jni/src/options.rs
@@ -177,6 +177,16 @@ pub fn extract_arrow_stream_options(
         _ => None, // "NONE" or any unknown value
     };
 
+    // Extract stream paused max wait time (-1 means None/wait full server duration)
+    let stream_paused_max_wait_time_raw = env
+        .call_method(options, "streamPausedMaxWaitTimeMs", "()J", &[])?
+        .j()?;
+    let stream_paused_max_wait_time_ms = if stream_paused_max_wait_time_raw < 0 {
+        None
+    } else {
+        Some(stream_paused_max_wait_time_raw as u64)
+    };
+
     Ok(ArrowStreamConfigurationOptions {
         max_inflight_batches,
         recovery,
@@ -187,6 +197,7 @@ pub fn extract_arrow_stream_options(
         flush_timeout_ms,
         connection_timeout_ms,
         ipc_compression,
+        stream_paused_max_wait_time_ms,
     })
 }
 

--- a/rust/sdk/src/arrow_configuration.rs
+++ b/rust/sdk/src/arrow_configuration.rs
@@ -95,6 +95,23 @@ pub struct ArrowStreamConfigurationOptions {
     ///
     /// Default: `None`
     pub ipc_compression: Option<CompressionType>,
+
+    /// Maximum time in milliseconds to wait during graceful stream close.
+    ///
+    /// When the server sends a close stream signal indicating it will close the stream,
+    /// the SDK enters a "paused" state where it:
+    /// - Continues accepting and buffering new `ingest_batch()` calls
+    /// - Stops sending buffered batches to the server
+    /// - Continues processing acknowledgments for in-flight batches
+    /// - Waits for either all in-flight batches to be acknowledged or the timeout to expire
+    ///
+    /// Configuration values:
+    /// - `None`: Wait for the full server-specified duration (most graceful)
+    /// - `Some(0)`: Immediate recovery, close stream right away
+    /// - `Some(x)`: Wait up to min(x, server_duration) milliseconds
+    ///
+    /// Default: `None` (wait for full server duration)
+    pub stream_paused_max_wait_time_ms: Option<u64>,
 }
 
 impl Default for ArrowStreamConfigurationOptions {
@@ -109,6 +126,7 @@ impl Default for ArrowStreamConfigurationOptions {
             flush_timeout_ms: defaults::FLUSH_TIMEOUT_MS,
             connection_timeout_ms: defaults::CONNECTION_TIMEOUT_MS,
             ipc_compression: None,
+            stream_paused_max_wait_time_ms: None,
         }
     }
 }

--- a/rust/sdk/src/arrow_metadata.rs
+++ b/rust/sdk/src/arrow_metadata.rs
@@ -163,8 +163,7 @@ mod tests {
 
     #[test]
     fn test_flight_ack_metadata_with_close_signal() {
-        let json =
-            r#"{"ack_up_to_offset": 5, "ack_up_to_records": 100, "close_stream_duration_ms": 2000}"#;
+        let json = r#"{"ack_up_to_offset": 5, "ack_up_to_records": 100, "close_stream_duration_ms": 2000}"#;
         let parsed = FlightAckMetadata::from_bytes(json.as_bytes()).unwrap();
         assert_eq!(parsed.ack_up_to_offset, 5);
         assert_eq!(parsed.ack_up_to_records, 100);

--- a/rust/sdk/src/arrow_metadata.rs
+++ b/rust/sdk/src/arrow_metadata.rs
@@ -68,6 +68,16 @@ pub struct FlightAckMetadata {
     pub ack_up_to_offset: OffsetId,
     /// Cumulative count of records durably stored up to this acknowledgment.
     pub ack_up_to_records: u64,
+    /// Optional close stream signal with grace period duration in milliseconds.
+    ///
+    /// When present, the server is signaling that it will close the stream after
+    /// this duration. The client should enter a "paused" state: stop sending new
+    /// batches but continue processing acknowledgments for in-flight batches.
+    /// After the grace period (or when all in-flight batches are acked), the client
+    /// triggers stream recovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub close_stream_duration_ms: Option<u64>,
 }
 
 impl FlightAckMetadata {
@@ -77,6 +87,7 @@ impl FlightAckMetadata {
         Self {
             ack_up_to_offset,
             ack_up_to_records,
+            close_stream_duration_ms: None,
         }
     }
 
@@ -87,7 +98,13 @@ impl FlightAckMetadata {
         Self {
             ack_up_to_offset: STREAM_READY_OFFSET,
             ack_up_to_records: 0,
+            close_stream_duration_ms: None,
         }
+    }
+
+    /// Returns true if this message contains a close stream signal.
+    pub fn is_close_signal(&self) -> bool {
+        self.close_stream_duration_ms.is_some()
     }
 
     /// Returns true if this is a stream ready signal (setup complete, no batches acked).
@@ -140,6 +157,29 @@ mod tests {
         let parsed = FlightAckMetadata::from_bytes(json.as_bytes()).unwrap();
         assert_eq!(parsed.ack_up_to_offset, 99);
         assert_eq!(parsed.ack_up_to_records, 5000);
+        assert!(parsed.close_stream_duration_ms.is_none());
+        assert!(!parsed.is_close_signal());
+    }
+
+    #[test]
+    fn test_flight_ack_metadata_with_close_signal() {
+        let json =
+            r#"{"ack_up_to_offset": 5, "ack_up_to_records": 100, "close_stream_duration_ms": 2000}"#;
+        let parsed = FlightAckMetadata::from_bytes(json.as_bytes()).unwrap();
+        assert_eq!(parsed.ack_up_to_offset, 5);
+        assert_eq!(parsed.ack_up_to_records, 100);
+        assert_eq!(parsed.close_stream_duration_ms, Some(2000));
+        assert!(parsed.is_close_signal());
+    }
+
+    #[test]
+    fn test_flight_ack_metadata_close_signal_only() {
+        let json =
+            r#"{"ack_up_to_offset": -1, "ack_up_to_records": 0, "close_stream_duration_ms": 5000}"#;
+        let parsed = FlightAckMetadata::from_bytes(json.as_bytes()).unwrap();
+        assert!(parsed.is_close_signal());
+        assert!(parsed.is_stream_ready());
+        assert_eq!(parsed.close_stream_duration_ms, Some(5000));
     }
 
     #[test]

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -23,7 +23,7 @@ use tokio::time::{sleep, Duration};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
 use tonic::transport::Channel;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 // Re-export arrow types for public API
 pub use arrow_array::RecordBatch;
@@ -807,10 +807,6 @@ impl ZerobusArrowStream {
                 )
                 .await;
 
-                // Capture whether this was a graceful close recovery before resetting.
-                // Graceful close recoveries should not consume the retry budget.
-                let was_graceful_close = is_paused.load(Ordering::Relaxed);
-
                 // Reset paused state after process_acks returns (before recovery).
                 is_paused.store(false, Ordering::Relaxed);
 
@@ -829,12 +825,7 @@ impl ZerobusArrowStream {
                     }
                     Err(ref error) if error.is_retryable() && options.recovery => {
                         // Retriable error - attempt recovery.
-                        // Graceful close recoveries don't count against the retry budget.
-                        let attempts = if was_graceful_close {
-                            recovery_attempts.load(Ordering::Relaxed)
-                        } else {
-                            recovery_attempts.fetch_add(1, Ordering::Relaxed)
-                        };
+                        let attempts = recovery_attempts.fetch_add(1, Ordering::Relaxed);
                         if attempts >= options.recovery_retries {
                             error!(
                                 attempts = attempts,
@@ -1357,6 +1348,10 @@ impl ZerobusArrowStream {
             });
         }
 
+        if self.is_paused.load(Ordering::Relaxed) {
+            return Ok(offset_id);
+        }
+
         let sender = {
             let guard = self.batch_tx.lock().await;
             guard.clone()
@@ -1577,7 +1572,7 @@ impl ZerobusArrowStream {
                 let current_ack = *offset_rx.borrow_and_update();
                 if let Some(ack_offset) = current_ack {
                     if ack_offset >= offset_to_wait {
-                        debug!(
+                        info!(
                             ack_offset = ack_offset,
                             target_offset = offset_to_wait,
                             "{} completed",
@@ -1585,7 +1580,7 @@ impl ZerobusArrowStream {
                         );
                         return Ok(());
                     }
-                    trace!(
+                    debug!(
                         current_ack = ack_offset,
                         target_offset = offset_to_wait,
                         "Waiting for more acks"

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1160,16 +1160,14 @@ impl ZerobusArrowStream {
 
                 if now >= deadline {
                     info!("Graceful close timeout reached. Triggering recovery.");
-                    return Err(ZerobusError::StreamClosedError(
-                        tonic::Status::unavailable("Graceful close timeout reached"),
-                    ));
+                    return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
+                        "Graceful close timeout reached",
+                    )));
                 } else if all_acked {
                     info!("All in-flight batches acknowledged during graceful close. Triggering recovery.");
-                    return Err(ZerobusError::StreamClosedError(
-                        tonic::Status::unavailable(
-                            "All in-flight batches acked during graceful close",
-                        ),
-                    ));
+                    return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
+                        "All in-flight batches acked during graceful close",
+                    )));
                 }
             }
 
@@ -1195,24 +1193,25 @@ impl ZerobusArrowStream {
                                     let server_duration_ms =
                                         ack.close_stream_duration_ms.unwrap_or(0);
 
-                                    let wait_duration_ms =
-                                        match options.stream_paused_max_wait_time_ms {
-                                            None => server_duration_ms,
-                                            Some(0) => {
-                                                info!(
+                                    let wait_duration_ms = match options
+                                        .stream_paused_max_wait_time_ms
+                                    {
+                                        None => server_duration_ms,
+                                        Some(0) => {
+                                            info!(
                                                     "Server will close the stream in {}ms. Triggering stream recovery.",
                                                     server_duration_ms
                                                 );
-                                                return Err(ZerobusError::StreamClosedError(
-                                                    tonic::Status::unavailable(
-                                                        "Immediate recovery on close signal",
-                                                    ),
-                                                ));
-                                            }
-                                            Some(max_wait) => {
-                                                std::cmp::min(max_wait, server_duration_ms)
-                                            }
-                                        };
+                                            return Err(ZerobusError::StreamClosedError(
+                                                tonic::Status::unavailable(
+                                                    "Immediate recovery on close signal",
+                                                ),
+                                            ));
+                                        }
+                                        Some(max_wait) => {
+                                            std::cmp::min(max_wait, server_duration_ms)
+                                        }
+                                    };
 
                                     if wait_duration_ms == 0 {
                                         info!("Server will close the stream. Triggering immediate recovery.");
@@ -1284,10 +1283,13 @@ impl ZerobusArrowStream {
                     // During graceful close, errors are expected (server closes after grace period).
                     // Return retriable error to trigger recovery.
                     if pause_deadline.is_some() {
-                        info!("Stream error during graceful close period, triggering recovery: {}", e);
-                        return Err(ZerobusError::StreamClosedError(
-                            tonic::Status::unavailable("Stream error during graceful close"),
-                        ));
+                        info!(
+                            "Stream error during graceful close period, triggering recovery: {}",
+                            e
+                        );
+                        return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
+                            "Stream error during graceful close",
+                        )));
                     }
                     error!("Flight stream error: {}", e);
                     let status: tonic::Status = e.into();
@@ -1300,11 +1302,9 @@ impl ZerobusArrowStream {
                     // Return retriable error to trigger recovery.
                     if pause_deadline.is_some() {
                         info!("Server closed stream during graceful close period, triggering recovery.");
-                        return Err(ZerobusError::StreamClosedError(
-                            tonic::Status::unavailable(
-                                "Server closed stream during graceful close",
-                            ),
-                        ));
+                        return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
+                            "Server closed stream during graceful close",
+                        )));
                     }
                     debug!("Server closed the stream");
                     let error = ZerobusError::StreamClosedError(tonic::Status::unknown(

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1579,7 +1579,7 @@ impl ZerobusArrowStream {
                         );
                         return Ok(());
                     }
-                    debug!(
+                    trace!(
                         current_ack = ack_offset,
                         target_offset = offset_to_wait,
                         "Waiting for more acks"

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -449,6 +449,10 @@ pub struct ZerobusArrowStream {
     cumulative_records_sent: Arc<AtomicU64>,
     /// Last acknowledged cumulative record count (for recovery slicing).
     last_acked_records: Arc<AtomicU64>,
+    /// Flag indicating the stream is paused due to a server close signal.
+    /// When true, new `ingest_batch()` calls are still accepted and buffered,
+    /// but the receiver continues draining in-flight acks before triggering recovery.
+    is_paused: Arc<AtomicBool>,
 }
 
 impl ZerobusArrowStream {
@@ -475,6 +479,7 @@ impl ZerobusArrowStream {
         let receiver_task = Arc::new(Mutex::new(None));
         let cumulative_records_sent = Arc::new(AtomicU64::new(0));
         let last_acked_records = Arc::new(AtomicU64::new(0));
+        let is_paused = Arc::new(AtomicBool::new(false));
 
         let (server_error_tx, server_error_rx) = watch::channel(None);
 
@@ -498,6 +503,7 @@ impl ZerobusArrowStream {
             server_error_rx,
             cumulative_records_sent,
             last_acked_records,
+            is_paused,
         };
 
         // Initialize the connection with retry logic.
@@ -568,6 +574,7 @@ impl ZerobusArrowStream {
             stream.server_error_tx.clone(),
             Arc::clone(&stream.cumulative_records_sent),
             Arc::clone(&stream.last_acked_records),
+            Arc::clone(&stream.is_paused),
             response_stream,
         );
 
@@ -773,6 +780,7 @@ impl ZerobusArrowStream {
         server_error_tx: watch::Sender<Option<ZerobusError>>,
         cumulative_records_sent: Arc<AtomicU64>,
         last_acked_records: Arc<AtomicU64>,
+        is_paused: Arc<AtomicBool>,
         initial_response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
         tokio::spawn(async move {
@@ -794,8 +802,17 @@ impl ZerobusArrowStream {
                     ack_timeout,
                     server_error_tx.clone(),
                     Arc::clone(&last_acked_records),
+                    Arc::clone(&is_paused),
+                    &options,
                 )
                 .await;
+
+                // Capture whether this was a graceful close recovery before resetting.
+                // Graceful close recoveries should not consume the retry budget.
+                let was_graceful_close = is_paused.load(Ordering::Relaxed);
+
+                // Reset paused state after process_acks returns (before recovery).
+                is_paused.store(false, Ordering::Relaxed);
 
                 // Check if stream was closed during processing.
                 if is_closed.load(Ordering::Relaxed) {
@@ -812,7 +829,12 @@ impl ZerobusArrowStream {
                     }
                     Err(ref error) if error.is_retryable() && options.recovery => {
                         // Retriable error - attempt recovery.
-                        let attempts = recovery_attempts.fetch_add(1, Ordering::Relaxed);
+                        // Graceful close recoveries don't count against the retry budget.
+                        let attempts = if was_graceful_close {
+                            recovery_attempts.load(Ordering::Relaxed)
+                        } else {
+                            recovery_attempts.fetch_add(1, Ordering::Relaxed)
+                        };
                         if attempts >= options.recovery_retries {
                             error!(
                                 attempts = attempts,
@@ -1119,19 +1141,106 @@ impl ZerobusArrowStream {
         ack_timeout: Duration,
         server_error_tx: watch::Sender<Option<ZerobusError>>,
         last_acked_records: Arc<AtomicU64>,
+        is_paused: Arc<AtomicBool>,
+        options: &ArrowStreamConfigurationOptions,
     ) -> ZerobusResult<()> {
+        let mut pause_deadline: Option<tokio::time::Instant> = None;
+
         loop {
             if is_closed.load(Ordering::Relaxed) {
                 debug!("Stream closed, stopping ack processor");
                 return Ok(());
             }
 
-            let result = tokio::time::timeout(ack_timeout, response_stream.next()).await;
+            // Check pause state: exit when deadline reached or all batches acked.
+            // Returns a retriable error to trigger recovery in the supervisor.
+            if let Some(deadline) = pause_deadline {
+                let now = tokio::time::Instant::now();
+                let all_acked = pending_batches.lock().await.is_empty();
+
+                if now >= deadline {
+                    info!("Graceful close timeout reached. Triggering recovery.");
+                    return Err(ZerobusError::StreamClosedError(
+                        tonic::Status::unavailable("Graceful close timeout reached"),
+                    ));
+                } else if all_acked {
+                    info!("All in-flight batches acknowledged during graceful close. Triggering recovery.");
+                    return Err(ZerobusError::StreamClosedError(
+                        tonic::Status::unavailable(
+                            "All in-flight batches acked during graceful close",
+                        ),
+                    ));
+                }
+            }
+
+            let result = if let Some(deadline) = pause_deadline {
+                tokio::select! {
+                    biased;
+                    _ = tokio::time::sleep_until(deadline) => {
+                        continue;
+                    }
+                    res = tokio::time::timeout(ack_timeout, response_stream.next()) => res,
+                }
+            } else {
+                tokio::time::timeout(ack_timeout, response_stream.next()).await
+            };
 
             match result {
                 Ok(Some(Ok(put_result))) => {
                     match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
                         Ok(ack) => {
+                            // Handle close stream signal.
+                            if ack.is_close_signal() {
+                                if options.recovery {
+                                    let server_duration_ms =
+                                        ack.close_stream_duration_ms.unwrap_or(0);
+
+                                    let wait_duration_ms =
+                                        match options.stream_paused_max_wait_time_ms {
+                                            None => server_duration_ms,
+                                            Some(0) => {
+                                                info!(
+                                                    "Server will close the stream in {}ms. Triggering stream recovery.",
+                                                    server_duration_ms
+                                                );
+                                                return Err(ZerobusError::StreamClosedError(
+                                                    tonic::Status::unavailable(
+                                                        "Immediate recovery on close signal",
+                                                    ),
+                                                ));
+                                            }
+                                            Some(max_wait) => {
+                                                std::cmp::min(max_wait, server_duration_ms)
+                                            }
+                                        };
+
+                                    if wait_duration_ms == 0 {
+                                        info!("Server will close the stream. Triggering immediate recovery.");
+                                        return Err(ZerobusError::StreamClosedError(
+                                            tonic::Status::unavailable(
+                                                "Immediate recovery on close signal",
+                                            ),
+                                        ));
+                                    }
+
+                                    is_paused.store(true, Ordering::Relaxed);
+                                    pause_deadline = Some(
+                                        tokio::time::Instant::now()
+                                            + Duration::from_millis(wait_duration_ms),
+                                    );
+                                    info!(
+                                        "Server will close the stream in {}ms. Entering graceful close period (waiting up to {}ms for in-flight acks).",
+                                        server_duration_ms, wait_duration_ms
+                                    );
+                                }
+                                // Process any ack data that came with the close signal.
+                                // Fall through to ack processing below only if there's
+                                // meaningful ack data (non-zero records count).
+                                if ack.ack_up_to_records == 0 {
+                                    continue;
+                                }
+                            }
+
                             let acked_records = ack.ack_up_to_records;
                             debug!(
                                 ack_up_to_offset = ack.ack_up_to_offset,
@@ -1172,29 +1281,42 @@ impl ZerobusArrowStream {
                     }
                 }
                 Ok(Some(Err(e))) => {
+                    // During graceful close, errors are expected (server closes after grace period).
+                    // Return retriable error to trigger recovery.
+                    if pause_deadline.is_some() {
+                        info!("Stream error during graceful close period, triggering recovery: {}", e);
+                        return Err(ZerobusError::StreamClosedError(
+                            tonic::Status::unavailable("Stream error during graceful close"),
+                        ));
+                    }
                     error!("Flight stream error: {}", e);
-                    // Convert FlightError to tonic::Status - this properly extracts
-                    // the underlying status if it's a Tonic error, preserving the
-                    // original error code and message from the server.
                     let status: tonic::Status = e.into();
                     let error = ZerobusError::StreamClosedError(status);
-                    // Store the error in watch channel for immediate, race-free access
-                    // by ingest_batch when channel send fails.
                     let _ = server_error_tx.send(Some(error.clone()));
-                    // Don't fail pending acks here - let the supervisor handle it.
-                    // If retriable, supervisor will recover and replay batches.
-                    // If non-retriable, supervisor will fail the acks.
                     return Err(error);
                 }
                 Ok(None) => {
+                    // During graceful close, stream end is expected.
+                    // Return retriable error to trigger recovery.
+                    if pause_deadline.is_some() {
+                        info!("Server closed stream during graceful close period, triggering recovery.");
+                        return Err(ZerobusError::StreamClosedError(
+                            tonic::Status::unavailable(
+                                "Server closed stream during graceful close",
+                            ),
+                        ));
+                    }
                     debug!("Server closed the stream");
                     let error = ZerobusError::StreamClosedError(tonic::Status::unknown(
                         "Server closed the stream",
                     ));
-                    // Don't fail pending acks here - let the supervisor handle it.
                     return Err(error);
                 }
                 Err(_timeout) => {
+                    // During graceful close, ack timeout is not an error.
+                    if pause_deadline.is_some() {
+                        continue;
+                    }
                     // Check if there are pending acks that should have been received.
                     let pending = pending_batches.lock().await;
                     if !pending.is_empty() {
@@ -1205,7 +1327,6 @@ impl ZerobusArrowStream {
                         let error = ZerobusError::StreamClosedError(
                             tonic::Status::deadline_exceeded("Server ack timeout"),
                         );
-                        // Don't fail pending acks here - let the supervisor handle it.
                         return Err(error);
                     }
                 }

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1579,7 +1579,7 @@ impl ZerobusArrowStream {
                         );
                         return Ok(());
                     }
-                    trace!(
+                    debug!(
                         current_ack = ack_offset,
                         target_offset = offset_to_wait,
                         "Waiting for more acks"

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -807,9 +807,6 @@ impl ZerobusArrowStream {
                 )
                 .await;
 
-                // Reset paused state after process_acks returns (before recovery).
-                is_paused.store(false, Ordering::Relaxed);
-
                 // Check if stream was closed during processing.
                 if is_closed.load(Ordering::Relaxed) {
                     debug!("Supervisor: Stream closed after process_acks, exiting");
@@ -878,6 +875,8 @@ impl ZerobusArrowStream {
                             Ok(Ok(new_response_stream)) => {
                                 info!("Supervisor: Recovery successful, resuming");
                                 recovery_attempts.store(0, Ordering::Relaxed);
+                                // Now that a fresh sender is installed, lift the pause gate.
+                                is_paused.store(false, Ordering::Relaxed);
                                 response_stream = new_response_stream;
                                 // Loop continues with new stream.
                             }
@@ -1572,7 +1571,7 @@ impl ZerobusArrowStream {
                 let current_ack = *offset_rx.borrow_and_update();
                 if let Some(ack_offset) = current_ack {
                     if ack_offset >= offset_to_wait {
-                        info!(
+                        debug!(
                             ack_offset = ack_offset,
                             target_offset = offset_to_wait,
                             "{} completed",

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -240,9 +240,13 @@ impl<'a> StreamBuilder<'a> {
         self
     }
 
-    /// Set the maximum wait time during graceful stream pause (gRPC streams only).
+    /// Set the maximum wait time during graceful stream pause (JSON/proto and Arrow streams).
     pub fn stream_paused_max_wait_time_ms(mut self, ms: Option<u64>) -> Self {
         self.grpc_config.stream_paused_max_wait_time_ms = ms;
+        #[cfg(feature = "arrow-flight")]
+        {
+            self.arrow_config.stream_paused_max_wait_time_ms = ms;
+        }
         self
     }
 
@@ -642,12 +646,17 @@ mod tests {
             .recovery_backoff_ms(500)
             .recovery_retries(2)
             .server_lack_of_ack_timeout_ms(10_000)
-            .flush_timeout_ms(20_000);
+            .flush_timeout_ms(20_000)
+            .stream_paused_max_wait_time_ms(Some(5_000));
         assert!(!builder.arrow_config.recovery);
         assert_eq!(builder.arrow_config.recovery_timeout_ms, 5_000);
         assert_eq!(builder.arrow_config.recovery_backoff_ms, 500);
         assert_eq!(builder.arrow_config.recovery_retries, 2);
         assert_eq!(builder.arrow_config.server_lack_of_ack_timeout_ms, 10_000);
         assert_eq!(builder.arrow_config.flush_timeout_ms, 20_000);
+        assert_eq!(
+            builder.arrow_config.stream_paused_max_wait_time_ms,
+            Some(5_000)
+        );
     }
 }

--- a/rust/tests/build.rs
+++ b/rust/tests/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
     tonic_build::configure()
         .build_server(true)
         .build_client(false)

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1822,4 +1822,473 @@ mod arrow_flight_tests {
             Ok(())
         }
     }
+
+    mod graceful_close_tests {
+        use super::*;
+        use std::time::Instant;
+
+        #[tokio::test]
+        async fn test_default_graceful_close_waits_for_full_server_duration(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_default_graceful_close_waits_for_full_server_duration (arrow)");
+
+            const SERVER_DURATION_MS: u64 = 1000;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Ack first 2 batches, then send graceful close, then ack batch 2 on reconnect.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 1,
+                            delay_ms: 0,
+                            ack_up_to_records: 6,
+                        },
+                        // Send graceful close signal after batch 2 arrives.
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: SERVER_DURATION_MS,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        // After recovery, the client replays batch 2. Ack it.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let table_properties = ArrowTableProperties {
+                table_name: TABLE_NAME.to_string(),
+                schema: schema.clone(),
+            };
+
+            let mut stream = sdk
+                .create_arrow_stream_with_headers_provider(
+                    table_properties,
+                    Arc::new(TestHeadersProvider::default()),
+                    Some(ArrowStreamConfigurationOptions {
+                        recovery: true,
+                        recovery_backoff_ms: 100,
+                        recovery_retries: 3,
+                        // Default: stream_paused_max_wait_time_ms = None (wait full server duration)
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            // Ingest batch 0 and 1 - these will be acked.
+            let batch0 = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            let offset0 = stream.ingest_batch(batch0).await?;
+            stream.wait_for_offset(offset0).await?;
+
+            let batch1 = create_test_record_batch(
+                schema.clone(),
+                vec![4, 5, 6],
+                vec![Some("d"), Some("e"), Some("f")],
+            );
+            let offset1 = stream.ingest_batch(batch1).await?;
+            stream.wait_for_offset(offset1).await?;
+
+            // Ingest batch 2 - triggers graceful close signal. The client should wait
+            // for the full server duration before triggering recovery.
+            let batch2 = create_test_record_batch(
+                schema.clone(),
+                vec![7, 8, 9],
+                vec![Some("g"), Some("h"), Some("i")],
+            );
+            let start = Instant::now();
+            let offset2 = stream.ingest_batch(batch2).await?;
+
+            // Wait for batch 2 to be acked (after recovery replays it).
+            stream.wait_for_offset(offset2).await?;
+            let elapsed = start.elapsed();
+
+            // Should have waited roughly the server duration before recovery.
+            assert!(
+                elapsed.as_millis() >= (SERVER_DURATION_MS as u128 - 200),
+                "Expected to wait at least ~{}ms for graceful close, but only waited {}ms",
+                SERVER_DURATION_MS,
+                elapsed.as_millis()
+            );
+
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_immediate_recovery_on_close_signal() -> Result<(), Box<dyn std::error::Error>>
+        {
+            setup_tracing();
+            info!("Starting test_immediate_recovery_on_close_signal (arrow)");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                        // Send graceful close with long duration after batch 1.
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 10_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        // After immediate recovery, ack batch 1.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let table_properties = ArrowTableProperties {
+                table_name: TABLE_NAME.to_string(),
+                schema: schema.clone(),
+            };
+
+            let mut stream = sdk
+                .create_arrow_stream_with_headers_provider(
+                    table_properties,
+                    Arc::new(TestHeadersProvider::default()),
+                    Some(ArrowStreamConfigurationOptions {
+                        recovery: true,
+                        recovery_backoff_ms: 100,
+                        recovery_retries: 3,
+                        // Immediate recovery: don't wait for grace period.
+                        stream_paused_max_wait_time_ms: Some(0),
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            let batch0 = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            let offset0 = stream.ingest_batch(batch0).await?;
+            stream.wait_for_offset(offset0).await?;
+
+            // Batch 1 triggers graceful close. With stream_paused_max_wait_time_ms=0,
+            // recovery should be triggered immediately.
+            let batch1 = create_test_record_batch(
+                schema.clone(),
+                vec![4, 5, 6],
+                vec![Some("d"), Some("e"), Some("f")],
+            );
+            let start = Instant::now();
+            let offset1 = stream.ingest_batch(batch1).await?;
+
+            stream.wait_for_offset(offset1).await?;
+            let elapsed = start.elapsed();
+
+            // Should recover quickly, not wait 10 seconds.
+            assert!(
+                elapsed.as_millis() < 5000,
+                "Expected immediate recovery, but waited {}ms",
+                elapsed.as_millis()
+            );
+
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_client_max_less_than_server() -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_client_max_less_than_server (arrow)");
+
+            const SERVER_DURATION_MS: u64 = 5000;
+            const CLIENT_MAX_WAIT_MS: u64 = 500;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // Send graceful close after batch 0.
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: SERVER_DURATION_MS,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        // After recovery, ack batch 0.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let table_properties = ArrowTableProperties {
+                table_name: TABLE_NAME.to_string(),
+                schema: schema.clone(),
+            };
+
+            let mut stream = sdk
+                .create_arrow_stream_with_headers_provider(
+                    table_properties,
+                    Arc::new(TestHeadersProvider::default()),
+                    Some(ArrowStreamConfigurationOptions {
+                        recovery: true,
+                        recovery_backoff_ms: 100,
+                        recovery_retries: 3,
+                        // Client max wait is less than server duration: should use min().
+                        stream_paused_max_wait_time_ms: Some(CLIENT_MAX_WAIT_MS),
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            let batch0 = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            let start = Instant::now();
+            let offset0 = stream.ingest_batch(batch0).await?;
+
+            stream.wait_for_offset(offset0).await?;
+            let elapsed = start.elapsed();
+
+            // Should wait roughly CLIENT_MAX_WAIT_MS (not SERVER_DURATION_MS).
+            assert!(
+                elapsed.as_millis() >= (CLIENT_MAX_WAIT_MS as u128 - 200),
+                "Expected to wait at least ~{}ms, but only waited {}ms",
+                CLIENT_MAX_WAIT_MS,
+                elapsed.as_millis()
+            );
+            assert!(
+                elapsed.as_millis() < (SERVER_DURATION_MS as u128 - 500),
+                "Expected to wait less than server duration {}ms, but waited {}ms",
+                SERVER_DURATION_MS,
+                elapsed.as_millis()
+            );
+
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_all_acked_during_graceful_close_exits_early(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_all_acked_during_graceful_close_exits_early (arrow)");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // Ack batch 0 first.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                        // Send graceful close with long duration after batch 1.
+                        // The close signal also carries ack data for batch 1,
+                        // so all in-flight batches are acked at the same time.
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 10_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: Some(1),
+                            ack_up_to_records: Some(6),
+                        },
+                        // After early recovery, no batches need replay since all were acked.
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let table_properties = ArrowTableProperties {
+                table_name: TABLE_NAME.to_string(),
+                schema: schema.clone(),
+            };
+
+            let mut stream = sdk
+                .create_arrow_stream_with_headers_provider(
+                    table_properties,
+                    Arc::new(TestHeadersProvider::default()),
+                    Some(ArrowStreamConfigurationOptions {
+                        recovery: true,
+                        recovery_backoff_ms: 100,
+                        recovery_retries: 3,
+                        // Wait full server duration (10s), but should exit early.
+                        stream_paused_max_wait_time_ms: None,
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            let batch0 = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            let offset0 = stream.ingest_batch(batch0).await?;
+            stream.wait_for_offset(offset0).await?;
+
+            let batch1 = create_test_record_batch(
+                schema.clone(),
+                vec![4, 5, 6],
+                vec![Some("d"), Some("e"), Some("f")],
+            );
+            let start = Instant::now();
+            let offset1 = stream.ingest_batch(batch1).await?;
+
+            // Batch 1 should be acked during the grace period (after 100ms delay).
+            // The graceful close should exit early since all batches are acked.
+            stream.wait_for_offset(offset1).await?;
+            let elapsed = start.elapsed();
+
+            // Should exit well before the 10s grace period.
+            assert!(
+                elapsed.as_millis() < 3000,
+                "Expected early exit from graceful close, but waited {}ms",
+                elapsed.as_millis()
+            );
+
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_ingest_accepted_during_graceful_close(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_ingest_accepted_during_graceful_close (arrow)");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // Send graceful close after batch 0.
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 5_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        // After recovery, ack both batches (batch 0 + batch 1 = 6 records).
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 1,
+                            delay_ms: 0,
+                            ack_up_to_records: 6,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let table_properties = ArrowTableProperties {
+                table_name: TABLE_NAME.to_string(),
+                schema: schema.clone(),
+            };
+
+            let mut stream = sdk
+                .create_arrow_stream_with_headers_provider(
+                    table_properties,
+                    Arc::new(TestHeadersProvider::default()),
+                    Some(ArrowStreamConfigurationOptions {
+                        recovery: true,
+                        recovery_backoff_ms: 100,
+                        recovery_retries: 3,
+                        stream_paused_max_wait_time_ms: None,
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+            let batch0 = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            let _offset0 = stream.ingest_batch(batch0).await?;
+
+            // Wait a bit for the graceful close signal to be processed.
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+            // Ingestion during the grace period should be accepted and buffered.
+            // The batch will be replayed after recovery.
+            let batch1 = create_test_record_batch(
+                schema.clone(),
+                vec![4, 5, 6],
+                vec![Some("d"), Some("e"), Some("f")],
+            );
+            let offset1 = stream.ingest_batch(batch1).await?;
+            assert_eq!(offset1, 1, "Expected offset 1 for second batch");
+
+            // After recovery, both batches should be acked.
+            stream.wait_for_offset(offset1).await?;
+
+            stream.close().await?;
+            Ok(())
+        }
+    }
 }

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -60,6 +60,19 @@ pub enum MockFlightResponse {
     Error { status: Status, delay_ms: u64 },
     /// Close stream (drop the connection) - useful for testing recovery.
     CloseStream { delay_ms: u64 },
+    /// Graceful close signal - sends a close signal with grace period duration.
+    /// Optionally carries ack data in the same message (simulating the server
+    /// acking in-flight batches alongside the close signal).
+    GracefulClose {
+        /// Grace period duration in milliseconds sent to the client.
+        duration_ms: u64,
+        delay_ms: u64,
+        /// Optional ack data to include with the close signal.
+        /// When set, the close signal PutResult also carries ack information,
+        /// allowing the client to mark batches as acked during the grace period.
+        ack_up_to_offset: Option<i64>,
+        ack_up_to_records: Option<u64>,
+    },
 }
 
 /// Mock Arrow Flight server for testing
@@ -378,6 +391,46 @@ impl FlightService for MockFlightServer {
                                 indices.insert(table_name.clone(), response_index);
                             }
                             return;
+                        }
+                        MockFlightResponse::GracefulClose {
+                            duration_ms,
+                            delay_ms,
+                            ack_up_to_offset,
+                            ack_up_to_records,
+                        } => {
+                            if *delay_ms > 0 {
+                                sleep(Duration::from_millis(*delay_ms)).await;
+                            }
+                            info!(
+                                "Sending graceful close signal with {}ms grace period",
+                                duration_ms
+                            );
+
+                            // Send close signal metadata via PutResult.
+                            // Optionally includes ack data if provided.
+                            let close_metadata = serde_json::json!({
+                                "ack_up_to_offset": ack_up_to_offset.unwrap_or(-1),
+                                "ack_up_to_records": ack_up_to_records.unwrap_or(0),
+                                "close_stream_duration_ms": duration_ms,
+                            });
+                            let close_bytes =
+                                serde_json::to_vec(&close_metadata).unwrap();
+                            let put_result = PutResult {
+                                app_metadata: close_bytes.into(),
+                            };
+
+                            if tx.send(Ok(put_result)).await.is_err() {
+                                error!("Failed to send graceful close signal - channel closed");
+                                return;
+                            }
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
+                            // Continue processing - the main loop waits for more batches.
+                            // During grace period the client won't send new batches,
+                            // so this effectively waits until the client disconnects.
                         }
                     }
                 } else {

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -413,8 +413,7 @@ impl FlightService for MockFlightServer {
                                 "ack_up_to_records": ack_up_to_records.unwrap_or(0),
                                 "close_stream_duration_ms": duration_ms,
                             });
-                            let close_bytes =
-                                serde_json::to_vec(&close_metadata).unwrap();
+                            let close_bytes = serde_json::to_vec(&close_metadata).unwrap();
                             let put_result = PutResult {
                                 app_metadata: close_bytes.into(),
                             };

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### New Features and Improvements
 
+- **Arrow Flight — graceful stream close**: When the server signals stream shutdown, the client pauses new sends, drains in-flight acknowledgments up to a configurable wait, then recovers; graceful-close recoveries do not count toward `recoveryRetries`.
+- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (ms) on the paused wait (`undefined`/omitted = full server duration, `0` = recover immediately).
+
 ### Bug Fixes
 
 ### Documentation

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -8,9 +8,6 @@
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: When the server signals stream shutdown, the client pauses new sends, drains in-flight acknowledgments up to a configurable wait, then recovers; graceful-close recoveries do not count toward `recoveryRetries`.
-- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (ms) on the paused wait (`undefined`/omitted = full server duration, `0` = recover immediately).
-
 ### Bug Fixes
 
 ### Documentation

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -1167,6 +1167,10 @@ pub struct ArrowStreamConfigurationOptions {
 
     /// Optional IPC compression type (0 = LZ4Frame, 1 = Zstd, undefined = no compression)
     pub ipc_compression: Option<i32>,
+
+    /// Maximum time in milliseconds to wait during graceful stream close.
+    /// undefined = wait full server duration, 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+    pub stream_paused_max_wait_time_ms: Option<u32>,
 }
 
 #[cfg(feature = "arrow-flight")]
@@ -1190,6 +1194,7 @@ impl From<ArrowStreamConfigurationOptions> for RustArrowStreamOptions {
             flush_timeout_ms: opts.flush_timeout_ms.map(|v| v as u64).unwrap_or(default.flush_timeout_ms),
             connection_timeout_ms: opts.connection_timeout_ms.map(|v| v as u64).unwrap_or(default.connection_timeout_ms),
             ipc_compression,
+            stream_paused_max_wait_time_ms: opts.stream_paused_max_wait_time_ms.map(|v| v as u64),
         }
     }
 }

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -13,22 +13,19 @@
 #![deny(clippy::all)]
 
 use napi::bindgen_prelude::*;
-use napi::threadsafe_function::{ThreadsafeFunction, ErrorStrategy};
-use napi::{Env, JsObject, JsFunction, JsUnknown, JsString, JsGlobal, ValueType};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use napi::{Env, JsFunction, JsGlobal, JsObject, JsString, JsUnknown, ValueType};
 use napi_derive::napi;
 
-use databricks_zerobus_ingest_sdk::{
-    EncodedRecord as RustRecordPayload,
-    StreamConfigurationOptions as RustStreamOptions,
-    TableProperties as RustTableProperties, ZerobusSdk as RustZerobusSdk,
-    ZerobusStream as RustZerobusStream,
-    HeadersProvider as RustHeadersProvider,
-    ZerobusResult as RustZerobusResult,
-    ZerobusError as RustZerobusError,
-    DefaultTokenFactory,
-};
-use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType as RustRecordType;
 use async_trait::async_trait;
+use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType as RustRecordType;
+use databricks_zerobus_ingest_sdk::{
+    DefaultTokenFactory, EncodedRecord as RustRecordPayload,
+    HeadersProvider as RustHeadersProvider, StreamConfigurationOptions as RustStreamOptions,
+    TableProperties as RustTableProperties, ZerobusError as RustZerobusError,
+    ZerobusResult as RustZerobusResult, ZerobusSdk as RustZerobusSdk,
+    ZerobusStream as RustZerobusStream,
+};
 use prost_types;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -107,13 +104,28 @@ impl From<StreamConfigurationOptions> for RustStreamOptions {
         };
 
         RustStreamOptions {
-            max_inflight_requests: opts.max_inflight_requests.unwrap_or(default.max_inflight_requests as u32) as usize,
+            max_inflight_requests: opts
+                .max_inflight_requests
+                .unwrap_or(default.max_inflight_requests as u32)
+                as usize,
             recovery: opts.recovery.unwrap_or(default.recovery),
-            recovery_timeout_ms: opts.recovery_timeout_ms.map(|v| v as u64).unwrap_or(default.recovery_timeout_ms),
-            recovery_backoff_ms: opts.recovery_backoff_ms.map(|v| v as u64).unwrap_or(default.recovery_backoff_ms),
+            recovery_timeout_ms: opts
+                .recovery_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.recovery_timeout_ms),
+            recovery_backoff_ms: opts
+                .recovery_backoff_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.recovery_backoff_ms),
             recovery_retries: opts.recovery_retries.unwrap_or(default.recovery_retries),
-            flush_timeout_ms: opts.flush_timeout_ms.map(|v| v as u64).unwrap_or(default.flush_timeout_ms),
-            server_lack_of_ack_timeout_ms: opts.server_lack_of_ack_timeout_ms.map(|v| v as u64).unwrap_or(default.server_lack_of_ack_timeout_ms),
+            flush_timeout_ms: opts
+                .flush_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.flush_timeout_ms),
+            server_lack_of_ack_timeout_ms: opts
+                .server_lack_of_ack_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.server_lack_of_ack_timeout_ms),
             record_type,
             callback_max_wait_time_ms: None, // Callbacks not supported in TS SDK
             stream_paused_max_wait_time_ms: opts.stream_paused_max_wait_time_ms.map(|v| v as u64),
@@ -139,12 +151,16 @@ pub struct TableProperties {
 
 impl TableProperties {
     fn to_rust(&self) -> Result<RustTableProperties> {
-        let descriptor: Option<prost_types::DescriptorProto> = if let Some(ref desc_str) = self.descriptor_proto {
+        let descriptor: Option<prost_types::DescriptorProto> = if let Some(ref desc_str) =
+            self.descriptor_proto
+        {
             let bytes = base64_decode(desc_str)
                 .map_err(|e| Error::from_reason(format!("Failed to decode descriptor: {}", e)))?;
 
             let descriptor_proto: prost_types::DescriptorProto = prost::Message::decode(&bytes[..])
-                .map_err(|e| Error::from_reason(format!("Failed to parse descriptor proto: {}", e)))?;
+                .map_err(|e| {
+                    Error::from_reason(format!("Failed to parse descriptor proto: {}", e))
+                })?;
 
             Some(descriptor_proto)
         } else {
@@ -209,17 +225,19 @@ fn convert_js_to_record_payload(env: &Env, payload: Unknown) -> Result<RustRecor
             if constructor_obj.has_named_property("encode")? {
                 let encode_fn: JsFunction = constructor_obj.get_named_property("encode")?;
                 let obj_as_unknown = obj.into_unknown();
-                let encode_result: JsUnknown = encode_fn.call::<JsUnknown>(Some(&constructor_obj), &[obj_as_unknown])?;
+                let encode_result: JsUnknown =
+                    encode_fn.call::<JsUnknown>(Some(&constructor_obj), &[obj_as_unknown])?;
                 let encode_obj = JsObject::from_unknown(encode_result)?;
 
                 if encode_obj.has_named_property("finish")? {
                     let finish_fn: JsFunction = encode_obj.get_named_property("finish")?;
-                    let buffer_result: JsUnknown = finish_fn.call::<JsUnknown>(Some(&encode_obj), &[])?;
+                    let buffer_result: JsUnknown =
+                        finish_fn.call::<JsUnknown>(Some(&encode_obj), &[])?;
                     let buffer: Buffer = Buffer::from_unknown(buffer_result)?;
                     Ok(RustRecordPayload::Proto(buffer.to_vec()))
                 } else {
                     Err(Error::from_reason(
-                        "Protobuf message .encode() must return an object with .finish() method"
+                        "Protobuf message .encode() must return an object with .finish() method",
                     ))
                 }
             } else {
@@ -227,7 +245,8 @@ fn convert_js_to_record_payload(env: &Env, payload: Unknown) -> Result<RustRecor
                 let json_obj: JsObject = global.get_named_property("JSON")?;
                 let stringify: JsFunction = json_obj.get_named_property("stringify")?;
                 let obj_as_unknown = obj.into_unknown();
-                let str_result: JsUnknown = stringify.call::<JsUnknown>(Some(&json_obj), &[obj_as_unknown])?;
+                let str_result: JsUnknown =
+                    stringify.call::<JsUnknown>(Some(&json_obj), &[obj_as_unknown])?;
                 let js_string = JsString::from_unknown(str_result)?;
                 let json_string = js_string.into_utf8()?.as_str()?.to_string();
 
@@ -240,11 +259,9 @@ fn convert_js_to_record_payload(env: &Env, payload: Unknown) -> Result<RustRecor
             let json_string = js_string.into_utf8()?.as_str()?.to_string();
             Ok(RustRecordPayload::Json(json_string))
         }
-        _ => {
-            Err(Error::from_reason(
-                "Payload must be a Buffer, string, protobuf message object, or plain JavaScript object"
-            ))
-        }
+        _ => Err(Error::from_reason(
+            "Payload must be a Buffer, string, protobuf message object, or plain JavaScript object",
+        )),
     }
 }
 
@@ -408,9 +425,10 @@ impl ZerobusStream {
                 match ack_future_option.await {
                     Ok(Some(offset_id)) => Ok(Some(offset_id)),
                     Ok(None) => Ok(None),
-                    Err(e) => Err(napi::Error::from_reason(
-                        format!("Batch acknowledgment failed: {}", e)
-                    )),
+                    Err(e) => Err(napi::Error::from_reason(format!(
+                        "Batch acknowledgment failed: {}",
+                        e
+                    ))),
                 }
             },
             |env, result| match result {
@@ -421,7 +439,7 @@ impl ZerobusStream {
                     let js_str = env.create_string(&offset_str)?;
                     let bigint = bigint_ctor.call(None, &[js_str.into_unknown()])?;
                     Ok(bigint.into_unknown())
-                },
+                }
                 None => env.get_null().map(|v| v.into_unknown()),
             },
         )
@@ -470,7 +488,9 @@ impl ZerobusStream {
                 stream_ref
                     .ingest_record_offset(record_payload)
                     .await
-                    .map_err(|e| napi::Error::from_reason(format!("Failed to ingest record: {}", e)))
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!("Failed to ingest record: {}", e))
+                    })
             },
             |env, offset_id| {
                 let offset_str = offset_id.to_string();
@@ -537,7 +557,7 @@ impl ZerobusStream {
                     let js_str = env.create_string(&offset_str)?;
                     let bigint = bigint_ctor.call(None, &[js_str.into_unknown()])?;
                     Ok(bigint.into_unknown())
-                },
+                }
                 None => env.get_null().map(|v| v.into_unknown()),
             },
         )
@@ -584,10 +604,9 @@ impl ZerobusStream {
                     .as_ref()
                     .ok_or_else(|| napi::Error::from_reason("Stream has been closed"))?;
 
-                stream_ref
-                    .wait_for_offset(offset)
-                    .await
-                    .map_err(|e| napi::Error::from_reason(format!("Failed to wait for offset: {}", e)))
+                stream_ref.wait_for_offset(offset).await.map_err(|e| {
+                    napi::Error::from_reason(format!("Failed to wait for offset: {}", e))
+                })
             },
             |_env, _| Ok(()),
         )
@@ -750,12 +769,12 @@ impl StaticHeadersProvider {
 
         if !map.contains_key("authorization") {
             return Err(RustZerobusError::InvalidArgument(
-                "HeadersProvider must include 'authorization' header with Bearer token".to_string()
+                "HeadersProvider must include 'authorization' header with Bearer token".to_string(),
             ));
         }
         if !map.contains_key("x-databricks-zerobus-table-name") {
             return Err(RustZerobusError::InvalidArgument(
-                "HeadersProvider must include 'x-databricks-zerobus-table-name' header".to_string()
+                "HeadersProvider must include 'x-databricks-zerobus-table-name' header".to_string(),
             ));
         }
 
@@ -776,13 +795,18 @@ impl RustHeadersProvider for StaticHeadersProvider {
 }
 
 /// Helper to create a threadsafe function from JavaScript callback
-fn create_headers_tsfn(js_func: JsFunction) -> Result<ThreadsafeFunction<(), ErrorStrategy::Fatal>> {
+fn create_headers_tsfn(
+    js_func: JsFunction,
+) -> Result<ThreadsafeFunction<(), ErrorStrategy::Fatal>> {
     js_func.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))
 }
 
 /// Helper to call headers callback and get result
-async fn call_headers_tsfn(tsfn: ThreadsafeFunction<(), ErrorStrategy::Fatal>) -> Result<Vec<(String, String)>> {
-    let raw_headers: Vec<Vec<String>> = tsfn.call_async(())
+async fn call_headers_tsfn(
+    tsfn: ThreadsafeFunction<(), ErrorStrategy::Fatal>,
+) -> Result<Vec<(String, String)>> {
+    let raw_headers: Vec<Vec<String>> = tsfn
+        .call_async(())
         .await
         .map_err(|e| Error::from_reason(format!("Failed to call headers callback: {}", e)))?;
 
@@ -898,7 +922,9 @@ impl ZerobusSdk {
             .and_then(|s| s.split('.').next())
             .map(|s| s.to_string())
             .ok_or_else(|| {
-                Error::from_reason("Failed to extract workspace_id from zerobus_endpoint".to_string())
+                Error::from_reason(
+                    "Failed to extract workspace_id from zerobus_endpoint".to_string(),
+                )
             })?;
 
         let inner = RustZerobusSdk::builder()
@@ -979,9 +1005,9 @@ impl ZerobusSdk {
         let rust_options: RustStreamOptions = options.map(|o| o.into()).unwrap_or_default();
 
         let headers_tsfn = match headers_provider {
-            Some(JsHeadersProvider { get_headers_callback }) => {
-                Some(create_headers_tsfn(get_headers_callback)?)
-            }
+            Some(JsHeadersProvider {
+                get_headers_callback,
+            }) => Some(create_headers_tsfn(get_headers_callback)?),
             None => None,
         };
 
@@ -992,10 +1018,13 @@ impl ZerobusSdk {
 
         env.execute_tokio_future(
             async move {
-                let headers_provider_arc: Arc<dyn RustHeadersProvider> = if let Some(tsfn) = headers_tsfn {
+                let headers_provider_arc: Arc<dyn RustHeadersProvider> = if let Some(tsfn) =
+                    headers_tsfn
+                {
                     // Custom headers provider from JavaScript callback
-                    let headers = call_headers_tsfn(tsfn).await
-                        .map_err(|e| napi::Error::from_reason(format!("Headers callback failed: {}", e)))?;
+                    let headers = call_headers_tsfn(tsfn).await.map_err(|e| {
+                        napi::Error::from_reason(format!("Headers callback failed: {}", e))
+                    })?;
 
                     let static_provider = StaticHeadersProvider::new(headers)
                         .map_err(|e| napi::Error::from_reason(format!("Invalid headers: {}", e)))?;
@@ -1019,7 +1048,9 @@ impl ZerobusSdk {
                         Some(rust_options),
                     )
                     .await
-                    .map_err(|e| napi::Error::from_reason(format!("Failed to create stream: {}", e)))?;
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!("Failed to create stream: {}", e))
+                    })?;
 
                 Ok(ZerobusStream {
                     inner: Arc::new(Mutex::new(Some(stream))),
@@ -1096,19 +1127,15 @@ fn base64_decode(input: &str) -> std::result::Result<Vec<u8>, String> {
 // =============================================================================
 
 #[cfg(feature = "arrow-flight")]
-use databricks_zerobus_ingest_sdk::{
-    ArrowStreamConfigurationOptions as RustArrowStreamOptions,
-    ArrowTableProperties as RustArrowTableProperties,
-    ZerobusArrowStream as RustZerobusArrowStream,
-    ArrowSchema as RustArrowSchema,
-    RecordBatch as RustRecordBatch,
-    Field as RustField,
-    DataType as RustDataType,
-};
-#[cfg(feature = "arrow-flight")]
 use arrow_ipc::reader::StreamReader;
 #[cfg(feature = "arrow-flight")]
 use arrow_ipc::writer::StreamWriter;
+#[cfg(feature = "arrow-flight")]
+use databricks_zerobus_ingest_sdk::{
+    ArrowSchema as RustArrowSchema, ArrowStreamConfigurationOptions as RustArrowStreamOptions,
+    ArrowTableProperties as RustArrowTableProperties, DataType as RustDataType, Field as RustField,
+    RecordBatch as RustRecordBatch, ZerobusArrowStream as RustZerobusArrowStream,
+};
 #[cfg(feature = "arrow-flight")]
 use std::io::Cursor;
 
@@ -1167,10 +1194,6 @@ pub struct ArrowStreamConfigurationOptions {
 
     /// Optional IPC compression type (0 = LZ4Frame, 1 = Zstd, undefined = no compression)
     pub ipc_compression: Option<i32>,
-
-    /// Maximum time in milliseconds to wait during graceful stream close.
-    /// undefined = wait full server duration, 0 = immediate recovery, >0 = wait up to min(this, server_duration).
-    pub stream_paused_max_wait_time_ms: Option<u32>,
 }
 
 #[cfg(feature = "arrow-flight")]
@@ -1185,16 +1208,33 @@ impl From<ArrowStreamConfigurationOptions> for RustArrowStreamOptions {
         };
 
         RustArrowStreamOptions {
-            max_inflight_batches: opts.max_inflight_batches.unwrap_or(default.max_inflight_batches as u32) as usize,
+            max_inflight_batches: opts
+                .max_inflight_batches
+                .unwrap_or(default.max_inflight_batches as u32)
+                as usize,
             recovery: opts.recovery.unwrap_or(default.recovery),
-            recovery_timeout_ms: opts.recovery_timeout_ms.map(|v| v as u64).unwrap_or(default.recovery_timeout_ms),
-            recovery_backoff_ms: opts.recovery_backoff_ms.map(|v| v as u64).unwrap_or(default.recovery_backoff_ms),
+            recovery_timeout_ms: opts
+                .recovery_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.recovery_timeout_ms),
+            recovery_backoff_ms: opts
+                .recovery_backoff_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.recovery_backoff_ms),
             recovery_retries: opts.recovery_retries.unwrap_or(default.recovery_retries),
-            server_lack_of_ack_timeout_ms: opts.server_lack_of_ack_timeout_ms.map(|v| v as u64).unwrap_or(default.server_lack_of_ack_timeout_ms),
-            flush_timeout_ms: opts.flush_timeout_ms.map(|v| v as u64).unwrap_or(default.flush_timeout_ms),
-            connection_timeout_ms: opts.connection_timeout_ms.map(|v| v as u64).unwrap_or(default.connection_timeout_ms),
+            server_lack_of_ack_timeout_ms: opts
+                .server_lack_of_ack_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.server_lack_of_ack_timeout_ms),
+            flush_timeout_ms: opts
+                .flush_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.flush_timeout_ms),
+            connection_timeout_ms: opts
+                .connection_timeout_ms
+                .map(|v| v as u64)
+                .unwrap_or(default.connection_timeout_ms),
             ipc_compression,
-            stream_paused_max_wait_time_ms: opts.stream_paused_max_wait_time_ms.map(|v| v as u64),
         }
     }
 }
@@ -1306,13 +1346,17 @@ pub struct ArrowTableProperties {
 #[cfg(feature = "arrow-flight")]
 impl ArrowTableProperties {
     fn to_rust(&self) -> Result<RustArrowTableProperties> {
-        let fields: Vec<RustField> = self.schema_fields.iter().map(|f| {
-            RustField::new(
-                &f.name,
-                convert_arrow_data_type(f.data_type),
-                f.nullable.unwrap_or(true),
-            )
-        }).collect();
+        let fields: Vec<RustField> = self
+            .schema_fields
+            .iter()
+            .map(|f| {
+                RustField::new(
+                    &f.name,
+                    convert_arrow_data_type(f.data_type),
+                    f.nullable.unwrap_or(true),
+                )
+            })
+            .collect();
 
         let schema = Arc::new(RustArrowSchema::new(fields));
 
@@ -1365,18 +1409,21 @@ pub struct ZerobusArrowStream {
 
 /// Helper to parse Arrow IPC buffer to RecordBatch
 #[cfg(feature = "arrow-flight")]
-fn parse_arrow_ipc_to_batch(ipc_buffer: &[u8], _expected_schema: &RustArrowSchema) -> Result<RustRecordBatch> {
+fn parse_arrow_ipc_to_batch(
+    ipc_buffer: &[u8],
+    _expected_schema: &RustArrowSchema,
+) -> Result<RustRecordBatch> {
     let cursor = Cursor::new(ipc_buffer);
     let reader = StreamReader::try_new(cursor, None)
         .map_err(|e| Error::from_reason(format!("Failed to parse Arrow IPC: {}", e)))?;
 
     // Collect all batches (typically just one)
-    let batches: Vec<RustRecordBatch> = reader
-        .filter_map(|r| r.ok())
-        .collect();
+    let batches: Vec<RustRecordBatch> = reader.filter_map(|r| r.ok()).collect();
 
     if batches.is_empty() {
-        return Err(Error::from_reason("Arrow IPC buffer contains no record batches"));
+        return Err(Error::from_reason(
+            "Arrow IPC buffer contains no record batches",
+        ));
     }
 
     // Return the first batch (or could concatenate if multiple)
@@ -1390,9 +1437,11 @@ fn serialize_batch_to_ipc(batch: &RustRecordBatch) -> Result<Vec<u8>> {
     {
         let mut writer = StreamWriter::try_new(&mut buffer, batch.schema().as_ref())
             .map_err(|e| Error::from_reason(format!("Failed to create Arrow IPC writer: {}", e)))?;
-        writer.write(batch)
+        writer
+            .write(batch)
             .map_err(|e| Error::from_reason(format!("Failed to write batch to IPC: {}", e)))?;
-        writer.finish()
+        writer
+            .finish()
             .map_err(|e| Error::from_reason(format!("Failed to finish IPC stream: {}", e)))?;
     }
     Ok(buffer)
@@ -1479,10 +1528,9 @@ impl ZerobusArrowStream {
                     .as_ref()
                     .ok_or_else(|| napi::Error::from_reason("Arrow stream has been closed"))?;
 
-                stream_ref
-                    .wait_for_offset(offset)
-                    .await
-                    .map_err(|e| napi::Error::from_reason(format!("Failed to wait for offset: {}", e)))
+                stream_ref.wait_for_offset(offset).await.map_err(|e| {
+                    napi::Error::from_reason(format!("Failed to wait for offset: {}", e))
+                })
             },
             |_env, _| Ok(()),
         )
@@ -1528,7 +1576,9 @@ impl ZerobusArrowStream {
     /// Returns the table name for this stream.
     #[napi(getter)]
     pub fn table_name(&self) -> Result<String> {
-        let guard = self.inner.try_lock()
+        let guard = self
+            .inner
+            .try_lock()
             .map_err(|_| Error::from_reason("Stream is busy"))?;
         let stream = guard
             .as_ref()
@@ -1629,7 +1679,9 @@ impl ZerobusSdk {
                 let stream = sdk
                     .create_arrow_stream(rust_table_props, client_id, client_secret, rust_options)
                     .await
-                    .map_err(|e| napi::Error::from_reason(format!("Failed to create arrow stream: {}", e)))?;
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!("Failed to create arrow stream: {}", e))
+                    })?;
 
                 Ok(ZerobusArrowStream {
                     inner: Arc::new(Mutex::new(Some(stream))),
@@ -1652,7 +1704,10 @@ impl ZerobusSdk {
     ///
     /// A Promise that resolves to a new ZerobusArrowStream with all unacknowledged batches re-ingested.
     #[napi]
-    pub async fn recreate_arrow_stream(&self, stream: &ZerobusArrowStream) -> Result<ZerobusArrowStream> {
+    pub async fn recreate_arrow_stream(
+        &self,
+        stream: &ZerobusArrowStream,
+    ) -> Result<ZerobusArrowStream> {
         let inner_guard = stream.inner.lock().await;
         let rust_stream = inner_guard
             .as_ref()


### PR DESCRIPTION
## What changes are proposed in this pull request?
 - Adds stream_paused_max_wait_time_ms config option to ArrowStreamConfigurationOptions across all SDKs (Rust, Go, Python, TypeScript, Java)
  - Implements client-side graceful close state machine: when the server signals it will close the stream, the SDK enters a paused state, stops sending new batches but drains in-flight ack responses before triggering recovery                                                                                                                                                                                          
  - Graceful close recoveries don't count against the recovery_retries budget, since they're intentional server-side restarts (e.g. rolling deploys)   

## How is this tested?

 - 5 new integration tests in rust/tests/src/arrow_tests.rs covering: full server duration wait, immediate recovery, client-capped wait, early exit when all batches acked, ingest accepted during grace period