### PR TITLE
[Rust] Expose `no_auth` and `no_tls` methods behind the `testing` flag

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v2.3.0
+## Release v2.3.1
 
 ### Major Changes
 
@@ -9,6 +9,12 @@
 - Token caching for the default OAuth path. Tokens obtained via `.oauth(...)` are now cached per table on the `ZerobusSdk` instance and reused across stream creations and recoveries until they near expiry, instead of minting a fresh token on every stream. This reduces load on the Unity Catalog token endpoint for clients that create many short-lived streams. Caching is on by default and can be tuned via `ZerobusSdkBuilder::token_cache_enabled` and `ZerobusSdkBuilder::token_refresh_buffer`.
 - On a server-side authentication rejection during stream creation, the cached token is invalidated so the next attempt re-mints (re-checking grants at Unity Catalog), rather than reusing a rejected token until the refresh window.
 - `OAuthHeadersProvider::new` now caches tokens for the lifetime of the returned provider (previously it minted a fresh token on every call). Behavior is unchanged for the common path of constructing streams through `ZerobusSdk`, which already shares a cache.
+- Add `StreamBuilder::no_auth()` and `NoAuthHeadersProvider` for local testing
+  against Zerobus endpoints that do not enforce authentication. Both are gated
+  behind the `testing` feature flag.
+- Add `ZerobusSdkBuilder::no_tls()` convenience method as a shortcut for
+  `.tls_config(Arc::new(NoTlsConfig))` when connecting to plaintext `http://`
+  endpoints. Gated behind the `testing` feature flag.
 
 ### Bug Fixes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v2.3.1
+## Release v2.3.0
 
 ### Major Changes
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -399,6 +399,8 @@ let sdk = ZerobusSdk::builder()
     .build()?;
 ```
 
+A `.no_tls()` shorthand on `ZerobusSdkBuilder` is also available behind the `testing` feature and is equivalent to the snippet above. Paired with `StreamBuilder::no_auth()` (also `testing`-gated, uses `NoAuthHeadersProvider`), it covers local testing against an unauthenticated plaintext server.
+
 For custom certificate handling, implement the `TlsConfig` trait:
 
 ```rust

--- a/rust/sdk/src/builder/sdk_builder.rs
+++ b/rust/sdk/src/builder/sdk_builder.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 
 use crate::proxy::ConnectorFactory;
 use crate::token_cache::DEFAULT_REFRESH_BUFFER;
+#[cfg(feature = "testing")]
+use crate::NoTlsConfig;
 use crate::{
     SecureTlsConfig, TlsConfig, ZerobusError, ZerobusResult, ZerobusSdk, DEFAULT_SDK_IDENTIFIER,
 };
@@ -86,6 +88,16 @@ impl ZerobusSdkBuilder {
     /// * `tls_config` - A TLS configuration implementing the `TlsConfig` trait
     pub fn tls_config(mut self, tls_config: Arc<dyn TlsConfig>) -> Self {
         self.tls_config = Some(tls_config);
+        self
+    }
+
+    /// Disable TLS and connect over plaintext.
+    ///
+    /// Intended only for local testing against a Zerobus service reached via an
+    /// `http://` endpoint. Available behind the `testing` feature flag.
+    #[cfg(feature = "testing")]
+    pub fn no_tls(mut self) -> Self {
+        self.tls_config = Some(Arc::new(NoTlsConfig));
         self
     }
 

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -23,6 +23,8 @@ use std::sync::Arc;
 
 use crate::callbacks::AckCallback;
 use crate::databricks::zerobus::RecordType;
+#[cfg(feature = "testing")]
+use crate::headers_provider::NoAuthHeadersProvider;
 use crate::headers_provider::{HeadersProvider, OAuthHeadersProvider};
 use crate::stream_configuration::StreamConfigurationOptions;
 use crate::{TableProperties, ZerobusError, ZerobusResult, ZerobusSdk, ZerobusStream};
@@ -39,6 +41,8 @@ enum AuthConfig {
         client_secret: String,
     },
     HeadersProvider(Arc<dyn HeadersProvider>),
+    #[cfg(feature = "testing")]
+    NoAuth,
 }
 
 /// Which record format was selected.
@@ -103,6 +107,8 @@ impl fmt::Debug for StreamBuilder<'_> {
         let auth_kind = match &self.auth {
             Some(AuthConfig::OAuth { .. }) => "OAuth",
             Some(AuthConfig::HeadersProvider(_)) => "HeadersProvider",
+            #[cfg(feature = "testing")]
+            Some(AuthConfig::NoAuth) => "NoAuth",
             None => "None",
         };
         let format_kind = match &self.format {
@@ -117,6 +123,17 @@ impl fmt::Debug for StreamBuilder<'_> {
             .field("auth", &auth_kind)
             .field("format", &format_kind)
             .finish_non_exhaustive()
+    }
+}
+
+const fn missing_auth_error() -> &'static str {
+    #[cfg(feature = "testing")]
+    {
+        "authentication is required: call .oauth(), .headers_provider(), or .no_auth()"
+    }
+    #[cfg(not(feature = "testing"))]
+    {
+        "authentication is required: call .oauth() or .headers_provider()"
     }
 }
 
@@ -152,6 +169,16 @@ impl<'a> StreamBuilder<'a> {
     /// Authenticate with a custom headers provider.
     pub fn headers_provider(mut self, provider: Arc<dyn HeadersProvider>) -> Self {
         self.auth = Some(AuthConfig::HeadersProvider(provider));
+        self
+    }
+
+    /// Use a no-op headers provider that sends no authentication credentials.
+    ///
+    /// Intended only for local testing against a Zerobus endpoint that does not
+    /// enforce authentication. Available behind the `testing` feature flag.
+    #[cfg(feature = "testing")]
+    pub fn no_auth(mut self) -> Self {
+        self.auth = Some(AuthConfig::NoAuth);
         self
     }
 
@@ -310,9 +337,7 @@ impl<'a> StreamBuilder<'a> {
             ));
         }
         if self.auth.is_none() {
-            return Err(ZerobusError::InvalidArgument(
-                "authentication is required: call .oauth() or .headers_provider()".into(),
-            ));
+            return Err(ZerobusError::InvalidArgument(missing_auth_error().into()));
         }
         if self.format.is_none() {
             return Err(ZerobusError::InvalidArgument(
@@ -337,9 +362,9 @@ impl<'a> StreamBuilder<'a> {
                 Arc::clone(&self.sdk.token_cache),
             ))),
             Some(AuthConfig::HeadersProvider(p)) => Ok(Arc::clone(p)),
-            None => Err(ZerobusError::InvalidArgument(
-                "authentication is required: call .oauth() or .headers_provider()".into(),
-            )),
+            #[cfg(feature = "testing")]
+            Some(AuthConfig::NoAuth) => Ok(Arc::new(NoAuthHeadersProvider)),
+            None => Err(ZerobusError::InvalidArgument(missing_auth_error().into())),
         }
     }
 
@@ -601,6 +626,39 @@ mod tests {
         let provider = builder.resolve_headers_provider().unwrap();
         let headers = provider.get_headers().await.unwrap();
         assert_eq!(headers.get("x-test").unwrap(), "value");
+    }
+
+    #[cfg(feature = "testing")]
+    #[tokio::test]
+    async fn no_auth_resolves_to_no_auth_provider() {
+        let sdk = test_sdk();
+        let builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .no_auth()
+            .json();
+        let provider = builder.resolve_headers_provider().unwrap();
+        let headers = provider.get_headers().await.unwrap();
+        assert!(headers.is_empty());
+    }
+
+    #[cfg(feature = "testing")]
+    #[tokio::test]
+    async fn no_auth_plus_no_tls_chain() {
+        let sdk = crate::ZerobusSdkBuilder::new()
+            .endpoint("http://localhost:1234")
+            .no_tls()
+            .build()
+            .expect("sdk should build with no_tls");
+        let builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .no_auth()
+            .json();
+        builder.validate().expect("validation should succeed");
+        let provider = builder.resolve_headers_provider().unwrap();
+        let headers = provider.get_headers().await.unwrap();
+        assert!(headers.is_empty());
     }
 
     #[tokio::test]

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -151,3 +151,29 @@ impl HeadersProvider for OAuthHeadersProvider {
             .await;
     }
 }
+
+/// A headers provider that returns no headers.
+///
+/// Intended only for local testing against a Zerobus endpoint not enforcing authentication.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "testing")] {
+/// use databricks_zerobus_ingest_sdk::NoAuthHeadersProvider;
+/// use std::sync::Arc;
+///
+/// // Pass directly to `headers_provider()`, or use the `.no_auth()` shorthand on `StreamBuilder`.
+/// let _provider: Arc<NoAuthHeadersProvider> = Arc::new(NoAuthHeadersProvider);
+/// # }
+/// ```
+#[cfg(feature = "testing")]
+pub struct NoAuthHeadersProvider;
+
+#[cfg(feature = "testing")]
+#[async_trait]
+impl HeadersProvider for NoAuthHeadersProvider {
+    async fn get_headers(&self) -> ZerobusResult<HashMap<&'static str, String>> {
+        Ok(HashMap::new())
+    }
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -93,6 +93,8 @@ pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
 pub use errors::ZerobusError;
+#[cfg(feature = "testing")]
+pub use headers_provider::NoAuthHeadersProvider;
 pub use headers_provider::{HeadersProvider, OAuthHeadersProvider};
 pub use offset_generator::{OffsetId, OffsetIdGenerator};
 pub use proxy::{ConnectorFactory, ProxyConnector};


### PR DESCRIPTION
## What changes are proposed in this pull request?

To ease testing against local endpoints without authorization and TLS, exposing a `no_tls` method on the SDK builder and `no_auth` method on the 

## How is this tested?

WIP