### PR TITLE
[Go] Add `WithApplicationName` method to `SdkOption`

### DIFF
--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Behavior changes
 
-- `NewZerobusSdk` no longer infers TLS-off from `http://` endpoints. Use `WithNoTLS()` explicitly. Matches the Rust SDK's model.
+- Removed an internal dead-code path in `NewZerobusSdk` that called `zerobus_sdk_set_use_tls(false)` on `http://` endpoints. That FFI symbol has been a no-op since the Rust core 2.0.0 release, so the runtime behavior is unchanged: tonic's gRPC transport already routes `http://` URLs through plain HTTP/2 regardless of TLS config. Use `WithNoTLS()` for explicit intent.
 
 ### Deprecations
 

--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -4,12 +4,28 @@
 
 ### New Features and Improvements
 
+- **`WithApplicationName`**: `SdkOption` for `NewZerobusSdk` that appends a caller-supplied identifier (e.g. `my-app/1.0`) to the HTTP `user-agent` header. Wire value becomes `zerobus-sdk-go/<version> <application_name>`. The SDK owns the `user-agent` at the gRPC channel level; values returned by a custom `HeadersProvider` cannot override it.
+- **`WithNoTLS`**: `SdkOption` for `NewZerobusSdk` that selects a no-TLS gRPC channel. Intended for local development; do not use against production.
+
+### Behavior changes
+
+- `NewZerobusSdk` no longer infers TLS-off from `http://` endpoints. Use `WithNoTLS()` explicitly. Matches the Rust SDK's model.
+
 ### Deprecations
 
 ### Bug Fixes
 
+- `user-agent` header now correctly identifies the Go SDK as `zerobus-sdk-go/<version>` instead of the underlying Rust default.
+
 ### Documentation
+
+- README: added section for `WithApplicationName`.
+- All examples under `go/examples/` now demonstrate `WithApplicationName`.
 
 ### Internal Changes
 
+- Rust FFI: introduced a C-builder API (`zerobus_sdk_builder_*`) mirroring the Rust `ZerobusSdkBuilder`. Future options are exposed as additive setters. The legacy `zerobus_sdk_new` entrypoint delegates to the builder.
+
 ### API Changes
+
+- `NewZerobusSdk` is now variadic: `func(zerobusEndpoint, unityCatalogURL string, opts ...SdkOption) (*ZerobusSdk, error)`. Strictly additive; existing two-arg callers are unaffected.

--- a/go/README.md
+++ b/go/README.md
@@ -439,6 +439,20 @@ if err != nil {
 defer sdk.Free()
 ```
 
+#### Identifying your application in the `user-agent` header
+
+The SDK sends `zerobus-sdk-go/<version>` as the HTTP `user-agent` header on every request, identifying the binding to the server. To additionally identify your application (recommended for server-side telemetry), pass `WithApplicationName`:
+
+```go
+sdk, err := zerobus.NewZerobusSdk(
+    "https://your-shard-id.zerobus.region.cloud.databricks.com",
+    "https://your-workspace.cloud.databricks.com",
+    zerobus.WithApplicationName("my-app/1.0"),
+)
+```
+
+The wire value becomes `zerobus-sdk-go/<version> my-app/1.0`. By convention, application names use `<product>/<version>`. The SDK owns the `user-agent` header at the gRPC channel level — values returned by a custom `HeadersProvider` cannot override it.
+
 ### 2. Configure Authentication
 
 The SDK handles authentication automatically. You just need to provide your OAuth credentials:

--- a/go/examples/README.md
+++ b/go/examples/README.md
@@ -14,6 +14,9 @@ Examples are organized by data format and ingestion pattern:
 | Proto Batch  | Protocol Buffers | Batch               | `examples/proto/batch/main.go`  |
 | Arrow Flight | Arrow IPC        | Batch (RecordBatch) | `examples/arrow/main.go`        |
 
+Every example demonstrates `WithApplicationName`, the optional SDK option
+that appends a caller identifier to the wire user-agent.
+
 ## Prerequisites
 
 ### 1. Create a Delta Table

--- a/go/examples/arrow/main.go
+++ b/go/examples/arrow/main.go
@@ -44,7 +44,14 @@ func main() {
 	}
 
 	// ── 2. Create the SDK instance ────────────────────────────────────────────
-	sdk, err := zerobus.NewZerobusSdk(endpoint, ucURL)
+	//
+	// WithApplicationName is optional; appends a caller identifier to the
+	// wire user-agent (final: `zerobus-sdk-go/<version> my-app/1.0`).
+	sdk, err := zerobus.NewZerobusSdk(
+		endpoint,
+		ucURL,
+		zerobus.WithApplicationName("my-app/1.0"),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create SDK: %v", err)
 	}

--- a/go/examples/json/batch/main.go
+++ b/go/examples/json/batch/main.go
@@ -19,8 +19,13 @@ func main() {
 		log.Fatal("Missing required environment variables")
 	}
 
-	// Create SDK instance.
-	sdk, err := zerobus.NewZerobusSdk(zerobusEndpoint, unityCatalogURL)
+	// WithApplicationName is optional; appends a caller identifier to the
+	// wire user-agent (final: `zerobus-sdk-go/<version> my-app/1.0`).
+	sdk, err := zerobus.NewZerobusSdk(
+		zerobusEndpoint,
+		unityCatalogURL,
+		zerobus.WithApplicationName("my-app/1.0"),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create SDK: %v", err)
 	}

--- a/go/examples/json/single/main.go
+++ b/go/examples/json/single/main.go
@@ -19,8 +19,13 @@ func main() {
 		log.Fatal("Missing required environment variables")
 	}
 
-	// Create SDK instance.
-	sdk, err := zerobus.NewZerobusSdk(zerobusEndpoint, unityCatalogURL)
+	// WithApplicationName is optional; appends a caller identifier to the
+	// wire user-agent (final: `zerobus-sdk-go/<version> my-app/1.0`).
+	sdk, err := zerobus.NewZerobusSdk(
+		zerobusEndpoint,
+		unityCatalogURL,
+		zerobus.WithApplicationName("my-app/1.0"),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create SDK: %v", err)
 	}

--- a/go/examples/proto/batch/main.go
+++ b/go/examples/proto/batch/main.go
@@ -24,8 +24,13 @@ func main() {
 		log.Fatal("Missing required environment variables")
 	}
 
-	// Create SDK instance
-	sdk, err := zerobus.NewZerobusSdk(zerobusEndpoint, unityCatalogURL)
+	// WithApplicationName is optional; appends a caller identifier to the
+	// wire user-agent (final: `zerobus-sdk-go/<version> my-app/1.0`).
+	sdk, err := zerobus.NewZerobusSdk(
+		zerobusEndpoint,
+		unityCatalogURL,
+		zerobus.WithApplicationName("my-app/1.0"),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create SDK: %v", err)
 	}

--- a/go/examples/proto/single/main.go
+++ b/go/examples/proto/single/main.go
@@ -24,8 +24,13 @@ func main() {
 		log.Fatal("Missing required environment variables")
 	}
 
-	// Create SDK instance
-	sdk, err := zerobus.NewZerobusSdk(zerobusEndpoint, unityCatalogURL)
+	// WithApplicationName is optional; appends a caller identifier to the
+	// wire user-agent (final: `zerobus-sdk-go/<version> my-app/1.0`).
+	sdk, err := zerobus.NewZerobusSdk(
+		zerobusEndpoint,
+		unityCatalogURL,
+		zerobus.WithApplicationName("my-app/1.0"),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create SDK: %v", err)
 	}

--- a/go/ffi.go
+++ b/go/ffi.go
@@ -15,6 +15,7 @@ package zerobus
 
 // Forward declare opaque types
 typedef struct CZerobusSdk CZerobusSdk;
+typedef struct CZerobusSdkBuilder CZerobusSdkBuilder;
 typedef struct CZerobusStream CZerobusStream;
 
 // Define result type
@@ -69,8 +70,15 @@ typedef struct CStreamConfigurationOptions {
 extern CZerobusSdk* zerobus_sdk_new(const char* zerobus_endpoint,
                                      const char* unity_catalog_url,
                                      CResult* result);
+extern CZerobusSdkBuilder* zerobus_sdk_builder_new(void);
+extern void zerobus_sdk_builder_endpoint(CZerobusSdkBuilder* builder, const char* value);
+extern void zerobus_sdk_builder_unity_catalog_url(CZerobusSdkBuilder* builder, const char* value);
+extern void zerobus_sdk_builder_sdk_identifier(CZerobusSdkBuilder* builder, const char* value);
+extern void zerobus_sdk_builder_application_name(CZerobusSdkBuilder* builder, const char* value);
+extern void zerobus_sdk_builder_disable_tls(CZerobusSdkBuilder* builder);
+extern CZerobusSdk* zerobus_sdk_builder_build(CZerobusSdkBuilder* builder, CResult* result);
+extern void zerobus_sdk_builder_free(CZerobusSdkBuilder* builder);
 extern void zerobus_sdk_free(CZerobusSdk* sdk);
-extern void zerobus_sdk_set_use_tls(CZerobusSdk* sdk, bool use_tls);
 extern CZerobusStream* zerobus_sdk_create_stream(CZerobusSdk* sdk,
                                                    const char* table_name,
                                                    const uint8_t* descriptor_proto_bytes,
@@ -270,26 +278,54 @@ func convertConfigToC(opts *StreamConfigurationOptions) C.CStreamConfigurationOp
 	}
 }
 
-// sdkNew creates a new SDK instance via FFI
-func sdkNew(zerobusEndpoint, unityCatalogURL string) (unsafe.Pointer, error) {
-	cEndpoint := C.CString(zerobusEndpoint)
-	defer C.free(unsafe.Pointer(cEndpoint))
+// setBuilderString wraps the cgo allocate/set/free boilerplate so adding a
+// new string-valued builder option is a one-liner.
+func setBuilderString(builder *C.CZerobusSdkBuilder, value string, setter func(*C.CZerobusSdkBuilder, *C.char)) {
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
+	setter(builder, cValue)
+}
 
-	cCatalogURL := C.CString(unityCatalogURL)
-	defer C.free(unsafe.Pointer(cCatalogURL))
+// sdkNew drives the C SDK builder. To expose a new option: add an sdkOptions
+// field, a WithFoo constructor in zerobus.go, and one builder setter call
+// below. The FFI surface stays additive.
+func sdkNew(zerobusEndpoint, unityCatalogURL string, opts sdkOptions) (unsafe.Pointer, error) {
+	builder := C.zerobus_sdk_builder_new()
+	// _build always consumes the builder. _free is only needed if we abandon
+	// it before reaching _build (defensive against panics in this function).
+	consumed := false
+	defer func() {
+		if !consumed {
+			C.zerobus_sdk_builder_free(builder)
+		}
+	}()
+
+	setBuilderString(builder, zerobusEndpoint, func(b *C.CZerobusSdkBuilder, v *C.char) {
+		C.zerobus_sdk_builder_endpoint(b, v)
+	})
+	setBuilderString(builder, unityCatalogURL, func(b *C.CZerobusSdkBuilder, v *C.char) {
+		C.zerobus_sdk_builder_unity_catalog_url(b, v)
+	})
+	setBuilderString(builder, sdkIdentifier(), func(b *C.CZerobusSdkBuilder, v *C.char) {
+		C.zerobus_sdk_builder_sdk_identifier(b, v)
+	})
+
+	if opts.applicationName != "" {
+		setBuilderString(builder, opts.applicationName, func(b *C.CZerobusSdkBuilder, v *C.char) {
+			C.zerobus_sdk_builder_application_name(b, v)
+		})
+	}
+	if opts.noTLS {
+		C.zerobus_sdk_builder_disable_tls(builder)
+	}
 
 	var cres C.CResult
-	ptr := C.zerobus_sdk_new(cEndpoint, cCatalogURL, &cres)
+	ptr := C.zerobus_sdk_builder_build(builder, &cres)
+	consumed = true
 
 	if ptr == nil {
 		return nil, ffiResult(cres)
 	}
-
-	// Disable TLS if using HTTP endpoint (for testing/mock servers)
-	if len(zerobusEndpoint) >= 7 && zerobusEndpoint[:7] == "http://" {
-		C.zerobus_sdk_set_use_tls(ptr, C.bool(false))
-	}
-
 	return unsafe.Pointer(ptr), nil
 }
 

--- a/go/ffi_test.go
+++ b/go/ffi_test.go
@@ -167,6 +167,44 @@ func TestMockHeadersProviderWithError(t *testing.T) {
 	}
 }
 
+// TestSdkIdentifierFormat verifies the SDK identifier is `zerobus-sdk-go/<version>`
+// — regression guard against the wrapper reporting `zerobus-sdk-rs/<version>`.
+func TestSdkIdentifierFormat(t *testing.T) {
+	got := sdkIdentifier()
+	want := "zerobus-sdk-go/" + sdkVersion
+	if got != want {
+		t.Errorf("sdkIdentifier() = %q, want %q", got, want)
+	}
+}
+
+// TestWithApplicationName verifies the option mutates resolved options.
+func TestWithApplicationName(t *testing.T) {
+	var o sdkOptions
+	WithApplicationName("my-app/1.0")(&o)
+	if o.applicationName != "my-app/1.0" {
+		t.Errorf("WithApplicationName did not set applicationName, got %q", o.applicationName)
+	}
+}
+
+// TestNewZerobusSdkSkipsNilOption verifies nil entries in the variadic opts
+// list are skipped rather than panicking.
+func TestNewZerobusSdkSkipsNilOption(t *testing.T) {
+	sdk, err := NewZerobusSdk(
+		"https://workspace.zerobus.databricks.com",
+		"https://workspace.cloud.databricks.com",
+		nil,
+		WithApplicationName("ok"),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewZerobusSdk should not error on nil opts, got: %v", err)
+	}
+	if sdk == nil {
+		t.Fatal("expected non-nil SDK")
+	}
+	sdk.Free()
+}
+
 // TestZerobusError tests the ZerobusError type
 func TestZerobusError(t *testing.T) {
 	err := &ZerobusError{

--- a/go/tests/mock_server.go
+++ b/go/tests/mock_server.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/databricks/zerobus-sdk/go/tests/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -61,6 +62,11 @@ type MockZerobusServer struct {
 	// Track response index across multiple connection attempts
 	responseIndices      map[string]int
 	responseIndicesMutex sync.Mutex
+
+	// Last user-agent observed on an incoming stream. Empty until the first
+	// stream is opened.
+	lastUserAgent      string
+	lastUserAgentMutex sync.Mutex
 }
 
 // NewMockZerobusServer creates a new mock server
@@ -121,8 +127,25 @@ func (m *MockZerobusServer) Reset() {
 	m.counterMutex.Unlock()
 }
 
+// GetLastUserAgent returns the most recent user-agent observed on an
+// incoming stream, or "" if no stream has been opened yet.
+func (m *MockZerobusServer) GetLastUserAgent() string {
+	m.lastUserAgentMutex.Lock()
+	defer m.lastUserAgentMutex.Unlock()
+	return m.lastUserAgent
+}
+
 // EphemeralStream implements the bidirectional streaming RPC
 func (m *MockZerobusServer) EphemeralStream(stream pb.Zerobus_EphemeralStreamServer) error {
+	// Capture the user-agent from incoming gRPC metadata.
+	if md, ok := metadata.FromIncomingContext(stream.Context()); ok {
+		if ua := md.Get("user-agent"); len(ua) > 0 {
+			m.lastUserAgentMutex.Lock()
+			m.lastUserAgent = ua[0]
+			m.lastUserAgentMutex.Unlock()
+		}
+	}
+
 	// Send initial headers/metadata to signal readiness
 	// This triggers the server to send HTTP/2 HEADERS frame
 	// This is CRITICAL: Without this, the Rust SDK will wait indefinitely

--- a/go/tests/user_agent_test.go
+++ b/go/tests/user_agent_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	zerobus "github.com/databricks/zerobus-sdk/go"
+)
+
+// openStream creates an SDK with the given options and opens a stream so
+// the mock server captures the user-agent metadata.
+func openStream(t *testing.T, serverURL string, opts ...zerobus.SdkOption) {
+	t.Helper()
+	sdk, err := zerobus.NewZerobusSdk(serverURL, "https://mock-uc.com", opts...)
+	if err != nil {
+		t.Fatalf("Failed to create SDK: %v", err)
+	}
+	defer sdk.Free()
+
+	stream, err := sdk.CreateStreamWithHeadersProvider(
+		zerobus.TableProperties{
+			TableName:       testTableName,
+			DescriptorProto: CreateTestDescriptorProto(),
+		},
+		&TestHeadersProvider{},
+		&zerobus.StreamConfigurationOptions{MaxInflightRequests: 100, Recovery: false},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create stream: %v", err)
+	}
+	defer stream.Close()
+}
+
+// TestDefaultUserAgentIdentifiesAsGo verifies the wire user-agent is
+// `zerobus-sdk-go/<version>`, not the Rust default.
+func TestDefaultUserAgentIdentifiesAsGo(t *testing.T) {
+	mockServer, serverURL, grpcServer, err := StartMockServer()
+	if err != nil {
+		t.Fatalf("Failed to start mock server: %v", err)
+	}
+	defer grpcServer.Stop()
+
+	mockServer.InjectResponses(testTableName, []MockResponse{
+		CreateStreamResponse("test_stream_1", 0),
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	openStream(t, serverURL)
+
+	ua := mockServer.GetLastUserAgent()
+	if !strings.Contains(ua, "zerobus-sdk-go/") {
+		t.Fatalf("expected user-agent to contain `zerobus-sdk-go/`, got %q", ua)
+	}
+	if strings.Contains(ua, "zerobus-sdk-rs/") {
+		t.Fatalf("user-agent must not advertise the Rust SDK prefix, got %q", ua)
+	}
+}
+
+// TestApplicationNameAppendedToUserAgent verifies WithApplicationName appends
+// the caller identifier after the SDK identifier.
+func TestApplicationNameAppendedToUserAgent(t *testing.T) {
+	mockServer, serverURL, grpcServer, err := StartMockServer()
+	if err != nil {
+		t.Fatalf("Failed to start mock server: %v", err)
+	}
+	defer grpcServer.Stop()
+
+	mockServer.InjectResponses(testTableName, []MockResponse{
+		CreateStreamResponse("test_stream_1", 0),
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	openStream(t, serverURL, zerobus.WithApplicationName("my-app/1.0"))
+
+	ua := mockServer.GetLastUserAgent()
+	if !strings.Contains(ua, "zerobus-sdk-go/") {
+		t.Fatalf("expected user-agent to keep `zerobus-sdk-go/` prefix, got %q", ua)
+	}
+	if !strings.Contains(ua, "my-app/1.0") {
+		t.Fatalf("expected user-agent to contain application name `my-app/1.0`, got %q", ua)
+	}
+}
+
+// TestEmptyApplicationNameIsIgnored verifies WithApplicationName("") is a
+// no-op (no trailing space, no extra token in the user-agent).
+func TestEmptyApplicationNameIsIgnored(t *testing.T) {
+	mockServer, serverURL, grpcServer, err := StartMockServer()
+	if err != nil {
+		t.Fatalf("Failed to start mock server: %v", err)
+	}
+	defer grpcServer.Stop()
+
+	mockServer.InjectResponses(testTableName, []MockResponse{
+		CreateStreamResponse("test_stream_1", 0),
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	openStream(t, serverURL, zerobus.WithApplicationName(""))
+
+	ua := mockServer.GetLastUserAgent()
+	if !strings.Contains(ua, "zerobus-sdk-go/") {
+		t.Fatalf("expected user-agent to contain `zerobus-sdk-go/`, got %q", ua)
+	}
+	if strings.Contains(ua, " my-app/") {
+		t.Fatalf("did not expect application name token in user-agent: %q", ua)
+	}
+}
+
+// TestWithNoTLSStreamCreationSucceeds verifies WithNoTLS() is forwarded
+// through Go → FFI → Rust builder and the stream opens successfully.
+func TestWithNoTLSStreamCreationSucceeds(t *testing.T) {
+	mockServer, serverURL, grpcServer, err := StartMockServer()
+	if err != nil {
+		t.Fatalf("Failed to start mock server: %v", err)
+	}
+	defer grpcServer.Stop()
+
+	mockServer.InjectResponses(testTableName, []MockResponse{
+		CreateStreamResponse("test_stream_1", 0),
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	openStream(t, serverURL, zerobus.WithNoTLS())
+}

--- a/go/version.go
+++ b/go/version.go
@@ -1,0 +1,11 @@
+package zerobus
+
+// sdkVersion must be bumped in sync with the `## Release vX.Y.Z` header in
+// NEXT_CHANGELOG.md at each release.
+const sdkVersion = "1.3.0"
+
+const sdkIdentifierPrefix = "zerobus-sdk-go"
+
+func sdkIdentifier() string {
+	return sdkIdentifierPrefix + "/" + sdkVersion
+}

--- a/go/zerobus.go
+++ b/go/zerobus.go
@@ -128,6 +128,7 @@ package zerobus
 
 import (
 	"runtime"
+	"strings"
 	"unsafe"
 )
 
@@ -143,17 +144,60 @@ type ZerobusStream struct {
 	ptr unsafe.Pointer
 }
 
+type sdkOptions struct {
+	applicationName string
+	noTLS           bool
+}
+
+// SdkOption configures a ZerobusSdk created via NewZerobusSdk.
+type SdkOption func(*sdkOptions)
+
+// WithNoTLS selects a no-TLS gRPC channel. Intended for local development
+// against a plain `http://` endpoint; do not use against production.
+func WithNoTLS() SdkOption {
+	return func(o *sdkOptions) {
+		o.noTLS = true
+	}
+}
+
+// WithApplicationName appends a caller-supplied identifier (e.g. "my-app/1.0")
+// to the HTTP `user-agent` header. The wire value becomes
+// `zerobus-sdk-go/<version> <name>`. Empty or whitespace-only values are
+// ignored.
+func WithApplicationName(name string) SdkOption {
+	name = strings.TrimSpace(name)
+	return func(o *sdkOptions) {
+		o.applicationName = name
+	}
+}
+
 // NewZerobusSdk creates a new SDK instance.
 //
 // Parameters:
-//   - zerobusEndpoint: The gRPC endpoint for the Zerobus service (e.g., "https://zerobus.databricks.com")
-//   - unityCatalogURL: The Unity Catalog URL for OAuth token acquisition (e.g., "https://workspace.databricks.com")
+//   - zerobusEndpoint: Zerobus gRPC endpoint
+//   - unityCatalogURL: Unity Catalog URL for OAuth token acquisition
+//   - opts: optional SdkOption values (e.g., WithApplicationName, WithNoTLS)
 //
-// Returns an error if:
-//   - Invalid endpoint URLs
-//   - Unable to extract workspace ID from Unity Catalog URL
-func NewZerobusSdk(zerobusEndpoint, unityCatalogURL string) (*ZerobusSdk, error) {
-	ptr, err := sdkNew(zerobusEndpoint, unityCatalogURL)
+// Returns an error if the endpoint URLs are invalid or the workspace ID
+// cannot be extracted.
+//
+// Example:
+//
+//	sdk, err := zerobus.NewZerobusSdk(
+//	    "https://workspace.zerobus.databricks.com",
+//	    "https://workspace.cloud.databricks.com",
+//	    zerobus.WithApplicationName("my-app/1.0"),
+//	)
+func NewZerobusSdk(zerobusEndpoint, unityCatalogURL string, opts ...SdkOption) (*ZerobusSdk, error) {
+	var resolved sdkOptions
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(&resolved)
+	}
+
+	ptr, err := sdkNew(zerobusEndpoint, unityCatalogURL, resolved)
 	if err != nil {
 		return nil, err
 	}

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,11 +6,17 @@
 
 ### New Features and Improvements
 
+- **C-builder API for SDK construction**: `zerobus_sdk_builder_new`, per-option setters (`_endpoint`, `_unity_catalog_url`, `_sdk_identifier`, `_application_name`, `_disable_tls`), and `_build` / `_free`. Mirrors the Rust `ZerobusSdkBuilder`; new options are added as setters without ABI breaks. Legacy `zerobus_sdk_new` is retained and delegates to the builder.
+
 ### Bug Fixes
 
 ### Documentation
 
 ### Internal Changes
+
+### Behavior Changes
+
+- `zerobus_sdk_new` no longer infers TLS-off from `http://` endpoints; it uses the default `SecureTlsConfig` regardless of scheme. Callers needing a plain-HTTP channel must use the builder API and call `zerobus_sdk_builder_disable_tls` explicitly.
 
 ### Breaking Changes
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -16,8 +16,6 @@
 
 ### Behavior Changes
 
-- `zerobus_sdk_new` no longer infers TLS-off from `http://` endpoints; it uses the default `SecureTlsConfig` regardless of scheme. Callers needing a plain-HTTP channel must use the builder API and call `zerobus_sdk_builder_disable_tls` explicitly.
-
 ### Breaking Changes
 
 ### Deprecations

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType;
 use databricks_zerobus_ingest_sdk::{
     EncodedRecord, HeadersProvider, NoTlsConfig, ZerobusError, ZerobusResult, ZerobusSdk,
-    ZerobusStream,
+    ZerobusSdkBuilder, ZerobusStream,
 };
 use databricks_zerobus_ingest_sdk::{RecordBatch, StreamBuilder, ZerobusArrowStream};
 use prost::Message;
@@ -974,56 +974,183 @@ pub(crate) fn write_success_result(result: *mut CResult) {
     }
 }
 
-/// Create a new ZerobusSdk instance
-/// Returns NULL on error. Check the result parameter for error details.
+// ============================================================================
+// ZerobusSdkBuilder FFI
+// ============================================================================
+//
+// C-builder mirroring the Rust `ZerobusSdkBuilder`. New options are added as
+// additive setter functions — no ABI breaks.
+//
+// Lifecycle: `_new` → zero or more `_<setter>` calls → `_build` (consumes) or
+// `_free` (abandon). Single-owner; not safe to share across threads.
+
+/// Opaque handle for an SDK builder. Allocated by `_new`, consumed by
+/// `_build`, or dropped by `_free`. Must not be used after either finalizer.
+#[repr(C)]
+pub struct CZerobusSdkBuilder {
+    _private: [u8; 0],
+}
+
+/// Concrete type behind `*mut CZerobusSdkBuilder`. All cast sites in this
+/// module must agree on this alias.
+type SdkBuilderAlloc = ZerobusSdkBuilder;
+
+/// SAFETY: `b` must be a valid pointer from `_new` that hasn't been consumed
+/// or freed. `mem::take` keeps the slot valid even if `f` panics.
+unsafe fn with_builder<F>(b: *mut CZerobusSdkBuilder, f: F)
+where
+    F: FnOnce(ZerobusSdkBuilder) -> ZerobusSdkBuilder,
+{
+    if b.is_null() {
+        return;
+    }
+    let slot = &mut *(b as *mut SdkBuilderAlloc);
+    let taken = std::mem::take(slot);
+    *slot = f(taken);
+}
+
+/// Allocates a new SDK builder. Must be terminated by exactly one of
+/// `_build` or `_free`.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_new() -> *mut CZerobusSdkBuilder {
+    init_logging();
+    let boxed: Box<SdkBuilderAlloc> = Box::new(ZerobusSdk::builder());
+    Box::into_raw(boxed) as *mut CZerobusSdkBuilder
+}
+
+/// Sets the Zerobus gRPC endpoint URL (required). No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_endpoint(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    unsafe { with_builder(builder, |b| b.endpoint(s)) }
+}
+
+/// Sets the Unity Catalog URL. Optional with a custom headers provider.
+/// No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_unity_catalog_url(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    unsafe { with_builder(builder, |b| b.unity_catalog_url(s)) }
+}
+
+/// Overrides the SDK prefix of the `user-agent` header (default
+/// `zerobus-sdk-rs/<version>`). Wrappers pass their own identifier here.
+/// Null and empty values are no-ops.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_sdk_identifier(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    unsafe { with_builder(builder, |b| b.sdk_identifier(s)) }
+}
+
+/// Appends an application identifier to the `user-agent` header. Wire value
+/// becomes `<sdk_identifier> <application_name>`. Null and empty values are
+/// no-ops.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_application_name(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    unsafe { with_builder(builder, |b| b.application_name(s)) }
+}
+
+/// Selects a no-TLS gRPC channel. TLS is on by default.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_disable_tls(builder: *mut CZerobusSdkBuilder) {
+    unsafe { with_builder(builder, |b| b.tls_config(Arc::new(NoTlsConfig))) }
+}
+
+/// Consumes the builder and returns a `CZerobusSdk*`, or NULL on error.
+/// Frees the builder on both paths — any further use of the pointer is
+/// undefined behavior. Null `builder` writes an error to `result`.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_build(
+    builder: *mut CZerobusSdkBuilder,
+    result: *mut CResult,
+) -> *mut CZerobusSdk {
+    if builder.is_null() {
+        write_error_result(result, "Builder pointer is null", false);
+        return ptr::null_mut();
+    }
+    // Reclaim ownership of the builder Box so it is dropped on every path,
+    // mirroring the Rust builder's consume-on-build semantics.
+    let inner = *unsafe { Box::from_raw(builder as *mut SdkBuilderAlloc) };
+    match inner.build() {
+        Ok(sdk) => {
+            write_success_result(result);
+            Box::into_raw(Box::new(sdk)) as *mut CZerobusSdk
+        }
+        Err(err) => {
+            if !result.is_null() {
+                unsafe {
+                    *result = CResult::error(err);
+                }
+            }
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Drops an unconsumed builder. No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_free(builder: *mut CZerobusSdkBuilder) {
+    if !builder.is_null() {
+        unsafe {
+            let _ = Box::from_raw(builder as *mut SdkBuilderAlloc);
+        }
+    }
+}
+
+/// Creates a new ZerobusSdk with default user-agent and TLS settings.
+///
+/// Retained for ABI back-compat with v1.2.x; new code should use the
+/// `zerobus_sdk_builder_*` API. Does not infer TLS state from the endpoint
+/// scheme — callers needing a plain-HTTP channel must use the builder API.
+///
+/// Returns NULL on error; see `result` for details.
 #[no_mangle]
 pub extern "C" fn zerobus_sdk_new(
     zerobus_endpoint: *const c_char,
     unity_catalog_url: *const c_char,
     result: *mut CResult,
 ) -> *mut CZerobusSdk {
-    init_logging();
-
-    let res = (|| -> Result<*mut CZerobusSdk, String> {
-        let endpoint = unsafe { c_str_to_string(zerobus_endpoint).map_err(|e| e.to_string())? };
-        let catalog_url = unsafe { c_str_to_string(unity_catalog_url).map_err(|e| e.to_string())? };
-
-        let uses_plain_http = endpoint.starts_with("http://");
-        let mut builder = ZerobusSdk::builder()
-            .endpoint(endpoint)
-            .unity_catalog_url(catalog_url);
-        if uses_plain_http {
-            builder = builder.tls_config(Arc::new(NoTlsConfig));
-        }
-        let sdk = builder.build().map_err(|e| e.to_string())?;
-        let boxed = Box::new(sdk);
-        Ok(Box::into_raw(boxed) as *mut CZerobusSdk)
-    })();
-
-    match res {
-        Ok(sdk_ptr) => {
-            if !result.is_null() {
-                unsafe {
-                    *result = CResult::success();
-                }
-            }
-            sdk_ptr
-        }
-        Err(err) => {
-            if !result.is_null() {
-                let err_msg =
-                    CString::new(err).unwrap_or_else(|_| CString::new("Unknown error").unwrap());
-                unsafe {
-                    *result = CResult {
-                        success: false,
-                        error_message: err_msg.into_raw(),
-                        is_retryable: false,
-                    };
-                }
-            }
-            ptr::null_mut()
-        }
-    }
+    let builder = zerobus_sdk_builder_new();
+    zerobus_sdk_builder_endpoint(builder, zerobus_endpoint);
+    zerobus_sdk_builder_unity_catalog_url(builder, unity_catalog_url);
+    zerobus_sdk_builder_build(builder, result)
 }
 
 /// Free the SDK instance

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -3,8 +3,11 @@ mod tests {
     use crate::{
         c_record_type, intern_header_key, validate_sdk_ptr, validate_stream_ptr,
         write_error_result, write_success_result, zerobus_free_error_message,
-        zerobus_get_default_config, CHeaders, CResult, CallbackHeadersProvider, RecordType,
-        ZerobusError,
+        zerobus_get_default_config, zerobus_sdk_builder_application_name,
+        zerobus_sdk_builder_build, zerobus_sdk_builder_disable_tls, zerobus_sdk_builder_endpoint,
+        zerobus_sdk_builder_free, zerobus_sdk_builder_new, zerobus_sdk_builder_sdk_identifier,
+        zerobus_sdk_builder_unity_catalog_url, zerobus_sdk_free, CHeaders, CResult,
+        CallbackHeadersProvider, RecordType, ZerobusError,
     };
     use databricks_zerobus_ingest_sdk::HeadersProvider;
     use std::ffi::{CStr, CString};
@@ -172,6 +175,161 @@ mod tests {
         assert_eq!(c_record_type(2), RecordType::Json);
         assert_eq!(c_record_type(999), RecordType::Unspecified);
         assert_eq!(c_record_type(0), RecordType::Unspecified);
+    }
+
+    // ========================================================================
+    // zerobus_sdk_builder Tests
+    // ========================================================================
+
+    /// Builds an SDK via the C builder API. Caller frees the SDK and any
+    /// error message.
+    fn build_via_c_builder(
+        endpoint: &str,
+        unity_catalog_url: &str,
+        sdk_identifier: Option<&str>,
+        application_name: Option<&str>,
+    ) -> (*mut crate::CZerobusSdk, CResult) {
+        let endpoint_c = CString::new(endpoint).unwrap();
+        let uc_c = CString::new(unity_catalog_url).unwrap();
+
+        let builder = zerobus_sdk_builder_new();
+        assert!(!builder.is_null());
+
+        zerobus_sdk_builder_endpoint(builder, endpoint_c.as_ptr());
+        zerobus_sdk_builder_unity_catalog_url(builder, uc_c.as_ptr());
+
+        if let Some(id) = sdk_identifier {
+            let id_c = CString::new(id).unwrap();
+            zerobus_sdk_builder_sdk_identifier(builder, id_c.as_ptr());
+        }
+        if let Some(app) = application_name {
+            let app_c = CString::new(app).unwrap();
+            zerobus_sdk_builder_application_name(builder, app_c.as_ptr());
+        }
+
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        (sdk, result)
+    }
+
+    #[test]
+    fn test_builder_minimal() {
+        let (sdk, result) =
+            build_via_c_builder("https://workspace.zerobus.databricks.com", "", None, None);
+        assert!(result.success, "expected success, got error");
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_with_sdk_identifier() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some("zerobus-sdk-go/1.3.0"),
+            None,
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_with_application_name() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            None,
+            Some("my-app/1.0"),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_both_user_agent_options() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some("zerobus-sdk-go/1.3.0"),
+            Some("my-app/1.0"),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_empty_strings_are_noops() {
+        // Empty identifier/application_name must not produce a trailing space.
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some(""),
+            Some(""),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_build_consumes_on_error() {
+        // Missing endpoint fails build. Builder must still be consumed —
+        // don't _free the pointer afterward (use-after-free).
+        let builder = zerobus_sdk_builder_new();
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        assert!(sdk.is_null());
+        assert!(!result.success);
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_builder_free_without_build() {
+        let builder = zerobus_sdk_builder_new();
+        zerobus_sdk_builder_free(builder);
+    }
+
+    #[test]
+    fn test_builder_free_on_null_is_safe() {
+        zerobus_sdk_builder_free(ptr::null_mut());
+    }
+
+    #[test]
+    fn test_builder_setters_on_null_are_safe() {
+        let s = CString::new("x").unwrap();
+        zerobus_sdk_builder_endpoint(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_unity_catalog_url(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_sdk_identifier(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_application_name(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_disable_tls(ptr::null_mut());
+    }
+
+    #[test]
+    fn test_builder_disable_tls_for_plain_http() {
+        let endpoint_c = CString::new("http://localhost:50051").unwrap();
+        let builder = zerobus_sdk_builder_new();
+        zerobus_sdk_builder_endpoint(builder, endpoint_c.as_ptr());
+        zerobus_sdk_builder_disable_tls(builder);
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
     }
 
     #[test]

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -103,6 +103,14 @@ typedef struct CArrowBatchArray {
   uintptr_t count;
 } CArrowBatchArray;
 
+/**
+ * Opaque handle for an SDK builder. Allocated by `_new`, consumed by
+ * `_build`, or dropped by `_free`. Must not be used after either finalizer.
+ */
+typedef struct CZerobusSdkBuilder {
+  uint8_t _private[0];
+} CZerobusSdkBuilder;
+
 typedef struct CZerobusStream {
   uint8_t _private[0];
 } CZerobusStream;
@@ -249,8 +257,62 @@ struct CArrowStreamConfigurationOptions zerobus_arrow_get_default_config(void);
 void zerobus_free_headers(struct CHeaders headers);
 
 /**
- * Create a new ZerobusSdk instance
- * Returns NULL on error. Check the result parameter for error details.
+ * Allocates a new SDK builder. Must be terminated by exactly one of
+ * `_build` or `_free`.
+ */
+struct CZerobusSdkBuilder *zerobus_sdk_builder_new(void);
+
+/**
+ * Sets the Zerobus gRPC endpoint URL (required). No-op on null.
+ */
+void zerobus_sdk_builder_endpoint(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Sets the Unity Catalog URL. Optional with a custom headers provider.
+ * No-op on null.
+ */
+void zerobus_sdk_builder_unity_catalog_url(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Overrides the SDK prefix of the `user-agent` header (default
+ * `zerobus-sdk-rs/<version>`). Wrappers pass their own identifier here.
+ * Null and empty values are no-ops.
+ */
+void zerobus_sdk_builder_sdk_identifier(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Appends an application identifier to the `user-agent` header. Wire value
+ * becomes `<sdk_identifier> <application_name>`. Null and empty values are
+ * no-ops.
+ */
+void zerobus_sdk_builder_application_name(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Selects a no-TLS gRPC channel. TLS is on by default.
+ */
+void zerobus_sdk_builder_disable_tls(struct CZerobusSdkBuilder *builder);
+
+/**
+ * Consumes the builder and returns a `CZerobusSdk*`, or NULL on error.
+ * Frees the builder on both paths — any further use of the pointer is
+ * undefined behavior. Null `builder` writes an error to `result`.
+ */
+struct CZerobusSdk *zerobus_sdk_builder_build(struct CZerobusSdkBuilder *builder,
+                                              struct CResult *result);
+
+/**
+ * Drops an unconsumed builder. No-op on null.
+ */
+void zerobus_sdk_builder_free(struct CZerobusSdkBuilder *builder);
+
+/**
+ * Creates a new ZerobusSdk with default user-agent and TLS settings.
+ *
+ * Retained for ABI back-compat with v1.2.x; new code should use the
+ * `zerobus_sdk_builder_*` API. Does not infer TLS state from the endpoint
+ * scheme — callers needing a plain-HTTP channel must use the builder API.
+ *
+ * Returns NULL on error; see `result` for details.
  */
 struct CZerobusSdk *zerobus_sdk_new(const char *zerobus_endpoint,
                                     const char *unity_catalog_url,


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Exposes configuring the `UserAgent` header through the `WithApplicationName` method to `SdkOption` for `NewZerobusSdk`. Wire value becomes `zerobus-sdk-go/<version> <application_name>`.
- Adds method `WithNoTLS` to `SdkOption` for `NewZerobusSdk` that selects a no-TLS gRPC channel.
- `user-agent` header now correctly identifies the Go SDK as `zerobus-sdk-go/<version>` instead of the underlying Rust default.

## How is this tested?

CI and testing against local server for propagation of the header.