### PR TITLE
[Rust][FFI] Expose UC-schema → protobuf descriptor + record encoding

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3689,7 +3689,9 @@ dependencies = [
  "libc",
  "once_cell",
  "prost",
+ "prost-reflect",
  "prost-types",
+ "serde_json",
  "tokio",
  "tracing-subscriber",
 ]

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -24,6 +24,12 @@ async-trait.workspace = true
 bytes.workspace = true
 libc.workspace = true
 
+# Dynamic protobuf: build a descriptor pool from a UC-derived DescriptorProto
+# and encode JSON records into protobuf bytes (UC schema -> proto path for
+# pure-C consumers). serde_json parses the UC table metadata + record JSON.
+prost-reflect = { workspace = true, features = ["serde"] }
+serde_json.workspace = true
+
 # Logging
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -7,6 +7,11 @@
 ### New Features and Improvements
 
 - **C-builder API for SDK construction**: `zerobus_sdk_builder_new`, per-option setters (`_endpoint`, `_unity_catalog_url`, `_sdk_identifier`, `_application_name`, `_disable_tls`), and `_build` / `_free`. Mirrors the Rust `ZerobusSdkBuilder`; new options are added as setters without ABI breaks. Legacy `zerobus_sdk_new` is retained and delegates to the builder.
+- **Dynamic protobuf from a Unity Catalog schema**: a pure-C consumer can now follow the same UC-schema → protobuf-descriptor → record-encoding path the Vector sink uses, without a companion Rust crate. New opaque type `CZerobusProtoSchema` and functions:
+  - `zerobus_proto_schema_from_uc_json` — build a schema handle from UC table-metadata JSON (the body of `GET /api/2.1/unity-catalog/tables/{name}`).
+  - `zerobus_proto_schema_descriptor_bytes` — borrow the serialized `DescriptorProto` to pass straight to `zerobus_sdk_create_stream` (byte-identical to the descriptor the encoder uses).
+  - `zerobus_proto_schema_encode_json` — encode one JSON record into protobuf bytes; unknown keys are ignored. `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` columns are integers (days / micros since epoch), not strings.
+  - `zerobus_free_proto_bytes` / `zerobus_proto_schema_free` — free an encoded buffer / a schema handle.
 
 ### Bug Fixes
 

--- a/rust/ffi/README.md
+++ b/rust/ffi/README.md
@@ -58,6 +58,40 @@ private static extern IntPtr zerobus_sdk_new(string endpoint, string ucUrl, ref 
 // Link with -lzerobus_ffi
 ```
 
+### Dynamic protobuf from a Unity Catalog schema (pure C)
+
+Build a protobuf descriptor and encode records straight from Unity Catalog
+table metadata — no pre-generated `.proto` file and no second Rust crate:
+
+```c
+CResult r = {0};
+
+/* init: fetch GET /api/2.1/unity-catalog/tables/{name} and pass its JSON body */
+CZerobusProtoSchema *schema = zerobus_proto_schema_from_uc_json(uc_table_json, &r);
+/* on error schema == NULL; read r.error_message then zerobus_free_error_message(r.error_message) */
+
+uintptr_t dlen;
+const uint8_t *desc = zerobus_proto_schema_descriptor_bytes(schema, &dlen);
+CZerobusStream *stream = zerobus_sdk_create_stream(sdk, table_name, desc, dlen,
+                                                   client_id, client_secret, &opts, &r);
+
+/* per record, at flush time */
+uint8_t *buf; uintptr_t len;
+if (zerobus_proto_schema_encode_json(schema, record_json, &buf, &len, &r)) {
+    /* collect buf/len into a batch, ingest via zerobus_stream_ingest_proto_records(...) */
+    zerobus_free_proto_bytes(buf, len);
+}
+
+/* shutdown */
+zerobus_proto_schema_free(schema);
+```
+
+Encoding contract: record object keys are matched to column names; unknown keys
+are ignored (upstream records often carry extra non-column metadata). `DATE`,
+`TIMESTAMP`, and `TIMESTAMP_NTZ` columns are encoded as integers — supply days
+(for `DATE`) or microseconds since the Unix epoch (for `TIMESTAMP*`), not
+ISO-8601 strings.
+
 ## API Reference
 
 See `zerobus.h` for the complete C API documentation.

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -8,6 +8,6 @@ namespace = "zerobus"
 cpp_compat = true
 
 [export]
-include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray"]
+include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CZerobusProtoSchema"]
 
 [export.rename]

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -17,12 +17,14 @@ use arrow_ipc::{reader::StreamReader, writer::StreamWriter, CompressionType};
 use async_trait::async_trait;
 use bytes::Bytes;
 use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType;
+use databricks_zerobus_ingest_sdk::schema::{descriptor_from_uc_schema, UcTableSchema};
 use databricks_zerobus_ingest_sdk::{
     EncodedRecord, HeadersProvider, NoTlsConfig, ZerobusError, ZerobusResult, ZerobusSdk,
     ZerobusSdkBuilder, ZerobusStream,
 };
 use databricks_zerobus_ingest_sdk::{RecordBatch, StreamBuilder, ZerobusArrowStream};
 use prost::Message;
+use prost_reflect::{DescriptorPool, DeserializeOptions, DynamicMessage, MessageDescriptor};
 use std::sync::Arc;
 
 // Test module
@@ -619,14 +621,10 @@ pub extern "C" fn zerobus_arrow_free_batch_array(array: CArrowBatchArray) {
             // Reconstruct as Box<[T]> using the original length. This is safe because
             // the pointers were produced by Box::into_raw(vec.into_boxed_slice()),
             // which guarantees capacity == len.
-            let ptrs = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-                array.batches,
-                array.count,
-            ));
-            let lens = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-                array.lengths,
-                array.count,
-            ));
+            let ptrs =
+                Box::from_raw(std::ptr::slice_from_raw_parts_mut(array.batches, array.count));
+            let lens =
+                Box::from_raw(std::ptr::slice_from_raw_parts_mut(array.lengths, array.count));
             for (&ptr, &len) in ptrs.iter().zip(lens.iter()) {
                 if !ptr.is_null() && len > 0 {
                     // Each batch slice was produced by Box::into_raw(bytes.into_boxed_slice()),
@@ -1973,5 +1971,207 @@ pub extern "C" fn zerobus_get_default_config() -> CStreamConfigurationOptions {
         has_stream_paused_max_wait_time_ms: false,
         callback_max_wait_time_ms: defaults::CALLBACK_MAX_WAIT_TIME_MS,
         has_callback_max_wait_time_ms: true,
+    }
+}
+
+// ============================================================================
+// Dynamic Protobuf FFI
+// ============================================================================
+//
+// Pure-C consumers can build a protobuf descriptor from Unity Catalog metadata
+// and encode JSON records to protobuf bytes without a companion Rust crate.
+// Lifecycle: `_from_uc_json` → `_descriptor_bytes` / `_encode_json` → `_free`.
+
+/// Holds a table's serialized `DescriptorProto` plus a prepared protobuf
+/// encoder built from it. Opaque to C; the concrete type is [`ProtoSchema`].
+#[repr(C)]
+pub struct CZerobusProtoSchema {
+    _private: [u8; 0],
+}
+
+/// Concrete type behind `*mut CZerobusProtoSchema`.
+struct ProtoSchema {
+    /// Serialized `DescriptorProto` bytes (passed to `zerobus_sdk_create_stream`).
+    descriptor_bytes: Vec<u8>,
+    /// Message descriptor for encoding JSON records to protobuf.
+    message: MessageDescriptor,
+}
+
+/// Safe wrapper to validate proto schema pointer
+fn validate_proto_schema_ptr<'a>(
+    schema: *const CZerobusProtoSchema,
+) -> Result<&'a ProtoSchema, &'static str> {
+    if schema.is_null() {
+        return Err("Proto schema pointer is null");
+    }
+    unsafe { Ok(&*(schema as *const ProtoSchema)) }
+}
+
+/// Builds a [`ProtoSchema`] from Unity Catalog table-metadata JSON.
+fn build_proto_schema(uc_table_json: &str) -> Result<ProtoSchema, String> {
+    let schema: UcTableSchema = serde_json::from_str(uc_table_json)
+        .map_err(|e| format!("failed to parse Unity Catalog table JSON: {e}"))?;
+    let descriptor = descriptor_from_uc_schema(&schema).map_err(|e| e.to_string())?;
+    let descriptor_bytes = descriptor.encode_to_vec();
+    let message_name = descriptor.name().to_string();
+
+    let file = prost_types::FileDescriptorProto {
+        name: Some("zerobus_dynamic.proto".to_string()),
+        message_type: vec![descriptor],
+        ..Default::default()
+    };
+    let mut pool = DescriptorPool::new();
+    pool.add_file_descriptor_proto(file)
+        .map_err(|e| format!("failed to build descriptor pool: {e}"))?;
+    // No package on the synthetic file, so the fully-qualified name is the
+    // bare message name.
+    let message = pool
+        .get_message_by_name(&message_name)
+        .ok_or_else(|| format!("message '{message_name}' not found in descriptor pool"))?;
+
+    Ok(ProtoSchema {
+        descriptor_bytes,
+        message,
+    })
+}
+
+/// Build a protobuf schema from Unity Catalog table metadata JSON.
+/// Returns NULL on error; free with `zerobus_proto_schema_free`.
+#[no_mangle]
+pub extern "C" fn zerobus_proto_schema_from_uc_json(
+    uc_table_json: *const c_char,
+    result: *mut CResult,
+) -> *mut CZerobusProtoSchema {
+    let json = match unsafe { c_str_to_string(uc_table_json) } {
+        Ok(s) => s,
+        Err(e) => {
+            write_error_result(result, e, false);
+            return ptr::null_mut();
+        }
+    };
+
+    match build_proto_schema(&json) {
+        Ok(schema) => {
+            write_success_result(result);
+            Box::into_raw(Box::new(schema)) as *mut CZerobusProtoSchema
+        }
+        Err(err) => {
+            write_error_result(result, &err, false);
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Borrow the serialized descriptor bytes. Valid until `zerobus_proto_schema_free`.
+/// Pass directly to `zerobus_sdk_create_stream`. Returns NULL on null handle.
+#[no_mangle]
+pub extern "C" fn zerobus_proto_schema_descriptor_bytes(
+    schema: *const CZerobusProtoSchema,
+    out_len: *mut usize,
+) -> *const u8 {
+    let schema_ref = match validate_proto_schema_ptr(schema) {
+        Ok(s) => s,
+        Err(_) => {
+            if !out_len.is_null() {
+                unsafe {
+                    *out_len = 0;
+                }
+            }
+            return ptr::null();
+        }
+    };
+    if !out_len.is_null() {
+        unsafe {
+            *out_len = schema_ref.descriptor_bytes.len();
+        }
+    }
+    schema_ref.descriptor_bytes.as_ptr()
+}
+
+/// Encode JSON record to protobuf bytes. Unknown keys are ignored.
+/// DATE/TIMESTAMP columns must be integers (days/micros since epoch), not strings.
+/// Returns true on success; caller must free buffer with `zerobus_free_proto_bytes`.
+#[no_mangle]
+pub extern "C" fn zerobus_proto_schema_encode_json(
+    schema: *const CZerobusProtoSchema,
+    record_json: *const c_char,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+    result: *mut CResult,
+) -> bool {
+    let schema_ref = match validate_proto_schema_ptr(schema) {
+        Ok(s) => s,
+        Err(msg) => {
+            write_error_result(result, msg, false);
+            return false;
+        }
+    };
+    if out_data.is_null() || out_len.is_null() {
+        write_error_result(result, "Output pointers are null", false);
+        return false;
+    }
+    let json = match unsafe { c_str_to_string(record_json) } {
+        Ok(s) => s,
+        Err(e) => {
+            write_error_result(result, e, false);
+            return false;
+        }
+    };
+
+    let mut deserializer = serde_json::Deserializer::from_str(&json);
+    // Records carry extra non-column fields; ignore them rather than erroring.
+    let options = DeserializeOptions::new().deny_unknown_fields(false);
+    let message = match DynamicMessage::deserialize_with_options(
+        schema_ref.message.clone(),
+        &mut deserializer,
+        &options,
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            write_error_result(result, &format!("failed to encode record: {e}"), false);
+            return false;
+        }
+    };
+    if let Err(e) = deserializer.end() {
+        write_error_result(
+            result,
+            &format!("unexpected trailing content in record JSON: {e}"),
+            false,
+        );
+        return false;
+    }
+
+    let bytes = message.encode_to_vec();
+    let len = bytes.len();
+    // into_boxed_slice() shrinks capacity to len so the matching
+    // zerobus_free_proto_bytes reconstruction is sound.
+    let data_ptr = Box::into_raw(bytes.into_boxed_slice()) as *mut u8;
+    unsafe {
+        *out_data = data_ptr;
+        *out_len = len;
+    }
+    write_success_result(result);
+    true
+}
+
+/// Free a buffer returned by `zerobus_proto_schema_encode_json`.
+#[no_mangle]
+pub extern "C" fn zerobus_free_proto_bytes(data: *mut u8, len: usize) {
+    if !data.is_null() && len > 0 {
+        unsafe {
+            // data came from Box::into_raw(bytes.into_boxed_slice()), so
+            // capacity == len and this reconstruction is sound.
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(data, len));
+        }
+    }
+}
+
+/// Free a handle from `zerobus_proto_schema_from_uc_json`.
+#[no_mangle]
+pub extern "C" fn zerobus_proto_schema_free(schema: *mut CZerobusProtoSchema) {
+    if !schema.is_null() {
+        unsafe {
+            let _ = Box::from_raw(schema as *mut ProtoSchema);
+        }
     }
 }

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -441,4 +441,244 @@ mod tests {
         assert_eq!(headers.len(), 1);
         assert!(headers.contains_key("Authorization"));
     }
+
+    // ========================================================================
+    // Dynamic protobuf schema tests
+    // ========================================================================
+
+    use crate::{
+        zerobus_free_proto_bytes, zerobus_proto_schema_descriptor_bytes,
+        zerobus_proto_schema_encode_json, zerobus_proto_schema_free,
+        zerobus_proto_schema_from_uc_json,
+    };
+    use prost::Message;
+    use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
+
+    // Minimal Unity Catalog table-metadata JSON, shaped like the body of
+    // GET /api/2.1/unity-catalog/tables/{name}.
+    fn sample_uc_table_json() -> CString {
+        let json = r#"{
+            "name": "events",
+            "catalog_name": "main",
+            "schema_name": "analytics",
+            "columns": [
+                {"name": "id", "type_name": "BIGINT", "type_text": "bigint", "nullable": false, "position": 0},
+                {"name": "payload", "type_name": "STRING", "type_text": "string", "nullable": true, "position": 1},
+                {"name": "ts", "type_name": "TIMESTAMP", "type_text": "timestamp", "nullable": true, "position": 2}
+            ]
+        }"#;
+        CString::new(json).unwrap()
+    }
+
+    // A CResult to be written into by the function under test. Starts as a
+    // failure so a success-path test proves the call flipped it to success.
+    fn unwritten_result() -> CResult {
+        CResult {
+            success: false,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        }
+    }
+
+    // As above but starts successful, so an error-path test proves the call
+    // flipped it to failure.
+    fn presumed_success_result() -> CResult {
+        CResult {
+            success: true,
+            error_message: ptr::null_mut(),
+            is_retryable: false,
+        }
+    }
+
+    // Rebuild a MessageDescriptor from the bare DescriptorProto bytes the handle
+    // exposes, so a test can decode encoded records back and assert field values
+    // — proving the descriptor given to the server and the encoder agree.
+    fn message_descriptor_from_bytes(descriptor_bytes: &[u8]) -> MessageDescriptor {
+        let descriptor = prost_types::DescriptorProto::decode(descriptor_bytes).unwrap();
+        let name = descriptor.name().to_string();
+        let file = prost_types::FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            message_type: vec![descriptor],
+            ..Default::default()
+        };
+        let mut pool = DescriptorPool::new();
+        pool.add_file_descriptor_proto(file).unwrap();
+        pool.get_message_by_name(&name).unwrap()
+    }
+
+    #[test]
+    fn test_proto_schema_from_uc_json_roundtrip() {
+        let json = sample_uc_table_json();
+        let mut result = unwritten_result();
+        let schema = zerobus_proto_schema_from_uc_json(json.as_ptr(), &mut result as *mut CResult);
+        assert!(!schema.is_null(), "schema build failed");
+        assert!(result.success);
+
+        // Descriptor bytes must decode to the bare DescriptorProto that the
+        // server is given via zerobus_sdk_create_stream.
+        let mut dlen: usize = 0;
+        let dptr = zerobus_proto_schema_descriptor_bytes(schema, &mut dlen as *mut usize);
+        assert!(!dptr.is_null());
+        assert!(dlen > 0);
+        let desc_bytes = unsafe { std::slice::from_raw_parts(dptr, dlen) };
+        let descriptor = prost_types::DescriptorProto::decode(desc_bytes).unwrap();
+        // schema_name + table_name, sanitized to PascalCase.
+        assert_eq!(descriptor.name(), "AnalyticsEvents");
+        assert_eq!(descriptor.field.len(), 3);
+
+        // Encode a record; unknown keys are ignored, timestamps are integers.
+        let record =
+            CString::new(r#"{"id": 7, "payload": "hello", "ts": 1700000000000000, "extra": "x"}"#)
+                .unwrap();
+        let mut out_data: *mut u8 = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let mut enc_result = unwritten_result();
+        let ok = zerobus_proto_schema_encode_json(
+            schema,
+            record.as_ptr(),
+            &mut out_data as *mut *mut u8,
+            &mut out_len as *mut usize,
+            &mut enc_result as *mut CResult,
+        );
+        assert!(ok, "encode failed");
+        assert!(enc_result.success);
+        assert!(!out_data.is_null());
+        assert!(out_len > 0);
+
+        // Decode the encoded bytes against the same descriptor and assert the
+        // values round-trip: the encoding is correct, not merely non-empty.
+        let encoded = unsafe { std::slice::from_raw_parts(out_data, out_len) };
+        let msg_desc = message_descriptor_from_bytes(desc_bytes);
+        let decoded = DynamicMessage::decode(msg_desc, encoded).unwrap();
+        assert_eq!(decoded.get_field_by_name("id").unwrap().as_i64(), Some(7));
+        assert_eq!(
+            decoded.get_field_by_name("payload").unwrap().as_str(),
+            Some("hello")
+        );
+        assert_eq!(
+            decoded.get_field_by_name("ts").unwrap().as_i64(),
+            Some(1700000000000000)
+        );
+
+        zerobus_free_proto_bytes(out_data, out_len);
+        zerobus_proto_schema_free(schema);
+    }
+
+    #[test]
+    fn test_proto_schema_from_uc_json_invalid_json_errors() {
+        let bad = CString::new("not json").unwrap();
+        let mut result = presumed_success_result();
+        let schema = zerobus_proto_schema_from_uc_json(bad.as_ptr(), &mut result as *mut CResult);
+        assert!(schema.is_null());
+        assert!(!result.success);
+        assert!(!result.error_message.is_null());
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_proto_schema_from_uc_json_unsupported_type_errors() {
+        // Parses cleanly into UcTableSchema but carries a column type the
+        // descriptor builder rejects — exercises the schema-conversion error
+        // path, distinct from a JSON parse failure.
+        let json = CString::new(
+            r#"{
+                "name": "t", "catalog_name": "c", "schema_name": "s",
+                "columns": [
+                    {"name": "x", "type_name": "GEOGRAPHY", "type_text": "geography", "nullable": true, "position": 0}
+                ]
+            }"#,
+        )
+        .unwrap();
+        let mut result = presumed_success_result();
+        let schema = zerobus_proto_schema_from_uc_json(json.as_ptr(), &mut result as *mut CResult);
+        assert!(schema.is_null());
+        assert!(!result.success);
+        assert!(!result.error_message.is_null());
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_proto_schema_from_uc_json_null_input_errors() {
+        let mut result = presumed_success_result();
+        let schema = zerobus_proto_schema_from_uc_json(ptr::null(), &mut result as *mut CResult);
+        assert!(schema.is_null());
+        assert!(!result.success);
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_proto_schema_descriptor_bytes_null_handle() {
+        // A null handle must yield a null pointer and zero the out-length so the
+        // caller never reads a stale length.
+        let mut len: usize = 123;
+        let dptr = zerobus_proto_schema_descriptor_bytes(ptr::null(), &mut len as *mut usize);
+        assert!(dptr.is_null());
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn test_proto_schema_encode_null_schema_errors() {
+        let record = CString::new(r#"{"id": 1}"#).unwrap();
+        let mut out_data: *mut u8 = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let mut result = presumed_success_result();
+        let ok = zerobus_proto_schema_encode_json(
+            ptr::null(),
+            record.as_ptr(),
+            &mut out_data as *mut *mut u8,
+            &mut out_len as *mut usize,
+            &mut result as *mut CResult,
+        );
+        assert!(!ok);
+        assert!(!result.success);
+        zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn test_proto_schema_encode_malformed_record_errors() {
+        let json = sample_uc_table_json();
+        let mut build = unwritten_result();
+        let schema = zerobus_proto_schema_from_uc_json(json.as_ptr(), &mut build as *mut CResult);
+        assert!(!schema.is_null());
+
+        let bad_record = CString::new("{ not valid json").unwrap();
+        let mut out_data: *mut u8 = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let mut enc_result = presumed_success_result();
+        let ok = zerobus_proto_schema_encode_json(
+            schema,
+            bad_record.as_ptr(),
+            &mut out_data as *mut *mut u8,
+            &mut out_len as *mut usize,
+            &mut enc_result as *mut CResult,
+        );
+        assert!(!ok);
+        assert!(!enc_result.success);
+        assert!(!enc_result.error_message.is_null());
+        assert!(out_data.is_null(), "no buffer should be allocated on error");
+        zerobus_free_error_message(enc_result.error_message);
+        zerobus_proto_schema_free(schema);
+    }
+
+    #[test]
+    fn test_proto_schema_encode_null_out_pointers_errors() {
+        let json = sample_uc_table_json();
+        let mut build = unwritten_result();
+        let schema = zerobus_proto_schema_from_uc_json(json.as_ptr(), &mut build as *mut CResult);
+        assert!(!schema.is_null());
+
+        let record = CString::new(r#"{"id": 1}"#).unwrap();
+        let mut enc_result = presumed_success_result();
+        let ok = zerobus_proto_schema_encode_json(
+            schema,
+            record.as_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut enc_result as *mut CResult,
+        );
+        assert!(!ok);
+        assert!(!enc_result.success);
+        zerobus_free_error_message(enc_result.error_message);
+        zerobus_proto_schema_free(schema);
+    }
 }

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -147,6 +147,14 @@ typedef struct CRecordArray {
   uintptr_t len;
 } CRecordArray;
 
+/**
+ * Holds a table's serialized `DescriptorProto` plus a prepared protobuf
+ * encoder built from it. Opaque to C; the concrete type is [`ProtoSchema`].
+ */
+typedef struct CZerobusProtoSchema {
+  uint8_t _private[0];
+} CZerobusProtoSchema;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -496,6 +504,41 @@ void zerobus_free_error_message(char *message);
  * Get default stream configuration options
  */
 struct CStreamConfigurationOptions zerobus_get_default_config(void);
+
+/**
+ * Build a protobuf schema from Unity Catalog table metadata JSON.
+ * Returns NULL on error; free with `zerobus_proto_schema_free`.
+ */
+struct CZerobusProtoSchema *zerobus_proto_schema_from_uc_json(const char *uc_table_json,
+                                                              struct CResult *result);
+
+/**
+ * Borrow the serialized descriptor bytes. Valid until `zerobus_proto_schema_free`.
+ * Pass directly to `zerobus_sdk_create_stream`. Returns NULL on null handle.
+ */
+const uint8_t *zerobus_proto_schema_descriptor_bytes(const struct CZerobusProtoSchema *schema,
+                                                     uintptr_t *out_len);
+
+/**
+ * Encode JSON record to protobuf bytes. Unknown keys are ignored.
+ * DATE/TIMESTAMP columns must be integers (days/micros since epoch), not strings.
+ * Returns true on success; caller must free buffer with `zerobus_free_proto_bytes`.
+ */
+bool zerobus_proto_schema_encode_json(const struct CZerobusProtoSchema *schema,
+                                      const char *record_json,
+                                      uint8_t **out_data,
+                                      uintptr_t *out_len,
+                                      struct CResult *result);
+
+/**
+ * Free a buffer returned by `zerobus_proto_schema_encode_json`.
+ */
+void zerobus_free_proto_bytes(uint8_t *data, uintptr_t len);
+
+/**
+ * Free a handle from `zerobus_proto_schema_from_uc_json`.
+ */
+void zerobus_proto_schema_free(struct CZerobusProtoSchema *schema);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Add a dynamic-protobuf C FFI so a pure-C consumer (e.g. a Fluent Bit output plugin) can follow the same UC-schema → descriptor → record-encode path the Vector sink uses, without a companion Rust crate. The logic already exists in the SDK (`schema::descriptor_from_uc_schema`) and prost-reflect; these are thin wrappers over it.

## New APIs

**Opaque type:** `CZerobusProtoSchema`

**Functions:**
- `zerobus_proto_schema_from_uc_json` — build a handle from UC table-metadata JSON
- `zerobus_proto_schema_descriptor_bytes` — borrow the serialized DescriptorProto to pass to `zerobus_sdk_create_stream` (byte-identical to the descriptor the encoder uses)
- `zerobus_proto_schema_encode_json` — encode one JSON record into protobuf bytes; unknown keys are ignored
- `zerobus_free_proto_bytes` / `zerobus_proto_schema_free` — free a buffer / a handle

## Usage Example

```c
CResult r = {0};

/* init: fetch GET /api/2.1/unity-catalog/tables/{name} and pass its JSON body */
CZerobusProtoSchema *schema = zerobus_proto_schema_from_uc_json(uc_table_json, &r);

uintptr_t dlen;
const uint8_t *desc = zerobus_proto_schema_descriptor_bytes(schema, &dlen);
CZerobusStream *stream = zerobus_sdk_create_stream(sdk, table_name, desc, dlen,
                                                   client_id, client_secret, &opts, &r);

/* per record, at flush time */
uint8_t *buf; uintptr_t len;
if (zerobus_proto_schema_encode_json(schema, record_json, &buf, &len, &r)) {
    /* collect buf/len into a batch, ingest via zerobus_stream_ingest_proto_records(...) */
    zerobus_free_proto_bytes(buf, len);
}

/* shutdown */
zerobus_proto_schema_free(schema);
```

## Encoding Contract

- Record object keys are matched to column names; unknown keys are ignored (upstream records often carry extra non-column metadata)
- `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` columns are integers (days / micros since epoch), not strings

## Testing

Adds prost-reflect (serde) + serde_json as direct deps of the ffi crate, exports the opaque type via cbindgen (regenerated `zerobus.h`), and updates `NEXT_CHANGELOG` and `README`. Covered by 8 unit tests including a round-trip that decodes the encoded bytes and asserts field values.

Co-authored-by: Isaac