### PR TITLE
[Rust] Set zerobuswrite operation on token mint

### DIFF
--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -55,7 +55,8 @@ impl DefaultTokenFactory {
                 "type": "unity_catalog_privileges",
                 "privileges": ["SELECT", "MODIFY"],
                 "object_type": "TABLE",
-                "object_full_path": format!("{}.{}.{}", catalog, schema, table)
+                "object_full_path": format!("{}.{}.{}", catalog, schema, table),
+                "operations": ["zerobuswrite"]
             }
         ]);
 

--- a/rust/tools/generate_files/src/token_factory.rs
+++ b/rust/tools/generate_files/src/token_factory.rs
@@ -29,7 +29,8 @@ pub async fn get_token(
             "type": "unity_catalog_privileges",
             "privileges": ["SELECT"],
             "object_type": "TABLE",
-            "object_full_path": format!("{}.{}.{}", catalog, schema, table)
+            "object_full_path": format!("{}.{}.{}", catalog, schema, table),
+            "operations": ["zerobuswrite"]
         }
     ]);
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add "operations": ["zerobuswrite"] to the TABLE authorization detail when minting OAuth tokens, in both the SDK token factory and the generate_files tool. This is done in order to make all priviliges working with the new sdk.

## How is this tested?
Tested on dev.