### PR TITLE
[Java] Add zero-copy ingestIpcBatch for Arrow Flight

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **Arrow Flight — graceful stream close**: On server signaled close, the client stops sending new batches, drains in-flight acknowledgments within a bounded wait, then recovers.
 - **`ArrowStreamConfigurationOptions`**: Added `streamPausedMaxWaitTimeMs` for the maximum time (milliseconds) to wait in the paused state during graceful close (`-1` = full server duration, `0` = immediate recovery).
+- **Arrow Flight — zero-copy IPC ingestion**: Added `ZerobusArrowStream.ingestIpcBatch(byte[])` for callers that already hold serialized Arrow IPC stream bytes. Forwards bytes directly into Flight wire format, skipping the deserialize → re-serialize round-trip performed by `ingestBatch(VectorSchemaRoot)`. Not compatible with streams configured with `ipcCompression`.
 
 ### Bug Fixes
 

--- a/java/src/main/java/com/databricks/zerobus/ZerobusArrowStream.java
+++ b/java/src/main/java/com/databricks/zerobus/ZerobusArrowStream.java
@@ -126,6 +126,33 @@ public class ZerobusArrowStream implements AutoCloseable {
     return Optional.of(nativeIngestBatch(nativeHandle, ipcBytes));
   }
 
+  /**
+   * Ingests a pre-serialized Arrow IPC batch (zero-copy path).
+   *
+   * <p>Use this when you already hold Arrow IPC stream bytes (e.g. produced by {@code
+   * ArrowStreamWriter}) and want to skip the deserialize → re-serialize round-trip performed by
+   * {@link #ingestBatch(VectorSchemaRoot)}. The bytes must form a valid Arrow IPC stream containing
+   * exactly one record batch whose schema matches the stream schema. Dictionary messages between
+   * the schema and the record batch are supported.
+   *
+   * <p>Cannot be used when the stream is configured with {@code ipcCompression} — the raw IPC bytes
+   * would not match the compression codec. Use {@link #ingestBatch(VectorSchemaRoot)} instead for
+   * compressed streams.
+   *
+   * @param ipcBytes Arrow IPC stream bytes containing exactly one record batch, or null/empty for a
+   *     no-op
+   * @return the offset ID assigned to this batch, or empty if {@code ipcBytes} is null or empty
+   * @throws ZerobusException if the stream is closed, the schema doesn't match, compression is
+   *     enabled, or another error occurs
+   */
+  public Optional<Long> ingestIpcBatch(byte[] ipcBytes) throws ZerobusException {
+    if (ipcBytes == null || ipcBytes.length == 0) {
+      return Optional.empty();
+    }
+    ensureOpen();
+    return Optional.of(nativeIngestIpcBatch(nativeHandle, ipcBytes));
+  }
+
   // ==================== Acknowledgment ====================
 
   /**
@@ -313,6 +340,8 @@ public class ZerobusArrowStream implements AutoCloseable {
   private static native void nativeDestroy(long handle);
 
   private native long nativeIngestBatch(long handle, byte[] batchData);
+
+  private native long nativeIngestIpcBatch(long handle, byte[] ipcBytes);
 
   private native void nativeWaitForOffset(long handle, long offset);
 

--- a/java/src/test/java/com/databricks/zerobus/ArrowIntegrationTest.java
+++ b/java/src/test/java/com/databricks/zerobus/ArrowIntegrationTest.java
@@ -3,6 +3,8 @@ package com.databricks.zerobus;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
@@ -11,6 +13,7 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -686,8 +689,109 @@ public class ArrowIntegrationTest {
   }
 
   // ===================================================================================
+  // Test 16: Arrow stream - zero-copy ingestIpcBatch happy path
+  // ===================================================================================
+
+  @Test
+  @Order(16)
+  @DisplayName("Arrow stream - ingestIpcBatch (zero-copy) happy path")
+  void testArrowIngestIpcBatch() throws Exception {
+    try (ZerobusSdk sdk = new ZerobusSdk(serverEndpoint, workspaceUrl);
+        BufferAllocator allocator = new RootAllocator()) {
+      ZerobusArrowStream stream =
+          sdk.createArrowStream(tableName, SCHEMA, clientId, clientSecret).join();
+
+      try {
+        byte[] ipcBytes;
+        try (VectorSchemaRoot batch = VectorSchemaRoot.create(SCHEMA, allocator)) {
+          fillBatch(batch, "test-arrow-ipc", 5);
+          ipcBytes = serializeBatchToIpc(batch);
+        }
+
+        long offset = stream.ingestIpcBatch(ipcBytes).get();
+        stream.waitForOffset(offset);
+
+        System.out.println("Arrow ingestIpcBatch: 5 rows ingested (offset: " + offset + ")");
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  // ===================================================================================
+  // Test 17: Arrow stream - ingestIpcBatch rejects with compression enabled
+  // ===================================================================================
+
+  @Test
+  @Order(17)
+  @DisplayName("Arrow stream - ingestIpcBatch rejects with ipcCompression set")
+  void testArrowIngestIpcBatchRejectsCompression() throws Exception {
+    ArrowStreamConfigurationOptions options =
+        ArrowStreamConfigurationOptions.builder()
+            .setIpcCompression(IPCCompressionType.ZSTD)
+            .build();
+
+    try (ZerobusSdk sdk = new ZerobusSdk(serverEndpoint, workspaceUrl);
+        BufferAllocator allocator = new RootAllocator()) {
+      ZerobusArrowStream stream =
+          sdk.createArrowStream(tableName, SCHEMA, clientId, clientSecret, options).join();
+
+      try {
+        byte[] ipcBytes;
+        try (VectorSchemaRoot batch = VectorSchemaRoot.create(SCHEMA, allocator)) {
+          fillBatch(batch, "test-arrow-ipc-compressed", 3);
+          ipcBytes = serializeBatchToIpc(batch);
+        }
+
+        ZerobusException ex =
+            assertThrows(ZerobusException.class, () -> stream.ingestIpcBatch(ipcBytes));
+        assertTrue(
+            ex.getMessage().toLowerCase().contains("compression"),
+            "Expected compression-rejection message, got: " + ex.getMessage());
+
+        System.out.println("Arrow ingestIpcBatch compression-rejection: correctly throws");
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  // ===================================================================================
+  // Test 18: Arrow stream - ingestIpcBatch null/empty bytes returns empty Optional
+  // ===================================================================================
+
+  @Test
+  @Order(18)
+  @DisplayName("Arrow stream - ingestIpcBatch null/empty returns empty Optional")
+  void testArrowIngestIpcBatchNullEmpty() throws Exception {
+    try (ZerobusSdk sdk = new ZerobusSdk(serverEndpoint, workspaceUrl)) {
+      ZerobusArrowStream stream =
+          sdk.createArrowStream(tableName, SCHEMA, clientId, clientSecret).join();
+
+      try {
+        assertFalse(stream.ingestIpcBatch(null).isPresent(), "null bytes should return empty");
+        assertFalse(
+            stream.ingestIpcBatch(new byte[0]).isPresent(), "empty bytes should return empty");
+        System.out.println("Arrow ingestIpcBatch null/empty: returns empty Optional");
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  // ===================================================================================
   // Helper
   // ===================================================================================
+
+  private static byte[] serializeBatchToIpc(VectorSchemaRoot batch) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ArrowStreamWriter writer = new ArrowStreamWriter(batch, null, Channels.newChannel(out))) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out.toByteArray();
+  }
 
   private static void fillBatch(VectorSchemaRoot batch, String prefix, int rowCount) {
     LargeVarCharVector nameVector = (LargeVarCharVector) batch.getVector("device_name");

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3405,6 +3405,7 @@ dependencies = [
  "arrow-array",
  "arrow-ipc",
  "arrow-schema",
+ "bytes",
  "databricks-zerobus-ingest-sdk",
  "jni",
  "prost",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Internal Changes
 
+- **JNI**: Added `nativeIngestIpcBatch` export wiring `ZerobusArrowStream::ingest_ipc_batch` through to the Java SDK. Internal to the Java wrapper; not part of the Rust public API.
+
 ### Breaking Changes
 
 ### Deprecations

--- a/rust/jni/Cargo.toml
+++ b/rust/jni/Cargo.toml
@@ -17,6 +17,7 @@ name = "zerobus_jni"
 databricks-zerobus-ingest-sdk = { path = "../sdk", version = "2.0.0", features = ["arrow-flight"] }
 jni.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+bytes.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 thiserror.workspace = true

--- a/rust/jni/src/arrow_stream.rs
+++ b/rust/jni/src/arrow_stream.rs
@@ -6,6 +6,7 @@
 use crate::class_cache::{as_jclass, get_class_cache};
 use crate::errors::{throw_from_zerobus_error, throw_zerobus_exception};
 use crate::runtime::block_on;
+use bytes::Bytes;
 use databricks_zerobus_ingest_sdk::ZerobusArrowStream;
 use jni::objects::{JByteArray, JClass, JObject, JValue};
 use jni::sys::{jboolean, jlong, JNI_FALSE, JNI_TRUE};
@@ -134,6 +135,55 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusArrowStream_nativeInge
 
         // Ingest the first batch
         stream.ingest_batch(batches.remove(0)).await
+    });
+
+    match result {
+        Ok(offset) => offset,
+        Err(e) => {
+            throw_from_zerobus_error(&mut env, &e);
+            -1
+        }
+    }
+}
+
+/// Ingest a pre-serialized Arrow IPC batch using the zero-copy path.
+///
+/// Forwards IPC bytes directly into Flight wire format without materializing a
+/// `RecordBatch`, skipping the deserialize → re-serialize round-trip performed by
+/// `nativeIngestBatch`. Returns `-1` and throws `ZerobusException` on error (e.g.
+/// when the stream is configured with `ipc_compression`).
+///
+/// # JNI Signature
+/// ```java
+/// private native long nativeIngestIpcBatch(long handle, byte[] ipcBytes);
+/// ```
+#[no_mangle]
+pub extern "system" fn Java_com_databricks_zerobus_ZerobusArrowStream_nativeIngestIpcBatch<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _obj: JObject<'local>,
+    handle: jlong,
+    ipc_bytes: JByteArray<'local>,
+) -> jlong {
+    let bytes: Vec<u8> = match env.convert_byte_array(ipc_bytes) {
+        Ok(b) => b,
+        Err(e) => {
+            throw_zerobus_exception(&mut env, &format!("Invalid IPC bytes: {}", e));
+            return -1;
+        }
+    };
+
+    let stream_handle = unsafe { NativeArrowStreamHandle::borrow_from_raw(handle) };
+
+    let result = block_on(async {
+        let mut guard = stream_handle.stream.lock().await;
+        let stream = guard.as_mut().ok_or_else(|| {
+            databricks_zerobus_ingest_sdk::ZerobusError::InvalidStateError(
+                "Arrow stream is closed".to_string(),
+            )
+        })?;
+        stream.ingest_ipc_batch(Bytes::from(bytes)).await
     });
 
     match result {


### PR DESCRIPTION
## What changes are proposed in this pull request?

  Adds `ZerobusArrowStream.ingestIpcBatch(byte[])` — a zero-copy ingestion path that forwards
   pre-serialized Arrow IPC bytes directly into the Flight wire format, skipping the
  deserialize → re-serialize round-trip performed by `ingestBatch(VectorSchemaRoot)`. Wires
  through a new `nativeIngestIpcBatch` JNI export to `ZerobusArrowStream::ingest_ipc_batch`
  in the Rust core.

  **Why:** the existing `ingestBatch` path materializes a `RecordBatch` JNI-side only to
  immediately re-encode it for Flight. Callers that already hold IPC bytes (e.g. from Kafka,
  files, network sources) had no way to skip this. The new method gives them one.

  Constraint: incompatible with streams configured with `ipcCompression` — raw IPC bytes
  wouldn't match the codec. Surfaces as a `ZerobusException`.

  ## How is this tested?

  - `mvn test -Dtest=ArrowIntegrationTest` against staging — 18 tests pass, including 3 new
  ones for this feature: happy-path ingest, compression-rejection, null/empty input.
  - `cargo clippy -p zerobus-jni -- -D warnings`, `cargo fmt --check`, `cargo test --lib` —
  clean.
  - `mvn spotless:check`, full Java unit tests — clean.