### PR TITLE
Fix h2 protocol errors

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -24,6 +24,9 @@
 
 ### Bug Fixes
 
+- **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
+- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** with a 500ms cap so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
+
 ### Documentation
 
 ### Internal Changes

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -25,7 +25,7 @@
 ### Bug Fixes
 
 - **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
-- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** with a 500ms cap so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
+- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
 
 ### Documentation
 

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -1134,6 +1134,12 @@ impl ZerobusStream {
 
             // 3. Spawn receiver and sender task.
             let is_paused = Arc::new(AtomicBool::new(false));
+
+            // Per-stream child token
+            let per_stream_token = cancellation_token.child_token();
+            // Separate token for recv_task's close path
+            let recv_drain_token = CancellationToken::new();
+
             let mut recv_task = Self::spawn_receiver_task(
                 response_grpc_stream,
                 logical_last_received_offset_id_tx.clone(),
@@ -1142,7 +1148,8 @@ impl ZerobusStream {
                 Arc::clone(&is_paused),
                 options.clone(),
                 server_error_tx.clone(),
-                cancellation_token.clone(),
+                per_stream_token.clone(),
+                recv_drain_token.clone(),
                 callback_tx.clone(),
             );
             let mut send_task = Self::spawn_sender_task(
@@ -1150,13 +1157,17 @@ impl ZerobusStream {
                 landing_zone_sender,
                 Arc::clone(&is_paused),
                 server_error_tx.clone(),
-                cancellation_token.clone(),
+                per_stream_token.clone(),
             );
 
             // 4. Wait for any of the two tasks to end.
             let result = tokio::select! {
                 recv_result = &mut recv_task => {
-                    send_task.abort();
+                    per_stream_token.cancel();
+                    let _ = tokio::time::timeout(Duration::from_millis(500), &mut send_task).await;
+                    if !send_task.is_finished() {
+                        send_task.abort();
+                    }
                     match recv_result {
                         Ok(Err(e)) => Err(e),
                         Err(e) => Err(ZerobusError::UnexpectedStreamResponseError(
@@ -1169,6 +1180,11 @@ impl ZerobusStream {
                     }
                 }
                 send_result = &mut send_task => {
+                    // Draining the recv_task prevents RST_STREAM(CANCEL) from being sent alongside END_STREAM.
+                    if matches!(send_result, Ok(Ok(()))) && cancellation_token.is_cancelled() {
+                        recv_drain_token.cancel();
+                        let _ = tokio::time::timeout(Duration::from_millis(2000), &mut recv_task).await;
+                    }
                     recv_task.abort();
                     match send_result {
                         Ok(Err(e)) => Err(e),
@@ -1706,7 +1722,8 @@ impl ZerobusStream {
         is_paused: Arc<AtomicBool>,
         options: StreamConfigurationOptions,
         server_error_tx: tokio::sync::watch::Sender<Option<ZerobusError>>,
-        cancellation_token: CancellationToken,
+        _cancellation_token: CancellationToken,
+        recv_drain_token: CancellationToken,
         callback_tx: Option<tokio::sync::mpsc::UnboundedSender<CallbackMessage>>,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
         tokio::spawn(async move {
@@ -1715,24 +1732,24 @@ impl ZerobusStream {
             let mut last_acked_offset = -1;
             let mut pause_deadline: Option<tokio::time::Instant> = None;
 
-            loop {
+            'recv_loop: loop {
                 if let Some(deadline) = pause_deadline {
                     let now = tokio::time::Instant::now();
                     let all_acked = landing_zone.is_observed_empty();
 
                     if now >= deadline {
                         info!("Graceful close timeout reached. Triggering recovery.");
-                        return Ok(());
+                        break 'recv_loop;
                     } else if all_acked {
                         info!("All in-flight records acknowledged during graceful close. Triggering recovery.");
-                        return Ok(());
+                        break 'recv_loop;
                     }
                 }
 
                 let message_result = if let Some(deadline) = pause_deadline {
                     tokio::select! {
                         biased;
-                        _ = cancellation_token.cancelled() => return Ok(()),
+                        _ = recv_drain_token.cancelled() => break 'recv_loop,
                         _ = tokio::time::sleep_until(deadline) => {
                             continue;
                         }
@@ -1744,7 +1761,7 @@ impl ZerobusStream {
                 } else {
                     tokio::select! {
                         biased;
-                        _ = cancellation_token.cancelled() => return Ok(()),
+                        _ = recv_drain_token.cancelled() => break 'recv_loop,
                         res = tokio::time::timeout(
                             Duration::from_millis(options.server_lack_of_ack_timeout_ms),
                             response_grpc_stream.message(),
@@ -1809,14 +1826,14 @@ impl ZerobusStream {
                                     Some(0) => {
                                         // Immediate recovery
                                         info!("Server will close the stream in {}ms. Triggering stream recovery.", server_duration_ms);
-                                        return Ok(());
+                                        break 'recv_loop;
                                     }
                                     Some(max_wait) => std::cmp::min(max_wait, server_duration_ms),
                                 };
 
                                 if wait_duration_ms == 0 {
                                     info!("Server will close the stream. Triggering immediate recovery.");
-                                    return Ok(());
+                                    break 'recv_loop;
                                 }
 
                                 is_paused.store(true, Ordering::Relaxed);
@@ -1869,6 +1886,19 @@ impl ZerobusStream {
                     }
                 }
             }
+
+            // Drain remaining server messages before dropping the stream. This lets the
+            // server close its response side cleanly (END_STREAM) instead of having the
+            // client reset it (RST_STREAM), which would cause broken pipe errors on the
+            // server's next read from the request body.
+            let _ = tokio::time::timeout(
+                Duration::from_millis(1000),
+                async {
+                    while response_grpc_stream.message().await.ok().flatten().is_some() {}
+                },
+            )
+            .await;
+            Ok(())
         })
     }
 

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -105,7 +105,7 @@ pub use stream_configuration::StreamConfigurationOptions;
 pub use tls_config::NoTlsConfig;
 pub use tls_config::{SecureTlsConfig, TlsConfig};
 
-const SHUTDOWN_TIMEOUT_SECS: u64 = 2;
+const SHUTDOWN_TIMEOUT_SECS: u64 = 1;
 
 /// The type of the stream connection created with the server.
 /// Currently we only support ephemeral streams on the server side, so we support only that in the SDK as well.
@@ -1183,7 +1183,7 @@ impl ZerobusStream {
                     // Draining the recv_task prevents RST_STREAM(CANCEL) from being sent alongside END_STREAM.
                     if matches!(send_result, Ok(Ok(()))) && cancellation_token.is_cancelled() {
                         recv_drain_token.cancel();
-                        let _ = tokio::time::timeout(Duration::from_millis(2000), &mut recv_task).await;
+                        let _ = tokio::time::timeout(Duration::from_millis(100), &mut recv_task).await;
                     }
                     recv_task.abort();
                     match send_result {
@@ -1731,6 +1731,11 @@ impl ZerobusStream {
             let _guard = span.enter();
             let mut last_acked_offset = -1;
             let mut pause_deadline: Option<tokio::time::Instant> = None;
+            // Set when we exit because the supervisor signalled close (`recv_drain_token`).
+            // On that path we drain the response stream inline so the server sees END_STREAM
+            // instead of RST_STREAM. On all other exits (recovery / errors) the runtime is
+            // still up, so a detached drain is used to avoid blocking recovery.
+            let mut close_initiated = false;
 
             'recv_loop: loop {
                 if let Some(deadline) = pause_deadline {
@@ -1749,7 +1754,10 @@ impl ZerobusStream {
                 let message_result = if let Some(deadline) = pause_deadline {
                     tokio::select! {
                         biased;
-                        _ = recv_drain_token.cancelled() => break 'recv_loop,
+                        _ = recv_drain_token.cancelled() => {
+                            close_initiated = true;
+                            break 'recv_loop;
+                        }
                         _ = tokio::time::sleep_until(deadline) => {
                             continue;
                         }
@@ -1761,7 +1769,10 @@ impl ZerobusStream {
                 } else {
                     tokio::select! {
                         biased;
-                        _ = recv_drain_token.cancelled() => break 'recv_loop,
+                        _ = recv_drain_token.cancelled() => {
+                            close_initiated = true;
+                            break 'recv_loop;
+                        }
                         res = tokio::time::timeout(
                             Duration::from_millis(options.server_lack_of_ack_timeout_ms),
                             response_grpc_stream.message(),
@@ -1887,17 +1898,34 @@ impl ZerobusStream {
                 }
             }
 
-            // Drain remaining server messages before dropping the stream. This lets the
-            // server close its response side cleanly (END_STREAM) instead of having the
-            // client reset it (RST_STREAM), which would cause broken pipe errors on the
-            // server's next read from the request body.
-            let _ = tokio::time::timeout(
-                Duration::from_millis(1000),
-                async {
-                    while response_grpc_stream.message().await.ok().flatten().is_some() {}
-                },
-            )
-            .await;
+            // Drain remaining server messages so the server sees END_STREAM instead of
+            // the client RST_STREAM-ing the response. Inline on close (runtime may exit
+            // right after); detached on recovery / errors so recovery isn't delayed.
+            if close_initiated {
+                let _ = tokio::time::timeout(Duration::from_millis(500), async {
+                    while response_grpc_stream
+                        .message()
+                        .await
+                        .ok()
+                        .flatten()
+                        .is_some()
+                    {}
+                })
+                .await;
+            } else {
+                tokio::spawn(async move {
+                    let _ = tokio::time::timeout(Duration::from_millis(500), async move {
+                        while response_grpc_stream
+                            .message()
+                            .await
+                            .ok()
+                            .flatten()
+                            .is_some()
+                        {}
+                    })
+                    .await;
+                });
+            }
             Ok(())
         })
     }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -107,6 +107,10 @@ pub use tls_config::{SecureTlsConfig, TlsConfig};
 
 const SHUTDOWN_TIMEOUT_SECS: u64 = 1;
 
+/// Maximum time to wait for the receiver/sender tasks to finish during stream
+/// teardown.
+const STREAM_TEARDOWN_DRAIN_TIMEOUT_MS: u64 = 500;
+
 /// The type of the stream connection created with the server.
 /// Currently we only support ephemeral streams on the server side, so we support only that in the SDK as well.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1148,7 +1152,6 @@ impl ZerobusStream {
                 Arc::clone(&is_paused),
                 options.clone(),
                 server_error_tx.clone(),
-                per_stream_token.clone(),
                 recv_drain_token.clone(),
                 callback_tx.clone(),
             );
@@ -1164,7 +1167,11 @@ impl ZerobusStream {
             let result = tokio::select! {
                 recv_result = &mut recv_task => {
                     per_stream_token.cancel();
-                    let _ = tokio::time::timeout(Duration::from_millis(500), &mut send_task).await;
+                    let _ = tokio::time::timeout(
+                        Duration::from_millis(STREAM_TEARDOWN_DRAIN_TIMEOUT_MS),
+                        &mut send_task,
+                    )
+                    .await;
                     if !send_task.is_finished() {
                         send_task.abort();
                     }
@@ -1183,7 +1190,11 @@ impl ZerobusStream {
                     // Draining the recv_task prevents RST_STREAM(CANCEL) from being sent alongside END_STREAM.
                     if matches!(send_result, Ok(Ok(()))) && cancellation_token.is_cancelled() {
                         recv_drain_token.cancel();
-                        let _ = tokio::time::timeout(Duration::from_millis(100), &mut recv_task).await;
+                        let _ = tokio::time::timeout(
+                            Duration::from_millis(STREAM_TEARDOWN_DRAIN_TIMEOUT_MS),
+                            &mut recv_task,
+                        )
+                        .await;
                     }
                     recv_task.abort();
                     match send_result {
@@ -1722,7 +1733,6 @@ impl ZerobusStream {
         is_paused: Arc<AtomicBool>,
         options: StreamConfigurationOptions,
         server_error_tx: tokio::sync::watch::Sender<Option<ZerobusError>>,
-        _cancellation_token: CancellationToken,
         recv_drain_token: CancellationToken,
         callback_tx: Option<tokio::sync::mpsc::UnboundedSender<CallbackMessage>>,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
@@ -1902,19 +1912,9 @@ impl ZerobusStream {
             // the client RST_STREAM-ing the response. Inline on close (runtime may exit
             // right after); detached on recovery / errors so recovery isn't delayed.
             if close_initiated {
-                let _ = tokio::time::timeout(Duration::from_millis(500), async {
-                    while response_grpc_stream
-                        .message()
-                        .await
-                        .ok()
-                        .flatten()
-                        .is_some()
-                    {}
-                })
-                .await;
-            } else {
-                tokio::spawn(async move {
-                    let _ = tokio::time::timeout(Duration::from_millis(500), async move {
+                let _ = tokio::time::timeout(
+                    Duration::from_millis(STREAM_TEARDOWN_DRAIN_TIMEOUT_MS),
+                    async {
                         while response_grpc_stream
                             .message()
                             .await
@@ -1922,7 +1922,23 @@ impl ZerobusStream {
                             .flatten()
                             .is_some()
                         {}
-                    })
+                    },
+                )
+                .await;
+            } else {
+                tokio::spawn(async move {
+                    let _ = tokio::time::timeout(
+                        Duration::from_millis(STREAM_TEARDOWN_DRAIN_TIMEOUT_MS),
+                        async move {
+                            while response_grpc_stream
+                                .message()
+                                .await
+                                .ok()
+                                .flatten()
+                                .is_some()
+                            {}
+                        },
+                    )
                     .await;
                 });
             }

--- a/rust/tools/generate_files/src/generate.rs
+++ b/rust/tools/generate_files/src/generate.rs
@@ -131,20 +131,20 @@ fn write_field(
     map_entries: &HashMap<String, MapEntry>,
     indent: &str,
 ) {
-    if f.label() == Label::Repeated
-        && f.r#type() == Type::Message
-        && let Some(type_name) = f.type_name.as_deref()
-        && let Some(entry) = map_entries.get(short_name(type_name))
-    {
-        out.push_str(&format!(
-            "{}map<{}, {}> {} = {};\n",
-            indent,
-            entry.key,
-            entry.value,
-            f.name(),
-            f.number()
-        ));
-        return;
+    if f.label() == Label::Repeated && f.r#type() == Type::Message {
+        if let Some(type_name) = f.type_name.as_deref() {
+            if let Some(entry) = map_entries.get(short_name(type_name)) {
+                out.push_str(&format!(
+                    "{}map<{}, {}> {} = {};\n",
+                    indent,
+                    entry.key,
+                    entry.value,
+                    f.name(),
+                    f.number()
+                ));
+                return;
+            }
+        }
     }
 
     let label = match f.label() {

--- a/rust/tools/generate_files/src/generate.rs
+++ b/rust/tools/generate_files/src/generate.rs
@@ -131,20 +131,20 @@ fn write_field(
     map_entries: &HashMap<String, MapEntry>,
     indent: &str,
 ) {
-    if f.label() == Label::Repeated && f.r#type() == Type::Message {
-        if let Some(type_name) = f.type_name.as_deref() {
-            if let Some(entry) = map_entries.get(short_name(type_name)) {
-                out.push_str(&format!(
-                    "{}map<{}, {}> {} = {};\n",
-                    indent,
-                    entry.key,
-                    entry.value,
-                    f.name(),
-                    f.number()
-                ));
-                return;
-            }
-        }
+    if f.label() == Label::Repeated
+        && f.r#type() == Type::Message
+        && let Some(type_name) = f.type_name.as_deref()
+        && let Some(entry) = map_entries.get(short_name(type_name))
+    {
+        out.push_str(&format!(
+            "{}map<{}, {}> {} = {};\n",
+            indent,
+            entry.key,
+            entry.value,
+            f.name(),
+            f.number()
+        ));
+        return;
     }
 
     let label = match f.label() {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Zerobus server was getting h2 protocol errors sporadically on stream closure from client side, causing noise in logs. The issue was caused by how we handled receiver and sender task abortion, creating a race condition between `END_STREAM` and `RST_STREAM` signals over which one was sent to the server first. If `END_STREAM` is sent first everything is handled properly, but if `RST_STREAM` is sent first, the h2 protocol errors would occur. The fix introduces another cancellation token to ensure proper ordering


## How is this tested?

Tested on staging server.