### PR TITLE
[Rust] Release v2.1.1

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -11,8 +11,6 @@
 - Fix the Arrow Flight example so it works against the prerequisite `orders`
   table — corrected the schema to `LargeUtf8` for `STRING`,
   `Timestamp(Microsecond, Some("UTC"))` for `TIMESTAMP`, and `nullable: true`.
-  JSON / Protocol Buffers examples now use `timestamp_micros()` for Delta
-  `TIMESTAMP` columns instead of seconds.
 
 ### Documentation
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 - Enable `all-features` on docs.rs so `arrow-flight` and `zeroparser` are
   visible. Re-export `TimeUnit` from the SDK root.
+- Refresh `rust/README.md`: correct `prost` / `tokio` versions in the
+  install snippet, fix the schema-tool build command, advertise the
+  `arrow-flight` Beta feature, and update Repository Structure.
 
 ### Internal Changes
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Fix the Arrow Flight example so it works against the prerequisite `orders`
   table — corrected the schema to `LargeUtf8` for `STRING`,
   `Timestamp(Microsecond, Some("UTC"))` for `TIMESTAMP`, and `nullable: true`.
+  All four `examples/{json,proto}/{batch,single}.rs` now use
+  `timestamp_micros()` so `created_at` / `updated_at` land at the current
+  time instead of January 1970 (the server stores any int64 in a TIMESTAMP
+  column without unit validation).
 
 ### Documentation
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Version changelog
 
+## Release v2.1.1
+
+### Major Changes
+
+### New Features and Improvements
+
+### Bug Fixes
+
+- Fix the Arrow Flight example so it works against the prerequisite `orders`
+  table — corrected the schema to `LargeUtf8` for `STRING`,
+  `Timestamp(Microsecond, Some("UTC"))` for `TIMESTAMP`, and `nullable: true`.
+  JSON / Protocol Buffers examples now use `timestamp_micros()` for Delta
+  `TIMESTAMP` columns instead of seconds.
+
+### Documentation
+
+- Enable `all-features` on docs.rs so `arrow-flight` and `zeroparser` are
+  visible. Re-export `TimeUnit` from the SDK root.
+
+### Internal Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.1.0
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v2.1.1
+## Release v2.1.2
 
 ### Major Changes
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -47,6 +47,7 @@ The Zerobus Rust SDK provides a robust, async-first interface for ingesting larg
 - **Flexible Configuration** - Fine-tune timeouts, retries, and recovery behavior
 - **Graceful Stream Management** - Proper flushing and acknowledgment tracking
 - **Acknowledgment Callbacks** - Receive notifications when records are acknowledged or encounter errors
+- **Arrow Flight Ingestion** *(Beta, opt-in)* — Stream Apache Arrow `RecordBatch` data directly to Zerobus over the Arrow Flight protocol on the same gRPC connection. Enable with `features = ["arrow-flight"]`; see [`examples/arrow/`](https://github.com/databricks/zerobus-sdk/tree/main/rust/examples/arrow).
 - **Zeroparser** *(opt-in)* — Zero-copy, single-pass protobuf parser for runtime-known schemas. Enable with `features = ["zeroparser"]`; see [`sdk/src/zeroparser/README.md`](https://github.com/databricks/zerobus-sdk/blob/main/rust/sdk/src/zeroparser/README.md).
 
 ## Installation
@@ -79,9 +80,9 @@ Then in your `Cargo.toml`:
 ```toml
 [dependencies]
 databricks-zerobus-ingest-sdk = { path = "../zerobus-sdk/rust/sdk" }
-prost = "0.13.3"
-prost-types = "0.13.3"
-tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread"] }
+prost = "0.14"
+prost-types = "0.14"
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 ```
 
 ## Quick Start
@@ -105,14 +106,23 @@ zerobus_rust_sdk/
 ├── sdk/                                # Core SDK library
 │   ├── src/
 │   │   ├── lib.rs                      # Main SDK and stream implementation
+│   │   ├── builder/                    # Builder pattern for SDK initialization
 │   │   ├── default_token_factory.rs    # OAuth 2.0 token handling
 │   │   ├── errors.rs                   # Error types and retryable logic
 │   │   ├── headers_provider.rs         # Trait for custom authentication headers
-│   │   ├── builder/                    # Builder pattern for SDK initialization
-│   │   ├── tls_config.rs              # TLS configuration strategies
+│   │   ├── callbacks.rs                # Ack/error callback traits
+│   │   ├── record_types.rs             # Record encoding types (JSON, proto, raw)
+│   │   ├── schema.rs                   # Unity Catalog → proto/Arrow schema generation
 │   │   ├── stream_configuration.rs     # Stream options
+│   │   ├── stream_options.rs           # Shared stream configuration
+│   │   ├── tls_config.rs               # TLS configuration strategies
 │   │   ├── landing_zone.rs             # Inflight record buffer
-│   │   └── offset_generator.rs         # Logical offset tracking
+│   │   ├── offset_generator.rs         # Logical offset tracking
+│   │   ├── proxy.rs                    # HTTP proxy support
+│   │   ├── arrow_stream.rs             # Arrow Flight stream (feature: arrow-flight)
+│   │   ├── arrow_configuration.rs      # Arrow Flight options (feature: arrow-flight)
+│   │   ├── arrow_metadata.rs           # Arrow Flight metadata (feature: arrow-flight)
+│   │   └── zeroparser/                 # Descriptor-driven protobuf parser (feature: zeroparser)
 │   ├── zerobus_service.proto           # gRPC protocol definition
 │   ├── build.rs                        # Build script for protobuf compilation
 │   └── Cargo.toml
@@ -132,7 +142,7 @@ zerobus_rust_sdk/
 │   └── Cargo.toml
 │
 ├── tools/
-│   └── generate_files/                 # Schema generation CLI tool
+│   └── generate_files/                 # Schema generation CLI tool (package `tools`)
 │       ├── src/
 │       │   ├── main.rs                 # CLI entry point
 │       │   └── generate.rs             # Unity Catalog -> Proto conversion
@@ -146,17 +156,25 @@ zerobus_rust_sdk/
 │   │   ├── Cargo.toml
 │   │   ├── single.rs                   # JSON single-record example
 │   │   └── batch.rs                    # JSON batch ingestion example
-│   └── proto/                          # Protocol Buffers examples (single Cargo package)
+│   ├── proto/                          # Protocol Buffers examples (single Cargo package)
+│   │   ├── README.md
+│   │   ├── Cargo.toml
+│   │   ├── single.rs                   # Protocol Buffers single-record example
+│   │   ├── batch.rs                    # Protocol Buffers batch ingestion example
+│   │   └── output/                     # Generated schema files (shared)
+│   └── arrow/                          # Arrow Flight example (feature: arrow-flight, Beta)
 │       ├── README.md
 │       ├── Cargo.toml
-│       ├── single.rs                   # Protocol Buffers single-record example
-│       ├── batch.rs                    # Protocol Buffers batch ingestion example
-│       └── output/                     # Generated schema files (shared)
+│       └── src/main.rs                 # Arrow `RecordBatch` ingestion example
 │
 ├── tests/                              # Integration tests crate
 │   ├── src/
 │   │   ├── mock_grpc.rs                # Mock Zerobus gRPC server
-│   │   └── rust_tests.rs               # Test suite
+│   │   ├── mock_arrow_flight.rs        # Mock Arrow Flight server
+│   │   ├── rust_tests.rs               # Core SDK test suite
+│   │   ├── proxy_tests.rs              # HTTP proxy tests
+│   │   ├── arrow_tests.rs              # Arrow Flight test suite
+│   │   └── utils.rs                    # Shared test utilities
 │   ├── build.rs
 │   └── Cargo.toml
 │
@@ -998,7 +1016,7 @@ cargo build --workspace
 cargo build -p databricks-zerobus-ingest-sdk
 
 # Build only schema tool
-cargo build -p generate_files
+cargo build -p tools
 
 # Build and run JSON single-record example
 cargo run -p rust-examples-json --example json_single

--- a/rust/README.md
+++ b/rust/README.md
@@ -47,7 +47,7 @@ The Zerobus Rust SDK provides a robust, async-first interface for ingesting larg
 - **Flexible Configuration** - Fine-tune timeouts, retries, and recovery behavior
 - **Graceful Stream Management** - Proper flushing and acknowledgment tracking
 - **Acknowledgment Callbacks** - Receive notifications when records are acknowledged or encounter errors
-- **Zeroparser** *(opt-in)* — Zero-copy, single-pass protobuf parser for runtime-known schemas. Enable with `features = ["zeroparser"]`; see [`sdk/src/zeroparser/README.md`](sdk/src/zeroparser/README.md).
+- **Zeroparser** *(opt-in)* — Zero-copy, single-pass protobuf parser for runtime-known schemas. Enable with `features = ["zeroparser"]`; see [`sdk/src/zeroparser/README.md`](https://github.com/databricks/zerobus-sdk/blob/main/rust/sdk/src/zeroparser/README.md).
 
 ## Installation
 

--- a/rust/examples/arrow/src/main.rs
+++ b/rust/examples/arrow/src/main.rs
@@ -1,9 +1,11 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use arrow_array::{Float64Array, Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow_array::{
+    Float64Array, Int32Array, LargeStringArray, RecordBatch, TimestampMicrosecondArray,
+};
 use arrow_ipc::CompressionType;
-use databricks_zerobus_ingest_sdk::{ArrowSchema, DataType, Field, ZerobusSdk};
+use databricks_zerobus_ingest_sdk::{ArrowSchema, DataType, Field, TimeUnit, ZerobusSdk};
 
 /// One row of the `orders` table.
 #[derive(Clone)]
@@ -33,17 +35,22 @@ const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.da
 // const DATABRICKS_WORKSPACE_URL: &str = "https://<your-workspace>.azuredatabricks.net";
 // const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.azuredatabricks.net";
 
-/// Builds the Arrow schema for the `orders` table.
+/// Builds the Arrow schema for the `orders` table, matching the canonical
+/// Arrow schema the Databricks Arrow Flight server derives from a Delta
+/// table: Delta `STRING` → `LargeUtf8`, Delta `TIMESTAMP` → `Timestamp(
+/// Microsecond, Some("UTC"))`, all columns nullable unless declared
+/// `NOT NULL` in the Delta DDL.
 fn orders_schema() -> Arc<ArrowSchema> {
+    let utc_micros = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
     Arc::new(ArrowSchema::new(vec![
-        Field::new("id", DataType::Int32, false),
-        Field::new("customer_name", DataType::Utf8, false),
-        Field::new("product_name", DataType::Utf8, false),
-        Field::new("quantity", DataType::Int32, false),
-        Field::new("price", DataType::Float64, false),
-        Field::new("status", DataType::Utf8, false),
-        Field::new("created_at", DataType::Int64, false),
-        Field::new("updated_at", DataType::Int64, false),
+        Field::new("id", DataType::Int32, true),
+        Field::new("customer_name", DataType::LargeUtf8, true),
+        Field::new("product_name", DataType::LargeUtf8, true),
+        Field::new("quantity", DataType::Int32, true),
+        Field::new("price", DataType::Float64, true),
+        Field::new("status", DataType::LargeUtf8, true),
+        Field::new("created_at", utc_micros.clone(), true),
+        Field::new("updated_at", utc_micros, true),
     ]))
 }
 
@@ -62,13 +69,13 @@ fn build_orders_batch(schema: &Arc<ArrowSchema>, orders: &[Order]) -> RecordBatc
         schema.clone(),
         vec![
             Arc::new(Int32Array::from(ids)),
-            Arc::new(StringArray::from(customer_names)),
-            Arc::new(StringArray::from(product_names)),
+            Arc::new(LargeStringArray::from(customer_names)),
+            Arc::new(LargeStringArray::from(product_names)),
             Arc::new(Int32Array::from(quantities)),
             Arc::new(Float64Array::from(prices)),
-            Arc::new(StringArray::from(statuses)),
-            Arc::new(Int64Array::from(created_at)),
-            Arc::new(Int64Array::from(updated_at)),
+            Arc::new(LargeStringArray::from(statuses)),
+            Arc::new(TimestampMicrosecondArray::from(created_at).with_timezone("UTC")),
+            Arc::new(TimestampMicrosecondArray::from(updated_at).with_timezone("UTC")),
         ],
     )
     .expect("Failed to build RecordBatch")
@@ -100,7 +107,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     const ROWS_PER_BATCH: usize = 3;
     const WAIT_EVERY: usize = 10;
 
-    let now = chrono::Utc::now().timestamp();
+    let now = chrono::Utc::now().timestamp_micros();
 
     for i in 0..NUM_BATCHES {
         let orders: Vec<Order> = (0..ROWS_PER_BATCH)

--- a/rust/examples/json/batch.rs
+++ b/rust/examples/json/batch.rs
@@ -59,7 +59,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Delta TIMESTAMP is int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-serializing: JsonValue - pass structs, SDK handles JSON conversion.
     let batch: Vec<JsonValue<Order>> = vec![

--- a/rust/examples/json/batch.rs
+++ b/rust/examples/json/batch.rs
@@ -59,7 +59,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-serializing: JsonValue - pass structs, SDK handles JSON conversion.
     let batch: Vec<JsonValue<Order>> = vec![

--- a/rust/examples/json/batch.rs
+++ b/rust/examples/json/batch.rs
@@ -59,8 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
-    let now = chrono::Utc::now().timestamp_micros();
+    let now = chrono::Utc::now().timestamp();
 
     // 1. Auto-serializing: JsonValue - pass structs, SDK handles JSON conversion.
     let batch: Vec<JsonValue<Order>> = vec![

--- a/rust/examples/json/single.rs
+++ b/rust/examples/json/single.rs
@@ -59,7 +59,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-serializing: JsonValue - pass struct, SDK handles JSON conversion.
     let order = Order {

--- a/rust/examples/json/single.rs
+++ b/rust/examples/json/single.rs
@@ -59,8 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
-    let now = chrono::Utc::now().timestamp_micros();
+    let now = chrono::Utc::now().timestamp();
 
     // 1. Auto-serializing: JsonValue - pass struct, SDK handles JSON conversion.
     let order = Order {

--- a/rust/examples/json/single.rs
+++ b/rust/examples/json/single.rs
@@ -59,7 +59,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Delta TIMESTAMP is int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-serializing: JsonValue - pass struct, SDK handles JSON conversion.
     let order = Order {

--- a/rust/examples/proto/batch.rs
+++ b/rust/examples/proto/batch.rs
@@ -56,7 +56,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-encoding: ProtoMessage - pass messages directly, SDK handles encoding.
     let batch: Vec<ProtoMessage<TableOrders>> = vec![

--- a/rust/examples/proto/batch.rs
+++ b/rust/examples/proto/batch.rs
@@ -56,8 +56,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
-    let now = chrono::Utc::now().timestamp_micros();
+    let now = chrono::Utc::now().timestamp();
 
     // 1. Auto-encoding: ProtoMessage - pass messages directly, SDK handles encoding.
     let batch: Vec<ProtoMessage<TableOrders>> = vec![

--- a/rust/examples/proto/batch.rs
+++ b/rust/examples/proto/batch.rs
@@ -56,7 +56,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Delta TIMESTAMP is int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-encoding: ProtoMessage - pass messages directly, SDK handles encoding.
     let batch: Vec<ProtoMessage<TableOrders>> = vec![

--- a/rust/examples/proto/single.rs
+++ b/rust/examples/proto/single.rs
@@ -56,7 +56,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-encoding: ProtoMessage - pass message directly, SDK handles encoding.
     let order = TableOrders {

--- a/rust/examples/proto/single.rs
+++ b/rust/examples/proto/single.rs
@@ -56,7 +56,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    let now = chrono::Utc::now().timestamp();
+    // Delta TIMESTAMP is int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
 
     // 1. Auto-encoding: ProtoMessage - pass message directly, SDK handles encoding.
     let order = TableOrders {

--- a/rust/examples/proto/single.rs
+++ b/rust/examples/proto/single.rs
@@ -56,8 +56,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn ingest_with_offset_api(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
     println!("=== Offset-based API (Recommended) ===");
 
-    // Zerobus encodes Delta TIMESTAMP as int64 microseconds since epoch UTC.
-    let now = chrono::Utc::now().timestamp_micros();
+    let now = chrono::Utc::now().timestamp();
 
     // 1. Auto-encoding: ProtoMessage - pass message directly, SDK handles encoding.
     let order = TableOrders {

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"
@@ -11,6 +11,11 @@ repository = "https://github.com/databricks/zerobus-sdk"
 keywords = ["databricks", "delta", "streaming", "ingestion", "zerobus"]
 categories = ["database", "api-bindings"]
 documentation = "https://docs.rs/databricks-zerobus-ingest-sdk"
+
+# Build docs on docs.rs with all optional features enabled so feature-gated
+# modules (arrow-flight, zeroparser) are visible on the rendered page.
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 async-trait.workspace = true

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 // Re-export arrow types for public API
 pub use arrow_array::RecordBatch;
-pub use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+pub use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
 
 use crate::arrow_configuration::ArrowStreamConfigurationOptions;
 use crate::arrow_metadata::{FlightAckMetadata, FlightBatchMetadata};

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -86,7 +86,7 @@ use landing_zone::LandingZone;
 #[cfg(feature = "arrow-flight")]
 pub use arrow_configuration::ArrowStreamConfigurationOptions;
 #[cfg(feature = "arrow-flight")]
-pub use arrow_stream::{ArrowSchema, DataType, Field, RecordBatch, ZerobusArrowStream};
+pub use arrow_stream::{ArrowSchema, DataType, Field, RecordBatch, TimeUnit, ZerobusArrowStream};
 pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;

--- a/rust/sdk/src/zeroparser/README.md
+++ b/rust/sdk/src/zeroparser/README.md
@@ -95,7 +95,7 @@ if let Some(FieldValueRef::String(s)) = parsed.get_scalar(1) {
 From `rust/sdk/`:
 
 ```
-cargo test --features zeroparser --lib                          # 72 unit tests inline in src/zeroparser/*.rs
+cargo test --features zeroparser --lib                          # unit tests inline in src/zeroparser/*.rs
 cargo test --features zeroparser --test zeroparser_e2e          # integration tests in src/zeroparser/tests/e2e.rs
 cargo test --features zeroparser                                # everything: lib + integration + doc tests
 cargo bench --features zeroparser --bench zeroparser_parser_bench   # full criterion sweep


### PR DESCRIPTION
## Summary

Patch release that fixes a handful of issues surfaced on the v2.1.0 crates.io and docs.rs pages.

- **docs.rs**: add `[package.metadata.docs.rs] all-features = true` to `rust/sdk/Cargo.toml`. Without this, the v2.1.0 build on docs.rs renders with zero features enabled — so the `arrow-flight` and `zeroparser` modules are invisible. After this release, both will appear on the rendered docs.rs page.
- **`rust/README.md` (crates.io page)**: the zeroparser link was a relative path that 404s from the crates.io URL; switched to an absolute GitHub URL. Also corrected `prost` / `tokio` versions in the path-dependency install snippet (were 0.13.3 / 1.42.0, workspace is at 0.14 / 1.52), replaced the broken `cargo build -p generate_files` command (the package's name is `tools`), advertised the `arrow-flight` Beta feature in the Features list (was unmentioned), and refreshed the Repository Structure tree (added `arrow_stream.rs`, `zeroparser/`, `examples/arrow/`, current `tests/src/*.rs` files).
- **Arrow Flight example**: the example's schema declared `Utf8` for `STRING` columns, `Int64` for `TIMESTAMP` columns, and `nullable: false` everywhere. The Databricks Arrow Flight server expects `LargeUtf8`, `Timestamp(Microsecond, Some("UTC"))`, and the column's actual nullability (the prerequisite SQL doesn't add `NOT NULL`). Verified end-to-end against the dev workspace — 100 batches ingest successfully against a table created from the README's SQL.
- **JSON / Protocol Buffers examples**: all four (`json/{batch,single}.rs`, `proto/{batch,single}.rs`) used `chrono::Utc::now().timestamp()` (seconds). Per `sdk/src/schema.rs`, Delta `TIMESTAMP` expects `int64` microseconds. Switched to `timestamp_micros()`.
- **SDK**: re-export `TimeUnit` from `arrow_schema` so callers building `DataType::Timestamp(...)` fields don't need an explicit `arrow-schema` dependency.

## Test plan

- [x] `cargo build --workspace --all-features` clean.
- [x] `cargo test -p databricks-zerobus-ingest-sdk --features zeroparser` — 188 unit + 98 e2e + 23 doctest pass.
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean.
- [x] `cargo run -p example_arrow` against a Delta table created from the README's prerequisite SQL ingests 100 batches and closes cleanly.
- [x] After merge, push tag `rust/v2.1.1` to trigger `release-rust.yml` → crates.io.
- [ ] After publish, verify the crates.io page shows the absolute zeroparser link and the Arrow Flight feature mention; verify docs.rs renders `arrow_stream`, `zeroparser`, and `TimeUnit`.

This pull request and its description were written by Isaac.