### PR TITLE
chore: reduce verbosity on the rust SDK

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ### Internal Changes
 
+- Reduced log verbosity in `wait_for_offset` / `wait_for_acks` polling loops.
+  Per-iteration progress logs are now emitted at `trace` level, and the
+  one-shot "completed" log is now at `debug` level (previously `info`). This
+  removes repeated `info`-level noise observed when callers wait for flushes
+  or graceful close.
+
 ### Breaking Changes
 
 ### Deprecations

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -23,7 +23,7 @@ use tokio::time::{sleep, Duration};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
 use tonic::transport::Channel;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 // Re-export arrow types for public API
 pub use arrow_array::RecordBatch;
@@ -1456,7 +1456,7 @@ impl ZerobusArrowStream {
                 let current_ack = *offset_rx.borrow_and_update();
                 if let Some(ack_offset) = current_ack {
                     if ack_offset >= offset_to_wait {
-                        info!(
+                        debug!(
                             ack_offset = ack_offset,
                             target_offset = offset_to_wait,
                             "{} completed",
@@ -1464,7 +1464,7 @@ impl ZerobusArrowStream {
                         );
                         return Ok(());
                     }
-                    debug!(
+                    trace!(
                         current_ack = ack_offset,
                         target_offset = offset_to_wait,
                         "Waiting for more acks"

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -70,7 +70,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tonic::metadata::MetadataValue;
 use tonic::transport::{Channel, Endpoint};
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, instrument, span, trace, warn, Level};
 
 use databricks::zerobus::ephemeral_stream_request::Payload as RequestPayload;
 use databricks::zerobus::ephemeral_stream_response::Payload as ResponsePayload;
@@ -1966,17 +1966,17 @@ impl ZerobusStream {
                 };
                 if let Some(offset) = offset {
                     if offset >= offset_to_wait {
-                        info!(stream_id = %stream_id, "Stream is caught up to the given offset. {} completed.", operation_name);
+                        debug!(stream_id = %stream_id, "Stream is caught up to the given offset. {} completed.", operation_name);
                         return Ok(());
                     } else {
-                        info!(
+                        trace!(
                             stream_id = %stream_id,
                             "Stream is caught up to offset {}. Waiting for offset {}.",
                             offset, offset_to_wait
                         );
                     }
                 } else {
-                    info!(
+                    trace!(
                         stream_id = %stream_id,
                         "Stream is not caught up to any offset yet. Waiting for the first offset."
                     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

I noticed that with the vector integration at https://github.com/vectordotdev/vector/pull/24840 the rust SDK can get quite chatty with many `info!` messages for `wait_for_offset`. Instead, emit `trace!` or `debug!` as needed.

## How is this tested?
Not needed.