### PR TITLE
[Rust] Introduce per-table minted OAuth token cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "self_cell",
  "serde",
  "serde_json",
+ "sha2",
  "smallvec",
  "strum",
  "thiserror 1.0.69",
@@ -2416,6 +2417,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,6 +53,7 @@ arrow-ipc = { version = "58.2", default-features = false }
 # Misc
 futures = "0.3"
 chrono = "0.4"
+sha2 = "0.10"
 once_cell = "1.21"
 bytes = "1.11"
 smallvec = "1.15.1"

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,7 +6,15 @@
 
 ### New Features and Improvements
 
+- Token caching for the default OAuth path. Tokens obtained via `.oauth(...)` are now cached per table on the `ZerobusSdk` instance and reused across stream creations and recoveries until they near expiry, instead of minting a fresh token on every stream. This reduces load on the Unity Catalog token endpoint for clients that create many short-lived streams. Caching is on by default and can be tuned via `ZerobusSdkBuilder::token_cache_enabled` and `ZerobusSdkBuilder::token_refresh_buffer`.
+- On a server-side authentication rejection during stream creation, the cached token is invalidated so the next attempt re-mints (re-checking grants at Unity Catalog), rather than reusing a rejected token until the refresh window.
+- `OAuthHeadersProvider::new` now caches tokens for the lifetime of the returned provider (previously it minted a fresh token on every call). Behavior is unchanged for the common path of constructing streams through `ZerobusSdk`, which already shares a cache.
+
 ### Bug Fixes
+
+- Redacted the OAuth authorization token from an error log and error message on the gRPC stream-setup path; a malformed token value is no longer written to logs.
+- A UC token that cannot be encoded as an HTTP `authorization` header value is now rejected at mint time rather than cached, so it cannot poison the cache and fail every stream creation until its refresh window.
+- Arrow Flight stream errors now preserve the server's gRPC status code instead of flattening it to `Unknown`. Previously a `FlightError` was wrapped via `tonic::Status::from_error`, which dropped the inner code, so non-retryable rejections (for example `PermissionDenied`) were misclassified as retryable and auth-rejection detection did not fire on the Arrow path.
 
 ### Documentation
 
@@ -17,3 +25,7 @@
 ### Deprecations
 
 ### API Changes
+
+- Added `ZerobusSdkBuilder::token_cache_enabled(bool)` to enable or disable OAuth token caching (default enabled).
+- Added `ZerobusSdkBuilder::token_refresh_buffer(Duration)` to configure how long before a cached token's expiry it is refreshed (default 5 minutes).
+- Added `HeadersProvider::invalidate` with a default no-op implementation; the SDK calls it when the server rejects the supplied credentials so a provider can drop cached auth state. Existing trait implementations are unaffected.

--- a/rust/README.md
+++ b/rust/README.md
@@ -252,7 +252,30 @@ The SDK uses OAuth 2.0 client credentials flow:
 2. Sends request to `{uc_endpoint}/oidc/v1/token` with client credentials
 3. Token includes scoped permissions for the specific table
 4. Token is attached to gRPC metadata as Bearer token
-5. Fresh tokens are fetched automatically on each connection
+5. Tokens are cached per table and reused across connections until they near expiry (see Token Caching below)
+
+### Token Caching
+
+OAuth tokens minted via Unity Catalog have a lifetime chosen by Unity Catalog (currently one hour) that the SDK cannot configure, while a single stream lives at most ~15 minutes. By default the SDK caches the token for each table on the `ZerobusSdk` instance and reuses it across stream creations and recoveries, refreshing it only once it nears the expiry the server reported (so it adapts to whatever lifetime UC returns). This avoids minting a fresh token on every stream and reduces load on the Unity Catalog token endpoint.
+
+Caching applies only to the built-in OAuth path (`.oauth(...)`). Tokens are shared only across streams created from the same `ZerobusSdk`, so reuse a single SDK instance rather than constructing a new one per stream. Custom `HeadersProvider` implementations manage their own caching.
+
+Two builder options tune the behavior:
+
+```rust
+use databricks_zerobus_ingest_sdk::ZerobusSdk;
+use std::time::Duration;
+
+let sdk = ZerobusSdk::builder()
+    .endpoint("https://<your-workspace>.zerobus.<region>.cloud.databricks.com")
+    .unity_catalog_url("https://<your-workspace>.cloud.databricks.com")
+    // Refresh a cached token once it is within 10 minutes of expiry (default: 5 minutes).
+    .token_refresh_buffer(Duration::from_secs(600))
+    // Or disable caching entirely to mint a fresh token per stream.
+    // .token_cache_enabled(false)
+    .build()?;
+# Ok::<(), databricks_zerobus_ingest_sdk::ZerobusError>(())
+```
 
 ### Custom Authentication
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -24,6 +24,7 @@ prost-types.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "sync"] }
 tokio-retry.workspace = true

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -410,7 +410,15 @@ impl ZerobusArrowStream {
         )
         .await?;
 
-        Self::start_stream_connection(client, table_properties, options).await
+        let result = Self::start_stream_connection(client, table_properties, options).await;
+
+        // Drop the rejected token so the next attempt re-mints.
+        if let Err(err) = &result {
+            if err.is_auth_rejection() {
+                headers_provider.invalidate().await;
+            }
+        }
+        result
     }
 
     /// Creates a Flight client connected to the endpoint.
@@ -515,7 +523,9 @@ impl ZerobusArrowStream {
         let mut response_stream = client
             .do_put(flight_data_stream)
             .await
-            .map_err(|e| ZerobusError::CreateStreamError(tonic::Status::from_error(Box::new(e))))?;
+            // `.into()` preserves the inner gRPC code; `Status::from_error` would
+            // flatten it to `Unknown` and break auth/retry classification.
+            .map_err(|e| ZerobusError::CreateStreamError(e.into()))?;
 
         // Wait for server's "ready" signal to confirm setup succeeded.
         // The server sends ack_up_to_offset = -1 after successful auth, schema validation,
@@ -552,9 +562,7 @@ impl ZerobusArrowStream {
             Ok(Some(Err(flight_error))) => {
                 // Server sent an error during setup (auth failed, schema mismatch, blocked table, etc.)
                 error!("Stream setup failed: {:?}", flight_error);
-                return Err(ZerobusError::CreateStreamError(tonic::Status::from_error(
-                    Box::new(flight_error),
-                )));
+                return Err(ZerobusError::CreateStreamError(flight_error.into()));
             }
             Ok(None) => {
                 // Server closed the stream without sending anything.
@@ -709,6 +717,11 @@ impl ZerobusArrowStream {
                                 // Loop continues with new stream.
                             }
                             Ok(Err(e)) => {
+                                // Mirror the initial-connect path: drop the cached
+                                // token on auth rejection so recovery re-mints.
+                                if e.is_auth_rejection() {
+                                    headers_provider.invalidate().await;
+                                }
                                 warn!("Supervisor: Reconnection failed: {}", e);
                                 // Loop continues, will retry if retries remain.
                                 // Create a dummy stream that immediately errors.
@@ -733,6 +746,11 @@ impl ZerobusArrowStream {
                         // Non-retriable error or recovery disabled.
                         error!("Supervisor: Non-retriable error, closing stream: {}", error);
                         is_closed.store(true, Ordering::Relaxed);
+                        // A mid-stream auth rejection means the cached token is no
+                        // longer accepted; drop it so the next stream re-mints.
+                        if error.is_auth_rejection() {
+                            headers_provider.invalidate().await;
+                        }
                         // Move pending batches to failed and fail the ack futures.
                         Self::move_pending_to_failed(&pending_batches, &failed_batches).await;
                         return Err(error);
@@ -809,7 +827,9 @@ impl ZerobusArrowStream {
         let mut response_stream = flight_client
             .do_put(flight_data_stream)
             .await
-            .map_err(|e| ZerobusError::CreateStreamError(tonic::Status::from_error(Box::new(e))))?;
+            // `.into()` preserves the inner gRPC code; `Status::from_error` would
+            // flatten it to `Unknown` and break auth/retry classification.
+            .map_err(|e| ZerobusError::CreateStreamError(e.into()))?;
 
         // Wait for server's "ready" signal to confirm reconnection succeeded.
         let setup_timeout = Duration::from_millis(options.connection_timeout_ms);
@@ -841,9 +861,7 @@ impl ZerobusArrowStream {
             }
             Ok(Some(Err(flight_error))) => {
                 error!("Reconnection setup failed: {:?}", flight_error);
-                return Err(ZerobusError::CreateStreamError(tonic::Status::from_error(
-                    Box::new(flight_error),
-                )));
+                return Err(ZerobusError::CreateStreamError(flight_error.into()));
             }
             Ok(None) => {
                 error!("Server closed stream during reconnect without response");

--- a/rust/sdk/src/builder/sdk_builder.rs
+++ b/rust/sdk/src/builder/sdk_builder.rs
@@ -1,8 +1,10 @@
 //! Builder for creating [`ZerobusSdk`] instances.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::proxy::ConnectorFactory;
+use crate::token_cache::DEFAULT_REFRESH_BUFFER;
 use crate::{
     SecureTlsConfig, TlsConfig, ZerobusError, ZerobusResult, ZerobusSdk, DEFAULT_SDK_IDENTIFIER,
 };
@@ -27,6 +29,8 @@ pub struct ZerobusSdkBuilder {
     connector_factory: Option<ConnectorFactory>,
     application_name: Option<String>,
     sdk_identifier_override: Option<String>,
+    token_cache_enabled: bool,
+    token_refresh_buffer: Duration,
 }
 
 impl ZerobusSdkBuilder {
@@ -41,6 +45,8 @@ impl ZerobusSdkBuilder {
             connector_factory: None,
             application_name: None,
             sdk_identifier_override: None,
+            token_cache_enabled: true,
+            token_refresh_buffer: DEFAULT_REFRESH_BUFFER,
         }
     }
 
@@ -132,6 +138,43 @@ impl ZerobusSdkBuilder {
         self
     }
 
+    /// Enables or disables caching of OAuth tokens for the default OAuth path.
+    ///
+    /// When enabled (the default), tokens obtained via `.oauth(...)` are cached
+    /// per table on the SDK instance and reused across stream creations and
+    /// recoveries until they near expiry, instead of minting a fresh token on
+    /// every stream. This reduces load on the Unity Catalog token endpoint for
+    /// clients that churn through many short-lived streams.
+    ///
+    /// Caching only applies to the built-in OAuth path. Custom
+    /// [`HeadersProvider`](crate::HeadersProvider) implementations are
+    /// responsible for their own caching. Tokens are shared only across streams
+    /// created from the same `ZerobusSdk` instance, so reuse the SDK rather than
+    /// constructing a new one per stream to benefit from the cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `enabled` - Whether to cache OAuth tokens.
+    pub fn token_cache_enabled(mut self, enabled: bool) -> Self {
+        self.token_cache_enabled = enabled;
+        self
+    }
+
+    /// Sets how long before a cached OAuth token's expiry it is refreshed.
+    ///
+    /// A cached token is re-minted on the next stream creation once it is within
+    /// this buffer of its expiry, providing headroom against clock skew and
+    /// token propagation delays. Defaults to 5 minutes. Has no effect when token
+    /// caching is disabled.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - Lead time before expiry at which to refresh.
+    pub fn token_refresh_buffer(mut self, buffer: Duration) -> Self {
+        self.token_refresh_buffer = buffer;
+        self
+    }
+
     /// Builds the [`ZerobusSdk`] instance.
     ///
     /// # Errors
@@ -186,6 +229,8 @@ impl ZerobusSdkBuilder {
             tls_config,
             self.connector_factory,
             sdk_identifier,
+            self.token_cache_enabled,
+            self.token_refresh_buffer,
         ))
     }
 }
@@ -216,6 +261,31 @@ mod tests {
             sdk.unity_catalog_url,
             "https://my-workspace.cloud.databricks.com"
         );
+    }
+
+    #[test]
+    fn test_builder_token_cache_options() {
+        // Both knobs are chainable and the SDK builds with non-default values.
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .token_cache_enabled(false)
+            .token_refresh_buffer(Duration::from_secs(120))
+            .build()
+            .expect("should build with token cache options");
+
+        // The builder accepts both knobs and produces a usable SDK; assert the
+        // build succeeded via a field on the result.
+        assert_eq!(sdk.workspace_id, "workspace");
+    }
+
+    #[test]
+    fn test_builder_token_cache_enabled_by_default() {
+        let sdk = ZerobusSdkBuilder::new()
+            .endpoint("https://workspace.zerobus.databricks.com")
+            .build()
+            .expect("should build");
+        // The cache is always present; enablement is internal state.
+        let _ = &sdk.token_cache;
     }
 
     #[test]

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -328,12 +328,13 @@ impl<'a> StreamBuilder<'a> {
             Some(AuthConfig::OAuth {
                 client_id,
                 client_secret,
-            }) => Ok(Arc::new(OAuthHeadersProvider::new(
+            }) => Ok(Arc::new(OAuthHeadersProvider::with_cache(
                 client_id.clone(),
                 client_secret.clone(),
                 self.table_name.clone(),
                 self.sdk.workspace_id.clone(),
                 self.sdk.unity_catalog_url.clone(),
+                Arc::clone(&self.sdk.token_cache),
             ))),
             Some(AuthConfig::HeadersProvider(p)) => Ok(Arc::clone(p)),
             None => Err(ZerobusError::InvalidArgument(
@@ -441,6 +442,8 @@ mod tests {
             Arc::new(crate::tls_config::SecureTlsConfig::new()),
             None,
             Arc::from(crate::DEFAULT_SDK_IDENTIFIER),
+            true,
+            crate::token_cache::DEFAULT_REFRESH_BUFFER,
         )
     }
 

--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -1,4 +1,45 @@
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tracing::{debug, info, warn};
+
 use crate::{ZerobusError, ZerobusResult};
+
+/// An access token together with its time-to-live as reported by the OAuth
+/// server, if any.
+pub(crate) struct FetchedToken {
+    /// The OAuth 2.0 access token.
+    pub(crate) token: String,
+    /// Lifetime of the token derived from the `expires_in` field of the OAuth
+    /// response. `None` if the server did not return a usable `expires_in`, in
+    /// which case the token must not be cached.
+    pub(crate) expires_in: Option<Duration>,
+}
+
+/// Why a token mint was triggered. Logged on the mint so operators can tell a
+/// cold start from a proactive refresh from caching being off.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum MintReason {
+    /// No usable cached token (cold start or the cached token had expired).
+    ColdMiss,
+    /// A cached token entered the refresh window and was proactively renewed.
+    Refresh,
+    /// Token caching is disabled, so every stream creation mints.
+    CacheDisabled,
+    /// Minted outside the cache via the public `get_token`.
+    Direct,
+}
+
+impl MintReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            MintReason::ColdMiss => "cold_miss",
+            MintReason::Refresh => "refresh",
+            MintReason::CacheDisabled => "cache_disabled",
+            MintReason::Direct => "direct",
+        }
+    }
+}
 
 /// Default OAuth 2.0 token factory for Unity Catalog authentication.
 ///
@@ -31,6 +72,79 @@ impl DefaultTokenFactory {
         client_secret: &str,
         workspace_id: &str,
     ) -> ZerobusResult<String> {
+        Self::fetch_token(
+            uc_endpoint,
+            table_name,
+            client_id,
+            client_secret,
+            workspace_id,
+            MintReason::Direct,
+        )
+        .await
+        .map(|fetched| fetched.token)
+    }
+
+    /// Obtains an OAuth 2.0 access token along with its reported lifetime.
+    ///
+    /// This is the caching-aware variant of [`get_token`](Self::get_token): in
+    /// addition to the token it returns the `expires_in` value from the OAuth
+    /// response so callers can cache the token until it nears expiry.
+    pub(crate) async fn fetch_token(
+        uc_endpoint: &str,
+        table_name: &str,
+        client_id: &str,
+        client_secret: &str,
+        workspace_id: &str,
+        reason: MintReason,
+    ) -> ZerobusResult<FetchedToken> {
+        debug!(table = %table_name, "requesting UC OAuth token");
+        let started = Instant::now();
+        let result = Self::fetch_token_inner(
+            uc_endpoint,
+            table_name,
+            client_id,
+            client_secret,
+            workspace_id,
+        )
+        .await;
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+        match &result {
+            Ok(FetchedToken {
+                expires_in: Some(ttl),
+                ..
+            }) => info!(
+                table = %table_name,
+                reason = reason.as_str(),
+                expires_in_secs = ttl.as_secs(),
+                elapsed_ms,
+                "minted UC OAuth token"
+            ),
+            Ok(FetchedToken {
+                expires_in: None, ..
+            }) => warn!(
+                table = %table_name,
+                reason = reason.as_str(),
+                elapsed_ms,
+                "minted UC OAuth token but UC returned no expires_in; token will not be cached"
+            ),
+            Err(err) => warn!(
+                table = %table_name,
+                reason = reason.as_str(),
+                retryable = err.is_retryable(),
+                elapsed_ms,
+                "failed to mint UC OAuth token: {err}"
+            ),
+        }
+        result
+    }
+
+    async fn fetch_token_inner(
+        uc_endpoint: &str,
+        table_name: &str,
+        client_id: &str,
+        client_secret: &str,
+        workspace_id: &str,
+    ) -> ZerobusResult<FetchedToken> {
         let (catalog, schema, table) = Self::parse_table_name(table_name)?;
 
         let uc_endpoint = uc_endpoint.to_string();
@@ -103,7 +217,35 @@ impl DefaultTokenFactory {
             .as_str()
             .ok_or_else(|| ZerobusError::InvalidUCTokenError("access_token missing".to_string()))?
             .to_string();
-        Ok(token)
+
+        // Reject a token that can't be a header value before it is returned, so
+        // an unusable token never enters the cache and poisons it until expiry.
+        if !Self::is_usable_as_header(&token) {
+            return Err(ZerobusError::InvalidUCTokenError(
+                "access token is not a valid HTTP header value".to_string(),
+            ));
+        }
+
+        let expires_in = Self::parse_expires_in(&body);
+
+        Ok(FetchedToken { token, expires_in })
+    }
+
+    /// Reports whether `token` can be sent as the `authorization` header value
+    /// (`Bearer <token>`). The gRPC and Arrow paths both encode it this way, so a
+    /// token that fails here is unusable and must not be cached.
+    fn is_usable_as_header(token: &str) -> bool {
+        tonic::metadata::AsciiMetadataValue::try_from(format!("Bearer {token}").as_str()).is_ok()
+    }
+
+    /// Parses the OAuth `expires_in` field (token lifetime in seconds) into a
+    /// `Duration`. It is optional in the OAuth spec; if it is missing or not a
+    /// positive integer the token has no known TTL and must not be cached.
+    fn parse_expires_in(body: &serde_json::Value) -> Option<Duration> {
+        body["expires_in"]
+            .as_u64()
+            .filter(|secs| *secs > 0)
+            .map(Duration::from_secs)
     }
 
     /// Classifies HTTP status codes as retryable or non-retryable errors.
@@ -209,6 +351,36 @@ mod tests {
         assert_eq!(catalog, "catalog_1");
         assert_eq!(schema, "schema_2");
         assert_eq!(table, "table_3");
+    }
+
+    #[test]
+    fn test_parse_expires_in() {
+        let with_ttl = serde_json::json!({ "expires_in": 3600 });
+        assert_eq!(
+            DefaultTokenFactory::parse_expires_in(&with_ttl),
+            Some(Duration::from_secs(3600))
+        );
+
+        let missing = serde_json::json!({ "access_token": "abc" });
+        assert_eq!(DefaultTokenFactory::parse_expires_in(&missing), None);
+
+        let zero = serde_json::json!({ "expires_in": 0 });
+        assert_eq!(DefaultTokenFactory::parse_expires_in(&zero), None);
+
+        // A string value (non-integer) is not usable and yields no TTL.
+        let non_numeric = serde_json::json!({ "expires_in": "3600" });
+        assert_eq!(DefaultTokenFactory::parse_expires_in(&non_numeric), None);
+    }
+
+    #[test]
+    fn test_is_usable_as_header() {
+        // A normal JWT-shaped token is a valid header value.
+        assert!(DefaultTokenFactory::is_usable_as_header(
+            "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.sig-_value"
+        ));
+        // Control characters (e.g. an embedded newline) make it unusable.
+        assert!(!DefaultTokenFactory::is_usable_as_header("bad\ntoken"));
+        assert!(!DefaultTokenFactory::is_usable_as_header("bad\0token"));
     }
 
     #[test]

--- a/rust/sdk/src/errors.rs
+++ b/rust/sdk/src/errors.rs
@@ -86,4 +86,66 @@ impl ZerobusError {
             ZerobusError::TokenFetchError(_) => true,
         }
     }
+
+    /// Reports whether this is a server-side authentication/authorization
+    /// rejection (as opposed to a transient or unrelated failure). Used to
+    /// decide when to invalidate cached credentials so the next attempt
+    /// re-derives them.
+    pub(crate) fn is_auth_rejection(&self) -> bool {
+        matches!(
+            self,
+            ZerobusError::CreateStreamError(status) | ZerobusError::StreamClosedError(status)
+                if matches!(
+                    status.code(),
+                    tonic::Code::Unauthenticated | tonic::Code::PermissionDenied
+                )
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_rejection_classification() {
+        assert!(
+            ZerobusError::CreateStreamError(tonic::Status::unauthenticated("x"))
+                .is_auth_rejection()
+        );
+        assert!(
+            ZerobusError::CreateStreamError(tonic::Status::permission_denied("x"))
+                .is_auth_rejection()
+        );
+        assert!(
+            ZerobusError::StreamClosedError(tonic::Status::unauthenticated("x"))
+                .is_auth_rejection()
+        );
+        // Non-auth gRPC codes are not rejections.
+        assert!(!ZerobusError::CreateStreamError(tonic::Status::internal("x")).is_auth_rejection());
+        assert!(
+            !ZerobusError::CreateStreamError(tonic::Status::unavailable("x")).is_auth_rejection()
+        );
+        // Other variants are never auth rejections.
+        assert!(!ZerobusError::TokenFetchError("x".to_string()).is_auth_rejection());
+    }
+
+    /// Pins the cross-crate invariant the Arrow path relies on: `FlightError ->
+    /// tonic::Status` via `From` preserves the inner gRPC code (unlike
+    /// `Status::from_error`, which flattens it to `Unknown`). A future
+    /// `arrow-flight` change to that `From` impl fails here instead of silently
+    /// disabling Arrow auth-rejection detection.
+    #[cfg(feature = "arrow-flight")]
+    #[test]
+    fn auth_rejection_survives_flight_error_conversion() {
+        use arrow_flight::error::FlightError;
+
+        let auth: tonic::Status =
+            FlightError::Tonic(Box::new(tonic::Status::permission_denied("denied"))).into();
+        assert!(ZerobusError::CreateStreamError(auth).is_auth_rejection());
+
+        let non_auth: tonic::Status =
+            FlightError::Tonic(Box::new(tonic::Status::unavailable("blip"))).into();
+        assert!(!ZerobusError::CreateStreamError(non_auth).is_auth_rejection());
+    }
 }

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -1,7 +1,9 @@
 use crate::default_token_factory::DefaultTokenFactory;
+use crate::token_cache::{TokenCache, DEFAULT_REFRESH_BUFFER};
 use crate::ZerobusResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// A trait for providing custom headers for gRPC requests.
 ///
@@ -44,6 +46,15 @@ pub trait HeadersProvider: Send + Sync {
     ///
     /// Returns a `ZerobusError` if header generation fails (e.g., token request fails).
     async fn get_headers(&self) -> ZerobusResult<HashMap<&'static str, String>>;
+
+    /// Invalidates any cached authentication state so the next `get_headers`
+    /// call re-derives it from scratch.
+    ///
+    /// The SDK calls this when the server rejects the supplied credentials with
+    /// an authentication error during stream creation. The default is a no-op,
+    /// which is correct for providers that hold no cache; the built-in OAuth
+    /// provider overrides it to drop its cached token so the next call re-mints.
+    async fn invalidate(&self) {}
 }
 
 /// The default headers provider that uses OAuth 2.0 with Unity Catalog.
@@ -56,10 +67,17 @@ pub struct OAuthHeadersProvider {
     table_name: String,
     workspace_id: String,
     unity_catalog_url: String,
+    token_cache: Arc<TokenCache>,
 }
 
 impl OAuthHeadersProvider {
     /// Creates a new `OAuthHeadersProvider`.
+    ///
+    /// This standalone constructor caches tokens for the lifetime of the
+    /// returned provider only. When streams are created via
+    /// [`ZerobusSdk::stream_builder`](crate::ZerobusSdk::stream_builder) the SDK
+    /// supplies a shared cache so tokens are reused across streams; see
+    /// [`with_cache`](Self::with_cache).
     pub fn new(
         client_id: String,
         client_secret: String,
@@ -67,12 +85,35 @@ impl OAuthHeadersProvider {
         workspace_id: String,
         unity_catalog_url: String,
     ) -> Self {
+        Self::with_cache(
+            client_id,
+            client_secret,
+            table_name,
+            workspace_id,
+            unity_catalog_url,
+            Arc::new(TokenCache::new(true, DEFAULT_REFRESH_BUFFER)),
+        )
+    }
+
+    /// Creates a new `OAuthHeadersProvider` backed by a shared token cache.
+    ///
+    /// Used internally so all streams created from one `ZerobusSdk` reuse cached
+    /// tokens rather than minting a fresh one per stream.
+    pub(crate) fn with_cache(
+        client_id: String,
+        client_secret: String,
+        table_name: String,
+        workspace_id: String,
+        unity_catalog_url: String,
+        token_cache: Arc<TokenCache>,
+    ) -> Self {
         Self {
             client_id,
             client_secret,
             table_name,
             workspace_id,
             unity_catalog_url,
+            token_cache,
         }
     }
 }
@@ -80,17 +121,33 @@ impl OAuthHeadersProvider {
 #[async_trait]
 impl HeadersProvider for OAuthHeadersProvider {
     async fn get_headers(&self) -> ZerobusResult<HashMap<&'static str, String>> {
-        let token = DefaultTokenFactory::get_token(
-            &self.unity_catalog_url,
-            &self.table_name,
-            &self.client_id,
-            &self.client_secret,
-            &self.workspace_id,
-        )
-        .await?;
+        let token = self
+            .token_cache
+            .get_or_fetch(
+                &self.client_id,
+                &self.client_secret,
+                &self.table_name,
+                |reason| {
+                    DefaultTokenFactory::fetch_token(
+                        &self.unity_catalog_url,
+                        &self.table_name,
+                        &self.client_id,
+                        &self.client_secret,
+                        &self.workspace_id,
+                        reason,
+                    )
+                },
+            )
+            .await?;
         let mut headers = HashMap::new();
         headers.insert("authorization", format!("Bearer {}", token));
         headers.insert("x-databricks-zerobus-table-name", self.table_name.clone());
         Ok(headers)
+    }
+
+    async fn invalidate(&self) {
+        self.token_cache
+            .invalidate(&self.client_id, &self.client_secret, &self.table_name)
+            .await;
     }
 }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -55,6 +55,7 @@ pub mod schema;
 mod stream_configuration;
 pub mod stream_options;
 mod tls_config;
+mod token_cache;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -275,6 +276,9 @@ pub struct ZerobusSdk {
     /// Final value sent as the HTTP `user-agent` header on every request.
     /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
     pub(crate) sdk_identifier: Arc<str>,
+    /// Shared cache of OAuth tokens, keyed per table, reused across all streams
+    /// created from this SDK instance via the default OAuth path.
+    pub(crate) token_cache: Arc<token_cache::TokenCache>,
 }
 
 impl ZerobusSdk {
@@ -336,6 +340,7 @@ impl ZerobusSdk {
     /// fully-resolved value sent as the HTTP `user-agent` header; the builder
     /// is responsible for composing it from the default prefix and any
     /// caller-supplied `application_name` or override.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_with_config(
         zerobus_endpoint: String,
         unity_catalog_url: String,
@@ -343,6 +348,8 @@ impl ZerobusSdk {
         tls_config: Arc<dyn TlsConfig>,
         connector_factory: Option<ConnectorFactory>,
         sdk_identifier: Arc<str>,
+        token_cache_enabled: bool,
+        token_refresh_buffer: Duration,
     ) -> Self {
         ZerobusSdk {
             zerobus_endpoint,
@@ -352,6 +359,10 @@ impl ZerobusSdk {
             tls_config,
             connector_factory,
             sdk_identifier,
+            token_cache: Arc::new(token_cache::TokenCache::new(
+                token_cache_enabled,
+                token_refresh_buffer,
+            )),
         }
     }
 
@@ -822,6 +833,11 @@ impl ZerobusStream {
                 let _ = server_error_tx.send(Some(error.clone()));
                 if !error.is_retryable() || !options.recovery {
                     is_closed.store(true, Ordering::Relaxed);
+                    // A mid-stream auth rejection means the cached token is no
+                    // longer accepted; drop it so the next stream re-mints.
+                    if error.is_auth_rejection() {
+                        headers_provider.invalidate().await;
+                    }
                     Self::fail_all_pending_records(
                         landing_zone.clone(),
                         oneshot_map.clone(),
@@ -839,8 +855,38 @@ impl ZerobusStream {
     /// Creates a stream connection to the Zerobus API.
     /// Returns a tuple containing the sender, response gRPC stream, and stream ID.
     /// If the stream creation fails, it returns an error.
-    #[instrument(level = "debug", skip_all, fields(table_name = %table_properties.table_name))]
+    ///
+    /// On a server-side authentication rejection it asks the headers provider to
+    /// invalidate cached credentials so the next attempt re-derives them. This
+    /// covers IdP-revoked tokens, not a same-named table recreated within the
+    /// token's lifetime, which the server accepts.
     async fn create_stream_connection(
+        channel: ZerobusClient<Channel>,
+        table_properties: &TableProperties,
+        headers_provider: &Arc<dyn HeadersProvider>,
+        record_type: RecordType,
+    ) -> ZerobusResult<(
+        tokio::sync::mpsc::Sender<EphemeralStreamRequest>,
+        tonic::Streaming<EphemeralStreamResponse>,
+        String,
+    )> {
+        let result = Self::create_stream_connection_inner(
+            channel,
+            table_properties,
+            headers_provider,
+            record_type,
+        )
+        .await;
+        if let Err(err) = &result {
+            if err.is_auth_rejection() {
+                headers_provider.invalidate().await;
+            }
+        }
+        result
+    }
+
+    #[instrument(level = "debug", skip_all, fields(table_name = %table_properties.table_name))]
+    async fn create_stream_connection_inner(
         mut channel: ZerobusClient<Channel>,
         table_properties: &TableProperties,
         headers_provider: &Arc<dyn HeadersProvider>,
@@ -866,8 +912,10 @@ impl ZerobusStream {
                 }
                 "authorization" => {
                     let mut auth_value = MetadataValue::try_from(value.as_str()).map_err(|_| {
-                        error!(table_name = %table_properties.table_name, "Invalid token: {}", value);
-                        ZerobusError::InvalidUCTokenError(value)
+                        error!(table_name = %table_properties.table_name, "authorization token is not a valid HTTP header value");
+                        ZerobusError::InvalidUCTokenError(
+                            "authorization token is not a valid HTTP header value".to_string(),
+                        )
                     })?;
                     auth_value.set_sensitive(true);
                     stream_metadata.insert("authorization", auth_value);

--- a/rust/sdk/src/token_cache.rs
+++ b/rust/sdk/src/token_cache.rs
@@ -1,0 +1,540 @@
+//! Per-table OAuth token cache for the default OAuth authentication path.
+//!
+//! Unity Catalog sets each token's lifetime (currently one hour), while a single
+//! stream lives at most ~15 minutes. Without caching, every stream creation (and
+//! every recovery) mints a fresh token, putting the Unity Catalog token endpoint
+//! under unnecessary load when a client churns through many streams. The cache
+//! does not assume a fixed lifetime — it serves a token until it nears the
+//! `expires_in` the server reported.
+//!
+//! [`TokenCache`] caches one token per `(client_id, secret, table_name)` key on
+//! the [`ZerobusSdk`](crate::ZerobusSdk) instance and serves it until it nears
+//! expiry, refreshing lazily on access. Tokens are downscoped to a single table
+//! (the authorization details embed the catalog/schema/table), so the table
+//! name is part of the cache key.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+use tracing::{debug, warn};
+
+use crate::default_token_factory::{FetchedToken, MintReason};
+use crate::ZerobusResult;
+
+/// Default lead time before expiry at which a cached token is refreshed.
+pub(crate) const DEFAULT_REFRESH_BUFFER: Duration = Duration::from_secs(300);
+
+/// A cached token and the instant at which it expires.
+struct CachedToken {
+    value: String,
+    expires_at: Instant,
+}
+
+impl CachedToken {
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+/// Identifies a cache entry. The client secret is keyed by its SHA-256 digest,
+/// not plaintext: the digest is collision-resistant (distinct secrets cannot in
+/// practice share a token) and keeps the raw secret out of the cache map. A
+/// rotated secret yields a different digest, hence a fresh entry.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct TokenKey {
+    client_id: String,
+    secret_digest: [u8; 32],
+    table_name: String,
+}
+
+impl TokenKey {
+    fn new(client_id: &str, client_secret: &str, table_name: &str) -> Self {
+        let secret_digest = Sha256::digest(client_secret.as_bytes()).into();
+        Self {
+            client_id: client_id.to_string(),
+            secret_digest,
+            table_name: table_name.to_string(),
+        }
+    }
+}
+
+/// Per-entry slot. Each key has its own mutex so that a cold-cache burst of
+/// concurrent stream creations for the same table mints a single token
+/// (single-flight) while creations for different tables never block each other.
+type Slot = Arc<Mutex<Option<CachedToken>>>;
+
+/// Caches OAuth tokens per table for the lifetime of a [`ZerobusSdk`].
+///
+/// Safe for concurrent use across streams created from the same SDK instance.
+pub(crate) struct TokenCache {
+    entries: Mutex<HashMap<TokenKey, Slot>>,
+    refresh_buffer: Duration,
+    enabled: bool,
+}
+
+impl TokenCache {
+    pub(crate) fn new(enabled: bool, refresh_buffer: Duration) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            refresh_buffer,
+            enabled,
+        }
+    }
+
+    /// Returns a valid token for the given credentials and table, fetching a new
+    /// one only if the cache is empty, the token has entered the refresh window,
+    /// or caching is disabled.
+    ///
+    /// `fetch` is invoked to mint a fresh token. It is only ever called once per
+    /// key at a time thanks to the per-entry lock.
+    pub(crate) async fn get_or_fetch<F, Fut>(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        table_name: &str,
+        fetch: F,
+    ) -> ZerobusResult<String>
+    where
+        F: FnOnce(MintReason) -> Fut,
+        Fut: std::future::Future<Output = ZerobusResult<FetchedToken>>,
+    {
+        if !self.enabled {
+            return fetch(MintReason::CacheDisabled)
+                .await
+                .map(|fetched| fetched.token);
+        }
+
+        let key = TokenKey::new(client_id, client_secret, table_name);
+
+        let slot = {
+            let mut entries = self.entries.lock().await;
+            // Sweep only on a miss, keeping the cost off the hot lookup path.
+            if !entries.contains_key(&key) {
+                Self::prune_expired(&mut entries);
+            }
+            Arc::clone(entries.entry(key).or_default())
+        };
+
+        // Hold the per-entry lock across the fetch so concurrent callers for the
+        // same key reuse a single mint instead of stampeding the token endpoint.
+        let mut guard = slot.lock().await;
+
+        if let Some(cached) = guard.as_ref() {
+            if !self.needs_refresh(cached) {
+                debug!(table = %table_name, "token cache hit, reusing cached token");
+                return Ok(cached.value.clone());
+            }
+        }
+
+        // A present-but-stale token means we are refreshing; an empty slot is a
+        // cold miss. The reason is surfaced on the mint log.
+        let reason = if guard.is_some() {
+            MintReason::Refresh
+        } else {
+            MintReason::ColdMiss
+        };
+
+        let fetched = match fetch(reason).await {
+            Ok(fetched) => fetched,
+            Err(err) => {
+                // On a retryable failure, serve the still-valid cached token;
+                // let non-retryable errors (bad/revoked creds) surface.
+                if err.is_retryable() {
+                    if let Some(cached) = guard.as_ref() {
+                        if !cached.is_expired() {
+                            warn!(table = %table_name, "token refresh failed (retryable); serving still-valid cached token");
+                            return Ok(cached.value.clone());
+                        }
+                    }
+                }
+                return Err(err);
+            }
+        };
+
+        let token = fetched.token.clone();
+
+        // Cache only tokens with a usable TTL. `checked_add` also drops an absurd
+        // `expires_in` that would overflow the clock instead of panicking.
+        let expires_at = fetched
+            .expires_in
+            .and_then(|ttl| Instant::now().checked_add(ttl));
+        match expires_at {
+            Some(expires_at) => {
+                *guard = Some(CachedToken {
+                    value: fetched.token,
+                    expires_at,
+                });
+            }
+            None => {
+                // No usable TTL: keep an existing still-valid token rather than
+                // discarding it.
+                let keep_existing = guard.as_ref().is_some_and(|cached| !cached.is_expired());
+                if !keep_existing {
+                    *guard = None;
+                }
+            }
+        }
+
+        Ok(token)
+    }
+
+    /// Drops any cached token for the given credentials and table so the next
+    /// `get_or_fetch` re-mints. Called when the server rejects the token (e.g.
+    /// it was revoked at the IdP), so the re-mint re-checks grants at UC. No-op
+    /// when caching is disabled or no entry exists.
+    pub(crate) async fn invalidate(&self, client_id: &str, client_secret: &str, table_name: &str) {
+        if !self.enabled {
+            return;
+        }
+        let key = TokenKey::new(client_id, client_secret, table_name);
+        if self.entries.lock().await.remove(&key).is_some() {
+            debug!(table = %table_name, "token cache entry invalidated after auth rejection");
+        }
+    }
+
+    fn needs_refresh(&self, cached: &CachedToken) -> bool {
+        // `checked_add` avoids a panic on an absurd refresh buffer (e.g.
+        // `Duration::MAX`); an overflowing deadline means "always refresh".
+        match Instant::now().checked_add(self.refresh_buffer) {
+            Some(deadline) => deadline >= cached.expires_at,
+            None => true,
+        }
+    }
+
+    /// Drops entries whose token has fully expired. Locked (in-flight) entries,
+    /// still-valid tokens, and empty slots are kept — keeping empty slots is
+    /// what preserves single-flight for a key being minted concurrently.
+    fn prune_expired(entries: &mut HashMap<TokenKey, Slot>) {
+        entries.retain(|_, slot| match slot.try_lock() {
+            Ok(guard) => match guard.as_ref() {
+                Some(cached) => !cached.is_expired(),
+                None => true,
+            },
+            Err(_) => true,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn fetched(token: &str, ttl_secs: Option<u64>) -> FetchedToken {
+        FetchedToken {
+            token: token.to_string(),
+            expires_in: ttl_secs.map(Duration::from_secs),
+        }
+    }
+
+    #[tokio::test]
+    async fn caches_token_across_calls() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched("tok", Some(3600)))
+        };
+
+        let a = cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+        let b = cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(a, "tok");
+        assert_eq!(b, "tok");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "second call should hit cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn refetches_when_within_refresh_buffer() {
+        // TTL (1s) is smaller than the refresh buffer (60s), so the token is
+        // always considered due for refresh and every call mints anew.
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched(&format!("tok{n}"), Some(1)))
+        };
+
+        let a = cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+        let b = cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(a, "tok0");
+        assert_eq!(b, "tok1");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn separate_tables_get_separate_entries() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched(&format!("tok{n}"), Some(3600)))
+        };
+
+        let a = cache
+            .get_or_fetch("id", "secret", "c.s.t1", make)
+            .await
+            .unwrap();
+        let b = cache
+            .get_or_fetch("id", "secret", "c.s.t2", make)
+            .await
+            .unwrap();
+
+        assert_ne!(a, b);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn rotated_secret_gets_new_entry() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched(&format!("tok{n}"), Some(3600)))
+        };
+
+        cache
+            .get_or_fetch("id", "secret-v1", "c.s.t", make)
+            .await
+            .unwrap();
+        cache
+            .get_or_fetch("id", "secret-v2", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn token_without_ttl_is_not_cached() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched("tok", None))
+        };
+
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "no TTL means no caching");
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_remint_on_next_call() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched("tok", Some(3600)))
+        };
+
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+        // Without invalidation a second call would hit the cache; invalidating
+        // the entry forces the next call to re-mint.
+        cache.invalidate("id", "secret", "c.s.t").await;
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn disabled_cache_always_fetches() {
+        let cache = TokenCache::new(false, Duration::from_secs(60));
+        let calls = AtomicUsize::new(0);
+
+        let make = |_reason| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(fetched("tok", Some(3600)))
+        };
+
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", make)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_error_leaves_no_cached_entry() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+
+        let err = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("boom".to_string()))
+            })
+            .await;
+        assert!(err.is_err());
+
+        // A subsequent successful fetch should still succeed and cache.
+        let ok = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("tok", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(ok, "tok");
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_serves_still_valid_token() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+
+        // Seed a token that is within the refresh buffer (ttl < buffer) but not
+        // yet expired, so the next call is due for a refresh.
+        let seeded = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(seeded, "valid");
+
+        // The refresh mint fails; the still-valid cached token is served instead
+        // of surfacing the error.
+        let served = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("blip".to_string()))
+            })
+            .await
+            .unwrap();
+        assert_eq!(served, "valid");
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_propagates_non_retryable_error() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+
+        // Seed a token that is within the refresh buffer but not yet expired.
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        // A non-retryable refresh error (e.g. revoked or invalid credentials)
+        // must surface rather than being masked by the still-valid cached token.
+        let result = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::InvalidUCTokenError(
+                    "revoked".to_string(),
+                ))
+            })
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::ZerobusError::InvalidUCTokenError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn no_ttl_response_does_not_evict_valid_token() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+
+        // Seed a still-valid (within-buffer) token.
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        // A refresh returns a token with no TTL: the caller gets the fresh token,
+        // but the cached valid token must not be discarded.
+        let fresh = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("nottl", None))
+            })
+            .await
+            .unwrap();
+        assert_eq!(fresh, "nottl");
+
+        // A later refresh failure still finds the original valid token, proving
+        // it was retained.
+        let served = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("blip".to_string()))
+            })
+            .await
+            .unwrap();
+        assert_eq!(served, "valid");
+    }
+
+    #[tokio::test]
+    async fn single_flight_mints_once_for_concurrent_callers() {
+        let cache = Arc::new(TokenCache::new(true, Duration::from_secs(60)));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let cache = Arc::clone(&cache);
+            let calls = Arc::clone(&calls);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        // Hold the slot briefly so the other callers pile up
+                        // behind the single-flight lock rather than racing.
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        Ok(fetched("tok", Some(3600)))
+                    })
+                    .await
+                    .unwrap()
+            }));
+        }
+
+        for handle in handles {
+            assert_eq!(handle.await.unwrap(), "tok");
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "single-flight must mint exactly once for concurrent same-key callers"
+        );
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This adds a per-table OAuth token cache to the Rust SDK so the built-in OAuth path stops minting a fresh Unity Catalog token on every stream creation.

What changes:

- New internal `token_cache` module. `TokenCache` lives on the `ZerobusSdk` instance and caches one token per `(client_id, sha256(client_secret), table_name)`, served until it nears expiry and refreshed lazily on access. Two builder knobs: `token_cache_enabled` (default on) and `token_refresh_buffer` (default 5 min).
- `DefaultTokenFactory` now reads the OAuth `expires_in` (previously discarded) via an internal `fetch_token`; the public `get_token` is unchanged and delegates to it.
- `OAuthHeadersProvider` is wired to the shared cache via an internal `with_cache(...)`; the public `new(...)` is unchanged (it now caches for its own lifetime).
- Cache invalidation on server-side auth rejection: a new `HeadersProvider::invalidate` (default no-op) is called when the server returns `Unauthenticated`/`PermissionDenied`, on both the gRPC and Arrow Flight paths, at initial creation, recovery, and mid-stream. The OAuth provider drops its cached token so the next attempt re-mints.
- Observability: an info `minted UC OAuth token` log (with `reason`, `expires_in_secs`, `elapsed_ms`), debug for cache hits, and warn for the degraded paths. Only the table name is logged, never the token or secret.
- Two bug fixes surfaced in the OAuth/stream-setup path (both pre-existing): the raw authorization token is no longer written to an error log or error message; and Arrow `FlightError → tonic::Status` now uses `.into()` (which preserves the inner gRPC code) instead of `Status::from_error` (which flattened it to `Unknown`, breaking retry and auth-rejection classification on the Arrow path).

Edge cases handled:

- Concurrent stream creations to the same table mint a single token (per-key single-flight lock), not one per caller.
- Refresh failure: a retryable error falls back to a still-valid cached token; a non-retryable error (bad/revoked credentials) propagates immediately rather than being masked.
- A response with no usable `expires_in` is never cached.
- A token that cannot be encoded as an `authorization` header value is rejected at mint, so it never enters the cache and can't poison it until expiry.
- An absurd `expires_in` or a caller-supplied `Duration::MAX` refresh buffer cannot panic (checked time arithmetic; overflow is treated as non-cacheable / always-refresh).
- A server auth rejection at any stream lifecycle point invalidates the cached token so the next attempt re-mints.

Why:

Service principal credentials are exchanged for a Unity Catalog token valid for ~1 hour, but a single stream lives at most ~15 minutes, and the SDK minted a new token on every stream connect and recovery. Clients that churn through many short-lived streams therefore hammered the UC token endpoint. Caching collapses that to roughly one mint per table per token lifetime.

Decisions not visible from the code:

- Keyed by table because the minted token is downscoped to a single `catalog.schema.table`; a token for one table is not valid for another.
- Scoped per `ZerobusSdk` instance (not process-global) to avoid global state; callers must reuse one SDK to benefit.
- The secret is keyed by its SHA-256 digest, not plaintext, so the raw secret never lives in the cache map while staying collision-free.
- The cache reuses a token until it nears expiry, so a permission change is re-checked at most once per token lifetime rather than per stream (the old per-stream minting re-checked every time as a side effect). A server-side rejection still invalidates immediately; UC also enforces grants at mint time, so a re-mint after a revocation is denied.

## How is this tested?

- Unit tests in `token_cache.rs`, `errors.rs`, `default_token_factory.rs`, and `builder/sdk_builder.rs`: cache reuse, per-table separation, secret rotation, no-TTL no-cache, disabled mode, single-flight under concurrency, retryable vs non-retryable refresh failure, no-TTL non-eviction, invalidate-forces-remint, header-validity check, `expires_in` parsing, `is_auth_rejection` classification, and the `FlightError → Status` code-preservation invariant. `make check` and the full suite pass under both the default and `arrow-flight` feature sets.
- Manual end-to-end on staging (e2-dogfood, `shinkansen.default.air_quality_managed`): five streams to one table from one SDK mint one token with the cache on (four cache hits) versus five with it off; the first stream is ~2.1 s (pays the ~0.8 s token round-trip) and cached ones ~0.6 s. Logs were inspected to confirm no token/secret appears at any level.
- [WIP] Testing edge cases around granting then revoking permissions to a service principal, as well as dropping and creating a table with the same name.