### PR TITLE
[Rust][FFI] Expose SDK builder from Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-ffi"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "arrow-ipc",
  "async-trait",

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-ffi"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 description = "C FFI bindings for the Zerobus Rust SDK"
 license = "Apache-2.0"

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ### New Features and Improvements
 
+- **C-builder API for SDK construction**: `zerobus_sdk_builder_new`, per-option setters (`_endpoint`, `_unity_catalog_url`, `_sdk_identifier`, `_application_name`, `_disable_tls`), and `_build` / `_free`. Mirrors the Rust `ZerobusSdkBuilder`; new options are added as setters without ABI breaks. Legacy `zerobus_sdk_new` is retained and delegates to the builder.
+
 ### Bug Fixes
 
 ### Documentation
 
 ### Internal Changes
+
+### Behavior Changes
 
 ### Breaking Changes
 

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType;
 use databricks_zerobus_ingest_sdk::{
     EncodedRecord, HeadersProvider, NoTlsConfig, ZerobusError, ZerobusResult, ZerobusSdk,
-    ZerobusStream,
+    ZerobusSdkBuilder, ZerobusStream,
 };
 use databricks_zerobus_ingest_sdk::{RecordBatch, StreamBuilder, ZerobusArrowStream};
 use prost::Message;
@@ -974,56 +974,183 @@ pub(crate) fn write_success_result(result: *mut CResult) {
     }
 }
 
-/// Create a new ZerobusSdk instance
-/// Returns NULL on error. Check the result parameter for error details.
+// ============================================================================
+// ZerobusSdkBuilder FFI
+// ============================================================================
+//
+// C-builder mirroring the Rust `ZerobusSdkBuilder`. New options are added as
+// additive setter functions — no ABI breaks.
+//
+// Lifecycle: `_new` → zero or more `_<setter>` calls → `_build` (consumes) or
+// `_free` (abandon). Single-owner; not safe to share across threads.
+
+/// Opaque handle for an SDK builder. Allocated by `_new`, consumed by
+/// `_build`, or dropped by `_free`. Must not be used after either finalizer.
+#[repr(C)]
+pub struct CZerobusSdkBuilder {
+    _private: [u8; 0],
+}
+
+/// Concrete type behind `*mut CZerobusSdkBuilder`. All cast sites in this
+/// module must agree on this alias.
+type SdkBuilderAlloc = ZerobusSdkBuilder;
+
+/// SAFETY: `b` must be a valid pointer from `_new` that hasn't been consumed
+/// or freed. `mem::take` keeps the slot valid even if `f` panics.
+unsafe fn with_builder<F>(b: *mut CZerobusSdkBuilder, f: F)
+where
+    F: FnOnce(ZerobusSdkBuilder) -> ZerobusSdkBuilder,
+{
+    if b.is_null() {
+        return;
+    }
+    let slot = &mut *(b as *mut SdkBuilderAlloc);
+    let taken = std::mem::take(slot);
+    *slot = f(taken);
+}
+
+/// Allocates a new SDK builder. Must be terminated by exactly one of
+/// `_build` or `_free`.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_new() -> *mut CZerobusSdkBuilder {
+    init_logging();
+    let boxed: Box<SdkBuilderAlloc> = Box::new(ZerobusSdk::builder());
+    Box::into_raw(boxed) as *mut CZerobusSdkBuilder
+}
+
+/// Sets the Zerobus gRPC endpoint URL (required). No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_endpoint(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    unsafe { with_builder(builder, |b| b.endpoint(s)) }
+}
+
+/// Sets the Unity Catalog URL. Optional with a custom headers provider.
+/// No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_unity_catalog_url(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    unsafe { with_builder(builder, |b| b.unity_catalog_url(s)) }
+}
+
+/// Overrides the SDK prefix of the `user-agent` header (default
+/// `zerobus-sdk-rs/<version>`). Wrappers pass their own identifier here.
+/// Null and empty values are no-ops.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_sdk_identifier(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    unsafe { with_builder(builder, |b| b.sdk_identifier(s)) }
+}
+
+/// Appends an application identifier to the `user-agent` header. Wire value
+/// becomes `<sdk_identifier> <application_name>`. Null and empty values are
+/// no-ops.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_application_name(
+    builder: *mut CZerobusSdkBuilder,
+    value: *const c_char,
+) {
+    if value.is_null() {
+        return;
+    }
+    let s = match unsafe { c_str_to_string(value) } {
+        Ok(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    unsafe { with_builder(builder, |b| b.application_name(s)) }
+}
+
+/// Selects a no-TLS gRPC channel. TLS is on by default.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_disable_tls(builder: *mut CZerobusSdkBuilder) {
+    unsafe { with_builder(builder, |b| b.tls_config(Arc::new(NoTlsConfig))) }
+}
+
+/// Consumes the builder and returns a `CZerobusSdk*`, or NULL on error.
+/// Frees the builder on both paths — any further use of the pointer is
+/// undefined behavior. Null `builder` writes an error to `result`.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_build(
+    builder: *mut CZerobusSdkBuilder,
+    result: *mut CResult,
+) -> *mut CZerobusSdk {
+    if builder.is_null() {
+        write_error_result(result, "Builder pointer is null", false);
+        return ptr::null_mut();
+    }
+    // Reclaim ownership of the builder Box so it is dropped on every path,
+    // mirroring the Rust builder's consume-on-build semantics.
+    let inner = *unsafe { Box::from_raw(builder as *mut SdkBuilderAlloc) };
+    match inner.build() {
+        Ok(sdk) => {
+            write_success_result(result);
+            Box::into_raw(Box::new(sdk)) as *mut CZerobusSdk
+        }
+        Err(err) => {
+            if !result.is_null() {
+                unsafe {
+                    *result = CResult::error(err);
+                }
+            }
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Drops an unconsumed builder. No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_free(builder: *mut CZerobusSdkBuilder) {
+    if !builder.is_null() {
+        unsafe {
+            let _ = Box::from_raw(builder as *mut SdkBuilderAlloc);
+        }
+    }
+}
+
+/// Creates a new ZerobusSdk with default user-agent and TLS settings.
+///
+/// Retained for ABI back-compat with v1.2.x; new code should use the
+/// `zerobus_sdk_builder_*` API. Does not infer TLS state from the endpoint
+/// scheme — callers needing a plain-HTTP channel must use the builder API.
+///
+/// Returns NULL on error; see `result` for details.
 #[no_mangle]
 pub extern "C" fn zerobus_sdk_new(
     zerobus_endpoint: *const c_char,
     unity_catalog_url: *const c_char,
     result: *mut CResult,
 ) -> *mut CZerobusSdk {
-    init_logging();
-
-    let res = (|| -> Result<*mut CZerobusSdk, String> {
-        let endpoint = unsafe { c_str_to_string(zerobus_endpoint).map_err(|e| e.to_string())? };
-        let catalog_url = unsafe { c_str_to_string(unity_catalog_url).map_err(|e| e.to_string())? };
-
-        let uses_plain_http = endpoint.starts_with("http://");
-        let mut builder = ZerobusSdk::builder()
-            .endpoint(endpoint)
-            .unity_catalog_url(catalog_url);
-        if uses_plain_http {
-            builder = builder.tls_config(Arc::new(NoTlsConfig));
-        }
-        let sdk = builder.build().map_err(|e| e.to_string())?;
-        let boxed = Box::new(sdk);
-        Ok(Box::into_raw(boxed) as *mut CZerobusSdk)
-    })();
-
-    match res {
-        Ok(sdk_ptr) => {
-            if !result.is_null() {
-                unsafe {
-                    *result = CResult::success();
-                }
-            }
-            sdk_ptr
-        }
-        Err(err) => {
-            if !result.is_null() {
-                let err_msg =
-                    CString::new(err).unwrap_or_else(|_| CString::new("Unknown error").unwrap());
-                unsafe {
-                    *result = CResult {
-                        success: false,
-                        error_message: err_msg.into_raw(),
-                        is_retryable: false,
-                    };
-                }
-            }
-            ptr::null_mut()
-        }
-    }
+    let builder = zerobus_sdk_builder_new();
+    zerobus_sdk_builder_endpoint(builder, zerobus_endpoint);
+    zerobus_sdk_builder_unity_catalog_url(builder, unity_catalog_url);
+    zerobus_sdk_builder_build(builder, result)
 }
 
 /// Free the SDK instance

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -3,8 +3,11 @@ mod tests {
     use crate::{
         c_record_type, intern_header_key, validate_sdk_ptr, validate_stream_ptr,
         write_error_result, write_success_result, zerobus_free_error_message,
-        zerobus_get_default_config, CHeaders, CResult, CallbackHeadersProvider, RecordType,
-        ZerobusError,
+        zerobus_get_default_config, zerobus_sdk_builder_application_name,
+        zerobus_sdk_builder_build, zerobus_sdk_builder_disable_tls, zerobus_sdk_builder_endpoint,
+        zerobus_sdk_builder_free, zerobus_sdk_builder_new, zerobus_sdk_builder_sdk_identifier,
+        zerobus_sdk_builder_unity_catalog_url, zerobus_sdk_free, CHeaders, CResult,
+        CallbackHeadersProvider, RecordType, ZerobusError,
     };
     use databricks_zerobus_ingest_sdk::HeadersProvider;
     use std::ffi::{CStr, CString};
@@ -172,6 +175,161 @@ mod tests {
         assert_eq!(c_record_type(2), RecordType::Json);
         assert_eq!(c_record_type(999), RecordType::Unspecified);
         assert_eq!(c_record_type(0), RecordType::Unspecified);
+    }
+
+    // ========================================================================
+    // zerobus_sdk_builder Tests
+    // ========================================================================
+
+    /// Builds an SDK via the C builder API. Caller frees the SDK and any
+    /// error message.
+    fn build_via_c_builder(
+        endpoint: &str,
+        unity_catalog_url: &str,
+        sdk_identifier: Option<&str>,
+        application_name: Option<&str>,
+    ) -> (*mut crate::CZerobusSdk, CResult) {
+        let endpoint_c = CString::new(endpoint).unwrap();
+        let uc_c = CString::new(unity_catalog_url).unwrap();
+
+        let builder = zerobus_sdk_builder_new();
+        assert!(!builder.is_null());
+
+        zerobus_sdk_builder_endpoint(builder, endpoint_c.as_ptr());
+        zerobus_sdk_builder_unity_catalog_url(builder, uc_c.as_ptr());
+
+        if let Some(id) = sdk_identifier {
+            let id_c = CString::new(id).unwrap();
+            zerobus_sdk_builder_sdk_identifier(builder, id_c.as_ptr());
+        }
+        if let Some(app) = application_name {
+            let app_c = CString::new(app).unwrap();
+            zerobus_sdk_builder_application_name(builder, app_c.as_ptr());
+        }
+
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        (sdk, result)
+    }
+
+    #[test]
+    fn test_builder_minimal() {
+        let (sdk, result) =
+            build_via_c_builder("https://workspace.zerobus.databricks.com", "", None, None);
+        assert!(result.success, "expected success, got error");
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_with_sdk_identifier() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some("zerobus-sdk-go/1.3.0"),
+            None,
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_with_application_name() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            None,
+            Some("my-app/1.0"),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_both_user_agent_options() {
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some("zerobus-sdk-go/1.3.0"),
+            Some("my-app/1.0"),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_empty_strings_are_noops() {
+        // Empty identifier/application_name must not produce a trailing space.
+        let (sdk, result) = build_via_c_builder(
+            "https://workspace.zerobus.databricks.com",
+            "",
+            Some(""),
+            Some(""),
+        );
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
+    }
+
+    #[test]
+    fn test_builder_build_consumes_on_error() {
+        // Missing endpoint fails build. Builder must still be consumed —
+        // don't _free the pointer afterward (use-after-free).
+        let builder = zerobus_sdk_builder_new();
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        assert!(sdk.is_null());
+        assert!(!result.success);
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_builder_free_without_build() {
+        let builder = zerobus_sdk_builder_new();
+        zerobus_sdk_builder_free(builder);
+    }
+
+    #[test]
+    fn test_builder_free_on_null_is_safe() {
+        zerobus_sdk_builder_free(ptr::null_mut());
+    }
+
+    #[test]
+    fn test_builder_setters_on_null_are_safe() {
+        let s = CString::new("x").unwrap();
+        zerobus_sdk_builder_endpoint(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_unity_catalog_url(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_sdk_identifier(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_application_name(ptr::null_mut(), s.as_ptr());
+        zerobus_sdk_builder_disable_tls(ptr::null_mut());
+    }
+
+    #[test]
+    fn test_builder_disable_tls_for_plain_http() {
+        let endpoint_c = CString::new("http://localhost:50051").unwrap();
+        let builder = zerobus_sdk_builder_new();
+        zerobus_sdk_builder_endpoint(builder, endpoint_c.as_ptr());
+        zerobus_sdk_builder_disable_tls(builder);
+        let mut result = CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        };
+        let sdk = zerobus_sdk_builder_build(builder, &mut result);
+        assert!(result.success);
+        assert!(!sdk.is_null());
+        zerobus_sdk_free(sdk);
     }
 
     #[test]

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -103,6 +103,14 @@ typedef struct CArrowBatchArray {
   uintptr_t count;
 } CArrowBatchArray;
 
+/**
+ * Opaque handle for an SDK builder. Allocated by `_new`, consumed by
+ * `_build`, or dropped by `_free`. Must not be used after either finalizer.
+ */
+typedef struct CZerobusSdkBuilder {
+  uint8_t _private[0];
+} CZerobusSdkBuilder;
+
 typedef struct CZerobusStream {
   uint8_t _private[0];
 } CZerobusStream;
@@ -249,8 +257,62 @@ struct CArrowStreamConfigurationOptions zerobus_arrow_get_default_config(void);
 void zerobus_free_headers(struct CHeaders headers);
 
 /**
- * Create a new ZerobusSdk instance
- * Returns NULL on error. Check the result parameter for error details.
+ * Allocates a new SDK builder. Must be terminated by exactly one of
+ * `_build` or `_free`.
+ */
+struct CZerobusSdkBuilder *zerobus_sdk_builder_new(void);
+
+/**
+ * Sets the Zerobus gRPC endpoint URL (required). No-op on null.
+ */
+void zerobus_sdk_builder_endpoint(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Sets the Unity Catalog URL. Optional with a custom headers provider.
+ * No-op on null.
+ */
+void zerobus_sdk_builder_unity_catalog_url(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Overrides the SDK prefix of the `user-agent` header (default
+ * `zerobus-sdk-rs/<version>`). Wrappers pass their own identifier here.
+ * Null and empty values are no-ops.
+ */
+void zerobus_sdk_builder_sdk_identifier(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Appends an application identifier to the `user-agent` header. Wire value
+ * becomes `<sdk_identifier> <application_name>`. Null and empty values are
+ * no-ops.
+ */
+void zerobus_sdk_builder_application_name(struct CZerobusSdkBuilder *builder, const char *value);
+
+/**
+ * Selects a no-TLS gRPC channel. TLS is on by default.
+ */
+void zerobus_sdk_builder_disable_tls(struct CZerobusSdkBuilder *builder);
+
+/**
+ * Consumes the builder and returns a `CZerobusSdk*`, or NULL on error.
+ * Frees the builder on both paths — any further use of the pointer is
+ * undefined behavior. Null `builder` writes an error to `result`.
+ */
+struct CZerobusSdk *zerobus_sdk_builder_build(struct CZerobusSdkBuilder *builder,
+                                              struct CResult *result);
+
+/**
+ * Drops an unconsumed builder. No-op on null.
+ */
+void zerobus_sdk_builder_free(struct CZerobusSdkBuilder *builder);
+
+/**
+ * Creates a new ZerobusSdk with default user-agent and TLS settings.
+ *
+ * Retained for ABI back-compat with v1.2.x; new code should use the
+ * `zerobus_sdk_builder_*` API. Does not infer TLS state from the endpoint
+ * scheme — callers needing a plain-HTTP channel must use the builder API.
+ *
+ * Returns NULL on error; see `result` for details.
  */
 struct CZerobusSdk *zerobus_sdk_new(const char *zerobus_endpoint,
                                     const char *unity_catalog_url,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose the Rust `ZerobusSdkBuilder` over the C FFI as a builder API, so
wrapper SDKs can configure SDK construction options that the existing
three-argument `zerobus_sdk_new` constructor cannot reach. Bumps the FFI
crate from `1.2.1` to `1.3.0`. ABI back-compat for `zerobus_sdk_new` is
preserved.

This PR is the FFI half of a two-part change. The matching Go SDK PR
sits on top of this release and exposes the new options as Go-level
`SdkOption` functions (`WithApplicationName`, `WithNoTLS`).

### Motivation

The legacy `zerobus_sdk_new(endpoint, unity_catalog_url, result)` cannot
configure:

- the SDK identifier on the `user-agent` header (so the Go SDK currently
  wears the Rust SDK's default identifier — a bug the matching Go PR
  fixes);
- an application name to append to the `user-agent` header;
- a no-TLS channel option for local development against plain-HTTP
  Shinkansen servers.

Adding a `zerobus_sdk_new_with_options(...)` variant would force a new
function per option set and risk an ABI break the next time an option
landed. A builder API is purely additive: each new option becomes a new
setter function with no impact on any existing entrypoint.

### New API surface

```c
struct CZerobusSdkBuilder;  // opaque

CZerobusSdkBuilder* zerobus_sdk_builder_new(void);

void zerobus_sdk_builder_endpoint(CZerobusSdkBuilder*, const char* value);
void zerobus_sdk_builder_unity_catalog_url(CZerobusSdkBuilder*, const char* value);
void zerobus_sdk_builder_sdk_identifier(CZerobusSdkBuilder*, const char* value);
void zerobus_sdk_builder_application_name(CZerobusSdkBuilder*, const char* value);
void zerobus_sdk_builder_disable_tls(CZerobusSdkBuilder*);

// Consumes the builder. Frees it on both success and failure paths;
// any further use of the pointer is undefined behavior.
CZerobusSdk* zerobus_sdk_builder_build(CZerobusSdkBuilder*, CResult* result);

// Drops a builder without consuming it (use only when abandoning a
// builder between _new and _build). No-op on NULL.
void zerobus_sdk_builder_free(CZerobusSdkBuilder*);
```

`zerobus.h` is regenerated by cbindgen.

### What stays the same

- `zerobus_sdk_new(endpoint, unity_catalog_url, result)` is retained with
  the same signature for ABI back-compat. It now internally drives the
  builder.
- `zerobus_sdk_set_use_tls` remains as a no-op (ABI placeholder, has been
  a no-op since the Rust core 2.0.0 release).

### Behavior change

`zerobus_sdk_new` no longer infers any TLS configuration from the
endpoint scheme — it constructs the SDK with the default
`SecureTlsConfig` regardless of whether the URL is `http://` or
`https://`. Callers that need a plain-HTTP channel must use the builder
API and call `zerobus_sdk_builder_disable_tls` explicitly.

In practice this is observationally a no-op for existing callers: tonic's
gRPC transport already selects plain HTTP/2 for `http://` URLs at the
scheme level, regardless of the configured `TlsConfig`.

### Implementation notes

- The opaque `*CZerobusSdkBuilder` is a reinterpret cast of
  `Box<ZerobusSdkBuilder>`. A `type SdkBuilderAlloc = ZerobusSdkBuilder;`
  alias is shared across the four cast sites (allocate, mutate, consume,
  drop) to keep them in lock-step.
- Setters mutate in place via `std::mem::take` (`ZerobusSdkBuilder`
  implements `Default`), so the slot stays valid even if a setter
  closure panics.
- `_build` reclaims ownership with `Box::from_raw` and drops on every
  outcome — null/empty/build-error all free the builder before
  returning.

### Migration for direct FFI consumers

If you currently call `zerobus_sdk_new("http://...", ...)` and relied on
TLS being disabled implicitly: explicitly call the new builder setter.

```c
CZerobusSdkBuilder* b = zerobus_sdk_builder_new();
zerobus_sdk_builder_endpoint(b, "http://...");
zerobus_sdk_builder_unity_catalog_url(b, "");
zerobus_sdk_builder_disable_tls(b);
CZerobusSdk* sdk = zerobus_sdk_builder_build(b, &result);
```

For most callers this is observationally a no-op (see "Behavior change"
above).

### Version bump

`rust/ffi/Cargo.toml`: `1.2.1` → `1.3.0`. Minor bump — new API,
back-compat preserved. `Cargo.lock` updated accordingly.

`rust/ffi/NEXT_CHANGELOG.md` documents the change. On version-bump
merge, contents move to `CHANGELOG.md` per release convention.

### Follow-up

A separate Go SDK PR (currently on `go/user-agent`) builds on this
release. After this PR merges and an `ffi/v1.3.0` release is cut, the Go
PR will:

- Add `WithApplicationName(name)` and `WithNoTLS()` as `SdkOption`
  functions on `NewZerobusSdk`.
- Set the SDK identifier to `zerobus-sdk-go/<version>` via the new
  builder setter (fixes the wire `user-agent` identification bug).
- Drop the now-dead `zerobus_sdk_set_use_tls` declaration from cgo.

### Reviewer focus

- `rust/ffi/src/lib.rs`: the `with_builder` helper, the `_build` /
  `_free` ownership story, and the `zerobus_sdk_new` delegation.
- `rust/ffi/zerobus.h`: cbindgen-regenerated; review the diff.
- `rust/ffi/src/tests.rs`: the new builder-API tests.
- `rust/ffi/Cargo.toml`: version bump.
- `rust/ffi/NEXT_CHANGELOG.md`: behavior-change wording.


## How is this tested?

10 new builder-API unit tests, all under
`rust/ffi/src/tests.rs`:

- minimal build (endpoint only)
- each setter individually + both user-agent setters together
- empty strings treated as no-ops
- error path: missing endpoint must still consume the builder
- `_free` without `_build` (abandonment)
- `_free` on null
- setters on null builder are no-ops
- `_disable_tls` for plain-http endpoint builds cleanly

Total FFI test count: **30 passing**, `cargo clippy --all -- -D warnings`
clean.