### PR TITLE
[Rust] Version 1.3.0

### DIFF
--- a/python/rust/Cargo.lock
+++ b/python/rust/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow-array",
  "arrow-flight",
@@ -1469,7 +1469,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Version changelog
 
+## Release v1.3.0
+
+### New Features and Improvements
+
+- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers.
+- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (milliseconds) on how long to wait during that paused phase (`None` = use full server duration, `Some(0)` = recover immediately, `Some(x)` = wait up to `min(x, server_duration)`).
+- Added `ZerobusSdkBuilder::connector_factory` for programmatic proxy
+  configuration. Callers can install a `ConnectorFactory` (a
+  `Fn(&str) -> Option<ProxyConnector>` closure) that fully overrides the
+  default env-var proxy detection — useful for embedders that already model
+  proxy config in their own configuration system (e.g. Vector's `ProxyConfig`).
+  When no factory is installed, the existing `grpc_proxy` / `https_proxy` /
+  `http_proxy` env-var behavior is unchanged.
+- The env-var proxy path now supports `https://` proxy URLs. The client→proxy
+  hop does a TLS handshake using the system trust store; the CONNECT tunnel
+  still carries raw TCP so tonic applies end-to-end TLS to the target endpoint
+  on top.
+- **`StreamBuilder` API**: New fluent builder for creating ingestion streams.
+  Setters can be called in any order; the builder validates at `build()` time
+  that both authentication and format have been configured.
+
+### Bug Fixes
+
+- **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
+- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
+- **`StreamBuilder::stream_paused_max_wait_time_ms`**: Now updates Arrow stream settings (`arrow_config`) as well as JSON/proto gRPC settings, so `.build_arrow()` respects this option (previously only JSON/proto streams saw the value).
+
+### Internal Changes
+
+- Reduced log verbosity in `wait_for_offset` / `wait_for_acks` polling loops.
+  Per-iteration progress logs are now emitted at `trace` level, and the
+  one-shot "completed" log is now at `debug` level (previously `info`). This
+  removes repeated `info`-level noise observed when callers wait for flushes
+  or graceful close.
+
+### Deprecations
+
+- **`ZerobusSdk::create_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).json().build().await` instead
+- **`ZerobusSdk::create_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).json().build().await` instead
+- **`ZerobusSdk::create_arrow_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).arrow(schema).build_arrow().await` instead
+- **`ZerobusSdk::create_arrow_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).arrow(schema).build_arrow().await` instead
+
+### API Changes
+
+- New public exports: `ProxyConnector`, `ConnectorFactory`, `StreamBuilder`.
+- New builder method: `ZerobusSdkBuilder::connector_factory`.
+- New entry point: `ZerobusSdk::stream_builder()`.
+- Changed `ZerobusSdk` fields `workspace_id` and `tls_config` to `pub(crate)` visibility (no public API impact).
+
 ## Release v1.2.0
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,57 +1,19 @@
 # NEXT CHANGELOG
 
-## Release v1.3.0
+## Release v1.4.0
 
 ### Major Changes
 
 ### New Features and Improvements
 
-- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers.
-- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (milliseconds) on how long to wait during that paused phase (`None` = use full server duration, `Some(0)` = recover immediately, `Some(x)` = wait up to `min(x, server_duration)`).
-- Added `ZerobusSdkBuilder::connector_factory` for programmatic proxy
-  configuration. Callers can install a `ConnectorFactory` (a
-  `Fn(&str) -> Option<ProxyConnector>` closure) that fully overrides the
-  default env-var proxy detection — useful for embedders that already model
-  proxy config in their own configuration system (e.g. Vector's `ProxyConfig`).
-  When no factory is installed, the existing `grpc_proxy` / `https_proxy` /
-  `http_proxy` env-var behavior is unchanged.
-- The env-var proxy path now supports `https://` proxy URLs. The client→proxy
-  hop does a TLS handshake using the system trust store; the CONNECT tunnel
-  still carries raw TCP so tonic applies end-to-end TLS to the target endpoint
-  on top.
-- **`StreamBuilder` API**: New fluent builder for creating ingestion streams.
-  Setters can be called in any order; the builder validates at `build()` time
-  that both authentication and format have been configured.
-
-
 ### Bug Fixes
-
-- **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
-- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
-- **`StreamBuilder::stream_paused_max_wait_time_ms`**: Now updates Arrow stream settings (`arrow_config`) as well as JSON/proto gRPC settings, so `.build_arrow()` respects this option (previously only JSON/proto streams saw the value).
 
 ### Documentation
 
 ### Internal Changes
 
-- Reduced log verbosity in `wait_for_offset` / `wait_for_acks` polling loops.
-  Per-iteration progress logs are now emitted at `trace` level, and the
-  one-shot "completed" log is now at `debug` level (previously `info`). This
-  removes repeated `info`-level noise observed when callers wait for flushes
-  or graceful close.
-
 ### Breaking Changes
 
 ### Deprecations
 
-- **`ZerobusSdk::create_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).json().build().await` instead
-- **`ZerobusSdk::create_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).json().build().await` instead
-- **`ZerobusSdk::create_arrow_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).arrow(schema).build_arrow().await` instead
-- **`ZerobusSdk::create_arrow_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).arrow(schema).build_arrow().await` instead
-
 ### API Changes
-
-- New public exports: `ProxyConnector`, `ConnectorFactory`, `StreamBuilder`.
-- New builder method: `ZerobusSdkBuilder::connector_factory`.
-- New entry point: `ZerobusSdk::stream_builder()`.
-- Changed `ZerobusSdk` fields `workspace_id` and `tls_config` to `pub(crate)` visibility (no public API impact).

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-databricks-zerobus-ingest-sdk = { path = "../sdk", version = "1.2.0", features = ["arrow-flight", "testing"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", version = "1.3.0", features = ["arrow-flight", "testing"] }
 
 # Arrow IPC for serializing/deserializing RecordBatches across the FFI boundary
 arrow-ipc = { version = "56.2.0", default-features = false }

--- a/rust/jni/Cargo.toml
+++ b/rust/jni/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 name = "zerobus_jni"
 
 [dependencies]
-databricks-zerobus-ingest-sdk = { path = "../sdk", version = "1.2.0", features = ["arrow-flight"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", version = "1.3.0", features = ["arrow-flight"] }
 jni = "0.21"
 tokio = { version = "1.42", features = ["rt-multi-thread", "sync"] }
 prost = "0.13"

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rust version 1.3.0:

### New Features and Improvements

- **Arrow Flight — graceful stream close**: When the server signals that the stream will close, the SDK enters a paused state: it stops sending new batches, drains in-flight acknowledgments up to a configurable wait, then recovers.
- **`stream_paused_max_wait_time_ms`** on `ArrowStreamConfigurationOptions`: Optional cap (milliseconds) on how long to wait during that paused phase (`None` = use full server duration, `Some(0)` = recover immediately, `Some(x)` = wait up to `min(x, server_duration)`).
- Added `ZerobusSdkBuilder::connector_factory` for programmatic proxy
  configuration. Callers can install a `ConnectorFactory` (a
  `Fn(&str) -> Option<ProxyConnector>` closure) that fully overrides the
  default env-var proxy detection — useful for embedders that already model
  proxy config in their own configuration system (e.g. Vector's `ProxyConfig`).
  When no factory is installed, the existing `grpc_proxy` / `https_proxy` /
  `http_proxy` env-var behavior is unchanged.
- The env-var proxy path now supports `https://` proxy URLs. The client→proxy
  hop does a TLS handshake using the system trust store; the CONNECT tunnel
  still carries raw TCP so tonic applies end-to-end TLS to the target endpoint
  on top.
- **`StreamBuilder` API**: New fluent builder for creating ingestion streams.
  Setters can be called in any order; the builder validates at `build()` time
  that both authentication and format have been configured.

### Bug Fixes

- **gRPC / HTTP/2 teardown on close and recovery**: Receive and send tasks now shut down with a per-stream `CancellationToken`, bounded waits before `abort`, and a separate `recv_drain_token` on the receiver. This avoids racing **`RST_STREAM` / `CANCEL`** from the client against **`END_STREAM`** from the server—failure modes that could show up as HTTP/2 protocol errors or broken pipe on the server.
- After the inbound receive loop exits, the response-stream drain is now split by exit reason: the close path (`recv_drain_token`) drains **inline** so the server sees `END_STREAM` before the client process exits and the runtime tears down; the recovery / error paths drain in a **detached** task so `flush()` and stream recovery aren't delayed.
- **`StreamBuilder::stream_paused_max_wait_time_ms`**: Now updates Arrow stream settings (`arrow_config`) as well as JSON/proto gRPC settings, so `.build_arrow()` respects this option (previously only JSON/proto streams saw the value).

### Internal Changes

- Reduced log verbosity in `wait_for_offset` / `wait_for_acks` polling loops.
  Per-iteration progress logs are now emitted at `trace` level, and the
  one-shot "completed" log is now at `debug` level (previously `info`). This
  removes repeated `info`-level noise observed when callers wait for flushes
  or graceful close.

### Deprecations

- **`ZerobusSdk::create_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).json().build().await` instead
- **`ZerobusSdk::create_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).json().build().await` instead
- **`ZerobusSdk::create_arrow_stream()`**: Use `sdk.stream_builder(table).oauth(id, secret).arrow(schema).build_arrow().await` instead
- **`ZerobusSdk::create_arrow_stream_with_headers_provider()`**: Use `sdk.stream_builder(table).headers_provider(p).arrow(schema).build_arrow().await` instead

### API Changes

- New public exports: `ProxyConnector`, `ConnectorFactory`, `StreamBuilder`.
- New builder method: `ZerobusSdkBuilder::connector_factory`.
- New entry point: `ZerobusSdk::stream_builder()`.
- Changed `ZerobusSdk` fields `workspace_id` and `tls_config` to `pub(crate)` visibility (no public API impact).

## How is this tested?

N/A