### PR TITLE
[Rust] Add ZerobusSdkBuilder::application_name for x-zerobus-sdk header

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -14,11 +14,12 @@
   `Map("entries", Struct{keys,values})`) matching the canonical Arrow schema
   the Databricks Arrow Flight server builds from Delta.
 - **`ZerobusSdkBuilder::application_name`**: Set a custom application identifier
-  appended to the `x-zerobus-sdk` gRPC metadata header on every request. The
-  default `zerobus-sdk-rs/<version>` prefix is preserved for server-side
-  telemetry, so the wire value becomes `zerobus-sdk-rs/<version> <application_name>`.
-  The SDK now owns this header at the gRPC layer: any `x-zerobus-sdk` value
-  returned by a `HeadersProvider` is ignored.
+  appended to the HTTP `user-agent` header (sent on the underlying tonic
+  `Endpoint`) on every request. The default `zerobus-sdk-rs/<version>` prefix
+  is preserved for server-side telemetry, so the wire value becomes
+  `zerobus-sdk-rs/<version> <application_name>`. The previous `x-zerobus-sdk`
+  gRPC metadata header is no longer emitted; downstream consumers that parsed
+  it should switch to reading `user-agent`.
 
 ### Bug Fixes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -20,6 +20,11 @@
   `zerobus-sdk-rs/<version> <application_name>`. The previous `x-zerobus-sdk`
   gRPC metadata header is no longer emitted; downstream consumers that parsed
   it should switch to reading `user-agent`.
+- **`ZerobusSdkBuilder::sdk_identifier`**: Override the SDK prefix of the
+  HTTP `user-agent` header, replacing the default `zerobus-sdk-rs/<version>`.
+  Intended for wrapper SDKs that need to replace the SDK identification; most
+  callers should prefer `application_name`, which preserves the SDK version
+  prefix. When both are set, `application_name` is still appended, so the wire value becomes `<sdk_identifier> <application_name>`.
 
 ### Bug Fixes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -13,6 +13,12 @@
   (`Date32`, `Timestamp(Microsecond, ..)`, `LargeUtf8`, `LargeBinary`,
   `Map("entries", Struct{keys,values})`) matching the canonical Arrow schema
   the Databricks Arrow Flight server builds from Delta.
+- **`ZerobusSdkBuilder::application_name`**: Set a custom application identifier
+  appended to the `x-zerobus-sdk` gRPC metadata header on every request. The
+  default `zerobus-sdk-rs/<version>` prefix is preserved for server-side
+  telemetry, so the wire value becomes `zerobus-sdk-rs/<version> <application_name>`.
+  The SDK now owns this header at the gRPC layer: any `x-zerobus-sdk` value
+  returned by a `HeadersProvider` is ignored.
 
 ### Bug Fixes
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -454,6 +454,8 @@ pub struct ZerobusArrowStream {
     /// When true, new `ingest_batch()` calls are still accepted and buffered,
     /// but the receiver continues draining in-flight acks before triggering recovery.
     is_paused: Arc<AtomicBool>,
+    /// Authoritative `x-zerobus-sdk` header value owned by the SDK.
+    sdk_identifier: Arc<str>,
 }
 
 impl ZerobusArrowStream {
@@ -470,6 +472,7 @@ impl ZerobusArrowStream {
         table_properties: ArrowTableProperties,
         headers_provider: Arc<dyn HeadersProvider>,
         options: ArrowStreamConfigurationOptions,
+        sdk_identifier: Arc<str>,
     ) -> ZerobusResult<Self> {
         let (last_ack_tx, _last_ack_rx) = tokio::sync::watch::channel(None);
         let is_closed = Arc::new(AtomicBool::new(false));
@@ -505,6 +508,7 @@ impl ZerobusArrowStream {
             cumulative_records_sent,
             last_acked_records,
             is_paused,
+            sdk_identifier,
         };
 
         // Initialize the connection with retry logic.
@@ -522,6 +526,7 @@ impl ZerobusArrowStream {
             let table_properties = table_properties.clone();
             let options = options.clone();
             let headers_provider = Arc::clone(&headers_provider);
+            let sdk_identifier = Arc::clone(&stream.sdk_identifier);
 
             async move {
                 tokio::time::timeout(
@@ -532,6 +537,7 @@ impl ZerobusArrowStream {
                         &table_properties,
                         &options,
                         &headers_provider,
+                        &sdk_identifier,
                     ),
                 )
                 .await
@@ -577,6 +583,7 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.last_acked_records),
             Arc::clone(&stream.is_paused),
             response_stream,
+            Arc::clone(&stream.sdk_identifier),
         );
 
         {
@@ -600,6 +607,7 @@ impl ZerobusArrowStream {
         table_properties: &ArrowTableProperties,
         options: &ArrowStreamConfigurationOptions,
         headers_provider: &Arc<dyn HeadersProvider>,
+        sdk_identifier: &str,
     ) -> ZerobusResult<(
         Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
         mpsc::Sender<Result<FlightData, FlightError>>,
@@ -610,6 +618,7 @@ impl ZerobusArrowStream {
             table_properties,
             options,
             headers_provider,
+            sdk_identifier,
         )
         .await?;
 
@@ -623,6 +632,7 @@ impl ZerobusArrowStream {
         table_properties: &ArrowTableProperties,
         options: &ArrowStreamConfigurationOptions,
         headers_provider: &Arc<dyn HeadersProvider>,
+        sdk_identifier: &str,
     ) -> ZerobusResult<FlightClient> {
         let connection_timeout = Duration::from_millis(options.connection_timeout_ms);
 
@@ -636,8 +646,9 @@ impl ZerobusArrowStream {
         let mut client = FlightClient::new(channel);
 
         // Add headers from the provider first, filtering out reserved headers.
-        // The table name header is authoritative and must not be overridden.
+        // The table name and SDK identifier headers are authoritative and must not be overridden.
         const TABLE_NAME_HEADER: &str = "x-databricks-zerobus-table-name";
+        const SDK_IDENTIFIER_HEADER: &str = "x-zerobus-sdk";
         let headers = headers_provider.get_headers().await?;
         for (key, value) in headers {
             if key.eq_ignore_ascii_case(TABLE_NAME_HEADER) {
@@ -645,6 +656,10 @@ impl ZerobusArrowStream {
                     "HeadersProvider attempted to set reserved header '{}', ignoring",
                     TABLE_NAME_HEADER
                 );
+                continue;
+            }
+            if key.eq_ignore_ascii_case(SDK_IDENTIFIER_HEADER) {
+                // Owned by the SDK (set below); silently ignore provider-supplied values.
                 continue;
             }
             client.add_header(key, &value).map_err(|e| {
@@ -657,6 +672,16 @@ impl ZerobusArrowStream {
             .add_header(TABLE_NAME_HEADER, &table_properties.table_name)
             .map_err(|e| {
                 ZerobusError::InvalidArgument(format!("Failed to add table name header: {}", e))
+            })?;
+
+        // Add the SDK identifier header (authoritative).
+        client
+            .add_header(SDK_IDENTIFIER_HEADER, sdk_identifier)
+            .map_err(|e| {
+                ZerobusError::InvalidArgument(format!(
+                    "Failed to add x-zerobus-sdk header: {}",
+                    e
+                ))
             })?;
 
         Ok(client)
@@ -783,6 +808,7 @@ impl ZerobusArrowStream {
         last_acked_records: Arc<AtomicU64>,
         is_paused: Arc<AtomicBool>,
         initial_response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
+        sdk_identifier: Arc<str>,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
         tokio::spawn(async move {
             let ack_timeout = Duration::from_millis(options.server_lack_of_ack_timeout_ms);
@@ -868,6 +894,7 @@ impl ZerobusArrowStream {
                                 &pending_batches,
                                 &cumulative_records_sent,
                                 &last_acked_records,
+                                &sdk_identifier,
                             ),
                         )
                         .await;
@@ -927,6 +954,7 @@ impl ZerobusArrowStream {
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
         cumulative_records_sent: &Arc<AtomicU64>,
         last_acked_records: &Arc<AtomicU64>,
+        sdk_identifier: &str,
     ) -> ZerobusResult<Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>> {
         // Create new client.
         let client = Self::create_flight_client(
@@ -935,6 +963,7 @@ impl ZerobusArrowStream {
             table_properties,
             options,
             headers_provider,
+            sdk_identifier,
         )
         .await?;
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -638,6 +638,8 @@ impl ZerobusArrowStream {
 
         let base_endpoint = Channel::from_shared(endpoint.to_string())
             .map_err(|e| ZerobusError::ChannelCreationError(e.to_string()))?
+            .user_agent(sdk_identifier)
+            .map_err(|e| ZerobusError::ChannelCreationError(e.to_string()))?
             .connect_timeout(connection_timeout)
             .timeout(connection_timeout);
 
@@ -646,9 +648,8 @@ impl ZerobusArrowStream {
         let mut client = FlightClient::new(channel);
 
         // Add headers from the provider first, filtering out reserved headers.
-        // The table name and SDK identifier headers are authoritative and must not be overridden.
+        // The table name header is authoritative and must not be overridden.
         const TABLE_NAME_HEADER: &str = "x-databricks-zerobus-table-name";
-        const SDK_IDENTIFIER_HEADER: &str = "x-zerobus-sdk";
         let headers = headers_provider.get_headers().await?;
         for (key, value) in headers {
             if key.eq_ignore_ascii_case(TABLE_NAME_HEADER) {
@@ -656,10 +657,6 @@ impl ZerobusArrowStream {
                     "HeadersProvider attempted to set reserved header '{}', ignoring",
                     TABLE_NAME_HEADER
                 );
-                continue;
-            }
-            if key.eq_ignore_ascii_case(SDK_IDENTIFIER_HEADER) {
-                // Owned by the SDK (set below); silently ignore provider-supplied values.
                 continue;
             }
             client.add_header(key, &value).map_err(|e| {
@@ -672,13 +669,6 @@ impl ZerobusArrowStream {
             .add_header(TABLE_NAME_HEADER, &table_properties.table_name)
             .map_err(|e| {
                 ZerobusError::InvalidArgument(format!("Failed to add table name header: {}", e))
-            })?;
-
-        // Add the SDK identifier header (authoritative).
-        client
-            .add_header(SDK_IDENTIFIER_HEADER, sdk_identifier)
-            .map_err(|e| {
-                ZerobusError::InvalidArgument(format!("Failed to add x-zerobus-sdk header: {}", e))
             })?;
 
         Ok(client)

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -454,7 +454,8 @@ pub struct ZerobusArrowStream {
     /// When true, new `ingest_batch()` calls are still accepted and buffered,
     /// but the receiver continues draining in-flight acks before triggering recovery.
     is_paused: Arc<AtomicBool>,
-    /// Authoritative `x-zerobus-sdk` header value owned by the SDK.
+    /// HTTP `user-agent` value owned by the SDK, re-applied to each fresh
+    /// Channel built during recovery.
     sdk_identifier: Arc<str>,
 }
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -454,8 +454,9 @@ pub struct ZerobusArrowStream {
     /// When true, new `ingest_batch()` calls are still accepted and buffered,
     /// but the receiver continues draining in-flight acks before triggering recovery.
     is_paused: Arc<AtomicBool>,
-    /// HTTP `user-agent` value owned by the SDK, re-applied to each fresh
-    /// Channel built during recovery.
+    /// Final value sent as the HTTP `user-agent` header on every request.
+    /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
+    /// Re-applied to each fresh Channel built during recovery.
     sdk_identifier: Arc<str>,
 }
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -678,10 +678,7 @@ impl ZerobusArrowStream {
         client
             .add_header(SDK_IDENTIFIER_HEADER, sdk_identifier)
             .map_err(|e| {
-                ZerobusError::InvalidArgument(format!(
-                    "Failed to add x-zerobus-sdk header: {}",
-                    e
-                ))
+                ZerobusError::InvalidArgument(format!("Failed to add x-zerobus-sdk header: {}", e))
             })?;
 
         Ok(client)

--- a/rust/sdk/src/builder/sdk_builder.rs
+++ b/rust/sdk/src/builder/sdk_builder.rs
@@ -23,6 +23,7 @@ pub struct ZerobusSdkBuilder {
     unity_catalog_url: Option<String>,
     tls_config: Option<Arc<dyn TlsConfig>>,
     connector_factory: Option<ConnectorFactory>,
+    application_name: Option<String>,
 }
 
 impl ZerobusSdkBuilder {
@@ -35,6 +36,7 @@ impl ZerobusSdkBuilder {
             unity_catalog_url: None,
             tls_config: None,
             connector_factory: None,
+            application_name: None,
         }
     }
 
@@ -84,6 +86,25 @@ impl ZerobusSdkBuilder {
         self
     }
 
+    /// Sets a custom application identifier appended to the `x-zerobus-sdk`
+    /// gRPC header on every request.
+    ///
+    /// The default header value is `zerobus-sdk-rs/<version>`. When this is
+    /// set, the value sent becomes `zerobus-sdk-rs/<version> <application_name>`,
+    /// preserving the SDK version prefix for server-side telemetry while
+    /// adding caller-supplied identification (e.g. `"my-app/1.0"`).
+    ///
+    /// This value takes precedence over any `x-zerobus-sdk` header returned
+    /// by a custom [`HeadersProvider`](crate::HeadersProvider).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Application identifier, conventionally `<product>/<version>`
+    pub fn application_name(mut self, name: impl Into<String>) -> Self {
+        self.application_name = Some(name.into());
+        self
+    }
+
     /// Builds the [`ZerobusSdk`] instance.
     ///
     /// # Errors
@@ -128,6 +149,7 @@ impl ZerobusSdkBuilder {
             workspace_id,
             tls_config,
             self.connector_factory,
+            self.application_name,
         ))
     }
 }
@@ -196,5 +218,38 @@ mod tests {
             .expect("should build successfully without unity_catalog_url");
 
         assert_eq!(sdk.unity_catalog_url, "");
+    }
+
+    #[test]
+    fn test_sdk_identifier_default() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .build()
+            .expect("should build");
+
+        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_X_ZEROBUS_SDK);
+    }
+
+    #[test]
+    fn test_sdk_identifier_with_application_name() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .application_name("my-app/1.0")
+            .build()
+            .expect("should build");
+
+        let expected = format!("{} my-app/1.0", crate::DEFAULT_X_ZEROBUS_SDK);
+        assert_eq!(&*sdk.sdk_identifier, expected);
+    }
+
+    #[test]
+    fn test_sdk_identifier_empty_application_name_falls_back_to_default() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .application_name("")
+            .build()
+            .expect("should build");
+
+        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_X_ZEROBUS_SDK);
     }
 }

--- a/rust/sdk/src/builder/sdk_builder.rs
+++ b/rust/sdk/src/builder/sdk_builder.rs
@@ -86,16 +86,17 @@ impl ZerobusSdkBuilder {
         self
     }
 
-    /// Sets a custom application identifier appended to the `x-zerobus-sdk`
-    /// gRPC header on every request.
+    /// Sets a custom application identifier appended to the HTTP `user-agent`
+    /// header sent on every request.
     ///
-    /// The default header value is `zerobus-sdk-rs/<version>`. When this is
+    /// The default user-agent value is `zerobus-sdk-rs/<version>`. When this is
     /// set, the value sent becomes `zerobus-sdk-rs/<version> <application_name>`,
     /// preserving the SDK version prefix for server-side telemetry while
     /// adding caller-supplied identification (e.g. `"my-app/1.0"`).
     ///
-    /// This value takes precedence over any `x-zerobus-sdk` header returned
-    /// by a custom [`HeadersProvider`](crate::HeadersProvider).
+    /// The SDK owns the `user-agent` header at the tonic `Endpoint` level;
+    /// values returned by a [`HeadersProvider`](crate::HeadersProvider) cannot
+    /// override it.
     ///
     /// # Arguments
     ///
@@ -227,7 +228,7 @@ mod tests {
             .build()
             .expect("should build");
 
-        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_X_ZEROBUS_SDK);
+        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_SDK_IDENTIFIER);
     }
 
     #[test]
@@ -238,7 +239,7 @@ mod tests {
             .build()
             .expect("should build");
 
-        let expected = format!("{} my-app/1.0", crate::DEFAULT_X_ZEROBUS_SDK);
+        let expected = format!("{} my-app/1.0", crate::DEFAULT_SDK_IDENTIFIER);
         assert_eq!(&*sdk.sdk_identifier, expected);
     }
 
@@ -250,6 +251,6 @@ mod tests {
             .build()
             .expect("should build");
 
-        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_X_ZEROBUS_SDK);
+        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_SDK_IDENTIFIER);
     }
 }

--- a/rust/sdk/src/builder/sdk_builder.rs
+++ b/rust/sdk/src/builder/sdk_builder.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use crate::proxy::ConnectorFactory;
-use crate::{SecureTlsConfig, TlsConfig, ZerobusError, ZerobusResult, ZerobusSdk};
+use crate::{
+    SecureTlsConfig, TlsConfig, ZerobusError, ZerobusResult, ZerobusSdk, DEFAULT_SDK_IDENTIFIER,
+};
 
 /// Builder for creating a [`ZerobusSdk`] instance with fluent configuration.
 ///
@@ -24,6 +26,7 @@ pub struct ZerobusSdkBuilder {
     tls_config: Option<Arc<dyn TlsConfig>>,
     connector_factory: Option<ConnectorFactory>,
     application_name: Option<String>,
+    sdk_identifier_override: Option<String>,
 }
 
 impl ZerobusSdkBuilder {
@@ -37,6 +40,7 @@ impl ZerobusSdkBuilder {
             tls_config: None,
             connector_factory: None,
             application_name: None,
+            sdk_identifier_override: None,
         }
     }
 
@@ -98,11 +102,33 @@ impl ZerobusSdkBuilder {
     /// values returned by a [`HeadersProvider`](crate::HeadersProvider) cannot
     /// override it.
     ///
+    /// If [`sdk_identifier`](Self::sdk_identifier) is also set, the override
+    /// replaces the SDK prefix but this value is still appended — the wire
+    /// value becomes `<sdk_identifier> <application_name>`.
+    ///
     /// # Arguments
     ///
     /// * `name` - Application identifier, conventionally `<product>/<version>`
     pub fn application_name(mut self, name: impl Into<String>) -> Self {
         self.application_name = Some(name.into());
+        self
+    }
+
+    /// Overrides the SDK prefix of the HTTP `user-agent` header, replacing the
+    /// default `zerobus-sdk-rs/<version>`.
+    ///
+    /// Used by wrapper SDKs that need to replace the SDK identification itself.
+    ///
+    /// Empty values are ignored and the default identifier is used. If
+    /// [`application_name`](Self::application_name) is also set, it is still
+    /// appended after this override — the wire value becomes
+    /// `<sdk_identifier> <application_name>`.
+    ///
+    /// # Arguments
+    ///
+    /// * `identifier` - Replacement SDK prefix (e.g. `"zerobus-sdk-py/2.0.0"`)
+    pub fn sdk_identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.sdk_identifier_override = Some(identifier.into());
         self
     }
 
@@ -144,13 +170,22 @@ impl ZerobusSdkBuilder {
             .tls_config
             .unwrap_or_else(|| Arc::new(SecureTlsConfig::new()));
 
+        let sdk_prefix: &str = match self.sdk_identifier_override.as_deref() {
+            Some(override_id) if !override_id.is_empty() => override_id,
+            _ => DEFAULT_SDK_IDENTIFIER,
+        };
+        let sdk_identifier: Arc<str> = match self.application_name.as_deref() {
+            Some(app) if !app.is_empty() => Arc::from(format!("{} {}", sdk_prefix, app)),
+            _ => Arc::from(sdk_prefix),
+        };
+
         Ok(ZerobusSdk::new_with_config(
             zerobus_endpoint,
             unity_catalog_url,
             workspace_id,
             tls_config,
             self.connector_factory,
-            self.application_name,
+            sdk_identifier,
         ))
     }
 }
@@ -252,5 +287,52 @@ mod tests {
             .expect("should build");
 
         assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_SDK_IDENTIFIER);
+    }
+
+    #[test]
+    fn test_sdk_identifier_override_replaces_default() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .sdk_identifier("custom-agent/2.0")
+            .build()
+            .expect("should build");
+
+        assert_eq!(&*sdk.sdk_identifier, "custom-agent/2.0");
+    }
+
+    #[test]
+    fn test_sdk_identifier_override_with_application_name_combines() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .application_name("my-app/1.0")
+            .sdk_identifier("custom-agent/2.0")
+            .build()
+            .expect("should build");
+
+        assert_eq!(&*sdk.sdk_identifier, "custom-agent/2.0 my-app/1.0");
+    }
+
+    #[test]
+    fn test_sdk_identifier_empty_override_falls_back_to_default() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .sdk_identifier("")
+            .build()
+            .expect("should build");
+
+        assert_eq!(&*sdk.sdk_identifier, crate::DEFAULT_SDK_IDENTIFIER);
+    }
+
+    #[test]
+    fn test_sdk_identifier_empty_override_with_application_name_uses_application_name() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .application_name("my-app/1.0")
+            .sdk_identifier("")
+            .build()
+            .expect("should build");
+
+        let expected = format!("{} my-app/1.0", crate::DEFAULT_SDK_IDENTIFIER);
+        assert_eq!(&*sdk.sdk_identifier, expected);
     }
 }

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -374,11 +374,13 @@ impl<'a> StreamBuilder<'a> {
         };
 
         let channel = self.sdk.get_or_create_channel_zerobus_client().await?;
+        let sdk_identifier = Arc::clone(&self.sdk.sdk_identifier);
         ZerobusStream::new_stream(
             channel,
             table_properties,
             headers_provider,
             self.grpc_config,
+            sdk_identifier,
         )
         .await
     }
@@ -417,6 +419,7 @@ impl<'a> StreamBuilder<'a> {
             table_properties,
             headers_provider,
             self.arrow_config,
+            Arc::clone(&self.sdk.sdk_identifier),
         )
         .await
     }
@@ -433,6 +436,7 @@ mod tests {
             "http://localhost:5678".to_string(),
             "test-workspace".to_string(),
             Arc::new(crate::tls_config::SecureTlsConfig::new()),
+            None,
             None,
         )
     }

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -374,13 +374,11 @@ impl<'a> StreamBuilder<'a> {
         };
 
         let channel = self.sdk.get_or_create_channel_zerobus_client().await?;
-        let sdk_identifier = Arc::clone(&self.sdk.sdk_identifier);
         ZerobusStream::new_stream(
             channel,
             table_properties,
             headers_provider,
             self.grpc_config,
-            sdk_identifier,
         )
         .await
     }

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -435,7 +435,7 @@ mod tests {
             "test-workspace".to_string(),
             Arc::new(crate::tls_config::SecureTlsConfig::new()),
             None,
-            None,
+            Arc::from(crate::DEFAULT_SDK_IDENTIFIER),
         )
     }
 

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -3,8 +3,10 @@ use crate::ZerobusResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-/// Default x-zerobus-sdk header value for Rust SDK requests.
-pub const DEFAULT_X_ZEROBUS_SDK: &str = concat!("zerobus-sdk-rs/", env!("CARGO_PKG_VERSION"));
+/// Default identifier the SDK sends as the HTTP `user-agent` header on every
+/// request. Use [`ZerobusSdkBuilder::application_name`](crate::ZerobusSdkBuilder::application_name)
+/// to append an application suffix.
+pub const DEFAULT_SDK_IDENTIFIER: &str = concat!("zerobus-sdk-rs/", env!("CARGO_PKG_VERSION"));
 
 /// A trait for providing custom headers for gRPC requests.
 ///
@@ -12,9 +14,9 @@ pub const DEFAULT_X_ZEROBUS_SDK: &str = concat!("zerobus-sdk-rs/", env!("CARGO_P
 /// such as fetching tokens from different OAuth providers or using alternative
 /// authentication mechanisms.
 ///
-/// The `x-zerobus-sdk` header is owned by the SDK itself and any value returned
-/// for that key from `get_headers` is ignored. Use
-/// [`ZerobusSdkBuilder::application_name`](crate::ZerobusSdkBuilder::application_name)
+/// The HTTP `user-agent` header is set by the SDK on the underlying tonic
+/// `Endpoint` and cannot be overridden by values returned from `get_headers`.
+/// Use [`ZerobusSdkBuilder::application_name`](crate::ZerobusSdkBuilder::application_name)
 /// to customize it.
 ///
 /// # Examples

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -12,6 +12,11 @@ pub const DEFAULT_X_ZEROBUS_SDK: &str = concat!("zerobus-sdk-rs/", env!("CARGO_P
 /// such as fetching tokens from different OAuth providers or using alternative
 /// authentication mechanisms.
 ///
+/// The `x-zerobus-sdk` header is owned by the SDK itself and any value returned
+/// for that key from `get_headers` is ignored. Use
+/// [`ZerobusSdkBuilder::application_name`](crate::ZerobusSdkBuilder::application_name)
+/// to customize it.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -89,7 +94,6 @@ impl HeadersProvider for OAuthHeadersProvider {
         let mut headers = HashMap::new();
         headers.insert("authorization", format!("Bearer {}", token));
         headers.insert("x-databricks-zerobus-table-name", self.table_name.clone());
-        headers.insert("x-zerobus-sdk", DEFAULT_X_ZEROBUS_SDK.to_string());
         Ok(headers)
     }
 }

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -3,11 +3,6 @@ use crate::ZerobusResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-/// Default identifier the SDK sends as the HTTP `user-agent` header on every
-/// request. Use [`ZerobusSdkBuilder::application_name`](crate::ZerobusSdkBuilder::application_name)
-/// to append an application suffix.
-pub const DEFAULT_SDK_IDENTIFIER: &str = concat!("zerobus-sdk-rs/", env!("CARGO_PKG_VERSION"));
-
 /// A trait for providing custom headers for gRPC requests.
 ///
 /// This trait allows you to implement custom logic for generating authentication headers,

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -93,7 +93,7 @@ pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
 pub use errors::ZerobusError;
-pub use headers_provider::{HeadersProvider, OAuthHeadersProvider, DEFAULT_SDK_IDENTIFIER};
+pub use headers_provider::{HeadersProvider, OAuthHeadersProvider};
 pub use offset_generator::{OffsetId, OffsetIdGenerator};
 pub use proxy::{ConnectorFactory, ProxyConnector};
 pub use record_types::{
@@ -229,6 +229,11 @@ pub struct ZerobusStream {
     /// Callback handler task that executes callbacks in a separate thread.
     callback_handler_task: Option<tokio::task::JoinHandle<()>>,
 }
+
+/// Default identifier the SDK sends as the HTTP `user-agent` header on every
+/// request. Use [`ZerobusSdkBuilder::application_name`] to append an
+/// application suffix.
+pub const DEFAULT_SDK_IDENTIFIER: &str = concat!("zerobus-sdk-rs/", env!("CARGO_PKG_VERSION"));
 
 /// The main interface for interacting with the Zerobus API.
 /// # Examples

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -268,6 +268,9 @@ pub struct ZerobusSdk {
     pub(crate) workspace_id: String,
     pub(crate) tls_config: Arc<dyn TlsConfig>,
     connector_factory: Option<ConnectorFactory>,
+    /// Final value sent in the `x-zerobus-sdk` gRPC header on every request.
+    /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
+    pub(crate) sdk_identifier: Arc<str>,
 }
 
 impl ZerobusSdk {
@@ -382,6 +385,7 @@ impl ZerobusSdk {
             shared_channel: tokio::sync::Mutex::new(None),
             tls_config: Arc::new(SecureTlsConfig::new()),
             connector_factory: None,
+            sdk_identifier: Arc::from(DEFAULT_X_ZEROBUS_SDK),
         })
     }
 
@@ -394,7 +398,14 @@ impl ZerobusSdk {
         workspace_id: String,
         tls_config: Arc<dyn TlsConfig>,
         connector_factory: Option<ConnectorFactory>,
+        application_name: Option<String>,
     ) -> Self {
+        let sdk_identifier: Arc<str> = match application_name {
+            Some(app) if !app.is_empty() => {
+                Arc::from(format!("{} {}", DEFAULT_X_ZEROBUS_SDK, app))
+            }
+            _ => Arc::from(DEFAULT_X_ZEROBUS_SDK),
+        };
         #[allow(deprecated)]
         ZerobusSdk {
             zerobus_endpoint,
@@ -404,6 +415,7 @@ impl ZerobusSdk {
             shared_channel: tokio::sync::Mutex::new(None),
             tls_config,
             connector_factory,
+            sdk_identifier,
         }
     }
 
@@ -567,6 +579,7 @@ impl ZerobusSdk {
             table_properties,
             Arc::clone(&headers_provider),
             options,
+            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -629,6 +642,7 @@ impl ZerobusSdk {
             stream.table_properties.clone(),
             Arc::clone(&stream.headers_provider),
             stream.options.clone(),
+            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -809,6 +823,7 @@ impl ZerobusSdk {
             table_properties,
             headers_provider,
             options,
+            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -887,6 +902,7 @@ impl ZerobusSdk {
             stream.table_properties().clone(),
             stream.headers_provider(),
             stream.options().clone(),
+            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -962,6 +978,7 @@ impl ZerobusStream {
         table_properties: TableProperties,
         headers_provider: Arc<dyn HeadersProvider>,
         options: StreamConfigurationOptions,
+        sdk_identifier: Arc<str>,
     ) -> ZerobusResult<Self> {
         let (stream_init_result_tx, stream_init_result_rx) =
             tokio::sync::oneshot::channel::<ZerobusResult<String>>();
@@ -1006,6 +1023,7 @@ impl ZerobusStream {
             server_error_tx,
             cancellation_token.clone(),
             callback_tx.clone(),
+            Arc::clone(&sdk_identifier),
         ));
         let stream_id = Some(stream_init_result_rx.await.map_err(|_| {
             ZerobusError::UnexpectedStreamResponseError(
@@ -1054,6 +1072,7 @@ impl ZerobusStream {
         server_error_tx: tokio::sync::watch::Sender<Option<ZerobusError>>,
         cancellation_token: CancellationToken,
         callback_tx: Option<tokio::sync::mpsc::UnboundedSender<CallbackMessage>>,
+        sdk_identifier: Arc<str>,
     ) -> ZerobusResult<()> {
         let mut initial_stream_creation = true;
         let mut stream_init_result_tx = Some(stream_init_result_tx);
@@ -1079,6 +1098,7 @@ impl ZerobusStream {
                 let table_properties = table_properties.clone();
                 let headers_provider = Arc::clone(&headers_provider);
                 let record_type = options.record_type;
+                let sdk_identifier = Arc::clone(&sdk_identifier);
 
                 async move {
                     tokio::time::timeout(
@@ -1088,6 +1108,7 @@ impl ZerobusStream {
                             &table_properties,
                             &headers_provider,
                             record_type,
+                            &sdk_identifier,
                         ),
                     )
                     .await
@@ -1246,6 +1267,7 @@ impl ZerobusStream {
         table_properties: &TableProperties,
         headers_provider: &Arc<dyn HeadersProvider>,
         record_type: RecordType,
+        sdk_identifier: &str,
     ) -> ZerobusResult<(
         tokio::sync::mpsc::Sender<EphemeralStreamRequest>,
         tonic::Streaming<EphemeralStreamResponse>,
@@ -1273,6 +1295,9 @@ impl ZerobusStream {
                     auth_value.set_sensitive(true);
                     stream_metadata.insert("authorization", auth_value);
                 }
+                "x-zerobus-sdk" => {
+                    // Owned by the SDK (set below); ignore provider-supplied values.
+                }
                 other_key => {
                     let header_value = MetadataValue::try_from(value.as_str())
                         .map_err(|_| ZerobusError::InvalidArgument(other_key.to_string()))?;
@@ -1280,6 +1305,14 @@ impl ZerobusStream {
                 }
             }
         }
+
+        let sdk_identifier_value = MetadataValue::try_from(sdk_identifier).map_err(|_| {
+            ZerobusError::InvalidArgument(format!(
+                "invalid x-zerobus-sdk value: {}",
+                sdk_identifier
+            ))
+        })?;
+        stream_metadata.insert("x-zerobus-sdk", sdk_identifier_value);
 
         let mut response_grpc_stream = channel
             .ephemeral_stream(request_stream)

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -93,7 +93,7 @@ pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
 pub use errors::ZerobusError;
-pub use headers_provider::{HeadersProvider, OAuthHeadersProvider, DEFAULT_X_ZEROBUS_SDK};
+pub use headers_provider::{HeadersProvider, OAuthHeadersProvider, DEFAULT_SDK_IDENTIFIER};
 pub use offset_generator::{OffsetId, OffsetIdGenerator};
 pub use proxy::{ConnectorFactory, ProxyConnector};
 pub use record_types::{
@@ -268,7 +268,7 @@ pub struct ZerobusSdk {
     pub(crate) workspace_id: String,
     pub(crate) tls_config: Arc<dyn TlsConfig>,
     connector_factory: Option<ConnectorFactory>,
-    /// Final value sent in the `x-zerobus-sdk` gRPC header on every request.
+    /// Final value sent as the HTTP `user-agent` header on every request.
     /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
     pub(crate) sdk_identifier: Arc<str>,
 }
@@ -385,7 +385,7 @@ impl ZerobusSdk {
             shared_channel: tokio::sync::Mutex::new(None),
             tls_config: Arc::new(SecureTlsConfig::new()),
             connector_factory: None,
-            sdk_identifier: Arc::from(DEFAULT_X_ZEROBUS_SDK),
+            sdk_identifier: Arc::from(DEFAULT_SDK_IDENTIFIER),
         })
     }
 
@@ -401,8 +401,8 @@ impl ZerobusSdk {
         application_name: Option<String>,
     ) -> Self {
         let sdk_identifier: Arc<str> = match application_name {
-            Some(app) if !app.is_empty() => Arc::from(format!("{} {}", DEFAULT_X_ZEROBUS_SDK, app)),
-            _ => Arc::from(DEFAULT_X_ZEROBUS_SDK),
+            Some(app) if !app.is_empty() => Arc::from(format!("{} {}", DEFAULT_SDK_IDENTIFIER, app)),
+            _ => Arc::from(DEFAULT_SDK_IDENTIFIER),
         };
         #[allow(deprecated)]
         ZerobusSdk {

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -396,19 +396,18 @@ impl ZerobusSdk {
 
     /// Creates a new SDK instance with explicit configuration.
     ///
-    /// This is used internally by the builder pattern.
+    /// This is used internally by the builder pattern. `sdk_identifier` is the
+    /// fully-resolved value sent as the HTTP `user-agent` header; the builder
+    /// is responsible for composing it from the default prefix and any
+    /// caller-supplied `application_name` or override.
     pub(crate) fn new_with_config(
         zerobus_endpoint: String,
         unity_catalog_url: String,
         workspace_id: String,
         tls_config: Arc<dyn TlsConfig>,
         connector_factory: Option<ConnectorFactory>,
-        application_name: Option<String>,
+        sdk_identifier: Arc<str>,
     ) -> Self {
-        let sdk_identifier: Arc<str> = match application_name {
-            Some(app) if !app.is_empty() => Arc::from(format!("{} {}", DEFAULT_SDK_IDENTIFIER, app)),
-            _ => Arc::from(DEFAULT_SDK_IDENTIFIER),
-        };
         #[allow(deprecated)]
         ZerobusSdk {
             zerobus_endpoint,

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -577,7 +577,6 @@ impl ZerobusSdk {
             table_properties,
             Arc::clone(&headers_provider),
             options,
-            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -640,7 +639,6 @@ impl ZerobusSdk {
             stream.table_properties.clone(),
             Arc::clone(&stream.headers_provider),
             stream.options.clone(),
-            Arc::clone(&self.sdk_identifier),
         )
         .await;
 
@@ -935,6 +933,8 @@ impl ZerobusSdk {
         if guard.is_none() {
             // Create the channel for the first time.
             let endpoint = Endpoint::from_shared(self.zerobus_endpoint.clone())
+                .map_err(|err| ZerobusError::ChannelCreationError(err.to_string()))?
+                .user_agent(self.sdk_identifier.as_ref())
                 .map_err(|err| ZerobusError::ChannelCreationError(err.to_string()))?;
 
             let endpoint = self.tls_config.configure_endpoint(endpoint)?;
@@ -976,7 +976,6 @@ impl ZerobusStream {
         table_properties: TableProperties,
         headers_provider: Arc<dyn HeadersProvider>,
         options: StreamConfigurationOptions,
-        sdk_identifier: Arc<str>,
     ) -> ZerobusResult<Self> {
         let (stream_init_result_tx, stream_init_result_rx) =
             tokio::sync::oneshot::channel::<ZerobusResult<String>>();
@@ -1021,7 +1020,6 @@ impl ZerobusStream {
             server_error_tx,
             cancellation_token.clone(),
             callback_tx.clone(),
-            Arc::clone(&sdk_identifier),
         ));
         let stream_id = Some(stream_init_result_rx.await.map_err(|_| {
             ZerobusError::UnexpectedStreamResponseError(
@@ -1070,7 +1068,6 @@ impl ZerobusStream {
         server_error_tx: tokio::sync::watch::Sender<Option<ZerobusError>>,
         cancellation_token: CancellationToken,
         callback_tx: Option<tokio::sync::mpsc::UnboundedSender<CallbackMessage>>,
-        sdk_identifier: Arc<str>,
     ) -> ZerobusResult<()> {
         let mut initial_stream_creation = true;
         let mut stream_init_result_tx = Some(stream_init_result_tx);
@@ -1096,7 +1093,6 @@ impl ZerobusStream {
                 let table_properties = table_properties.clone();
                 let headers_provider = Arc::clone(&headers_provider);
                 let record_type = options.record_type;
-                let sdk_identifier = Arc::clone(&sdk_identifier);
 
                 async move {
                     tokio::time::timeout(
@@ -1106,7 +1102,6 @@ impl ZerobusStream {
                             &table_properties,
                             &headers_provider,
                             record_type,
-                            &sdk_identifier,
                         ),
                     )
                     .await
@@ -1265,7 +1260,6 @@ impl ZerobusStream {
         table_properties: &TableProperties,
         headers_provider: &Arc<dyn HeadersProvider>,
         record_type: RecordType,
-        sdk_identifier: &str,
     ) -> ZerobusResult<(
         tokio::sync::mpsc::Sender<EphemeralStreamRequest>,
         tonic::Streaming<EphemeralStreamResponse>,
@@ -1293,9 +1287,6 @@ impl ZerobusStream {
                     auth_value.set_sensitive(true);
                     stream_metadata.insert("authorization", auth_value);
                 }
-                "x-zerobus-sdk" => {
-                    // Owned by the SDK (set below); ignore provider-supplied values.
-                }
                 other_key => {
                     let header_value = MetadataValue::try_from(value.as_str())
                         .map_err(|_| ZerobusError::InvalidArgument(other_key.to_string()))?;
@@ -1303,14 +1294,6 @@ impl ZerobusStream {
                 }
             }
         }
-
-        let sdk_identifier_value = MetadataValue::try_from(sdk_identifier).map_err(|_| {
-            ZerobusError::InvalidArgument(format!(
-                "invalid x-zerobus-sdk value: {}",
-                sdk_identifier
-            ))
-        })?;
-        stream_metadata.insert("x-zerobus-sdk", sdk_identifier_value);
 
         let mut response_grpc_stream = channel
             .ephemeral_stream(request_stream)

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -401,9 +401,7 @@ impl ZerobusSdk {
         application_name: Option<String>,
     ) -> Self {
         let sdk_identifier: Arc<str> = match application_name {
-            Some(app) if !app.is_empty() => {
-                Arc::from(format!("{} {}", DEFAULT_X_ZEROBUS_SDK, app))
-            }
+            Some(app) if !app.is_empty() => Arc::from(format!("{} {}", DEFAULT_X_ZEROBUS_SDK, app)),
             _ => Arc::from(DEFAULT_X_ZEROBUS_SDK),
         };
         #[allow(deprecated)]


### PR DESCRIPTION
  ## Summary
  - Adds `ZerobusSdkBuilder::application_name(...)` so callers can append a custom identifier to the `x-zerobus-sdk` gRPC metadata header (e.g. `zerobus-sdk-rs/1.3.0 my-app/1.0`). The SDK version
  prefix is preserved so server-side telemetry still sees the SDK version.
  - Moves `x-zerobus-sdk` injection from `OAuthHeadersProvider` to the gRPC layer. The SDK now owns this header on both the proto stream and Arrow Flight paths; any `x-zerobus-sdk` value returned by
  a custom `HeadersProvider` is ignored.
  - `OAuthHeadersProvider::get_headers` no longer sets `x-zerobus-sdk` (now redundant). `DEFAULT_X_ZEROBUS_SDK` remains exported.

The intent is to set the application name in the vector zerobus sink so we know how much traffic is from vector.

  ## Motivation
  Embedders (e.g. Vector) want to identify their application in server-side telemetry without having to implement a custom `HeadersProvider` solely to set one header. Making this a first-class
  builder option also guarantees the SDK version prefix can't be accidentally dropped by a buggy custom provider.

  ## Behavior change
  Custom `HeadersProvider` implementations that previously set their own `x-zerobus-sdk` value will now have that value silently overridden by the SDK-owned one. Use `.application_name(...)` to
  customize. Noted in `NEXT_CHANGELOG.md`.

  ## Test plan
  - [x] `cargo test --release` — all 107 unit + 80 arrow + integration tests pass
  - [x] `cargo clippy --release --all-targets` clean (only pre-existing warnings)
  - [x] New unit tests cover default, custom, and empty-string `application_name` cases
  - [ ] **Follow-up:** add mock-server integration tests asserting the header lands on the wire (proto + Arrow paths) and that provider-supplied values are overridden. Current tests verify
  composition logic but not wire behavior.
  - [ ] Manual smoke against a real Zerobus endpoint to confirm server-side telemetry receives the expected value

  Two notes:
  - I left the wire-level test as an unchecked follow-up rather than claiming coverage we don't have — flag it for yourself or me to address before merge.
  - If you'd rather not advertise the behavior change to custom-provider users in the PR body (it's already in the changelog), drop the "Behavior change" section.
