### PR TITLE
Add client-side warning to detect non-optimal use of the SDKs

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,1 +1,2 @@
 target/
+.cargo/

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -808,9 +808,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+- Added a process-wide stream churn warning: logs a `WARN` when 100 or more streams for the same table are opened within a 60-second sliding window, which may indicate a "one stream per record" misuse pattern. Applies to `ZerobusStream` and `ZerobusArrowStream`. Set `ZEROBUS_SDK_WARNINGS_ENABLED=false` to suppress.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/README.md
+++ b/rust/README.md
@@ -18,6 +18,7 @@ A high-performance Rust client for streaming data ingestion into Databricks Delt
   - [5. Ingest Data](#5-ingest-data)
   - [6. Handle Acknowledgments](#6-handle-acknowledgments)
   - [7. Close the Stream](#7-close-the-stream)
+- [Client-side warnings](#client-side-warnings)
 - [Configuration Options](#configuration-options)
 - [Error Handling](#error-handling)
 - [Examples](#examples)
@@ -675,6 +676,18 @@ match stream.close().await {
     Ok(_) => println!("Stream closed successfully"),
 }
 ```
+
+## Client-side warnings
+
+The SDK logs a `WARN`-level message via [`tracing`](https://docs.rs/tracing) when **100 or more** streams for the same table are opened within a 60-second sliding window. This usually indicates a "one stream per record" misuse pattern. The warning fires again if the rate drops below the threshold and later surges again.
+
+To suppress, set the environment variable before starting the process:
+
+```bash
+ZEROBUS_SDK_WARNINGS_ENABLED=false
+```
+
+Also accepts `0` or `no`.
 
 ## Configuration Options
 

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -374,13 +374,15 @@ impl<'a> StreamBuilder<'a> {
         };
 
         let channel = self.sdk.get_or_create_channel_zerobus_client().await?;
-        ZerobusStream::new_stream(
+        let stream = ZerobusStream::new_stream(
             channel,
             table_properties,
             headers_provider,
             self.grpc_config,
         )
-        .await
+        .await?;
+        crate::client_warnings::notify_stream_opened(stream.table_properties.table_name.as_str());
+        Ok(stream)
     }
 
     /// Build and open an Arrow Flight ingestion stream.
@@ -411,7 +413,8 @@ impl<'a> StreamBuilder<'a> {
             schema,
         };
 
-        ZerobusArrowStream::new(
+        let table_name = table_properties.table_name.clone();
+        let stream = ZerobusArrowStream::new(
             &self.sdk.zerobus_endpoint,
             Arc::clone(&self.sdk.tls_config),
             table_properties,
@@ -419,7 +422,9 @@ impl<'a> StreamBuilder<'a> {
             self.arrow_config,
             Arc::clone(&self.sdk.sdk_identifier),
         )
-        .await
+        .await?;
+        crate::client_warnings::notify_stream_opened(&table_name);
+        Ok(stream)
     }
 }
 

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -381,7 +381,7 @@ impl<'a> StreamBuilder<'a> {
             self.grpc_config,
         )
         .await?;
-        crate::client_warnings::notify_stream_opened(stream.table_properties.table_name.as_str());
+        crate::client_warnings::record_stream_creation(stream.table_properties.table_name.as_str());
         Ok(stream)
     }
 
@@ -423,7 +423,7 @@ impl<'a> StreamBuilder<'a> {
             Arc::clone(&self.sdk.sdk_identifier),
         )
         .await?;
-        crate::client_warnings::notify_stream_opened(&table_name);
+        crate::client_warnings::record_stream_creation(&table_name);
         Ok(stream)
     }
 }

--- a/rust/sdk/src/client_warnings.rs
+++ b/rust/sdk/src/client_warnings.rs
@@ -1,0 +1,294 @@
+//! Process-wide client-side warnings that surface common SDK misuse patterns.
+//!
+//! A warning is emitted via [`tracing::warn!`] when 100 or more streams for
+//! the same table are opened within a 60-second sliding window, which usually
+//! indicates a "one stream per record" misuse pattern.
+//!
+//! The warning is process-wide and keyed by table name.
+//!
+//! ## Opt-out
+//!
+//! Set the environment variable `ZEROBUS_SDK_WARNINGS_ENABLED=false` (or `0`
+//! or `no`) before the process starts to suppress all warnings.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, OnceLock};
+
+use tracing::warn;
+
+// ─── Opt-out ──────────────────────────────────────────────────────────────────
+
+fn warnings_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("ZEROBUS_SDK_WARNINGS_ENABLED")
+            .map(|v| !matches!(v.to_lowercase().as_str(), "false" | "0" | "no"))
+            .unwrap_or(true)
+    })
+}
+
+// ─── Stream churn monitor ─────────────────────────────────────────────────────
+
+/// Sliding window length in milliseconds.
+const CHURN_WINDOW_MS: u64 = 60_000;
+/// Logs a warning when this many streams are opened within [`CHURN_WINDOW_MS`].
+const CHURN_WARN_THRESHOLD: usize = 100;
+/// Maximum number of distinct tables tracked; oldest is evicted when exceeded.
+const CHURN_MAX_TABLES: usize = 1000;
+
+fn default_clock_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+struct StreamChurnState {
+    /// Replaceable clock; overridden in tests to control time.
+    clock: fn() -> u64,
+    /// Per-table queue of stream-open timestamps (ms since Unix epoch).
+    timestamps: HashMap<String, VecDeque<u64>>,
+    /// Tracks insertion order for eviction when `CHURN_MAX_TABLES` is reached.
+    insertion_order: VecDeque<String>,
+}
+
+impl StreamChurnState {
+    fn new() -> Self {
+        Self {
+            clock: default_clock_ms,
+            timestamps: HashMap::new(),
+            insertion_order: VecDeque::new(),
+        }
+    }
+}
+
+static CHURN_MONITOR: OnceLock<Mutex<StreamChurnState>> = OnceLock::new();
+
+fn churn_monitor() -> &'static Mutex<StreamChurnState> {
+    CHURN_MONITOR.get_or_init(|| Mutex::new(StreamChurnState::new()))
+}
+
+/// Records one user-initiated stream open for `table_name`.
+///
+/// Maintains a per-table sliding window of open timestamps. Logs a `WARN`-level
+/// message when the count within the window reaches [`CHURN_WARN_THRESHOLD`]
+/// (100). "Recovery" is purely time-based: old timestamps age out of the
+/// 60-second window automatically, so no `notify_stream_closed` is needed.
+/// The warning re-fires if the rate surges again after the window drains.
+///
+/// Must only be called from user-facing stream creation paths, not from internal
+/// reconnect / recovery paths.
+pub(crate) fn notify_stream_opened(table_name: &str) {
+    if !warnings_enabled() {
+        return;
+    }
+
+    let count = {
+        let mut state = churn_monitor().lock().unwrap_or_else(|e| e.into_inner());
+        let now = (state.clock)();
+
+        if !state.timestamps.contains_key(table_name) {
+            // Evict the oldest-tracked table when the cap is reached.
+            if state.insertion_order.len() >= CHURN_MAX_TABLES {
+                if let Some(oldest) = state.insertion_order.pop_front() {
+                    state.timestamps.remove(&oldest);
+                }
+            }
+            state
+                .timestamps
+                .insert(table_name.to_string(), VecDeque::new());
+            state.insertion_order.push_back(table_name.to_string());
+        }
+
+        let deque = state.timestamps.get_mut(table_name).unwrap();
+        // Evict timestamps that have fallen outside the sliding window.
+        while deque
+            .front()
+            .map(|&t| now.saturating_sub(t) > CHURN_WINDOW_MS)
+            .unwrap_or(false)
+        {
+            deque.pop_front();
+        }
+        deque.push_back(now);
+        deque.len()
+    };
+
+    // Fire exactly when the window count hits the threshold. Old timestamps are
+    // evicted above, so the count falls naturally over time without any close
+    // signal — re-fires if the rate surges again after the window drains.
+    if count == CHURN_WARN_THRESHOLD {
+        warn!(
+            "Zerobus SDK: {} ingest streams opened for table `{}` in the last {}s in this \
+             process. If this is unexpected, check that streams are being reused across records.",
+            count,
+            table_name,
+            CHURN_WINDOW_MS / 1000
+        );
+    }
+}
+
+// ─── Test utilities ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub(crate) fn reset_for_testing() {
+    if let Ok(mut state) = churn_monitor().lock() {
+        *state = StreamChurnState::new();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn set_churn_clock_for_testing(f: fn() -> u64) {
+    if let Ok(mut state) = churn_monitor().lock() {
+        state.clock = f;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn open_count_in_window_for_testing(table_name: &str) -> usize {
+    let state = churn_monitor().lock().unwrap_or_else(|e| e.into_inner());
+    let now = (state.clock)();
+    state
+        .timestamps
+        .get(table_name)
+        .map(|deque| {
+            deque
+                .iter()
+                .filter(|&&t| now.saturating_sub(t) <= CHURN_WINDOW_MS)
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, OnceLock};
+
+    use super::*;
+
+    // All tests share a global fake clock and call reset_for_testing(). Each
+    // acquires the serial lock so they run one at a time without corrupting
+    // each other's clock or timestamp state.
+    static SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+    fn serial() -> std::sync::MutexGuard<'static, ()> {
+        SERIAL
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    static FAKE_CLOCK_MS: AtomicU64 = AtomicU64::new(0);
+
+    fn fake_clock() -> u64 {
+        FAKE_CLOCK_MS.load(Ordering::Relaxed)
+    }
+
+    #[test]
+    fn churn_open_count_tracks_opens_within_window() {
+        let _lock = serial();
+        reset_for_testing();
+        set_churn_clock_for_testing(fake_clock);
+        FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
+        let table = "cat.sch.churn_tracks";
+
+        notify_stream_opened(table);
+        notify_stream_opened(table);
+        assert_eq!(open_count_in_window_for_testing(table), 2);
+    }
+
+    #[test]
+    fn churn_entries_older_than_window_evicted_on_next_open() {
+        let _lock = serial();
+        reset_for_testing();
+        set_churn_clock_for_testing(fake_clock);
+        FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
+        let table = "cat.sch.churn_evict";
+
+        for _ in 0..10 {
+            notify_stream_opened(table);
+        }
+        assert_eq!(open_count_in_window_for_testing(table), 10);
+
+        // Advance past the window; the next open evicts all 10 old entries.
+        FAKE_CLOCK_MS.store(61_000, Ordering::Relaxed);
+        notify_stream_opened(table);
+        assert_eq!(open_count_in_window_for_testing(table), 1);
+    }
+
+    #[test]
+    fn churn_warning_fires_at_exactly_threshold_not_before() {
+        let _lock = serial();
+        reset_for_testing();
+        set_churn_clock_for_testing(fake_clock);
+        FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
+        let table = "cat.sch.churn_threshold";
+
+        for _ in 0..99 {
+            notify_stream_opened(table);
+        }
+        assert_eq!(open_count_in_window_for_testing(table), 99);
+
+        // 100th open crosses the threshold.
+        notify_stream_opened(table);
+        assert_eq!(open_count_in_window_for_testing(table), 100);
+
+        // 101st does not re-fire (count != CHURN_WARN_THRESHOLD).
+        notify_stream_opened(table);
+        assert_eq!(open_count_in_window_for_testing(table), 101);
+    }
+
+    #[test]
+    fn churn_warning_refires_after_window_rolls_below_threshold() {
+        let _lock = serial();
+        reset_for_testing();
+        set_churn_clock_for_testing(fake_clock);
+        FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
+        let table = "cat.sch.churn_refire";
+
+        for _ in 0..100 {
+            notify_stream_opened(table);
+        }
+        assert_eq!(open_count_in_window_for_testing(table), 100);
+
+        // Advance past window so all previous opens are evicted.
+        FAKE_CLOCK_MS.store(61_000, Ordering::Relaxed);
+        for _ in 0..99 {
+            notify_stream_opened(table);
+        }
+        assert_eq!(open_count_in_window_for_testing(table), 99);
+
+        // 100th open in the new window crosses the threshold again.
+        notify_stream_opened(table);
+        assert_eq!(open_count_in_window_for_testing(table), 100);
+    }
+
+    #[test]
+    fn churn_two_tables_tracked_independently() {
+        let _lock = serial();
+        reset_for_testing();
+        set_churn_clock_for_testing(fake_clock);
+        FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
+        let t1 = "cat.sch.churn_indep1";
+        let t2 = "cat.sch.churn_indep2";
+
+        for _ in 0..5 {
+            notify_stream_opened(t1);
+        }
+        for _ in 0..3 {
+            notify_stream_opened(t2);
+        }
+        assert_eq!(open_count_in_window_for_testing(t1), 5);
+        assert_eq!(open_count_in_window_for_testing(t2), 3);
+    }
+
+    #[test]
+    fn churn_unknown_table_returns_zero() {
+        assert_eq!(
+            open_count_in_window_for_testing("cat.sch.churn_unknown_xyz"),
+            0
+        );
+    }
+}

--- a/rust/sdk/src/client_warnings.rs
+++ b/rust/sdk/src/client_warnings.rs
@@ -69,17 +69,16 @@ fn churn_monitor() -> &'static Mutex<StreamChurnState> {
     CHURN_MONITOR.get_or_init(|| Mutex::new(StreamChurnState::new()))
 }
 
-/// Records one user-initiated stream open for `table_name`.
+/// Records one user-initiated stream creation for `table_name`.
 ///
-/// Maintains a per-table sliding window of open timestamps. Logs a `WARN`-level
-/// message when the count within the window reaches [`CHURN_WARN_THRESHOLD`]
-/// (100). "Recovery" is purely time-based: old timestamps age out of the
-/// 60-second window automatically, so no `notify_stream_closed` is needed.
-/// The warning re-fires if the rate surges again after the window drains.
+/// Maintains a per-table sliding window of creation timestamps. Logs a
+/// `WARN`-level message when the count within the window reaches
+/// [`CHURN_WARN_THRESHOLD`] (100), and again each time the window drains
+/// and a new surge reaches the threshold.
 ///
 /// Must only be called from user-facing stream creation paths, not from internal
 /// reconnect / recovery paths.
-pub(crate) fn notify_stream_opened(table_name: &str) {
+pub(crate) fn record_stream_creation(table_name: &str) {
     if !warnings_enabled() {
         return;
     }
@@ -114,9 +113,8 @@ pub(crate) fn notify_stream_opened(table_name: &str) {
         deque.len()
     };
 
-    // Fire exactly when the window count hits the threshold. Old timestamps are
-    // evicted above, so the count falls naturally over time without any close
-    // signal — re-fires if the rate surges again after the window drains.
+    // Fire exactly when the window count hits the threshold; re-fires each time
+    // the window drains below the threshold and a new surge reaches it.
     if count == CHURN_WARN_THRESHOLD {
         warn!(
             "Zerobus SDK: {} ingest streams opened for table `{}` in the last {}s in this \
@@ -194,8 +192,8 @@ mod tests {
         FAKE_CLOCK_MS.store(0, Ordering::Relaxed);
         let table = "cat.sch.churn_tracks";
 
-        notify_stream_opened(table);
-        notify_stream_opened(table);
+        record_stream_creation(table);
+        record_stream_creation(table);
         assert_eq!(open_count_in_window_for_testing(table), 2);
     }
 
@@ -208,13 +206,13 @@ mod tests {
         let table = "cat.sch.churn_evict";
 
         for _ in 0..10 {
-            notify_stream_opened(table);
+            record_stream_creation(table);
         }
         assert_eq!(open_count_in_window_for_testing(table), 10);
 
         // Advance past the window; the next open evicts all 10 old entries.
         FAKE_CLOCK_MS.store(61_000, Ordering::Relaxed);
-        notify_stream_opened(table);
+        record_stream_creation(table);
         assert_eq!(open_count_in_window_for_testing(table), 1);
     }
 
@@ -227,16 +225,16 @@ mod tests {
         let table = "cat.sch.churn_threshold";
 
         for _ in 0..99 {
-            notify_stream_opened(table);
+            record_stream_creation(table);
         }
         assert_eq!(open_count_in_window_for_testing(table), 99);
 
         // 100th open crosses the threshold.
-        notify_stream_opened(table);
+        record_stream_creation(table);
         assert_eq!(open_count_in_window_for_testing(table), 100);
 
         // 101st does not re-fire (count != CHURN_WARN_THRESHOLD).
-        notify_stream_opened(table);
+        record_stream_creation(table);
         assert_eq!(open_count_in_window_for_testing(table), 101);
     }
 
@@ -249,19 +247,19 @@ mod tests {
         let table = "cat.sch.churn_refire";
 
         for _ in 0..100 {
-            notify_stream_opened(table);
+            record_stream_creation(table);
         }
         assert_eq!(open_count_in_window_for_testing(table), 100);
 
         // Advance past window so all previous opens are evicted.
         FAKE_CLOCK_MS.store(61_000, Ordering::Relaxed);
         for _ in 0..99 {
-            notify_stream_opened(table);
+            record_stream_creation(table);
         }
         assert_eq!(open_count_in_window_for_testing(table), 99);
 
         // 100th open in the new window crosses the threshold again.
-        notify_stream_opened(table);
+        record_stream_creation(table);
         assert_eq!(open_count_in_window_for_testing(table), 100);
     }
 
@@ -275,10 +273,10 @@ mod tests {
         let t2 = "cat.sch.churn_indep2";
 
         for _ in 0..5 {
-            notify_stream_opened(t1);
+            record_stream_creation(t1);
         }
         for _ in 0..3 {
-            notify_stream_opened(t2);
+            record_stream_creation(t2);
         }
         assert_eq!(open_count_in_window_for_testing(t1), 5);
         assert_eq!(open_count_in_window_for_testing(t2), 3);

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -43,6 +43,7 @@ mod arrow_metadata;
 mod arrow_stream;
 mod builder;
 mod callbacks;
+mod client_warnings;
 mod default_token_factory;
 mod errors;
 mod headers_provider;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a process-wide client-side warning to `ZerobusStream` and `ZerobusArrowStream` that surface common stream misuse patterns at runtime.

**Stream churn** - fires a `WARN` when 100 or more streams for the same table are opened within a 60-second sliding window. Re-fires after the rate recovers and rises again.

The warning lives in a new `client_warnings` module and can be suppressed with `ZEROBUS_SDK_WARNINGS_ENABLED=false`.

**Why**: Users sometimes accidentally create a new stream per record instead of reusing streams. This pattern causes unnecessary load on the service and is hard to spot from the outside. 

Python and TypeScript pick these up automatically; Go and Java will on the next FFI release.

 ## How is this tested?

Added unit tests.

For manual verification, a temporary test was added that initialised a tracing subscriber and opened streams in a loop to confirm `WARN` line fired correctly. It was removed before this PR.