### PR TITLE
[Rust] Version 2.2.0

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Version changelog
 
+## Release v2.2.0
+
+### Major Changes
+
+### New Features and Improvements
+
+- Added a process-wide stream churn warning: logs a `WARN` when 100 or more streams for the same table are opened within a 60-second sliding window, which may indicate a "one stream per record" misuse pattern. Applies to `ZerobusStream` and `ZerobusArrowStream`. Set `ZEROBUS_SDK_WARNINGS_ENABLED=false` to suppress.
+
+### Bug Fixes
+
+### Documentation
+
+### Internal Changes
+
+- `DefaultTokenFactory` now requests OAuth tokens scoped to the `zerobuswrite` operation by including `"operations": ["zerobuswrite"]` in the token mint authorization details. Tightens token scope on the target table; transparent to callers using `ZerobusSdkBuilder::oauth(...)`.
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.1.1
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -1,12 +1,10 @@
 # NEXT CHANGELOG
 
-## Release v2.1.2
+## Release v2.3.0
 
 ### Major Changes
 
 ### New Features and Improvements
-
-- Added a process-wide stream churn warning: logs a `WARN` when 100 or more streams for the same table are opened within a 60-second sliding window, which may indicate a "one stream per record" misuse pattern. Applies to `ZerobusStream` and `ZerobusArrowStream`. Set `ZEROBUS_SDK_WARNINGS_ENABLED=false` to suppress.
 
 ### Bug Fixes
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps Rust SDK version to 2.2.0. Changes in this version are:
- Client warnings when opening a lot of streams for the same table in a short period of time.
- Scoping the OAuth token with `zerobuswrite` operation.

## How is this tested?

N/A