### PR TITLE
[Java] Add native library support for Linux musl (Alpine)

### DIFF
--- a/.github/workflows/release-jni.yml
+++ b/.github/workflows/release-jni.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Build JNI library (zigbuild)
         if: matrix.zigbuild
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
         run: cargo zigbuild --release -p zerobus-jni --target ${{ matrix.target }}
 
       - name: Upload artifact

--- a/.github/workflows/release-jni.yml
+++ b/.github/workflows/release-jni.yml
@@ -22,6 +22,20 @@ jobs:
             artifact: libzerobus_jni.so
             native_dir: linux-aarch64
             cross: true
+          - os: linux-ubuntu-latest
+            runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-unknown-linux-musl
+            artifact: libzerobus_jni.so
+            native_dir: linux-musl-x86_64
+            cross: false
+            zigbuild: true
+          - os: linux-ubuntu-latest
+            runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-unknown-linux-musl
+            artifact: libzerobus_jni.so
+            native_dir: linux-musl-aarch64
+            cross: false
+            zigbuild: true
           - os: windows-server-latest
             runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
@@ -69,8 +83,23 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (musl cross-builds)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac # v2.0.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (musl cross-builds)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build JNI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-jni --target ${{ matrix.target }}
+
+      - name: Build JNI library (zigbuild)
+        if: matrix.zigbuild
+        run: cargo zigbuild --release -p zerobus-jni --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+- Added native library support for Linux musl (Alpine) on x86_64 and aarch64. The libc flavor is detected automatically at runtime; override with `-Dzerobus.libc=musl|glibc`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/java/README.md
+++ b/java/README.md
@@ -75,11 +75,16 @@ This SDK includes native libraries for the following platforms:
 
 | Platform | Architecture | Status |
 |----------|--------------|--------|
-| Linux    | x86_64       | Supported |
-| Linux    | aarch64      | Supported |
+| Linux (glibc) | x86_64  | Supported |
+| Linux (glibc) | aarch64 | Supported |
+| Linux (musl / Alpine) | x86_64  | Supported |
+| Linux (musl / Alpine) | aarch64 | Supported |
 | Windows  | x86_64       | Supported |
 | macOS    | x86_64       | Supported |
 | macOS    | aarch64 (Apple Silicon) | Supported |
+
+On Linux, the libc flavor (glibc vs musl) is detected at runtime. To override detection, set
+`-Dzerobus.libc=musl` or `-Dzerobus.libc=glibc` on the JVM command line.
 
 ### Dependencies
 

--- a/java/src/main/java/com/databricks/zerobus/NativeLoader.java
+++ b/java/src/main/java/com/databricks/zerobus/NativeLoader.java
@@ -1,7 +1,9 @@
 package com.databricks.zerobus;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -22,12 +24,17 @@ import org.slf4j.LoggerFactory;
  * <p>Supported platforms:
  *
  * <ul>
- *   <li>Linux x86_64 (linux-x86_64)
- *   <li>Linux aarch64 (linux-aarch64)
+ *   <li>Linux glibc x86_64 (linux-x86_64)
+ *   <li>Linux glibc aarch64 (linux-aarch64)
+ *   <li>Linux musl x86_64 / Alpine (linux-musl-x86_64)
+ *   <li>Linux musl aarch64 / Alpine (linux-musl-aarch64)
  *   <li>macOS x86_64 (osx-x86_64)
  *   <li>macOS aarch64 / Apple Silicon (osx-aarch64)
  *   <li>Windows x86_64 (windows-x86_64)
  * </ul>
+ *
+ * <p>On Linux, the libc flavor (glibc vs musl) is detected automatically. To override detection,
+ * set the system property {@code -Dzerobus.libc=musl} or {@code -Dzerobus.libc=glibc}.
  */
 public final class NativeLoader {
   private static final Logger logger = LoggerFactory.getLogger(NativeLoader.class);
@@ -143,13 +150,14 @@ public final class NativeLoader {
     return tempFile;
   }
 
-  private static String getPlatformIdentifier() {
+  // Package-private for unit testing.
+  static String getPlatformIdentifier() {
     String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
     String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
 
     String osName;
     if (os.contains("linux")) {
-      osName = "linux";
+      osName = isMuslLinux() ? "linux-musl" : "linux";
     } else if (os.contains("mac") || os.contains("darwin")) {
       osName = "osx";
     } else if (os.contains("windows")) {
@@ -168,6 +176,47 @@ public final class NativeLoader {
     }
 
     return osName + "-" + archName;
+  }
+
+  private static boolean isMuslLinux() {
+    String override = System.getProperty("zerobus.libc");
+    if (override != null && !override.isEmpty()) {
+      if ("musl".equalsIgnoreCase(override)) {
+        return true;
+      }
+      if ("glibc".equalsIgnoreCase(override)) {
+        return false;
+      }
+      throw new UnsatisfiedLinkError(
+          "Invalid value for system property zerobus.libc: '"
+              + override
+              + "'. Expected 'musl' or 'glibc'.");
+    }
+    // Prefer /proc/self/maps — it reflects the libc actually loaded into THIS process,
+    // which is authoritative on hosts that have both glibc and musl tooling installed.
+    try (BufferedReader reader = new BufferedReader(new FileReader("/proc/self/maps"))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains("ld-musl-") || line.contains("libc.musl-")) {
+          return true;
+        }
+        if (line.contains("ld-linux-") || line.contains("/libc.so.6")) {
+          return false;
+        }
+      }
+    } catch (IOException | SecurityException ignored) {
+      // /proc/self/maps unavailable (sandboxed JVM / restrictive SecurityManager);
+      // fall through to loader-file existence check below.
+    }
+    try {
+      if (new File("/lib/ld-musl-x86_64.so.1").exists()
+          || new File("/lib/ld-musl-aarch64.so.1").exists()) {
+        return true;
+      }
+    } catch (SecurityException ignored) {
+      // File.exists() blocked by SecurityManager; assume glibc.
+    }
+    return false;
   }
 
   private static String getLibraryFileName() {

--- a/java/src/test/java/com/databricks/zerobus/NativeLoaderTest.java
+++ b/java/src/test/java/com/databricks/zerobus/NativeLoaderTest.java
@@ -1,0 +1,114 @@
+package com.databricks.zerobus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link NativeLoader} platform-identifier resolution and the {@code zerobus.libc}
+ * override.
+ *
+ * <p>The libc override paths are Linux-specific; non-Linux hosts skip those tests via {@link
+ * org.junit.jupiter.api.Assumptions#assumeTrue}.
+ */
+public class NativeLoaderTest {
+
+  private static final String OS_NAME = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+  private static final String OS_ARCH = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
+
+  private String savedOverride;
+
+  @BeforeAll
+  static void forceStaticInitWithoutOverride() {
+    // Trigger NativeLoader's static initializer under the natural environment, so it isn't
+    // re-run inside a test method where the override may point at a non-existent .so path.
+    String saved = System.getProperty("zerobus.libc");
+    System.clearProperty("zerobus.libc");
+    try {
+      NativeLoader.isLoaded();
+    } finally {
+      if (saved != null) {
+        System.setProperty("zerobus.libc", saved);
+      }
+    }
+  }
+
+  @BeforeEach
+  void saveAndClearOverride() {
+    savedOverride = System.getProperty("zerobus.libc");
+    System.clearProperty("zerobus.libc");
+  }
+
+  @AfterEach
+  void restoreOverride() {
+    if (savedOverride == null) {
+      System.clearProperty("zerobus.libc");
+    } else {
+      System.setProperty("zerobus.libc", savedOverride);
+    }
+  }
+
+  @Test
+  void muslOverridePicksMuslPath() {
+    assumeTrue(OS_NAME.contains("linux"), "Linux-only test");
+    System.setProperty("zerobus.libc", "musl");
+    String id = NativeLoader.getPlatformIdentifier();
+    assertEquals("linux-musl-" + expectedArch(), id);
+  }
+
+  @Test
+  void glibcOverridePicksGlibcPath() {
+    assumeTrue(OS_NAME.contains("linux"), "Linux-only test");
+    System.setProperty("zerobus.libc", "glibc");
+    String id = NativeLoader.getPlatformIdentifier();
+    assertEquals("linux-" + expectedArch(), id);
+  }
+
+  @Test
+  void invalidOverrideThrows() {
+    assumeTrue(OS_NAME.contains("linux"), "Linux-only test");
+    System.setProperty("zerobus.libc", "msul");
+    UnsatisfiedLinkError err =
+        assertThrows(UnsatisfiedLinkError.class, NativeLoader::getPlatformIdentifier);
+    assertTrue(
+        err.getMessage().contains("Invalid value"),
+        "Expected clear error message, got: " + err.getMessage());
+  }
+
+  @Test
+  void overrideIsCaseInsensitive() {
+    assumeTrue(OS_NAME.contains("linux"), "Linux-only test");
+    System.setProperty("zerobus.libc", "MUSL");
+    assertEquals("linux-musl-" + expectedArch(), NativeLoader.getPlatformIdentifier());
+    System.setProperty("zerobus.libc", "Glibc");
+    assertEquals("linux-" + expectedArch(), NativeLoader.getPlatformIdentifier());
+  }
+
+  @Test
+  void emptyOverrideFallsThroughToDetection() {
+    assumeTrue(OS_NAME.contains("linux"), "Linux-only test");
+    System.setProperty("zerobus.libc", "");
+    // Should not throw — empty value is ignored, auto-detection runs.
+    String id = NativeLoader.getPlatformIdentifier();
+    assertTrue(
+        id.equals("linux-" + expectedArch()) || id.equals("linux-musl-" + expectedArch()),
+        "Unexpected platform id: " + id);
+  }
+
+  private static String expectedArch() {
+    if (OS_ARCH.equals("amd64") || OS_ARCH.equals("x86_64")) {
+      return "x86_64";
+    }
+    if (OS_ARCH.equals("aarch64") || OS_ARCH.equals("arm64")) {
+      return "aarch64";
+    }
+    throw new IllegalStateException("Unsupported test arch: " + OS_ARCH);
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds native library support for Linux musl (Alpine) on x86_64 and aarch64. The libc flavor is detected automatically at runtime; override with `-Dzerobus.libc=musl|glibc`.

## How is this tested?

- Unit tests.
- Triggered [`release-ini.yml`](https://github.com/databricks/zerobus-sdk/actions/runs/26958303643)