### PR TITLE
[Rust] Release v2.1.0

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Version changelog
 
+## Release v2.1.0
+
+### Major Changes
+
+### New Features and Improvements
+
+- **`zeroparser` (opt-in Cargo feature): zero-copy, descriptor-driven
+  protobuf parser** for ingestion paths where the schema is only known at
+  runtime. Exposes `databricks_zerobus_ingest_sdk::zeroparser`. Off by
+  default; see `sdk/src/zeroparser/README.md`.
+
+### Bug Fixes
+
+### Documentation
+
+### Internal Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.0.1
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v2.1.0
+## Release v2.1.1
 
 ### Major Changes
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
## Summary

- Bumps `rust/sdk/Cargo.toml` from 2.0.1 to 2.1.0.
- Rolls `rust/NEXT_CHANGELOG.md` (v2.1.0 placeholder) into `rust/CHANGELOG.md`; resets `NEXT_CHANGELOG.md` with a v2.1.1 placeholder.
- v2.1.0 ships the opt-in `zeroparser` Cargo feature (zero-copy descriptor-driven protobuf parser) added in #323.

Per the Rust release process, merging this commit and tagging `rust/v2.1.0` triggers `release-rust.yml` to publish to crates.io.

## Test plan

- [ ] CI green (build/test/lint workspace).
- [ ] After merge, push tag `rust/v2.1.0`.
- [ ] Confirm `release-rust.yml` publishes `databricks-zerobus-ingest-sdk@2.1.0` to crates.io.

This pull request and its description were written by Isaac.