### PR TITLE
[Rust] Fix autochunking, Rust release v2.0.1, ffi release v1.2.1

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Version changelog
 
+## Release v2.0.1
+
+### Major Changes
+
+### New Features and Improvements
+
+### Bug Fixes
+
+- **Arrow Flight: fix race condition causing stale wire offsets after non-close-signal
+  recovery.** When a stream broke via a server error or ack timeout (rather than a graceful
+  close signal), the supervisor did not set the ingest-pause gate before starting reconnect.
+  A concurrent `ingest_batch` call could send a batch with a pre-recovery wire offset,
+  which the server rejects with error code 4002 (`NonIncrementalOffset`), exhausting
+  recovery retries and failing the entire stream. Fix: set `is_paused = true` immediately
+  when entering the retriable-error retry branch, symmetric with the existing close-signal
+  path.
+
+- **Arrow Flight: restore automatic batch chunking at 2 MiB.** Reverted the manual
+  zero-copy IPC encoding introduced in v2.0.0 back to `FlightDataEncoderBuilder`, which
+  automatically chunks large `RecordBatch` values at 2 MiB. The zero-copy refactor had
+  removed this chunking, causing large batches to exceed the server's message size limit of 10MB and be rejected. `ingest_ipc_batch` now deserialises IPC bytes into a `RecordBatch`
+  before encoding, so it correctly benefits from the same chunking and supports streams
+  with `ipc_compression` enabled.
+
+### Documentation
+
+### Internal Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.0.0
 
 ### New Features and Improvements
@@ -97,12 +131,12 @@
   `sdk.stream_builder().table(name).headers_provider(p).json()` /
   `.compiled_proto(desc).build().await` instead. Removed from all
   examples, documentation, and tests.
-- Removed `ZerobusSdk::create_arrow_stream()` *(feature `arrow-flight`)*
+- Removed `ZerobusSdk::create_arrow_stream()` _(feature `arrow-flight`)_
   (in deprecation since v1.3.0). Use
   `sdk.stream_builder().table(name).oauth(id, secret).arrow(schema).build_arrow().await`
   instead. Removed from all examples, documentation, and tests.
 - Removed `ZerobusSdk::create_arrow_stream_with_headers_provider()`
-  *(feature `arrow-flight`)* (in deprecation since v1.3.0). Use
+  _(feature `arrow-flight`)_ (in deprecation since v1.3.0). Use
   `sdk.stream_builder().table(name).headers_provider(p).arrow(schema).build_arrow().await`
   instead. Removed from all examples, documentation, and tests.
 - Removed `ZerobusStream::ingest_record()` (in deprecation since v0.4.0).
@@ -244,9 +278,11 @@
 ## Release v1.0.1
 
 ### Bug Fixes
+
 - Fixed TLS certificate validation failure when behind corporate VPN/proxy with MITM certificates (e.g., GlobalProtect). Changed `reqwest` TLS configuration from `rustls-tls` to `rustls-tls-native-roots` + `rustls-tls-webpki-roots`, so the SDK now loads CA certificates from the OS native trust store (respecting `SSL_CERT_FILE` and system certificate stores) while keeping bundled Mozilla roots as a fallback for minimal environments.
 
 ### New Features and Improvements
+
 - Exported `OAuthHeadersProvider` in the public API, allowing clients to directly construct and use the built-in OAuth 2.0 headers provider.
 
 ## Release v1.0.0
@@ -254,11 +290,13 @@
 GA release of the Databricks Zerobus Ingest SDK for Rust.
 
 ### New Features and Improvements
+
 - Added HTTP proxy support via standard environment variables (`grpc_proxy`, `https_proxy`, `http_proxy`), following gRPC core conventions. Proxied connections use HTTP CONNECT tunneling with end-to-end TLS. Supports `no_grpc_proxy` / `no_proxy` for bypass rules.
 
 ### Deprecations
 
 ### Bug Fixes
+
 - Fixed a rare race condition in `wait_for_offset_internal` where the actual server error (e.g., `InvalidArgument`) was lost and replaced by a generic `StreamClosedError`. This occurred when `error_rx.changed()` fired but `is_closed` had not yet been set by the supervisor, causing the error to be missed on the next loop iteration.
 
 ## Release v0.6.0
@@ -297,7 +335,6 @@ GA release of the Databricks Zerobus Ingest SDK for Rust.
 - **`ZerobusSdk::new()`**: Use `ZerobusSdk::builder()` instead
 - **`ZerobusSdk.use_tls` field**: TLS is now controlled via the `TlsConfig` trait passed to the builder
 
-
 ### Bug Fixes
 
 - **[Experimental] Record-based acknowledgment tracking for Arrow Flight streams**: Added cumulative record counting to support proper ack tracking and correct recovery when batches are auto-chunked.
@@ -309,7 +346,6 @@ GA release of the Databricks Zerobus Ingest SDK for Rust.
 - Updated all examples to demonstrate three data-passing approaches: auto-encoding/serializing wrappers, pre-encoded/serialized wrappers, and backward-compatible raw types
 
 ### Internal Changes
-
 
 ### API Changes
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -600,7 +600,7 @@ name = "example_arrow"
 version = "0.1.0"
 dependencies = [
  "arrow-array",
- "arrow-ipc",
+ "arrow-schema",
  "chrono",
  "databricks-zerobus-ingest-sdk",
  "tokio",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-ffi"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arrow-ipc",
  "async-trait",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v2.2.0
+## Release v2.1.0
 
 ### Major Changes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -20,10 +20,9 @@
 - **Arrow Flight: restore automatic batch chunking at 2 MiB.** Reverted the manual
   zero-copy IPC encoding introduced in v2.0.0 back to `FlightDataEncoderBuilder`, which
   automatically chunks large `RecordBatch` values at 2 MiB. The zero-copy refactor had
-  removed this chunking, causing large batches to exceed tonic's default 4 MiB server
-  decode limit and be silently dropped. `ingest_ipc_batch` now deserialises IPC bytes
-  into a `RecordBatch` before encoding, so it correctly benefits from the same chunking
-  and supports streams with `ipc_compression` enabled.
+  removed this chunking, causing large batches to exceed the server's message size limit of 10MB and be rejected. `ingest_ipc_batch` now deserialises IPC bytes into a `RecordBatch`
+  before encoding, so it correctly benefits from the same chunking and supports streams
+  with `ipc_compression` enabled.
 
 ### Documentation
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,6 +8,23 @@
 
 ### Bug Fixes
 
+- **Arrow Flight: fix race condition causing stale wire offsets after non-close-signal
+  recovery.** When a stream broke via a server error or ack timeout (rather than a graceful
+  close signal), the supervisor did not set the ingest-pause gate before starting reconnect.
+  A concurrent `ingest_batch` call could send a batch with a pre-recovery wire offset,
+  which the server rejects with error code 4002 (`NonIncrementalOffset`), exhausting
+  recovery retries and failing the entire stream. Fix: set `is_paused = true` immediately
+  when entering the retriable-error retry branch, symmetric with the existing close-signal
+  path.
+
+- **Arrow Flight: restore automatic batch chunking at 2 MiB.** Reverted the manual
+  zero-copy IPC encoding introduced in v2.0.0 back to `FlightDataEncoderBuilder`, which
+  automatically chunks large `RecordBatch` values at 2 MiB. The zero-copy refactor had
+  removed this chunking, causing large batches to exceed tonic's default 4 MiB server
+  decode limit and be silently dropped. `ingest_ipc_batch` now deserialises IPC bytes
+  into a `RecordBatch` before encoding, so it correctly benefits from the same chunking
+  and supports streams with `ipc_compression` enabled.
+
 ### Documentation
 
 ### Internal Changes

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,28 +1,12 @@
 # NEXT CHANGELOG
 
-## Release v2.1.0
+## Release v2.2.0
 
 ### Major Changes
 
 ### New Features and Improvements
 
 ### Bug Fixes
-
-- **Arrow Flight: fix race condition causing stale wire offsets after non-close-signal
-  recovery.** When a stream broke via a server error or ack timeout (rather than a graceful
-  close signal), the supervisor did not set the ingest-pause gate before starting reconnect.
-  A concurrent `ingest_batch` call could send a batch with a pre-recovery wire offset,
-  which the server rejects with error code 4002 (`NonIncrementalOffset`), exhausting
-  recovery retries and failing the entire stream. Fix: set `is_paused = true` immediately
-  when entering the retriable-error retry branch, symmetric with the existing close-signal
-  path.
-
-- **Arrow Flight: restore automatic batch chunking at 2 MiB.** Reverted the manual
-  zero-copy IPC encoding introduced in v2.0.0 back to `FlightDataEncoderBuilder`, which
-  automatically chunks large `RecordBatch` values at 2 MiB. The zero-copy refactor had
-  removed this chunking, causing large batches to exceed the server's message size limit of 10MB and be rejected. `ingest_ipc_batch` now deserialises IPC bytes into a `RecordBatch`
-  before encoding, so it correctly benefits from the same chunking and supports streams
-  with `ipc_compression` enabled.
 
 ### Documentation
 

--- a/rust/ffi/CHANGELOG.md
+++ b/rust/ffi/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Version changelog
 
+## Release v1.2.1
+
+### Major Changes
+
+### New Features and Improvements
+
+### Bug Fixes
+
+- **`zerobus_arrow_stream_ingest_batch_via_record_batch` now works correctly on compression-enabled streams.** Previously the function performed its own IPC deserialization and called `ingest_batch` directly, bypassing the compression re-encoding step. It now delegates to `ingest_ipc_batch`, which handles compression transparently. The function is now fully equivalent to `zerobus_arrow_stream_ingest_batch` regardless of stream configuration.
+
+### Documentation
+
+### Internal Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v1.2.0
 
 ### Major Changes
@@ -43,6 +63,7 @@
 Initial tracked release of the FFI C bindings for the Zerobus SDK.
 
 ### Platforms
+
 - Linux x86_64
 - Linux aarch64
 - macOS x86_64
@@ -50,6 +71,7 @@ Initial tracked release of the FFI C bindings for the Zerobus SDK.
 - Windows x86_64
 
 ### Libraries
+
 - Static library (.a / .lib)
 - Dynamic library (.so / .dylib / .dll)
 - C header file (zerobus.h)

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-ffi"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "C FFI bindings for the Zerobus Rust SDK"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-databricks-zerobus-ingest-sdk = { path = "../sdk", version = "2.0.0", features = ["arrow-flight", "testing"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", version = "2.0.1", features = ["arrow-flight", "testing"] }
 
 # Arrow IPC for serializing/deserializing RecordBatches across the FFI boundary
 arrow-ipc.workspace = true

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -123,20 +123,6 @@ fn ipc_bytes_to_schema(
     Ok(reader.schema().clone())
 }
 
-/// Deserializes the first `RecordBatch` from Arrow IPC stream bytes.
-#[allow(clippy::result_large_err)]
-fn ipc_bytes_to_record_batch(bytes: &[u8]) -> ZerobusResult<RecordBatch> {
-    use std::io::Cursor;
-    let cursor = Cursor::new(bytes);
-    let mut reader = StreamReader::try_new(cursor, None).map_err(|e| {
-        ZerobusError::InvalidArgument(format!("Failed to parse Arrow IPC stream: {e}"))
-    })?;
-    reader
-        .next()
-        .ok_or_else(|| ZerobusError::InvalidArgument("No record batch in IPC stream".to_string()))?
-        .map_err(|e| ZerobusError::InvalidArgument(format!("Failed to read Arrow IPC batch: {e}")))
-}
-
 /// Serializes a `RecordBatch` to Arrow IPC stream bytes (schema + one batch).
 #[allow(clippy::result_large_err)]
 fn record_batch_to_ipc_bytes(batch: &RecordBatch) -> ZerobusResult<Vec<u8>> {
@@ -388,11 +374,11 @@ pub extern "C" fn zerobus_arrow_stream_ingest_batch(
     }
 }
 
-/// Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes, deserializing
-/// to a `RecordBatch` first so that any configured `ipc_compression` is applied.
+/// Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes.
 ///
-/// Use this instead of `zerobus_arrow_stream_ingest_batch` when the stream was created
-/// with `LZ4_FRAME` or `ZSTD` compression.
+/// Equivalent to `zerobus_arrow_stream_ingest_batch`. Both functions deserialise the IPC
+/// bytes to a `RecordBatch` and re-encode with the stream's compression settings, so
+/// either works regardless of whether the stream was created with compression.
 /// Returns the logical offset assigned to this batch, or -1 on error.
 #[no_mangle]
 pub extern "C" fn zerobus_arrow_stream_ingest_batch_via_record_batch(
@@ -416,19 +402,11 @@ pub extern "C" fn zerobus_arrow_stream_ingest_batch_via_record_batch(
 
     let bytes = unsafe { std::slice::from_raw_parts(ipc_bytes, ipc_len) };
 
-    let batch = match ipc_bytes_to_record_batch(bytes) {
-        Ok(b) => b,
-        Err(e) => {
-            if !result.is_null() {
-                unsafe {
-                    *result = CResult::error(e);
-                }
-            }
-            return -1;
-        }
-    };
-
-    let offset_res = RUNTIME.block_on(async { stream_ref.ingest_batch(batch).await });
+    let offset_res = RUNTIME.block_on(async {
+        stream_ref
+            .ingest_ipc_batch(bytes::Bytes::copy_from_slice(bytes))
+            .await
+    });
 
     match offset_res {
         Ok(offset) => {

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -342,9 +342,8 @@ pub extern "C" fn zerobus_arrow_stream_free(stream: *mut CArrowStream) {
 /// Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes.
 ///
 /// `ipc_bytes` must be a valid Arrow IPC stream (schema + one record batch).
-/// Uses the zero-copy path (`ingest_ipc_batch`). If the stream was created with
-/// IPC compression, use `zerobus_arrow_stream_ingest_batch_via_record_batch` instead.
-/// Returns the logical offset assigned to this batch, or -1 on error.
+/// The bytes are deserialised to a RecordBatch internally. Works with all
+/// compression settings. Returns the logical offset assigned to this batch, or -1 on error.
 #[no_mangle]
 pub extern "C" fn zerobus_arrow_stream_ingest_batch(
     stream: *mut CArrowStream,

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -190,11 +190,11 @@ int64_t zerobus_arrow_stream_ingest_batch(struct CArrowStream *stream,
                                           struct CResult *result);
 
 /**
- * Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes, deserializing
- * to a `RecordBatch` first so that any configured `ipc_compression` is applied.
+ * Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes.
  *
- * Use this instead of `zerobus_arrow_stream_ingest_batch` when the stream was created
- * with `LZ4_FRAME` or `ZSTD` compression.
+ * Equivalent to `zerobus_arrow_stream_ingest_batch`. Both functions deserialise the IPC
+ * bytes to a `RecordBatch` and re-encode with the stream's compression settings, so
+ * either works regardless of whether the stream was created with compression.
  * Returns the logical offset assigned to this batch, or -1 on error.
  */
 int64_t zerobus_arrow_stream_ingest_batch_via_record_batch(struct CArrowStream *stream,

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -181,9 +181,8 @@ void zerobus_arrow_stream_free(struct CArrowStream *stream);
  * Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes.
  *
  * `ipc_bytes` must be a valid Arrow IPC stream (schema + one record batch).
- * Uses the zero-copy path (`ingest_ipc_batch`). If the stream was created with
- * IPC compression, use `zerobus_arrow_stream_ingest_batch_via_record_batch` instead.
- * Returns the logical offset assigned to this batch, or -1 on error.
+ * The bytes are deserialised to a RecordBatch internally. Works with all
+ * compression settings. Returns the logical offset assigned to this batch, or -1 on error.
  */
 int64_t zerobus_arrow_stream_ingest_batch(struct CArrowStream *stream,
                                           const uint8_t *ipc_bytes,

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -92,9 +92,6 @@ fn slice_batch_for_recovery(
     if remaining_rows == 0 {
         // Fully acked
         None
-    } else if records_already_acked == 0 {
-        // No records acked (shouldn't happen given first check, but be safe)
-        Some(pb.batch.clone())
     } else {
         // Partially acked - slice to get un-acked portion
         debug!(
@@ -668,7 +665,7 @@ impl ZerobusArrowStream {
                         // Pause ingest before reconnect so that concurrent ingest_batch
                         // callers don't push to pending_batches while reconnect is replaying.
                         // Symmetric with the close-signal path in process_acks.
-                        // The gate is lifted after a successful reconnect below.
+                        // The gate is lifted inside reconnect() while holding ingest_mutex.
                         is_paused.store(true, Ordering::Relaxed);
 
                         // Backoff before retry.
@@ -698,6 +695,7 @@ impl ZerobusArrowStream {
                                 &last_acked_records,
                                 &sdk_identifier,
                                 &ingest_mutex,
+                                &is_paused,
                             ),
                         )
                         .await;
@@ -706,11 +704,8 @@ impl ZerobusArrowStream {
                             Ok(Ok(new_response_stream)) => {
                                 info!("Supervisor: Recovery successful, resuming");
                                 recovery_attempts.store(0, Ordering::Relaxed);
-                                // Now that a fresh sender is installed and replay is done,
-                                // lift the pause gate. No await between here and the
-                                // ingest_mutex release in reconnect(), so woken
-                                // ingest_batch tasks cannot race through before this store.
-                                is_paused.store(false, Ordering::Relaxed);
+                                // is_paused was already cleared inside reconnect() while
+                                // holding ingest_mutex, so no action needed here.
                                 response_stream = new_response_stream;
                                 // Loop continues with new stream.
                             }
@@ -750,11 +745,11 @@ impl ZerobusArrowStream {
 
     /// Reconnects to the server and replays pending batches.
     ///
-    /// Holds `ingest_mutex` for the entire replay so that concurrent `ingest_batch`
-    /// callers cannot interleave with the replay. `is_paused` is set to `true` by
-    /// the supervisor before calling this, so callers that are not yet blocked on
-    /// the mutex will buffer into `pending_batches` and be picked up by the next
-    /// recovery cycle.
+    /// Holds `ingest_mutex` for the entire replay and clears `is_paused` before
+    /// releasing the mutex. This guarantees that any `ingest_batch` caller that
+    /// acquires the mutex after this function returns sees `is_paused = false` and
+    /// sends normally — there is no window in which a batch can be buffered but
+    /// never sent.
     #[allow(clippy::too_many_arguments)]
     async fn reconnect(
         endpoint: &str,
@@ -768,6 +763,7 @@ impl ZerobusArrowStream {
         last_acked_records: &Arc<AtomicU64>,
         sdk_identifier: &str,
         ingest_mutex: &Arc<Mutex<()>>,
+        is_paused: &Arc<AtomicBool>,
     ) -> ZerobusResult<Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>> {
         // Create new client.
         let client = Self::create_flight_client(
@@ -887,10 +883,12 @@ impl ZerobusArrowStream {
         // Replay pending batches, slicing partially-acked ones if present.
         // We rebuild the pending list to drop fully-acked batches.
         //
-        // Hold ingest_mutex for the entire replay so that concurrent ingest_batch
-        // callers (which are blocked on the mutex) cannot push new batches into
-        // pending_batches until the replay is finished and is_paused is cleared
-        // by the supervisor. Lock order matches ingest_batch: ingest_mutex -> pending_batches.
+        // Hold ingest_mutex for the entire replay and clear is_paused before
+        // releasing it. This ensures that any ingest_batch caller waiting on
+        // the mutex sees is_paused = false when it acquires — there is no window
+        // between the mutex release and the is_paused clear on which another
+        // thread could observe is_paused = true and silently buffer a batch.
+        // Lock order matches ingest_batch: ingest_mutex -> pending_batches.
         let _ingest_guard = ingest_mutex.lock().await;
         {
             let mut pending = pending_batches.lock().await;
@@ -933,6 +931,27 @@ impl ZerobusArrowStream {
                 cumulative_records_sent.store(new_cumulative, Ordering::Relaxed);
             }
         }
+
+        #[cfg(debug_assertions)]
+        {
+            let pending = pending_batches.lock().await;
+            let mut expected_start: u64 = 0;
+            for pb in pending.iter() {
+                debug_assert_eq!(
+                    pb.start_record, expected_start,
+                    "pending_batches has non-contiguous record ranges after recovery \
+                     (expected start_record = {}, found {} for offset_id {}); \
+                     possible orphaned buffered batch from pause-gate handoff race",
+                    expected_start, pb.start_record, pb.offset_id,
+                );
+                expected_start = pb.end_record;
+            }
+        }
+
+        // Clear the pause gate while still holding ingest_mutex. Any ingest_batch
+        // caller that acquires the mutex after this point will see is_paused = false
+        // and send normally.
+        is_paused.store(false, Ordering::Relaxed);
 
         Ok(response_stream)
     }

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -101,7 +101,10 @@ fn slice_batch_for_recovery(
             remaining_rows = remaining_rows,
             "Slicing partially-acked batch for recovery"
         );
-        Some(pb.batch.slice(records_already_acked as usize, remaining_rows))
+        Some(
+            pb.batch
+                .slice(records_already_acked as usize, remaining_rows),
+        )
     }
 }
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -665,10 +665,7 @@ impl ZerobusArrowStream {
                             "Supervisor: Attempting recovery after retriable error"
                         );
 
-                        // Pause ingest before reconnect so that concurrent ingest_batch
-                        // callers don't push to pending_batches while reconnect is replaying.
-                        // Symmetric with the close-signal path in process_acks.
-                        // The gate is lifted inside reconnect() while holding ingest_mutex.
+                        // Pause ingest before reconnect; gate is lifted inside reconnect().
                         is_paused.store(true, Ordering::Relaxed);
 
                         // Backoff before retry.
@@ -707,8 +704,7 @@ impl ZerobusArrowStream {
                             Ok(Ok(new_response_stream)) => {
                                 info!("Supervisor: Recovery successful, resuming");
                                 recovery_attempts.store(0, Ordering::Relaxed);
-                                // is_paused was already cleared inside reconnect() while
-                                // holding ingest_mutex, so no action needed here.
+                                // is_paused was already cleared inside reconnect().
                                 response_stream = new_response_stream;
                                 // Loop continues with new stream.
                             }
@@ -885,12 +881,6 @@ impl ZerobusArrowStream {
 
         // Replay pending batches, slicing partially-acked ones if present.
         // We rebuild the pending list to drop fully-acked batches.
-        //
-        // Hold ingest_mutex for the entire replay and clear is_paused before
-        // releasing it. This ensures that any ingest_batch caller waiting on
-        // the mutex sees is_paused = false when it acquires — there is no window
-        // between the mutex release and the is_paused clear on which another
-        // thread could observe is_paused = true and silently buffer a batch.
         // Lock order matches ingest_batch: ingest_mutex -> pending_batches.
         let _ingest_guard = ingest_mutex.lock().await;
         {
@@ -951,9 +941,7 @@ impl ZerobusArrowStream {
             }
         }
 
-        // Clear the pause gate while still holding ingest_mutex. Any ingest_batch
-        // caller that acquires the mutex after this point will see is_paused = false
-        // and send normally.
+        // Clear the pause gate while still holding ingest_mutex.
         is_paused.store(false, Ordering::Relaxed);
 
         Ok(response_stream)

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -7,15 +7,16 @@
 //! data into Databricks Delta tables using the Arrow Flight protocol.
 //! Native Rust callers use `ingest_batch` with `RecordBatch` values; FFI callers
 //! (Go, Python, Java, TypeScript) can use `ingest_ipc_batch` with pre-serialised
-//! Arrow IPC bytes to avoid an extra deserialisation round-trip.
+//! Arrow IPC bytes.
 
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
+use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
-use arrow_flight::{FlightClient, FlightData, PutResult, SchemaAsIpc};
-use arrow_ipc::writer::{CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
+use arrow_flight::{FlightClient, PutResult};
+use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, watch, Mutex};
@@ -38,29 +39,7 @@ use crate::tls_config::TlsConfig;
 use crate::ZerobusResult;
 
 /// Type alias for the batch sender channel, wrapped for thread-safe sharing.
-type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<FlightData, FlightError>>>>>;
-
-/// Payload stored in pending batches — either raw IPC bytes (from FFI callers) or a
-/// materialised RecordBatch (from native Rust callers).
-#[derive(Clone)]
-enum ArrowPayload {
-    /// Raw Arrow IPC stream bytes from FFI callers.
-    Ipc(Bytes),
-    /// A materialised RecordBatch from native Rust callers.
-    Batch(RecordBatch),
-}
-
-impl ArrowPayload {
-    /// Converts this payload to a [`RecordBatch`].
-    /// For `Ipc` variants this deserialises the IPC bytes.
-    #[allow(clippy::result_large_err)]
-    fn materialize(&self) -> ZerobusResult<RecordBatch> {
-        match self {
-            ArrowPayload::Batch(b) => Ok(b.clone()),
-            ArrowPayload::Ipc(bytes) => materialize_ipc(bytes),
-        }
-    }
-}
+type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
 
 /// Properties for an Arrow Flight ingestion table.
 ///
@@ -79,13 +58,9 @@ pub(crate) struct ArrowTableProperties {
 /// A pending batch waiting for acknowledgment.
 #[derive(Clone)]
 struct PendingBatch {
-    payload: ArrowPayload,
-    /// Logical (user-visible) offset ID assigned by the client for this batch.
-    /// Monotonic across the lifetime of the stream — never resets on recovery.
-    /// This is the value handed back from `ingest_batch` / `ingest_ipc_batch`
-    /// and broadcast on `last_ack_tx` so that `wait_for_offset` callers see a
-    /// monotonically non-decreasing acked offset.
-    logical_offset_id: OffsetId,
+    batch: RecordBatch,
+    /// Offset ID assigned by the client for this batch.
+    offset_id: OffsetId,
     /// Cumulative record count before this batch.
     start_record: u64,
     /// Cumulative record count after this batch.
@@ -98,58 +73,42 @@ struct PendingBatch {
 /// - If batch is fully acked: returns `None`
 /// - If batch is partially acked: returns sliced batch with only un-acked records
 /// - If batch is fully un-acked: returns the full batch
-#[allow(clippy::result_large_err)]
 fn slice_batch_for_recovery(
     pb: &PendingBatch,
     acked_before_disconnect: u64,
-) -> ZerobusResult<Option<ArrowPayload>> {
+) -> Option<RecordBatch> {
     if pb.start_record >= acked_before_disconnect {
-        return Ok(Some(pb.payload.clone()));
+        // Fully un-acked
+        return Some(pb.batch.clone());
     }
 
-    let total_rows = pb.end_record - pb.start_record;
-    let records_already_acked = (acked_before_disconnect - pb.start_record).min(total_rows);
-    let remaining_rows = total_rows.saturating_sub(records_already_acked);
+    let records_already_acked =
+        (acked_before_disconnect - pb.start_record).min(pb.batch.num_rows() as u64);
+    let remaining_rows = pb
+        .batch
+        .num_rows()
+        .saturating_sub(records_already_acked as usize);
 
     if remaining_rows == 0 {
         // Fully acked
-        Ok(None)
+        None
     } else if records_already_acked == 0 {
         // No records acked (shouldn't happen given first check, but be safe)
-        Ok(Some(pb.payload.clone()))
+        Some(pb.batch.clone())
     } else {
+        // Partially acked - slice to get un-acked portion
         debug!(
-            offset_id = pb.logical_offset_id,
-            total_rows = total_rows,
+            offset_id = pb.offset_id,
+            total_rows = pb.batch.num_rows(),
             records_already_acked = records_already_acked,
             remaining_rows = remaining_rows,
             "Slicing partially-acked batch for recovery"
         );
-        match &pb.payload {
-            ArrowPayload::Batch(b) => Ok(Some(ArrowPayload::Batch(
-                b.slice(records_already_acked as usize, remaining_rows as usize),
-            ))),
-            ArrowPayload::Ipc(bytes) => {
-                // Rare path: partially-acked IPC batch must be deserialised and sliced.
-                // TODO: zero-copy partial-ack recovery — slice IPC bytes at buffer level
-                // instead of materializing (tracked in #147).
-                let b = materialize_ipc(bytes).map_err(|e| {
-                    ZerobusError::InvalidArgument(format!(
-                        "IPC batch could not be deserialised for partial recovery (offset_id={}): {e}",
-                        pb.logical_offset_id
-                    ))
-                })?;
-                Ok(Some(ArrowPayload::Batch(b.slice(
-                    records_already_acked as usize,
-                    remaining_rows as usize,
-                ))))
-            }
-        }
+        Some(pb.batch.slice(records_already_acked as usize, remaining_rows))
     }
 }
 
 /// Deserialises Arrow IPC stream bytes into a [`RecordBatch`].
-/// Enforces the same single-batch contract as [`ipc_bytes_to_flight_data`].
 #[allow(clippy::result_large_err)]
 fn materialize_ipc(bytes: &Bytes) -> ZerobusResult<RecordBatch> {
     use std::io::Cursor;
@@ -181,156 +140,7 @@ fn materialize_ipc(bytes: &Bytes) -> ZerobusResult<RecordBatch> {
     }
 }
 
-/// Result of parsing raw Arrow IPC stream bytes: the extracted schema, row count,
-/// and FlightData messages (dictionary batches followed by the record batch).
-struct ParsedIpcBatch {
-    /// The Arrow schema extracted from the IPC stream.
-    schema: ArrowSchema,
-    /// Number of rows in the record batch.
-    num_rows: u64,
-    /// FlightData messages: dictionary batches (if any) followed by the record batch.
-    flight_data: Vec<FlightData>,
-}
-
-/// Converts raw Arrow IPC stream bytes into [`FlightData`] messages and metadata.
-///
-/// Parses the IPC stream without materialising Arrow arrays (zero-copy). Handles
-/// dictionary messages between the schema and the record batch, and enforces the
-/// single-batch contract (exactly one RecordBatch in the stream).
-///
-/// All offsets are rounded to 8-byte boundaries per the Arrow IPC encapsulated
-/// message format specification.
-#[allow(clippy::result_large_err)]
-fn ipc_bytes_to_flight_data(ipc_bytes: &Bytes) -> ZerobusResult<ParsedIpcBatch> {
-    let bytes = &ipc_bytes[..];
-
-    /// Round up to next 8-byte boundary (Arrow IPC alignment requirement).
-    fn align8(n: usize) -> usize {
-        (n + 7) & !7
-    }
-
-    #[allow(clippy::result_large_err)]
-    fn read_meta_range(bytes: &[u8], mut p: usize) -> ZerobusResult<(usize, usize)> {
-        // Optional continuation token (0xFFFFFFFF).
-        if p + 4 <= bytes.len() && bytes[p..p + 4] == [0xFF, 0xFF, 0xFF, 0xFF] {
-            p += 4;
-        }
-        if p + 4 > bytes.len() {
-            return Err(ZerobusError::InvalidArgument(
-                "IPC: truncated at length field".into(),
-            ));
-        }
-        let meta_len = i32::from_le_bytes([bytes[p], bytes[p + 1], bytes[p + 2], bytes[p + 3]]);
-        if meta_len <= 0 {
-            return Err(ZerobusError::InvalidArgument(
-                "IPC: invalid metadata length".into(),
-            ));
-        }
-        let meta_start = p + 4;
-        let meta_end = meta_start + meta_len as usize;
-        if meta_end > bytes.len() {
-            return Err(ZerobusError::InvalidArgument(
-                "IPC: truncated metadata".into(),
-            ));
-        }
-        Ok((meta_start, meta_end))
-    }
-
-    // Parse Schema message
-    let (ms, me) = read_meta_range(bytes, 0)?;
-    let schema_msg = arrow_ipc::root_as_message(&bytes[ms..me])
-        .map_err(|e| ZerobusError::InvalidArgument(format!("IPC flatbuffer: {e}")))?;
-    let fb_schema = schema_msg.header_as_schema().ok_or_else(|| {
-        ZerobusError::InvalidArgument("IPC: first message is not a Schema".into())
-    })?;
-    let schema = arrow_ipc::convert::fb_to_schema(fb_schema);
-    let after_schema = align8(me + schema_msg.bodyLength().max(0) as usize);
-    if after_schema > bytes.len() {
-        return Err(ZerobusError::InvalidArgument(
-            "IPC: truncated schema body".into(),
-        ));
-    }
-
-    // Walk remaining messages: collect dictionary batches, find the RecordBatch
-    let mut pos = after_schema;
-    let mut flight_data_messages: Vec<FlightData> = Vec::new();
-    let mut num_rows: Option<u64> = None;
-
-    while pos < bytes.len() {
-        // Check for end-of-stream marker (continuation token + zero-length metadata).
-        if pos + 8 <= bytes.len()
-            && bytes[pos..pos + 4] == [0xFF, 0xFF, 0xFF, 0xFF]
-            && bytes[pos + 4..pos + 8] == [0x00, 0x00, 0x00, 0x00]
-        {
-            break; // End-of-stream marker
-        }
-
-        let (msg_ms, msg_me) = match read_meta_range(bytes, pos) {
-            Ok(r) => r,
-            Err(_) => {
-                debug!(pos, "IPC: ignoring trailing bytes");
-                break;
-            }
-        };
-        let msg = arrow_ipc::root_as_message(&bytes[msg_ms..msg_me])
-            .map_err(|e| ZerobusError::InvalidArgument(format!("IPC flatbuffer: {e}")))?;
-        let body_end = align8(msg_me + msg.bodyLength().max(0) as usize);
-        if body_end > bytes.len() {
-            return Err(ZerobusError::InvalidArgument(
-                "IPC: truncated message body".into(),
-            ));
-        }
-
-        match msg.header_type() {
-            arrow_ipc::MessageHeader::DictionaryBatch => {
-                flight_data_messages.push(FlightData {
-                    data_header: ipc_bytes.slice(msg_ms..msg_me),
-                    data_body: ipc_bytes.slice(msg_me..body_end),
-                    ..Default::default()
-                });
-            }
-            arrow_ipc::MessageHeader::RecordBatch => {
-                if num_rows.is_some() {
-                    return Err(ZerobusError::InvalidArgument(
-                        "IPC stream must contain exactly one RecordBatch (found extra batch)"
-                            .into(),
-                    ));
-                }
-                let rb = msg.header_as_record_batch().ok_or_else(|| {
-                    ZerobusError::InvalidArgument(
-                        "IPC: RecordBatch header could not be parsed".into(),
-                    )
-                })?;
-                num_rows = Some(rb.length().max(0) as u64);
-                flight_data_messages.push(FlightData {
-                    data_header: ipc_bytes.slice(msg_ms..msg_me),
-                    data_body: ipc_bytes.slice(msg_me..body_end),
-                    ..Default::default()
-                });
-            }
-            _ => {
-                return Err(ZerobusError::InvalidArgument(format!(
-                    "IPC: unexpected message type {:?}",
-                    msg.header_type()
-                )));
-            }
-        }
-
-        pos = body_end;
-    }
-
-    let num_rows = num_rows.ok_or_else(|| {
-        ZerobusError::InvalidArgument("IPC stream contains no RecordBatch".into())
-    })?;
-
-    Ok(ParsedIpcBatch {
-        schema,
-        num_rows,
-        flight_data: flight_data_messages,
-    })
-}
-
-/// Encodes a schema into the first [`FlightData`] message for a DoPut stream.
+/// Builds [`IpcWriteOptions`] for the given optional compression codec.
 #[allow(clippy::result_large_err)]
 fn make_ipc_write_options(
     compression: Option<arrow_ipc::CompressionType>,
@@ -345,36 +155,6 @@ fn make_ipc_write_options(
                 ))
             }),
     }
-}
-
-fn schema_to_flight_data(schema: &ArrowSchema, opts: &IpcWriteOptions) -> FlightData {
-    SchemaAsIpc::new(schema, opts).into()
-}
-
-/// Serialises a [`RecordBatch`] into [`FlightData`] messages.
-///
-/// Returns dictionary FlightData messages (if the batch contains dictionary-encoded
-/// columns) followed by the record batch FlightData.
-#[allow(clippy::result_large_err)]
-fn record_batch_to_flight_data(
-    batch: &RecordBatch,
-    opts: &IpcWriteOptions,
-) -> ZerobusResult<Vec<FlightData>> {
-    let data_gen = IpcDataGenerator::default();
-    let mut dict_tracker = DictionaryTracker::new(true);
-    // Register dictionary IDs from the schema so encoded_batch can find them.
-    let _ = data_gen.schema_to_bytes_with_dictionary_tracker(
-        batch.schema_ref(),
-        &mut dict_tracker,
-        opts,
-    );
-    let mut compression_context = CompressionContext::default();
-    let (dict_batches, encoded) = data_gen
-        .encode(batch, &mut dict_tracker, opts, &mut compression_context)
-        .map_err(|e| ZerobusError::InvalidArgument(format!("Failed to encode RecordBatch: {e}")))?;
-    let mut flight_data: Vec<FlightData> = dict_batches.into_iter().map(Into::into).collect();
-    flight_data.push(encoded.into());
-    Ok(flight_data)
 }
 
 /// An Arrow Flight stream for ingesting Arrow RecordBatches into a Delta table.
@@ -421,22 +201,10 @@ pub struct ZerobusArrowStream {
     pub(crate) table_properties: ArrowTableProperties,
     /// Configuration options for this stream.
     pub(crate) options: ArrowStreamConfigurationOptions,
-    /// Channel to send FlightData to the encoder task.
+    /// Channel to send RecordBatches to the encoder task.
     batch_tx: BatchSender,
-    /// Generator for logical (user-visible) offset IDs.
-    ///
-    /// Monotonic across the lifetime of the stream — never reset on recovery.
-    /// The values returned by `ingest_batch` / `ingest_ipc_batch` come from
-    /// here, so that `wait_for_offset` semantics hold even if the underlying
-    /// Flight stream reconnects.
-    logical_offset_generator: Arc<OffsetIdGenerator>,
-    /// Generator for physical (wire) offset IDs sent in `FlightBatchMetadata`.
-    ///
-    /// The server enforces sequential offsets starting at 0 per Flight stream,
-    /// so this is reset to `0` on each successful reconnect (specifically,
-    /// repositioned to `replay_offset` so fresh ingests continue from where
-    /// the replay's wire offsets left off).
-    physical_offset_generator: Arc<OffsetIdGenerator>,
+    /// Generator for offset IDs returned from `ingest_batch` / `ingest_ipc_batch`.
+    offset_generator: OffsetIdGenerator,
     /// Watch channel for tracking the last acknowledged offset.
     last_ack_tx: tokio::sync::watch::Sender<Option<OffsetId>>,
     /// Receiver for the watch channel (kept alive to prevent sender errors).
@@ -448,7 +216,7 @@ pub struct ZerobusArrowStream {
     /// Batches that have been sent but not yet acknowledged (for recovery).
     pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
     /// Batches that failed and couldn't be recovered.
-    failed_batches: Arc<Mutex<Vec<ArrowPayload>>>,
+    failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
     /// Count of recovery attempts.
     recovery_attempts: Arc<AtomicU32>,
     /// Connection details for recovery.
@@ -510,8 +278,7 @@ impl ZerobusArrowStream {
             table_properties,
             options,
             batch_tx,
-            logical_offset_generator: Arc::new(OffsetIdGenerator::default()),
-            physical_offset_generator: Arc::new(OffsetIdGenerator::default()),
+            offset_generator: OffsetIdGenerator::default(),
             last_ack_tx,
             _last_ack_rx,
             is_closed,
@@ -602,7 +369,6 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.cumulative_records_sent),
             Arc::clone(&stream.last_acked_records),
             Arc::clone(&stream.is_paused),
-            Arc::clone(&stream.physical_offset_generator),
             Arc::clone(&stream.ingest_mutex),
             response_stream,
             Arc::clone(&stream.sdk_identifier),
@@ -632,7 +398,7 @@ impl ZerobusArrowStream {
         sdk_identifier: &str,
     ) -> ZerobusResult<(
         Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
-        mpsc::Sender<Result<FlightData, FlightError>>,
+        mpsc::Sender<Result<RecordBatch, FlightError>>,
     )> {
         let client = Self::create_flight_client(
             endpoint,
@@ -709,21 +475,41 @@ impl ZerobusArrowStream {
         options: &ArrowStreamConfigurationOptions,
     ) -> ZerobusResult<(
         Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
-        mpsc::Sender<Result<FlightData, FlightError>>,
+        mpsc::Sender<Result<RecordBatch, FlightError>>,
     )> {
-        // Create channel for sending pre-encoded FlightData.
-        // Metadata (offset IDs) is set by the sender before enqueueing, so the
-        // stream simply forwards messages as-is. Dictionary FlightData messages
-        // carry empty app_metadata; only the RecordBatch FlightData has offset info.
+        // Create channel for sending RecordBatches.
         let (batch_tx, batch_rx) =
-            mpsc::channel::<Result<FlightData, FlightError>>(options.max_inflight_batches);
+            mpsc::channel::<Result<RecordBatch, FlightError>>(options.max_inflight_batches);
 
         let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
-        let schema_fd = schema_to_flight_data(&table_properties.schema, &ipc_write_options);
-        let data_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
+        let schema = Arc::clone(&table_properties.schema);
+        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
 
-        let flight_data_stream =
-            futures::stream::once(futures::future::ready(Ok(schema_fd))).chain(data_stream);
+        // Build the Flight data stream. FlightDataEncoderBuilder handles schema
+        // framing, dictionary encoding, and automatic batch chunking at 2 MiB.
+        // Each non-schema FlightData message gets a sequential wire offset in
+        // its app_metadata (index 0 is the schema message; data messages start at 1).
+        let offset_counter = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let offset_counter_clone = Arc::clone(&offset_counter);
+        let flight_data_stream = FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .with_options(ipc_write_options)
+            .build(batch_stream)
+            .enumerate()
+            .map(move |(idx, result)| {
+                result.map(|mut flight_data| {
+                    // Skip schema message (idx 0); add metadata to data messages.
+                    if idx > 0 {
+                        let offset =
+                            offset_counter_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let metadata = FlightBatchMetadata::new(offset);
+                        if let Ok(bytes) = metadata.to_bytes() {
+                            flight_data.app_metadata = bytes.into();
+                        }
+                    }
+                    flight_data
+                })
+            });
 
         // Start the DoPut stream.
         let mut response_stream = client
@@ -810,13 +596,12 @@ impl ZerobusArrowStream {
         is_closed: Arc<AtomicBool>,
         last_ack_tx: tokio::sync::watch::Sender<Option<OffsetId>>,
         pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
-        failed_batches: Arc<Mutex<Vec<ArrowPayload>>>,
+        failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
         recovery_attempts: Arc<AtomicU32>,
         server_error_tx: watch::Sender<Option<ZerobusError>>,
         cumulative_records_sent: Arc<AtomicU64>,
         last_acked_records: Arc<AtomicU64>,
         is_paused: Arc<AtomicBool>,
-        physical_offset_generator: Arc<OffsetIdGenerator>,
         ingest_mutex: Arc<Mutex<()>>,
         initial_response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
         sdk_identifier: Arc<str>,
@@ -880,6 +665,12 @@ impl ZerobusArrowStream {
                             "Supervisor: Attempting recovery after retriable error"
                         );
 
+                        // Pause ingest before reconnect so that concurrent ingest_batch
+                        // callers don't push to pending_batches while reconnect is replaying.
+                        // Symmetric with the close-signal path in process_acks.
+                        // The gate is lifted after a successful reconnect below.
+                        is_paused.store(true, Ordering::Relaxed);
+
                         // Backoff before retry.
                         sleep(Duration::from_millis(options.recovery_backoff_ms)).await;
 
@@ -906,7 +697,6 @@ impl ZerobusArrowStream {
                                 &cumulative_records_sent,
                                 &last_acked_records,
                                 &sdk_identifier,
-                                &physical_offset_generator,
                                 &ingest_mutex,
                             ),
                         )
@@ -916,7 +706,10 @@ impl ZerobusArrowStream {
                             Ok(Ok(new_response_stream)) => {
                                 info!("Supervisor: Recovery successful, resuming");
                                 recovery_attempts.store(0, Ordering::Relaxed);
-                                // Now that a fresh sender is installed, lift the pause gate.
+                                // Now that a fresh sender is installed and replay is done,
+                                // lift the pause gate. No await between here and the
+                                // ingest_mutex release in reconnect(), so woken
+                                // ingest_batch tasks cannot race through before this store.
                                 is_paused.store(false, Ordering::Relaxed);
                                 response_stream = new_response_stream;
                                 // Loop continues with new stream.
@@ -956,6 +749,12 @@ impl ZerobusArrowStream {
     }
 
     /// Reconnects to the server and replays pending batches.
+    ///
+    /// Holds `ingest_mutex` for the entire replay so that concurrent `ingest_batch`
+    /// callers cannot interleave with the replay. `is_paused` is set to `true` by
+    /// the supervisor before calling this, so callers that are not yet blocked on
+    /// the mutex will buffer into `pending_batches` and be picked up by the next
+    /// recovery cycle.
     #[allow(clippy::too_many_arguments)]
     async fn reconnect(
         endpoint: &str,
@@ -968,7 +767,6 @@ impl ZerobusArrowStream {
         cumulative_records_sent: &Arc<AtomicU64>,
         last_acked_records: &Arc<AtomicU64>,
         sdk_identifier: &str,
-        physical_offset_generator: &Arc<OffsetIdGenerator>,
         ingest_mutex: &Arc<Mutex<()>>,
     ) -> ZerobusResult<Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>> {
         // Create new client.
@@ -984,14 +782,32 @@ impl ZerobusArrowStream {
 
         // Create new channel.
         let (tx, batch_rx) =
-            mpsc::channel::<Result<FlightData, FlightError>>(options.max_inflight_batches);
+            mpsc::channel::<Result<RecordBatch, FlightError>>(options.max_inflight_batches);
 
         let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
-        let schema_fd = schema_to_flight_data(&table_properties.schema, &ipc_write_options);
-        let data_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
+        let schema = Arc::clone(&table_properties.schema);
+        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
 
-        let flight_data_stream =
-            futures::stream::once(futures::future::ready(Ok(schema_fd))).chain(data_stream);
+        let offset_counter = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let offset_counter_clone = Arc::clone(&offset_counter);
+        let flight_data_stream = FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .with_options(ipc_write_options)
+            .build(batch_stream)
+            .enumerate()
+            .map(move |(idx, result)| {
+                result.map(|mut flight_data| {
+                    if idx > 0 {
+                        let offset =
+                            offset_counter_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let metadata = FlightBatchMetadata::new(offset);
+                        if let Ok(bytes) = metadata.to_bytes() {
+                            flight_data.app_metadata = bytes.into();
+                        }
+                    }
+                    flight_data
+                })
+            });
 
         // Start the DoPut stream.
         let mut flight_client = client;
@@ -1071,13 +887,11 @@ impl ZerobusArrowStream {
         // Replay pending batches, slicing partially-acked ones if present.
         // We rebuild the pending list to drop fully-acked batches.
         //
-        // The `ingest_mutex` is held for the entire replay so that concurrent
-        // `ingest_batch` callers cannot read a stale value from
-        // `physical_offset_generator` between the replay (which renumbers wire
-        // offsets from 0) and the generator reset at the end. Lock order
-        // matches `ingest_batch`: `ingest_mutex` -> `pending_batches`.
+        // Hold ingest_mutex for the entire replay so that concurrent ingest_batch
+        // callers (which are blocked on the mutex) cannot push new batches into
+        // pending_batches until the replay is finished and is_paused is cleared
+        // by the supervisor. Lock order matches ingest_batch: ingest_mutex -> pending_batches.
         let _ingest_guard = ingest_mutex.lock().await;
-        let mut replay_offset: i64 = 0;
         {
             let mut pending = pending_batches.lock().await;
             if !pending.is_empty() {
@@ -1091,58 +905,25 @@ impl ZerobusArrowStream {
                 let mut new_cumulative: u64 = 0;
 
                 for pb in pending.drain(..) {
-                    let payload = match slice_batch_for_recovery(&pb, acked_before_disconnect)? {
-                        None => {
-                            debug!(
-                                offset_id = pb.logical_offset_id,
-                                "Skipping fully-acked batch"
-                            );
-                            continue;
-                        }
-                        Some(p) => p,
+                    let Some(batch) = slice_batch_for_recovery(&pb, acked_before_disconnect) else {
+                        debug!(offset_id = pb.offset_id, "Skipping fully-acked batch");
+                        continue;
                     };
 
-                    let (flight_data_messages, num_records) = match &payload {
-                        ArrowPayload::Batch(b) => (
-                            record_batch_to_flight_data(b, &ipc_write_options).map_err(|e| {
-                                ZerobusError::InvalidArgument(format!(
-                                    "Failed to encode batch for replay: {e}"
-                                ))
-                            })?,
-                            b.num_rows() as u64,
-                        ),
-                        ArrowPayload::Ipc(bytes) => {
-                            let parsed = ipc_bytes_to_flight_data(bytes).map_err(|e| {
-                                ZerobusError::InvalidArgument(format!(
-                                    "Failed to encode batch for replay: {e}"
-                                ))
-                            })?;
-                            (parsed.flight_data, parsed.num_rows)
-                        }
-                    };
-
-                    let fd_count = flight_data_messages.len();
-                    for (i, mut fd) in flight_data_messages.into_iter().enumerate() {
-                        if i == fd_count - 1 {
-                            let metadata = FlightBatchMetadata::new(replay_offset);
-                            replay_offset += 1;
-                            if let Ok(bytes) = metadata.to_bytes() {
-                                fd.app_metadata = bytes.into();
-                            }
-                        }
-                        if tx.send(Ok(fd)).await.is_err() {
-                            return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                                "Failed to replay batch during recovery",
-                            )));
-                        }
+                    if tx.send(Ok(batch.clone())).await.is_err() {
+                        return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                            "Failed to replay batch during recovery",
+                        )));
                     }
+
+                    let num_records = batch.num_rows() as u64;
                     let start_record = new_cumulative;
                     let end_record = new_cumulative + num_records;
                     new_cumulative = end_record;
 
                     new_pending.push(PendingBatch {
-                        payload,
-                        logical_offset_id: pb.logical_offset_id,
+                        batch,
+                        offset_id: pb.offset_id,
                         start_record,
                         end_record,
                     });
@@ -1153,17 +934,13 @@ impl ZerobusArrowStream {
             }
         }
 
-        // Reposition the physical (wire) offset generator so the next fresh
-        // `ingest_batch` continues from where the replay left off.
-        physical_offset_generator.set_next(replay_offset);
-
         Ok(response_stream)
     }
 
     /// Moves all pending batches to the failed batches list.
     async fn move_pending_to_failed(
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
-        failed_batches: &Arc<Mutex<Vec<ArrowPayload>>>,
+        failed_batches: &Arc<Mutex<Vec<RecordBatch>>>,
     ) {
         let pending: Vec<PendingBatch> = {
             let mut pending_guard = pending_batches.lock().await;
@@ -1171,7 +948,7 @@ impl ZerobusArrowStream {
         };
         let mut failed = failed_batches.lock().await;
         for pb in pending {
-            failed.push(pb.payload);
+            failed.push(pb.batch);
         }
     }
 
@@ -1180,7 +957,8 @@ impl ZerobusArrowStream {
     /// Uses record-based tracking: the server sends `ack_up_to_records` indicating
     /// the cumulative number of records durably stored. We match this against
     /// pending batches' record ranges to determine which batches are fully acked.
-    /// This correctly handles Arrow Flight's automatic batch chunking.
+    /// This correctly handles batches that were split into multiple Flight chunks
+    /// by `FlightDataEncoderBuilder`.
     #[allow(clippy::too_many_arguments)]
     async fn process_acks(
         mut response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
@@ -1308,9 +1086,8 @@ impl ZerobusArrowStream {
                                     if acked_records >= pb.end_record {
                                         // Batch is fully acknowledged
                                         max_acked_offset = Some(
-                                            max_acked_offset.map_or(pb.logical_offset_id, |o| {
-                                                o.max(pb.logical_offset_id)
-                                            }),
+                                            max_acked_offset
+                                                .map_or(pb.offset_id, |o| o.max(pb.offset_id)),
                                         );
                                         false // Remove from pending
                                     } else {
@@ -1319,7 +1096,7 @@ impl ZerobusArrowStream {
                                 });
                             }
 
-                            // Notify waiters of the highest acknowledged logical offset.
+                            // Notify waiters of the highest acknowledged offset.
                             if let Some(offset) = max_acked_offset {
                                 let _ = last_ack_tx.send(Some(offset));
                             }
@@ -1384,96 +1161,9 @@ impl ZerobusArrowStream {
         }
     }
 
-    /// Shared send path for both `ingest_batch` and `ingest_ipc_batch`.
-    ///
-    /// Sends all `flight_data_messages` (dictionary batches followed by the record batch)
-    /// in order. Caller must hold `ingest_mutex` and must have already updated
-    /// `cumulative_records_sent`.
-    async fn send_flight_data_internal(
-        &self,
-        payload: ArrowPayload,
-        flight_data_messages: Vec<FlightData>,
-        logical_offset_id: OffsetId,
-        physical_offset_id: OffsetId,
-        start_record: u64,
-        end_record: u64,
-    ) -> ZerobusResult<OffsetId> {
-        {
-            let mut pending = self.pending_batches.lock().await;
-            pending.push(PendingBatch {
-                payload,
-                logical_offset_id,
-                start_record,
-                end_record,
-            });
-        }
-
-        if self.is_paused.load(Ordering::Relaxed) {
-            return Ok(logical_offset_id);
-        }
-
-        let sender = {
-            let guard = self.batch_tx.lock().await;
-            guard.clone()
-        };
-
-        let sender = match sender {
-            Some(s) => s,
-            None => {
-                if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                    return Err(server_error);
-                }
-                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                    "Stream sender is closed",
-                )));
-            }
-        };
-
-        // Assign offset metadata only to the last message (the RecordBatch).
-        // Dictionary FlightData messages (if any) are sent with empty app_metadata.
-        let msg_count = flight_data_messages.len();
-        for (i, mut flight_data) in flight_data_messages.into_iter().enumerate() {
-            if i == msg_count - 1 {
-                let metadata = FlightBatchMetadata::new(physical_offset_id);
-                if let Ok(bytes) = metadata.to_bytes() {
-                    flight_data.app_metadata = bytes.into();
-                }
-            }
-            if let Err(e) = sender.send(Ok(flight_data)).await {
-                warn!("Send failed: {}", e);
-                if self.options.recovery {
-                    debug!(
-                        logical_offset_id = logical_offset_id,
-                        physical_offset_id = physical_offset_id,
-                        "Send failed but recovery enabled - supervisor will handle recovery"
-                    );
-                    return Ok(logical_offset_id);
-                } else {
-                    {
-                        let mut pending = self.pending_batches.lock().await;
-                        pending.retain(|pb| pb.logical_offset_id != logical_offset_id);
-                    }
-                    let _ = tokio::time::timeout(
-                        Duration::from_millis(100),
-                        self.server_error_rx.clone().changed(),
-                    )
-                    .await;
-                    if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                        return Err(server_error);
-                    }
-                    return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                        "Failed to send batch",
-                    )));
-                }
-            }
-        }
-
-        Ok(logical_offset_id)
-    }
-
     /// Ingests a single Arrow RecordBatch into the stream.
     ///
-    /// This method queues the batch for transmission and returns the assigned logical offset
+    /// This method queues the batch for transmission and returns the assigned offset
     /// immediately. Use `wait_for_offset()` to explicitly wait for server acknowledgment
     /// of this batch when needed.
     ///
@@ -1483,7 +1173,7 @@ impl ZerobusArrowStream {
     ///
     /// # Returns
     ///
-    /// The logical offset ID assigned to this batch.
+    /// The offset ID assigned to this batch.
     ///
     /// # Errors
     ///
@@ -1522,55 +1212,92 @@ impl ZerobusArrowStream {
             )));
         }
 
+        // Serialize ingestion operations.
         let _guard = self.ingest_mutex.lock().await;
 
+        let offset_id = self.offset_generator.next();
         let record_count = batch.num_rows() as u64;
-        let logical_offset_id = self.logical_offset_generator.next();
-        let physical_offset_id = self.physical_offset_generator.next();
         let start_record = self
             .cumulative_records_sent
             .fetch_add(record_count, Ordering::Relaxed);
         let end_record = start_record + record_count;
 
-        let flight_data_messages = record_batch_to_flight_data(
-            &batch,
-            &make_ipc_write_options(self.options.ipc_compression)?,
-        )?;
+        // Store in pending batches for recovery with record range for ack matching.
+        {
+            let mut pending = self.pending_batches.lock().await;
+            pending.push(PendingBatch {
+                batch: batch.clone(),
+                offset_id,
+                start_record,
+                end_record,
+            });
+        }
 
-        debug!(
-            logical_offset_id = logical_offset_id,
-            physical_offset_id = physical_offset_id,
-            "Batch queued for ingestion"
-        );
-        self.send_flight_data_internal(
-            ArrowPayload::Batch(batch),
-            flight_data_messages,
-            logical_offset_id,
-            physical_offset_id,
-            start_record,
-            end_record,
-        )
-        .await
+        // When paused (graceful close or pre-reconnect), buffer the batch.
+        // It will be replayed by reconnect() after recovery.
+        if self.is_paused.load(Ordering::Relaxed) {
+            return Ok(offset_id);
+        }
+
+        let sender = {
+            let guard = self.batch_tx.lock().await;
+            guard.clone()
+        };
+
+        let sender = match sender {
+            Some(s) => s,
+            None => {
+                if let Some(server_error) = self.server_error_rx.borrow().clone() {
+                    return Err(server_error);
+                }
+                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                    "Stream sender is closed",
+                )));
+            }
+        };
+
+        if let Err(e) = sender.send(Ok(batch)).await {
+            warn!("Send failed: {}", e);
+            if self.options.recovery {
+                debug!(
+                    offset_id = offset_id,
+                    "Send failed but recovery enabled - supervisor will handle recovery"
+                );
+                return Ok(offset_id);
+            } else {
+                {
+                    let mut pending = self.pending_batches.lock().await;
+                    pending.retain(|pb| pb.offset_id != offset_id);
+                }
+                let _ = tokio::time::timeout(
+                    Duration::from_millis(100),
+                    self.server_error_rx.clone().changed(),
+                )
+                .await;
+                if let Some(server_error) = self.server_error_rx.borrow().clone() {
+                    return Err(server_error);
+                }
+                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                    "Failed to send batch",
+                )));
+            }
+        }
+
+        debug!(offset_id = offset_id, "Batch queued for ingestion");
+        Ok(offset_id)
     }
 
     /// Ingests a single Arrow RecordBatch supplied as raw Arrow IPC stream bytes.
     ///
-    /// Preferred entry point for FFI callers (Go, Python, Java, TypeScript) that already
-    /// hold IPC-serialised bytes. Forwards bytes directly to the Flight wire format
-    /// without deserialising to a [`RecordBatch`] — eliminating one IPC round-trip
-    /// compared to calling `ingest_batch`.
+    /// Convenience wrapper for callers that already hold IPC-serialised bytes.
+    /// Deserialises the bytes to a [`RecordBatch`] and delegates to `ingest_batch`.
+    /// Prefer `ingest_batch` directly when you already have a [`RecordBatch`].
     ///
     /// The `ipc_bytes` must be a valid Arrow IPC *stream* containing exactly one
     /// RecordBatch (i.e. the output of `pyarrow.RecordBatch.serialize()`,
     /// `tableToIPC(table, 'stream')`, etc.). Dictionary messages between the schema and
     /// the RecordBatch are supported. Trailing stream metadata (such as an end-of-stream
     /// marker after `finish()`) is allowed after that batch.
-    ///
-    /// # Compression
-    ///
-    /// This method forwards raw IPC bytes as-is. If the stream is configured with
-    /// `ipc_compression`, this method will return an error since the raw IPC bytes
-    /// would not match the expected compression codec.
     #[instrument(level = "debug", skip_all, fields(table_name = %self.table_properties.table_name))]
     pub async fn ingest_ipc_batch(&self, ipc_bytes: Bytes) -> ZerobusResult<OffsetId> {
         if self.is_closed.load(Ordering::Relaxed) {
@@ -1579,48 +1306,20 @@ impl ZerobusArrowStream {
             )));
         }
 
-        // Raw IPC bytes are forwarded as-is; they cannot match a compression codec.
-        if let Some(codec) = self.options.ipc_compression {
-            return Err(ZerobusError::InvalidArgument(format!(
-                "ingest_ipc_batch cannot be used when ipc_compression is enabled ({codec:?}). \
-                 Use ingest_batch instead, or disable compression for this stream."
-            )));
-        }
-
-        let parsed = ipc_bytes_to_flight_data(&ipc_bytes)
+        // Deserialise IPC bytes into a RecordBatch.
+        let batch = materialize_ipc(&ipc_bytes)
             .map_err(|e| ZerobusError::InvalidArgument(format!("Invalid Arrow IPC bytes: {e}")))?;
 
         // Validate schema matches the stream schema.
-        if parsed.schema != *self.table_properties.schema {
+        if batch.schema() != self.table_properties.schema {
             return Err(ZerobusError::InvalidArgument(format!(
                 "IPC batch schema does not match stream schema. Expected: {:?}, Got: {:?}",
-                self.table_properties.schema, parsed.schema
+                self.table_properties.schema,
+                batch.schema()
             )));
         }
 
-        let _guard = self.ingest_mutex.lock().await;
-
-        let logical_offset_id = self.logical_offset_generator.next();
-        let physical_offset_id = self.physical_offset_generator.next();
-        let start_record = self
-            .cumulative_records_sent
-            .fetch_add(parsed.num_rows, Ordering::Relaxed);
-        let end_record = start_record + parsed.num_rows;
-
-        debug!(
-            logical_offset_id = logical_offset_id,
-            physical_offset_id = physical_offset_id,
-            "IPC batch queued for ingestion"
-        );
-        self.send_flight_data_internal(
-            ArrowPayload::Ipc(ipc_bytes),
-            parsed.flight_data,
-            logical_offset_id,
-            physical_offset_id,
-            start_record,
-            end_record,
-        )
-        .await
+        self.ingest_batch(batch).await
     }
 
     /// Internal method to wait for a specific offset to be acknowledged.
@@ -1738,7 +1437,7 @@ impl ZerobusArrowStream {
             )));
         }
 
-        let target_offset = match self.logical_offset_generator.last() {
+        let target_offset = match self.offset_generator.last() {
             Some(offset) => offset,
             None => {
                 debug!("No batches to flush");
@@ -1749,7 +1448,7 @@ impl ZerobusArrowStream {
         self.wait_for_offset_internal(target_offset, "Flush").await
     }
 
-    /// Waits for server acknowledgment of a specific logical offset.
+    /// Waits for server acknowledgment of a specific offset.
     ///
     /// This method blocks until the server has acknowledged the batch at the
     /// specified offset. Use this with offsets returned from `ingest_batch()` to
@@ -1757,7 +1456,7 @@ impl ZerobusArrowStream {
     ///
     /// # Arguments
     ///
-    /// * `offset` - The logical offset ID to wait for (returned from `ingest_batch()`)
+    /// * `offset` - The offset ID to wait for (returned from `ingest_batch()`)
     ///
     /// # Returns
     ///
@@ -1870,7 +1569,6 @@ impl ZerobusArrowStream {
     /// # Errors
     ///
     /// * `InvalidStateError` - If the stream is still active
-    /// * `InvalidArgument` - If an IPC-backed batch cannot be deserialised (e.g. corrupt bytes)
     ///
     /// # Examples
     ///
@@ -1904,30 +1602,18 @@ impl ZerobusArrowStream {
             ));
         }
 
-        // Combine pending and failed batches, materialising RecordBatches from ArrowPayload.
         let mut result = Vec::new();
 
         {
             let pending = self.pending_batches.lock().await;
             for pb in pending.iter() {
-                result.push(pb.payload.materialize().map_err(|e| {
-                    ZerobusError::InvalidArgument(format!(
-                        "unacked batch at offset_id {} could not be materialised: {e}",
-                        pb.logical_offset_id
-                    ))
-                })?);
+                result.push(pb.batch.clone());
             }
         }
 
         {
             let failed = self.failed_batches.lock().await;
-            for (i, payload) in failed.iter().enumerate() {
-                result.push(payload.materialize().map_err(|e| {
-                    ZerobusError::InvalidArgument(format!(
-                        "failed batch at index {i} could not be materialised: {e}"
-                    ))
-                })?);
-            }
+            result.extend(failed.iter().cloned());
         }
 
         Ok(result)

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1057,6 +1057,118 @@ mod arrow_flight_tests {
 
             Ok(())
         }
+
+        /// Regression test: after a non-close-signal recovery (server Error, ack timeout, etc.)
+        /// the supervisor must set `is_paused = true` before reconnecting so that concurrent
+        /// `ingest_batch` calls cannot reach the new sender while `physical_offset_generator`
+        /// still holds a stale value.
+        ///
+        /// Setup: advance `physical_offset_generator` to N by acking N batches on connection 1,
+        /// then trigger a server Error while one more batch is pending.  Ingest a further batch
+        /// immediately (simulating a concurrent caller) before recovery completes.  The mock
+        /// validates strictly-sequential offsets on every new DoPut connection (resets to 0).
+        /// If the pause gate is missing, the concurrent batch may be sent with offset N on the
+        /// new connection → mock rejects with `NonIncrementalOffset` → recovery fails.
+        #[tokio::test]
+        async fn test_no_stale_offset_after_non_close_signal_recovery(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_no_stale_offset_after_non_close_signal_recovery");
+
+            const INITIAL_BATCHES: usize = 5;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Ack each of the initial batches individually, then Error on the next one,
+            // then ack the replay (which starts at offset 0 on the new connection).
+            let mut responses: Vec<MockFlightResponse> = (0..INITIAL_BATCHES)
+                .map(|i| MockFlightResponse::BatchAck {
+                    ack_up_to_offset: i as i64,
+                    delay_ms: 0,
+                    ack_up_to_records: (i + 1) as u64,
+                })
+                .collect();
+            responses.push(MockFlightResponse::Error {
+                status: tonic::Status::unavailable("Simulated disconnect"),
+                delay_ms: 0,
+            });
+            // On the new connection offsets restart from 0.  Ack covers all replayed rows.
+            responses.push(MockFlightResponse::BatchAck {
+                ack_up_to_offset: 0,
+                delay_ms: 0,
+                ack_up_to_records: (INITIAL_BATCHES + 2) as u64,
+            });
+
+            mock_server
+                .inject_responses(TABLE_NAME, responses)
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_retries(3)
+                .recovery_backoff_ms(100)
+                .recovery_timeout_ms(10_000)
+                .flush_timeout_ms(15_000)
+                .build_arrow()
+                .await?;
+
+            // Ingest INITIAL_BATCHES batches and wait for each ack, advancing
+            // physical_offset_generator to INITIAL_BATCHES.
+            for i in 0..INITIAL_BATCHES {
+                let batch = create_test_record_batch(
+                    schema.clone(),
+                    vec![i as i64],
+                    vec![Some("init")],
+                );
+                let offset = stream.ingest_batch(batch).await?;
+                stream.wait_for_offset(offset).await?;
+            }
+
+            // This batch lands in flight when the server fires the Error.
+            let pending_batch = create_test_record_batch(
+                schema.clone(),
+                vec![INITIAL_BATCHES as i64],
+                vec![Some("pending")],
+            );
+            let pending_offset = stream.ingest_batch(pending_batch).await?;
+
+            // Ingest one more batch WITHOUT waiting for pending_offset — this simulates a
+            // caller that is unaware of the in-progress recovery.  With the pause gate the
+            // SDK buffers it; without the gate it may race onto the new connection with a
+            // stale physical offset (e.g. INITIAL_BATCHES+1 instead of 1), causing the
+            // mock to reject with NonIncrementalOffset and breaking the wait below.
+            let concurrent_batch = create_test_record_batch(
+                schema.clone(),
+                vec![(INITIAL_BATCHES + 1) as i64],
+                vec![Some("concurrent")],
+            );
+            let concurrent_offset = stream.ingest_batch(concurrent_batch).await?;
+
+            let r1 = stream.wait_for_offset(pending_offset).await;
+            let r2 = stream.wait_for_offset(concurrent_offset).await;
+
+            assert!(
+                r1.is_ok(),
+                "Pending batch recovery failed (stale offset on new connection?): {r1:?}",
+            );
+            assert!(
+                r2.is_ok(),
+                "Concurrent batch recovery failed (stale offset on new connection?): {r2:?}",
+            );
+
+            Ok(())
+        }
     }
 
     mod ipc_ingestion_tests {
@@ -1429,10 +1541,10 @@ mod arrow_flight_tests {
         }
 
         #[tokio::test]
-        async fn test_ingest_ipc_batch_compression_mismatch(
+        async fn test_ingest_ipc_batch_with_compression(
         ) -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
-            info!("Starting test_ingest_ipc_batch_compression_mismatch");
+            info!("Starting test_ingest_ipc_batch_with_compression");
 
             let (_mock_server, server_url) = start_mock_flight_server().await?;
             let schema = create_test_arrow_schema();
@@ -1452,15 +1564,15 @@ mod arrow_flight_tests {
                 .build_arrow()
                 .await?;
 
+            // ingest_ipc_batch now materialises the IPC bytes and re-encodes with the
+            // stream compression setting, so this should succeed.
             let batch = create_test_record_batch(schema, vec![1], vec![Some("test")]);
             let ipc_bytes = record_batch_to_ipc_bytes(&batch);
-
             let result = stream.ingest_ipc_batch(ipc_bytes).await;
-            assert!(result.is_err(), "Expected compression mismatch error");
-            let err_msg = format!("{}", result.unwrap_err());
             assert!(
-                err_msg.contains("ipc_compression"),
-                "Error should mention compression: {err_msg}"
+                result.is_ok(),
+                "ingest_ipc_batch should succeed when compression is enabled: {:?}",
+                result.err()
             );
 
             Ok(())
@@ -1539,6 +1651,226 @@ mod arrow_flight_tests {
             stream.wait_for_offset(offset3).await?;
 
             assert_eq!(mock_server.get_batch_count().await, 3);
+
+            Ok(())
+        }
+    }
+
+    mod chunking_tests {
+        use super::*;
+        use crate::utils::create_large_test_record_batch;
+
+        // 10 500 rows × 200-byte payload ≈ 2.12 MiB IPC-encoded — safely above the
+        // 2 MiB chunking threshold and below tonic's 4 MiB default decode limit.
+        // At 2 MiB/chunk this batch requires at least 2 physical Flight messages.
+        const LARGE_BATCH_ROWS: usize = 10_500;
+        const PAYLOAD_BYTES_PER_ROW: usize = 200;
+
+        /// A large RecordBatch must be split into multiple physical Flight messages
+        /// (`ingest_batch` path). Fails before the fix (batch_count == 1) and
+        /// passes after (batch_count >= 2, max_offset >= 1).
+        #[tokio::test]
+        async fn test_large_batch_is_split_into_chunks(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_large_batch_is_split_into_chunks");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Ack fires on the first chunk (offset 0) and covers all rows, so the
+            // logical batch is fully acknowledged regardless of how many physical
+            // chunks follow. Subsequent chunks hit the auto-ack path, but
+            // pending_batches is already empty so no re-ack occurs.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        // Fire ack only when offset 1 arrives (second chunk).
+                        // This guarantees both chunks are counted before wait_for_offset returns.
+                        ack_up_to_offset: 1,
+                        delay_ms: 0,
+                        ack_up_to_records: LARGE_BATCH_ROWS as u64,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .flush_timeout_ms(10_000)
+                .build_arrow()
+                .await?;
+
+            let batch =
+                create_large_test_record_batch(schema, LARGE_BATCH_ROWS, PAYLOAD_BYTES_PER_ROW);
+            let offset = stream.ingest_batch(batch).await?;
+            assert_eq!(offset, 0);
+
+            stream.wait_for_offset(offset).await?;
+
+            // Without chunking the whole batch lands in one Flight message
+            // (batch_count == 1, max_offset == 0).  With chunking in place each
+            // chunk gets its own physical offset, so both counters grow.
+            let batch_count = mock_server.get_batch_count().await;
+            assert!(
+                batch_count >= 2,
+                "Expected large batch to be split into ≥2 Flight messages (chunks), got {batch_count}",
+            );
+
+            let max_offset = mock_server.get_max_offset_received().await;
+            assert!(
+                max_offset >= 1,
+                "Expected max wire offset ≥1 (multiple chunks), got {max_offset}",
+            );
+
+            Ok(())
+        }
+
+        /// A large IPC batch must be split into multiple physical Flight messages
+        /// (`ingest_ipc_batch` path). Same failure/pass criterion as the Batch test.
+        #[tokio::test]
+        async fn test_large_ipc_batch_is_split_into_chunks(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_large_ipc_batch_is_split_into_chunks");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        // Fire ack only when offset 1 arrives (second chunk).
+                        ack_up_to_offset: 1,
+                        delay_ms: 0,
+                        ack_up_to_records: LARGE_BATCH_ROWS as u64,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .flush_timeout_ms(10_000)
+                .build_arrow()
+                .await?;
+
+            let batch =
+                create_large_test_record_batch(schema, LARGE_BATCH_ROWS, PAYLOAD_BYTES_PER_ROW);
+            let ipc_bytes = record_batch_to_ipc_bytes(&batch);
+
+            let offset = stream.ingest_ipc_batch(ipc_bytes).await?;
+            assert_eq!(offset, 0);
+
+            stream.wait_for_offset(offset).await?;
+
+            let batch_count = mock_server.get_batch_count().await;
+            assert!(
+                batch_count >= 2,
+                "Expected large IPC batch to be split into ≥2 Flight messages (chunks), got {batch_count}",
+            );
+
+            let max_offset = mock_server.get_max_offset_received().await;
+            assert!(
+                max_offset >= 1,
+                "Expected max wire offset ≥1 (multiple chunks), got {max_offset}",
+            );
+
+            Ok(())
+        }
+
+        /// When a large pending batch is replayed after a disconnect, the replay path
+        /// must also chunk it — not blast a single oversized Flight message.
+        ///
+        /// Failure criterion (before fix):  batch_count == 2  (1 failed + 1 replayed, no chunking)
+        /// Pass criterion   (after  fix):   batch_count >= 3  (1 failed + ≥2 replayed chunks)
+        #[tokio::test]
+        async fn test_large_batch_chunking_preserved_on_recovery(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_large_batch_chunking_preserved_on_recovery");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // Drop the connection when the first (or only) chunk arrives,
+                        // before sending any ack.
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("Simulated disconnect"),
+                            delay_ms: 0,
+                        },
+                        // On reconnect the batch is replayed. Ack fires on the second
+                        // replayed chunk (offset 1 on the new connection), guaranteeing both
+                        // chunks are counted before wait_for_offset returns.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 1,
+                            delay_ms: 0,
+                            ack_up_to_records: LARGE_BATCH_ROWS as u64,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_retries(3)
+                .recovery_backoff_ms(100)
+                .recovery_timeout_ms(10_000)
+                .flush_timeout_ms(15_000)
+                .build_arrow()
+                .await?;
+
+            let batch =
+                create_large_test_record_batch(schema, LARGE_BATCH_ROWS, PAYLOAD_BYTES_PER_ROW);
+            let offset = stream.ingest_batch(batch).await?;
+
+            let result = stream.wait_for_offset(offset).await;
+            assert!(
+                result.is_ok(),
+                "Expected recovery replay of large batch to succeed: {result:?}",
+            );
+
+            // batch_count accumulates across connections.
+            // Before fix: ack_up_to_offset=1 never fires (only 1 chunk per connection),
+            //             so wait_for_offset times out and result.is_ok() fails above.
+            // After  fix: 1 (failed first chunk) + 2 (both replay chunks) = 3 ≥ 3.
+            let batch_count = mock_server.get_batch_count().await;
+            assert!(
+                batch_count >= 3,
+                "Expected ≥3 total Flight messages (1 failed + ≥2 replayed chunks), got {batch_count}",
+            );
 
             Ok(())
         }

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1099,9 +1099,7 @@ mod arrow_flight_tests {
                 ack_up_to_records: (INITIAL_BATCHES + 2) as u64,
             });
 
-            mock_server
-                .inject_responses(TABLE_NAME, responses)
-                .await;
+            mock_server.inject_responses(TABLE_NAME, responses).await;
 
             let sdk = ZerobusSdk::builder()
                 .endpoint(server_url)
@@ -1125,11 +1123,8 @@ mod arrow_flight_tests {
             // Ingest INITIAL_BATCHES batches and wait for each ack, advancing
             // the wire offset counter to INITIAL_BATCHES on connection 1.
             for i in 0..INITIAL_BATCHES {
-                let batch = create_test_record_batch(
-                    schema.clone(),
-                    vec![i as i64],
-                    vec![Some("init")],
-                );
+                let batch =
+                    create_test_record_batch(schema.clone(), vec![i as i64], vec![Some("init")]);
                 let offset = stream.ingest_batch(batch).await?;
                 stream.wait_for_offset(offset).await?;
             }
@@ -1243,8 +1238,9 @@ mod arrow_flight_tests {
                     let stream = Arc::clone(&stream);
                     let schema = schema.clone();
                     tokio::spawn(async move {
-                        let ids: Vec<i64> =
-                            (0..ROWS_PER_BATCH as i64).map(|r| i as i64 * 100 + r).collect();
+                        let ids: Vec<i64> = (0..ROWS_PER_BATCH as i64)
+                            .map(|r| i as i64 * 100 + r)
+                            .collect();
                         let strings: Vec<Option<&str>> = vec![Some("row"); ROWS_PER_BATCH];
                         let batch = create_test_record_batch(schema, ids, strings);
                         stream.ingest_batch(batch).await
@@ -1349,8 +1345,9 @@ mod arrow_flight_tests {
                     let stream = Arc::clone(&stream);
                     let schema = schema.clone();
                     tokio::spawn(async move {
-                        let ids: Vec<i64> =
-                            (0..ROWS_PER_BATCH as i64).map(|r| i as i64 * 100 + r).collect();
+                        let ids: Vec<i64> = (0..ROWS_PER_BATCH as i64)
+                            .map(|r| i as i64 * 100 + r)
+                            .collect();
                         let strings: Vec<Option<&str>> = vec![Some("row"); ROWS_PER_BATCH];
                         let batch = create_test_record_batch(schema, ids, strings);
                         stream.ingest_batch(batch).await
@@ -1753,8 +1750,8 @@ mod arrow_flight_tests {
         }
 
         #[tokio::test]
-        async fn test_ingest_ipc_batch_with_compression(
-        ) -> Result<(), Box<dyn std::error::Error>> {
+        async fn test_ingest_ipc_batch_with_compression() -> Result<(), Box<dyn std::error::Error>>
+        {
             setup_tracing();
             info!("Starting test_ingest_ipc_batch_with_compression");
 
@@ -1882,8 +1879,7 @@ mod arrow_flight_tests {
         /// (`ingest_batch` path). Fails before the fix (batch_count == 1) and
         /// passes after (batch_count >= 2, max_offset >= 1).
         #[tokio::test]
-        async fn test_large_batch_is_split_into_chunks(
-        ) -> Result<(), Box<dyn std::error::Error>> {
+        async fn test_large_batch_is_split_into_chunks() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
             info!("Starting test_large_batch_is_split_into_chunks");
 

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1142,11 +1142,6 @@ mod arrow_flight_tests {
             );
             let pending_offset = stream.ingest_batch(pending_batch).await?;
 
-            // Ingest one more batch WITHOUT waiting for pending_offset — this simulates a
-            // caller that is unaware of the in-progress recovery.  With the pause gate the
-            // SDK buffers it; without the gate it may race onto the new connection with a
-            // stale physical offset (e.g. INITIAL_BATCHES+1 instead of 1), causing the
-            // mock to reject with NonIncrementalOffset and breaking the wait below.
             let concurrent_batch = create_test_record_batch(
                 schema.clone(),
                 vec![(INITIAL_BATCHES + 1) as i64],

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1060,10 +1060,9 @@ mod arrow_flight_tests {
 
         /// Regression test: after a non-close-signal recovery (server Error, ack timeout, etc.)
         /// the supervisor must set `is_paused = true` before reconnecting so that concurrent
-        /// `ingest_batch` calls cannot reach the new sender while `physical_offset_generator`
-        /// still holds a stale value.
+        /// `ingest_batch` calls cannot send to the new connection with a stale wire offset.
         ///
-        /// Setup: advance `physical_offset_generator` to N by acking N batches on connection 1,
+        /// Setup: advance the wire offset counter to N by acking N batches on connection 1,
         /// then trigger a server Error while one more batch is pending.  Ingest a further batch
         /// immediately (simulating a concurrent caller) before recovery completes.  The mock
         /// validates strictly-sequential offsets on every new DoPut connection (resets to 0).
@@ -1124,7 +1123,7 @@ mod arrow_flight_tests {
                 .await?;
 
             // Ingest INITIAL_BATCHES batches and wait for each ack, advancing
-            // physical_offset_generator to INITIAL_BATCHES.
+            // the wire offset counter to INITIAL_BATCHES on connection 1.
             for i in 0..INITIAL_BATCHES {
                 let batch = create_test_record_batch(
                     schema.clone(),
@@ -1165,6 +1164,224 @@ mod arrow_flight_tests {
             assert!(
                 r2.is_ok(),
                 "Concurrent batch recovery failed (stale offset on new connection?): {r2:?}",
+            );
+
+            // All INITIAL_BATCHES + 2 rows must have physically reached the server.
+            // This catches silent data loss: if a batch is falsely acked without being
+            // sent, the server row count will fall short.
+            let total_rows = mock_server.get_total_records_received().await;
+            assert!(
+                total_rows >= (INITIAL_BATCHES + 2) as u64,
+                "Server received {total_rows} rows, expected at least {}",
+                INITIAL_BATCHES + 2,
+            );
+
+            Ok(())
+        }
+
+        /// Verifies no records are silently dropped when many concurrent `ingest_batch`
+        /// calls are in flight during a server-error recovery.
+        ///
+        /// The `is_paused` gate + `ingest_mutex` ordering must ensure that every batch
+        /// pushed to `pending_batches` is either sent on the current connection or
+        /// replayed on the new one — never buffered-but-unsent and then falsely acked.
+        ///
+        /// Uses a multi-threaded runtime so the ingest_mutex-release / is_paused-clear
+        /// race that this PR fixes can actually manifest if the gate is broken.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn test_no_lost_records_during_non_close_signal_recovery(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            use futures::future::join_all;
+
+            setup_tracing();
+            info!("Starting test_no_lost_records_during_non_close_signal_recovery");
+
+            const CONCURRENT_TASKS: usize = 10;
+            const ROWS_PER_BATCH: usize = 3;
+            const TOTAL_UNIQUE_ROWS: u64 = (CONCURRENT_TASKS * ROWS_PER_BATCH) as u64;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Fire Error before any ack → all CONCURRENT_TASKS batches are pending at recovery.
+            // On the new connection, ack everything in one shot.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("Simulated disconnect"),
+                            delay_ms: 0,
+                        },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: CONCURRENT_TASKS as i64 - 1,
+                            delay_ms: 0,
+                            ack_up_to_records: TOTAL_UNIQUE_ROWS,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = Arc::new(
+                sdk.stream_builder()
+                    .table(TABLE_NAME)
+                    .headers_provider(Arc::new(TestHeadersProvider::default()))
+                    .arrow(schema.clone())
+                    .recovery(true)
+                    .recovery_retries(3)
+                    .recovery_backoff_ms(50)
+                    .recovery_timeout_ms(10_000)
+                    .flush_timeout_ms(15_000)
+                    .build_arrow()
+                    .await?,
+            );
+
+            // Kick off CONCURRENT_TASKS ingest_batch calls simultaneously.
+            let handles: Vec<_> = (0..CONCURRENT_TASKS)
+                .map(|i| {
+                    let stream = Arc::clone(&stream);
+                    let schema = schema.clone();
+                    tokio::spawn(async move {
+                        let ids: Vec<i64> =
+                            (0..ROWS_PER_BATCH as i64).map(|r| i as i64 * 100 + r).collect();
+                        let strings: Vec<Option<&str>> = vec![Some("row"); ROWS_PER_BATCH];
+                        let batch = create_test_record_batch(schema, ids, strings);
+                        stream.ingest_batch(batch).await
+                    })
+                })
+                .collect();
+
+            let offsets: Vec<_> = join_all(handles)
+                .await
+                .into_iter()
+                .enumerate()
+                .map(|(i, r)| {
+                    r.unwrap_or_else(|e| panic!("task {i} panicked: {e:?}"))
+                        .unwrap_or_else(|e| panic!("task {i} ingest_batch failed: {e}"))
+                })
+                .collect();
+
+            // Every batch must be acknowledged — a falsely-acked batch would cause
+            // wait_for_offset to succeed even though the server never received it,
+            // but the row-count assertion below would catch the discrepancy.
+            for offset in &offsets {
+                stream.wait_for_offset(*offset).await?;
+            }
+
+            // The server must have physically received at least TOTAL_UNIQUE_ROWS rows.
+            // Replay means the actual count may be higher, but never lower — a shortfall
+            // indicates a batch was falsely acked without being sent to the server.
+            let total_rows = mock_server.get_total_records_received().await;
+            assert!(
+                total_rows >= TOTAL_UNIQUE_ROWS,
+                "Server received {total_rows} rows; expected at least {TOTAL_UNIQUE_ROWS} \
+                 (possible silent data loss from pause-gate race)",
+            );
+
+            Ok(())
+        }
+
+        /// Same as `test_no_lost_records_during_non_close_signal_recovery` but recovery
+        /// is triggered by a server-sent graceful-close signal rather than an error.
+        ///
+        /// The graceful-close path sets `is_paused = true` inside `process_acks` and
+        /// then waits for the grace period to expire before triggering reconnect.
+        /// Concurrent `ingest_batch` callers that arrive after the close signal must
+        /// buffer into `pending_batches` and be replayed — not silently dropped.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn test_no_lost_records_during_close_signal_recovery(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            use futures::future::join_all;
+
+            setup_tracing();
+            info!("Starting test_no_lost_records_during_close_signal_recovery");
+
+            const CONCURRENT_TASKS: usize = 10;
+            const ROWS_PER_BATCH: usize = 3;
+            const TOTAL_UNIQUE_ROWS: u64 = (CONCURRENT_TASKS * ROWS_PER_BATCH) as u64;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // GracefulClose with a short grace period, then ack everything on the new connection.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 100,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: CONCURRENT_TASKS as i64 - 1,
+                            delay_ms: 0,
+                            ack_up_to_records: TOTAL_UNIQUE_ROWS,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = Arc::new(
+                sdk.stream_builder()
+                    .table(TABLE_NAME)
+                    .headers_provider(Arc::new(TestHeadersProvider::default()))
+                    .arrow(schema.clone())
+                    .recovery(true)
+                    .recovery_retries(3)
+                    .recovery_backoff_ms(50)
+                    .recovery_timeout_ms(10_000)
+                    .flush_timeout_ms(15_000)
+                    .build_arrow()
+                    .await?,
+            );
+
+            let handles: Vec<_> = (0..CONCURRENT_TASKS)
+                .map(|i| {
+                    let stream = Arc::clone(&stream);
+                    let schema = schema.clone();
+                    tokio::spawn(async move {
+                        let ids: Vec<i64> =
+                            (0..ROWS_PER_BATCH as i64).map(|r| i as i64 * 100 + r).collect();
+                        let strings: Vec<Option<&str>> = vec![Some("row"); ROWS_PER_BATCH];
+                        let batch = create_test_record_batch(schema, ids, strings);
+                        stream.ingest_batch(batch).await
+                    })
+                })
+                .collect();
+
+            let offsets: Vec<_> = join_all(handles)
+                .await
+                .into_iter()
+                .enumerate()
+                .map(|(i, r)| {
+                    r.unwrap_or_else(|e| panic!("task {i} panicked: {e:?}"))
+                        .unwrap_or_else(|e| panic!("task {i} ingest_batch failed: {e}"))
+                })
+                .collect();
+
+            for offset in &offsets {
+                stream.wait_for_offset(*offset).await?;
+            }
+
+            let total_rows = mock_server.get_total_records_received().await;
+            assert!(
+                total_rows >= TOTAL_UNIQUE_ROWS,
+                "Server received {total_rows} rows; expected at least {TOTAL_UNIQUE_ROWS} \
+                 (possible silent data loss from pause-gate race)",
             );
 
             Ok(())

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
-use arrow_ipc;
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
+use arrow_ipc;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_ipc;
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
@@ -120,6 +121,11 @@ impl MockFlightServer {
     /// Get the number of batches received
     pub async fn get_batch_count(&self) -> u64 {
         *self.batch_count.lock().await
+    }
+
+    /// Get the total number of rows received across all batches
+    pub async fn get_total_records_received(&self) -> u64 {
+        *self.row_count.lock().await
     }
 
     /// Reset the server state
@@ -311,10 +317,15 @@ impl FlightService for MockFlightServer {
                         *count += 1;
                     }
 
-                    // Try to decode and count rows (simplified - just count data_body presence)
-                    if !flight_data.data_body.is_empty() {
+                    // Decode the IPC data_header flatbuffer to get the actual row count.
+                    let rows = arrow_ipc::root_as_message(&flight_data.data_header)
+                        .ok()
+                        .and_then(|msg| msg.header_as_record_batch())
+                        .map(|rb| rb.length() as u64)
+                        .unwrap_or(0);
+                    if rows > 0 {
                         let mut count = row_count.lock().await;
-                        *count += 1; // Simplified: count batches as rows for testing
+                        *count += rows;
                     }
                 }
 

--- a/rust/tests/src/utils.rs
+++ b/rust/tests/src/utils.rs
@@ -109,6 +109,22 @@ pub fn create_test_dict_record_batch(
         .expect("Failed to create dictionary RecordBatch")
 }
 
+/// Creates a large RecordBatch for testing chunking behavior.
+///
+/// Produces `num_rows` rows where the `message` column contains a fixed-size string
+/// of `payload_bytes_per_row` bytes. The resulting batch is roughly
+/// `num_rows * (8 + payload_bytes_per_row)` bytes when IPC-encoded.
+pub fn create_large_test_record_batch(
+    schema: Arc<ArrowSchema>,
+    num_rows: usize,
+    payload_bytes_per_row: usize,
+) -> RecordBatch {
+    let ids: Vec<i64> = (0..num_rows as i64).collect();
+    let payload = "x".repeat(payload_bytes_per_row);
+    let messages: Vec<Option<&str>> = vec![Some(payload.as_str()); num_rows];
+    create_test_record_batch(schema, ids, messages)
+}
+
 /// Deserialise Arrow IPC stream bytes back into a [`RecordBatch`].
 pub fn ipc_bytes_to_record_batch(bytes: &bytes::Bytes) -> RecordBatch {
     let mut reader = arrow_ipc::reader::StreamReader::try_new(Cursor::new(bytes.as_ref()), None)


### PR DESCRIPTION
## What changes are proposed in this pull request?

**Revert encoding to `FlightDataEncoderBuilder`** (`arrow_stream.rs`):
- `BatchSender` restored to `mpsc::Sender<Result<RecordBatch, FlightError>>`. Batches are sent as `RecordBatch` values; `FlightDataEncoderBuilder` handles schema framing, dictionary encoding, and automatic chunking at 2 MiB.
- `PendingBatch` simplified back to `{ batch: RecordBatch, offset_id, start_record, end_record }`.
- `reconnect()` replays pending batches by resending `RecordBatch` values through a fresh encoder stream; wire offsets are renumbered from 0 automatically.
- Removed: `ArrowPayload`, `ParsedIpcBatch`, `ipc_bytes_to_flight_data`, `record_batch_to_flight_data`, `schema_to_flight_data`, `chunk_record_batch`, `encode_batch_with_offsets`, `encode_ipc_with_offsets`, `send_flight_data_internal`, `physical_offset_generator`, `logical_offset_generator`.

**Fix stale offset race condition**:
- Added `is_paused.store(true)` in the supervisor's retriable-error branch before the backoff sleep, symmetric with the existing close-signal path in `process_acks`. This prevents concurrent `ingest_batch` calls from reaching the new sender before replay is complete.

**`ingest_ipc_batch`**:
- Kept for API compatibility. Now deserialises IPC bytes → `RecordBatch` → delegates to `ingest_batch`. No longer restricted when `ipc_compression` is enabled.
- The previously separate FFI function `zerobus_arrow_stream_ingest_batch_via_record_batch` (which existed to work around the compression restriction) is now redundant but kept to avoid a breaking FFI change.

**Doc fixes**: removed stale "zero-copy" and "use the other function for compression" references from both the SDK and FFI doc comments.

## How is this tested?

- Added `chunking_tests` module: verifies that batches exceeding 2 MiB are split into multiple Flight messages on both the `ingest_batch` and `ingest_ipc_batch` paths, and that chunking is preserved through recovery replay.
- Added `test_no_stale_offset_after_non_close_signal_recovery` in `recovery_tests`.
- Updated `test_ingest_ipc_batch_compression_mismatch` → `test_ingest_ipc_batch_with_compression`: the restriction no longer exists, so the test now asserts the call succeeds.

Against a real server
```
Sending 5 small batches (10 rows each)…
  Small batch 1 queued (offset 0)
  Small batch 2 queued (offset 1)
  Small batch 3 queued (offset 2)
  Small batch 4 queued (offset 3)
  Small batch 5 queued (offset 4)
  All small batches acknowledged.

Sending one large batch (~16 MiB, 25 000 rows) — exercises auto-chunking…
  Large batch acknowledged (25000 rows, offset 5).

Sending 5 more small batches after the large one…
  Small batch 1 queued (offset 6)
  Small batch 2 queued (offset 7)
  Small batch 3 queued (offset 8)
  Small batch 4 queued (offset 9)
  Small batch 5 queued (offset 10)
  All small batches acknowledged.

Stream closed successfully. Total rows sent: 25100
```