### PR TITLE
[Go] Preserve FFI archives in `go mod vendor`

### DIFF
--- a/go/CLAUDE.md
+++ b/go/CLAUDE.md
@@ -16,11 +16,11 @@ go/
 ├── build.go         # Build tags and cgo link directives
 ├── build_rust.sh    # Script to build the Rust FFI library
 ├── lib/             # Pre-built static libraries per platform
-│   ├── linux_x86_64/libzerobus_ffi.a
+│   ├── linux_amd64/libzerobus_ffi.a
 │   ├── linux_arm64/libzerobus_ffi.a
-│   ├── darwin_x86_64/libzerobus_ffi.a
+│   ├── darwin_amd64/libzerobus_ffi.a
 │   ├── darwin_arm64/libzerobus_ffi.a
-│   └── windows_x86_64/libzerobus_ffi.a
+│   └── windows_amd64/libzerobus_ffi.a
 ├── tests/           # Integration tests
 └── examples/        # Usage examples
 ```

--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 - **Reduced GC pressure in batch ingest FFI paths** ([#271](https://github.com/databricks/zerobus-sdk/issues/271)): `streamIngestJSONRecords` was allocating one heap-allocated closure per record per call (defer-in-loop). These closures are not pooled by the Go runtime, causing measurable allocation growth at high ingestion rates. Fixed by replacing N defers with a single closure. `streamIngestProtoRecords` was also allocating the pointer/length arrays on the Go heap and unnecessarily pinning them; both are now allocated in C memory via `C.malloc`.
+- **Vendoring support**: `go mod vendor` now preserves the prebuilt FFI archives under `lib/<GOOS>_<GOARCH>/` when downstream consumers vendor this module. Previously, cgo `#cgo LDFLAGS` paths were invisible to the vendor tool's dependency analysis, so vendored builds failed to link.
 
 ### Documentation
 

--- a/go/vendor_assets.go
+++ b/go/vendor_assets.go
@@ -1,0 +1,15 @@
+// This file exists only so `go mod vendor` preserves the prebuilt FFI
+// archives in lib/<GOOS>_<GOARCH>/, which are referenced by ffi.go via
+// `#cgo LDFLAGS`. cgo path strings are invisible to the vendor tool's
+// dependency analysis, but `//go:embed` directives are. The `//go:build
+// ignore` tag keeps the archives from being linked into any binary as
+// embedded bytes.
+//
+//go:build ignore
+
+package zerobus
+
+import "embed"
+
+//go:embed lib/*/libzerobus_ffi.a
+var _ embed.FS


### PR DESCRIPTION
## What changes are proposed in this pull request?

**WHAT**

1. Add `go/vendor_assets.go` — a `//go:build ignore`'d helper with `//go:embed lib/*/libzerobus_ffi.a`, so `go mod vendor` preserves the prebuilt static FFI libraries under `go/lib/<GOOS>_<GOARCH>/`. The `ignore` tag keeps the bytes from being linked into any binary.
2. Drive-by: fix stale `x86_64` → `amd64` paths in `go/CLAUDE.md`, which disagreed with the on-disk layout and `ffi.go`'s `#cgo LDFLAGS`.

**WHY**

`#cgo LDFLAGS` paths are invisible to `go mod vendor`'s dependency analysis, but `//go:embed` directives are. Without this helper, downstream `go mod vendor` users get a tree with the static libs stripped and builds fail at link time.

The glob (`lib/*/libzerobus_ffi.a`) was chosen over an explicit per-platform list because it auto-includes `darwin_amd64` / `darwin_arm64` once those land, and listing a platform whose `.a` doesn't yet exist makes `go mod vendor` fail outright.

`go/NEXT_CHANGELOG.md` updated under Bug Fixes.

## How is this tested?

- `go mod vendor` from a throwaway consumer module pulls in all three current `.a` files; empty platform dirs are silently skipped; new platforms are auto-included.
- `go build ./...` confirms `//go:build ignore` keeps the helper out of normal builds.