### PR TITLE
[Python] Expose application_name to customize user-agent

### DIFF
--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -8,10 +8,13 @@
 
 - **`ZerobusSdk(application_name=...)`**: Both the sync and async `ZerobusSdk`
   constructors accept an optional `application_name` argument. When set, it is
-  appended to the HTTP `user-agent` header sent on every request, so callers
-  can be identified in server-side telemetry. The SDK prefix is preserved, so
-  the wire value becomes `zerobus-sdk-py/<version> <application_name>`. By
-  convention use `<product>/<version>` (e.g. `"my-app/1.0"`).
+  appended to the HTTP `user-agent` header on gRPC requests to the Zerobus
+  server (it is not sent on the requests to the login service that mint the
+  OAuth token), so callers can be identified in server-side telemetry. The SDK
+  prefix is preserved, so the wire value becomes
+  `zerobus-sdk-py/<version> <application_name>`. By convention use
+  `<product>/<version>` (e.g. `"my-app/1.0"`). The value is trimmed; blank
+  values are ignored and control characters are rejected.
 
 ### Bug Fixes
 

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -6,9 +6,19 @@
 
 ### New Features and Improvements
 
+- **`ZerobusSdk(application_name=...)`**: Both the sync and async `ZerobusSdk`
+  constructors accept an optional `application_name` argument. When set, it is
+  appended to the HTTP `user-agent` header sent on every request, so callers
+  can be identified in server-side telemetry. The SDK prefix is preserved, so
+  the wire value becomes `zerobus-sdk-py/<version> <application_name>`. By
+  convention use `<product>/<version>` (e.g. `"my-app/1.0"`).
+
 ### Bug Fixes
 
 ### Documentation
+
+- README: documented the `application_name` constructor argument.
+- Examples: all examples under `examples/` now demonstrate `application_name`.
 
 ### Internal Changes
 
@@ -17,3 +27,7 @@
 ### Deprecations
 
 ### API Changes
+
+- `ZerobusSdk.__init__` gains an optional `application_name: Optional[str] = None`
+  parameter (sync and async). Strictly additive; existing two-argument callers
+  are unaffected.

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -13,8 +13,7 @@
   OAuth token), so callers can be identified in server-side telemetry. The SDK
   prefix is preserved, so the wire value becomes
   `zerobus-sdk-py/<version> <application_name>`. By convention use
-  `<product>/<version>` (e.g. `"my-app/1.0"`). The value is trimmed; blank
-  values are ignored and control characters are rejected.
+  `<product>/<version>` (e.g. `"my-app/1.0"`).
 
 ### Bug Fixes
 

--- a/python/README.md
+++ b/python/README.md
@@ -368,7 +368,7 @@ Main entry point. Sync: `from zerobus.sdk.sync import ZerobusSdk` / Async: `from
 sdk = ZerobusSdk(server_endpoint: str, unity_catalog_endpoint: str, application_name: Optional[str] = None)
 ```
 
-`application_name` is optional; when set it is appended to the `user-agent` header on gRPC requests to the Zerobus server (not on the OAuth token requests to the login service). It follows the `"<product>/<version>"` convention (e.g. `my-app/1.0`). The value is trimmed; blank is ignored and control characters are rejected.
+`application_name` is optional; when set it is appended to the `user-agent` header on gRPC requests to the Zerobus server (not on the OAuth token requests to the login service). It follows the `"<product>/<version>"` convention (e.g. `my-app/1.0`).
 
 ```python
 # Sync

--- a/python/README.md
+++ b/python/README.md
@@ -368,7 +368,7 @@ Main entry point. Sync: `from zerobus.sdk.sync import ZerobusSdk` / Async: `from
 sdk = ZerobusSdk(server_endpoint: str, unity_catalog_endpoint: str, application_name: Optional[str] = None)
 ```
 
-`application_name` is optional; when set it is appended to the `user-agent` header (e.g. `zerobus-sdk-py/<version> my-app/1.0`).
+`application_name` is optional; when set it is appended to the `user-agent` header on gRPC requests to the Zerobus server (not on the OAuth token requests to the login service). It follows the `"<product>/<version>"` convention (e.g. `my-app/1.0`). The value is trimmed; blank is ignored and control characters are rejected.
 
 ```python
 # Sync

--- a/python/README.md
+++ b/python/README.md
@@ -365,8 +365,10 @@ for batch in unacked_batches:
 Main entry point. Sync: `from zerobus.sdk.sync import ZerobusSdk` / Async: `from zerobus.sdk.aio import ZerobusSdk`
 
 ```python
-sdk = ZerobusSdk(server_endpoint: str, unity_catalog_endpoint: str)
+sdk = ZerobusSdk(server_endpoint: str, unity_catalog_endpoint: str, application_name: Optional[str] = None)
 ```
+
+`application_name` is optional; when set it is appended to the `user-agent` header (e.g. `zerobus-sdk-py/<version> my-app/1.0`).
 
 ```python
 # Sync

--- a/python/examples/async_example_arrow.py
+++ b/python/examples/async_example_arrow.py
@@ -90,7 +90,7 @@ async def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("SDK initialized")
 
         # Step 2: Configure arrow stream options (all optional, shown with defaults)

--- a/python/examples/async_example_json.py
+++ b/python/examples/async_example_json.py
@@ -142,7 +142,7 @@ async def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("✓ SDK initialized")
 
         # Step 2: Configure stream options with JSON record type and ack callback

--- a/python/examples/async_example_proto.py
+++ b/python/examples/async_example_proto.py
@@ -139,7 +139,7 @@ async def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("✓ SDK initialized")
 
         # Step 2: Configure stream options with protobuf record type and ack callback

--- a/python/examples/sync_example_arrow.py
+++ b/python/examples/sync_example_arrow.py
@@ -89,7 +89,7 @@ def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("SDK initialized")
 
         # Step 2: Configure arrow stream options (all optional, shown with defaults)

--- a/python/examples/sync_example_json.py
+++ b/python/examples/sync_example_json.py
@@ -114,7 +114,7 @@ def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("✓ SDK initialized")
 
         # Step 2: Define table properties

--- a/python/examples/sync_example_proto.py
+++ b/python/examples/sync_example_proto.py
@@ -113,7 +113,7 @@ def main():
 
     try:
         # Step 1: Initialize the SDK
-        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)
+        sdk = ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, application_name="my-app/1.0")
         logger.info("✓ SDK initialized")
 
         # Step 2: Define table properties

--- a/python/rust/src/async_wrapper.rs
+++ b/python/rust/src/async_wrapper.rs
@@ -268,16 +268,23 @@ pub struct ZerobusSdk {
 #[pymethods]
 impl ZerobusSdk {
     #[new]
-    fn new(host: String, unity_catalog_url: String) -> PyResult<Self> {
+    fn new(
+        host: String,
+        unity_catalog_url: String,
+        application_name: Option<String>,
+    ) -> PyResult<Self> {
         let py_version = env!("CARGO_PKG_VERSION");
         let sdk_identifier = format!("{}/{}", SDK_IDENTIFIER_PREFIX, py_version);
 
-        let sdk = RustSdk::builder()
+        let builder = RustSdk::builder()
             .endpoint(host)
             .unity_catalog_url(unity_catalog_url)
-            .sdk_identifier(sdk_identifier)
-            .build()
-            .map_err(map_error)?;
+            .sdk_identifier(sdk_identifier);
+        let builder = match application_name {
+            Some(application_name) => builder.application_name(application_name),
+            None => builder,
+        };
+        let sdk = builder.build().map_err(map_error)?;
 
         Ok(ZerobusSdk {
             inner: Arc::new(RwLock::new(sdk)),

--- a/python/rust/src/async_wrapper.rs
+++ b/python/rust/src/async_wrapper.rs
@@ -15,7 +15,8 @@ use crate::arrow::{ArrowStreamConfigurationOptions, AsyncZerobusArrowStream};
 use crate::auth::HeadersProviderWrapper;
 use crate::common::{
     apply_grpc_options, encoded_record_to_pybytes, extract_record_payload, extract_record_payloads,
-    map_error, StreamConfigurationOptions, TableProperties, SDK_IDENTIFIER_PREFIX,
+    map_error, normalize_application_name, StreamConfigurationOptions, TableProperties,
+    SDK_IDENTIFIER_PREFIX,
 };
 
 // =============================================================================
@@ -268,11 +269,14 @@ pub struct ZerobusSdk {
 #[pymethods]
 impl ZerobusSdk {
     #[new]
+    #[pyo3(signature = (host, unity_catalog_url, application_name = None))]
     fn new(
         host: String,
         unity_catalog_url: String,
         application_name: Option<String>,
     ) -> PyResult<Self> {
+        let application_name = normalize_application_name(application_name)?;
+
         let py_version = env!("CARGO_PKG_VERSION");
         let sdk_identifier = format!("{}/{}", SDK_IDENTIFIER_PREFIX, py_version);
 

--- a/python/rust/src/async_wrapper.rs
+++ b/python/rust/src/async_wrapper.rs
@@ -15,8 +15,7 @@ use crate::arrow::{ArrowStreamConfigurationOptions, AsyncZerobusArrowStream};
 use crate::auth::HeadersProviderWrapper;
 use crate::common::{
     apply_grpc_options, encoded_record_to_pybytes, extract_record_payload, extract_record_payloads,
-    map_error, normalize_application_name, StreamConfigurationOptions, TableProperties,
-    SDK_IDENTIFIER_PREFIX,
+    map_error, StreamConfigurationOptions, TableProperties, SDK_IDENTIFIER_PREFIX,
 };
 
 // =============================================================================
@@ -275,8 +274,6 @@ impl ZerobusSdk {
         unity_catalog_url: String,
         application_name: Option<String>,
     ) -> PyResult<Self> {
-        let application_name = normalize_application_name(application_name)?;
-
         let py_version = env!("CARGO_PKG_VERSION");
         let sdk_identifier = format!("{}/{}", SDK_IDENTIFIER_PREFIX, py_version);
 

--- a/python/rust/src/common.rs
+++ b/python/rust/src/common.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 
 use databricks_zerobus_ingest_sdk::{
-    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder,
+    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder, ZerobusError,
 };
 
 /// User-agent prefix emitted by this wrapper SDK. Combined with the wrapper
@@ -494,6 +494,31 @@ pub(crate) fn apply_grpc_options<'a>(
     }
 
     Ok(b)
+}
+
+/// Validate and normalize a caller-supplied `application_name`.
+///
+/// Trims surrounding whitespace and treats a blank result as unset (`None`),
+/// consistent with how the core builder ignores an empty identifier. Rejects
+/// values containing control characters (e.g. `\r`, `\n`) with an
+/// `InvalidArgument` error naming the parameter.
+pub(crate) fn normalize_application_name(
+    application_name: Option<String>,
+) -> PyResult<Option<String>> {
+    let name = match application_name {
+        Some(name) => name,
+        None => return Ok(None),
+    };
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err(map_error(ZerobusError::InvalidArgument(
+            "application_name must not contain control characters".to_string(),
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
 }
 
 // =============================================================================

--- a/python/rust/src/common.rs
+++ b/python/rust/src/common.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 
 use databricks_zerobus_ingest_sdk::{
-    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder, ZerobusError,
+    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder,
 };
 
 /// User-agent prefix emitted by this wrapper SDK. Combined with the wrapper
@@ -494,31 +494,6 @@ pub(crate) fn apply_grpc_options<'a>(
     }
 
     Ok(b)
-}
-
-/// Validate and normalize a caller-supplied `application_name`.
-///
-/// Trims surrounding whitespace and treats a blank result as unset (`None`),
-/// consistent with how the core builder ignores an empty identifier. Rejects
-/// values containing control characters (e.g. `\r`, `\n`) with an
-/// `InvalidArgument` error naming the parameter.
-pub(crate) fn normalize_application_name(
-    application_name: Option<String>,
-) -> PyResult<Option<String>> {
-    let name = match application_name {
-        Some(name) => name,
-        None => return Ok(None),
-    };
-    let trimmed = name.trim();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-    if trimmed.chars().any(char::is_control) {
-        return Err(map_error(ZerobusError::InvalidArgument(
-            "application_name must not contain control characters".to_string(),
-        )));
-    }
-    Ok(Some(trimmed.to_string()))
 }
 
 // =============================================================================

--- a/python/rust/src/sync_wrapper.rs
+++ b/python/rust/src/sync_wrapper.rs
@@ -14,8 +14,7 @@ use crate::arrow::{ArrowStreamConfigurationOptions, ZerobusArrowStream};
 use crate::auth::HeadersProviderWrapper;
 use crate::common::{
     apply_grpc_options, encoded_record_to_pybytes, extract_record_payload, extract_record_payloads,
-    map_error, normalize_application_name, StreamConfigurationOptions, TableProperties,
-    SDK_IDENTIFIER_PREFIX,
+    map_error, StreamConfigurationOptions, TableProperties, SDK_IDENTIFIER_PREFIX,
 };
 
 // =============================================================================
@@ -290,8 +289,6 @@ impl ZerobusSdk {
         unity_catalog_url: String,
         application_name: Option<String>,
     ) -> PyResult<Self> {
-        let application_name = normalize_application_name(application_name)?;
-
         let runtime = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/python/rust/src/sync_wrapper.rs
+++ b/python/rust/src/sync_wrapper.rs
@@ -14,7 +14,8 @@ use crate::arrow::{ArrowStreamConfigurationOptions, ZerobusArrowStream};
 use crate::auth::HeadersProviderWrapper;
 use crate::common::{
     apply_grpc_options, encoded_record_to_pybytes, extract_record_payload, extract_record_payloads,
-    map_error, StreamConfigurationOptions, TableProperties, SDK_IDENTIFIER_PREFIX,
+    map_error, normalize_application_name, StreamConfigurationOptions, TableProperties,
+    SDK_IDENTIFIER_PREFIX,
 };
 
 // =============================================================================
@@ -283,11 +284,14 @@ pub struct ZerobusSdk {
 #[pymethods]
 impl ZerobusSdk {
     #[new]
+    #[pyo3(signature = (host, unity_catalog_url, application_name = None))]
     fn new(
         host: String,
         unity_catalog_url: String,
         application_name: Option<String>,
     ) -> PyResult<Self> {
+        let application_name = normalize_application_name(application_name)?;
+
         let runtime = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/python/rust/src/sync_wrapper.rs
+++ b/python/rust/src/sync_wrapper.rs
@@ -283,7 +283,11 @@ pub struct ZerobusSdk {
 #[pymethods]
 impl ZerobusSdk {
     #[new]
-    fn new(host: String, unity_catalog_url: String) -> PyResult<Self> {
+    fn new(
+        host: String,
+        unity_catalog_url: String,
+        application_name: Option<String>,
+    ) -> PyResult<Self> {
         let runtime = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -299,12 +303,15 @@ impl ZerobusSdk {
         let py_version = env!("CARGO_PKG_VERSION");
         let sdk_identifier = format!("{}/{}", SDK_IDENTIFIER_PREFIX, py_version);
 
-        let inner = RustSdk::builder()
+        let builder = RustSdk::builder()
             .endpoint(host)
             .unity_catalog_url(unity_catalog_url)
-            .sdk_identifier(sdk_identifier)
-            .build()
-            .map_err(map_error)?;
+            .sdk_identifier(sdk_identifier);
+        let builder = match application_name {
+            Some(application_name) => builder.application_name(application_name),
+            None => builder,
+        };
+        let inner = builder.build().map_err(map_error)?;
 
         Ok(Self {
             inner: Arc::new(RwLock::new(inner)),

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -227,6 +227,19 @@ class TestApplicationName(unittest.TestCase):
         self.assertIsNotNone(SyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
         self.assertIsNotNone(AsyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
 
+    def test_application_name_blank_is_treated_as_unset(self):
+        """A blank/whitespace-only application_name is accepted (treated as unset)."""
+        self.assertIsNotNone(SyncSdk(self.HOST, self.UC_URL, application_name="   "))
+        self.assertIsNotNone(AsyncSdk(self.HOST, self.UC_URL, application_name=""))
+
+    def test_application_name_rejects_control_characters(self):
+        """Control characters (newline, carriage return, tab) are rejected."""
+        for bad in ("my-app\n1.0", "my-app\r1.0", "my\tapp"):
+            with self.assertRaises(ZerobusException):
+                SyncSdk(self.HOST, self.UC_URL, application_name=bad)
+            with self.assertRaises(ZerobusException):
+                AsyncSdk(self.HOST, self.UC_URL, application_name=bad)
+
 
 class TestStreamConfigurationDefaults(unittest.TestCase):
     """Test StreamConfigurationOptions defaults."""

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -227,19 +227,6 @@ class TestApplicationName(unittest.TestCase):
         self.assertIsNotNone(SyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
         self.assertIsNotNone(AsyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
 
-    def test_application_name_blank_is_treated_as_unset(self):
-        """A blank/whitespace-only application_name is accepted (treated as unset)."""
-        self.assertIsNotNone(SyncSdk(self.HOST, self.UC_URL, application_name="   "))
-        self.assertIsNotNone(AsyncSdk(self.HOST, self.UC_URL, application_name=""))
-
-    def test_application_name_rejects_control_characters(self):
-        """Control characters (newline, carriage return, tab) are rejected."""
-        for bad in ("my-app\n1.0", "my-app\r1.0", "my\tapp"):
-            with self.assertRaises(ZerobusException):
-                SyncSdk(self.HOST, self.UC_URL, application_name=bad)
-            with self.assertRaises(ZerobusException):
-                AsyncSdk(self.HOST, self.UC_URL, application_name=bad)
-
 
 class TestStreamConfigurationDefaults(unittest.TestCase):
     """Test StreamConfigurationOptions defaults."""

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -192,6 +192,42 @@ class TestRecordTypeConstants(unittest.TestCase):
         self.assertNotEqual(proto1, json_type)
 
 
+class TestApplicationName(unittest.TestCase):
+    """Test the optional application_name SDK construction parameter.
+
+    SDK construction validates the endpoint and extracts the workspace ID but
+    does not open a network connection, so these tests run offline.
+    """
+
+    HOST = "https://test-workspace.zerobus.region.cloud.databricks.com"
+    UC_URL = "https://test-workspace.cloud.databricks.com"
+
+    def test_sync_sdk_constructs_with_application_name(self):
+        """Sync SDK accepts application_name without error."""
+        sdk = SyncSdk(self.HOST, self.UC_URL, application_name="my-app/1.0")
+        self.assertIsNotNone(sdk)
+
+    def test_async_sdk_constructs_with_application_name(self):
+        """Async SDK accepts application_name without error."""
+        sdk = AsyncSdk(self.HOST, self.UC_URL, application_name="my-app/1.0")
+        self.assertIsNotNone(sdk)
+
+    def test_sync_sdk_constructs_without_application_name(self):
+        """application_name is optional; sync SDK still constructs by default."""
+        sdk = SyncSdk(self.HOST, self.UC_URL)
+        self.assertIsNotNone(sdk)
+
+    def test_async_sdk_constructs_without_application_name(self):
+        """application_name is optional; async SDK still constructs by default."""
+        sdk = AsyncSdk(self.HOST, self.UC_URL)
+        self.assertIsNotNone(sdk)
+
+    def test_application_name_accepts_positional(self):
+        """application_name may also be passed positionally."""
+        self.assertIsNotNone(SyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
+        self.assertIsNotNone(AsyncSdk(self.HOST, self.UC_URL, "my-app/1.0"))
+
+
 class TestStreamConfigurationDefaults(unittest.TestCase):
     """Test StreamConfigurationOptions defaults."""
 

--- a/python/zerobus/__init__.py
+++ b/python/zerobus/__init__.py
@@ -35,7 +35,7 @@ Example (Async):
     >>> from zerobus.sdk.aio import ZerobusSdk, TableProperties
     >>>
     >>> async def main():
-    ...     sdk = ZerobusSdk(host, unity_catalog_url)
+    ...     sdk = ZerobusSdk(host, unity_catalog_url, application_name="my-app/1.0")
     ...     stream = await sdk.create_stream(props, client_id, client_secret)
     ...     offset = await stream.ingest_record_offset(b"data")
     ...     await stream.flush()

--- a/python/zerobus/__init__.py
+++ b/python/zerobus/__init__.py
@@ -14,7 +14,8 @@ Example (Sync):
     >>>
     >>> sdk = ZerobusSdk(
     ...     host="https://your-shard-id.zerobus.region.cloud.databricks.com",
-    ...     unity_catalog_url="https://your-workspace.cloud.databricks.com"
+    ...     unity_catalog_url="https://your-workspace.cloud.databricks.com",
+    ...     application_name="my-app/1.0",  # optional
     ... )
     >>>
     >>> props = TableProperties("catalog.schema.table")

--- a/python/zerobus/_zerobus_core.pyi
+++ b/python/zerobus/_zerobus_core.pyi
@@ -311,7 +311,9 @@ class sync:
             Args:
                 host: Zerobus server endpoint
                 unity_catalog_url: Unity Catalog / workspace URL
-                application_name: Optional app identifier appended to the ``user-agent``
+                application_name: Optional caller identifier (conventionally
+                    "<product>/<version>") appended to the HTTP user-agent header on
+                    gRPC requests toward the Zerobus server.
             """
             ...
 
@@ -462,7 +464,9 @@ class aio:
             Args:
                 host: Zerobus server endpoint
                 unity_catalog_url: Unity Catalog / workspace URL
-                application_name: Optional app identifier appended to the ``user-agent``
+                application_name: Optional caller identifier (conventionally
+                    "<product>/<version>") appended to the HTTP user-agent header on
+                    gRPC requests toward the Zerobus server.
             """
             ...
 

--- a/python/zerobus/_zerobus_core.pyi
+++ b/python/zerobus/_zerobus_core.pyi
@@ -304,7 +304,17 @@ class sync:
     class ZerobusSdk:
         """Main entry point for synchronous Zerobus ingestion."""
 
-        def __init__(self, host: str, unity_catalog_url: str) -> None: ...
+        def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None) -> None:
+            """
+            Create a synchronous Zerobus SDK instance.
+
+            Args:
+                host: Zerobus server endpoint
+                unity_catalog_url: Unity Catalog / workspace URL
+                application_name: Optional app identifier appended to the ``user-agent``
+            """
+            ...
+
         def set_use_tls(self, use_tls: bool) -> None:
             """
             Set whether to use TLS for connections (default: True).
@@ -445,7 +455,17 @@ class aio:
     class ZerobusSdk:
         """Main entry point for asynchronous Zerobus ingestion."""
 
-        def __init__(self, host: str, unity_catalog_url: str) -> None: ...
+        def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None) -> None:
+            """
+            Create an asynchronous Zerobus SDK instance.
+
+            Args:
+                host: Zerobus server endpoint
+                unity_catalog_url: Unity Catalog / workspace URL
+                application_name: Optional app identifier appended to the ``user-agent``
+            """
+            ...
+
         async def set_use_tls(self, use_tls: bool) -> None:
             """
             Set whether to use TLS for connections (default: True).

--- a/python/zerobus/sdk/aio/zerobus_sdk.py
+++ b/python/zerobus/sdk/aio/zerobus_sdk.py
@@ -39,7 +39,7 @@ Example:
     >>> asyncio.run(main())
 """
 
-from typing import Any
+from typing import Any, Optional
 
 # Import Rust-backed implementations
 import zerobus._zerobus_core as _core
@@ -220,8 +220,8 @@ class ZerobusArrowStream:
 class ZerobusSdk:
     """Python wrapper around Rust ZerobusSdk that returns wrapped streams."""
 
-    def __init__(self, host: str, unity_catalog_url: str):
-        self._inner = _core.aio.ZerobusSdk(host, unity_catalog_url)
+    def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None):
+        self._inner = _core.aio.ZerobusSdk(host, unity_catalog_url, application_name)
 
     async def create_arrow_stream(
         self, table_name: str, schema, client_id: str, client_secret: str, options=None

--- a/python/zerobus/sdk/aio/zerobus_sdk.py
+++ b/python/zerobus/sdk/aio/zerobus_sdk.py
@@ -12,7 +12,8 @@ Example:
     >>> async def main():
     ...     sdk = ZerobusSdk(
     ...         host="https://your-shard-id.zerobus.region.cloud.databricks.com",
-    ...         unity_catalog_url="https://your-workspace.cloud.databricks.com"
+    ...         unity_catalog_url="https://your-workspace.cloud.databricks.com",
+    ...         application_name="my-app/1.0",  # optional
     ...     )
     ...
     ...     props = TableProperties("catalog.schema.table")
@@ -221,6 +222,17 @@ class ZerobusSdk:
     """Python wrapper around Rust ZerobusSdk that returns wrapped streams."""
 
     def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None):
+        """
+        Create a Zerobus SDK instance.
+
+        Args:
+            host: Zerobus endpoint URL
+                (e.g. "https://<workspace>.zerobus.<region>.cloud.databricks.com").
+            unity_catalog_url: Unity Catalog URL used for OAuth.
+            application_name: Optional caller identifier (conventionally
+                "<product>/<version>") appended to the HTTP user-agent header on
+                gRPC requests toward the Zerobus server.
+        """
         self._inner = _core.aio.ZerobusSdk(host, unity_catalog_url, application_name)
 
     async def create_arrow_stream(

--- a/python/zerobus/sdk/sync/zerobus_sdk.py
+++ b/python/zerobus/sdk/sync/zerobus_sdk.py
@@ -38,7 +38,7 @@ Example:
     >>> offset = ack.wait_for_ack(timeout_sec=30)
 """
 
-from typing import Iterator
+from typing import Iterator, Optional
 
 # Import Rust-backed implementations
 import zerobus._zerobus_core as _core
@@ -197,8 +197,8 @@ class ZerobusArrowStream:
 class ZerobusSdk:
     """Python wrapper around Rust ZerobusSdk that provides unified create_stream API."""
 
-    def __init__(self, host: str, unity_catalog_url: str):
-        self._inner = _RustZerobusSdk(host, unity_catalog_url)
+    def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None):
+        self._inner = _RustZerobusSdk(host, unity_catalog_url, application_name)
 
     def create_arrow_stream(
         self, table_name: str, schema, client_id: str, client_secret: str, options=None

--- a/python/zerobus/sdk/sync/zerobus_sdk.py
+++ b/python/zerobus/sdk/sync/zerobus_sdk.py
@@ -10,7 +10,8 @@ Example:
     >>>
     >>> sdk = ZerobusSdk(
     ...     host="https://your-shard-id.zerobus.region.cloud.databricks.com",
-    ...     unity_catalog_url="https://your-workspace.cloud.databricks.com"
+    ...     unity_catalog_url="https://your-workspace.cloud.databricks.com",
+    ...     application_name="my-app/1.0",  # optional
     ... )
     >>>
     >>> props = TableProperties("catalog.schema.table")
@@ -198,6 +199,17 @@ class ZerobusSdk:
     """Python wrapper around Rust ZerobusSdk that provides unified create_stream API."""
 
     def __init__(self, host: str, unity_catalog_url: str, application_name: Optional[str] = None):
+        """
+        Create a Zerobus SDK instance.
+
+        Args:
+            host: Zerobus endpoint URL
+                (e.g. "https://<workspace>.zerobus.<region>.cloud.databricks.com").
+            unity_catalog_url: Unity Catalog URL used for OAuth.
+            application_name: Optional caller identifier (conventionally
+                "<product>/<version>") appended to the HTTP user-agent header on
+                gRPC requests toward the Zerobus server.
+        """
         self._inner = _RustZerobusSdk(host, unity_catalog_url, application_name)
 
     def create_arrow_stream(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Accept an optional `application_name` argument on SDK initialization.  When set, it is appended to the HTTP `user-agent` header sent on every request, so callers can be identified in server-side telemetry. The SDK prefix is preserved, so the wire value becomes `"zerobus-sdk-py/<version> <application_name>"` (e.g. `"my-app/1.0"`).

Closes #382

## How is this tested?

Tested with existing tests. New tests are added as well.
