### PR TITLE
[Rust] Release version 2.2.2

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Version changelog
 
+## Release v2.2.2
+
+### Major Changes
+
+### New Features and Improvements
+
+### Bug Fixes
+
+### Documentation
+
+### Internal Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.2.1
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
Bumps the Rust SDK to **2.2.2**
