### PR TITLE
[Rust][FFI] Release version 1.3.0

### DIFF
--- a/rust/ffi/CHANGELOG.md
+++ b/rust/ffi/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Version changelog
 
+## Release v1.3.0
+
+### Major Changes
+
+### New Features and Improvements
+
+- **C-builder API for SDK construction**: `zerobus_sdk_builder_new`, per-option setters (`_endpoint`, `_unity_catalog_url`, `_sdk_identifier`, `_application_name`, `_disable_tls`), and `_build` / `_free`. Mirrors the Rust `ZerobusSdkBuilder`; new options are added as setters without ABI breaks. Legacy `zerobus_sdk_new` is retained and delegates to the builder.
+- **Dynamic protobuf from a Unity Catalog schema**: a pure-C consumer can now build a protobuf descriptor from UC table metadata and encode records without a companion Rust crate. New opaque type `CZerobusProtoSchema` and functions:
+  - `zerobus_proto_schema_from_uc_json` — build a schema handle from UC table-metadata JSON (the body of `GET /api/2.1/unity-catalog/tables/{name}`).
+  - `zerobus_proto_schema_descriptor_bytes` — borrow the serialized `DescriptorProto` to pass straight to `zerobus_sdk_create_stream` (byte-identical to the descriptor the encoder uses).
+  - `zerobus_proto_schema_encode_json` — encode one JSON record into protobuf bytes; unknown keys are ignored. `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` columns are integers (days / micros since epoch), `BINARY` is a base64 string, `DECIMAL` is a string, and large 64-bit integers are accepted as JSON strings (the protobuf-JSON canonical form) to avoid precision loss in producers that emit numbers as IEEE-754 doubles. Top-level non-nullable scalar/struct columns are proto2 `required`; a record missing one is rejected (ARRAY/MAP map to `repeated`, which has no presence, so an omitted one encodes as empty).
+  - `zerobus_free_proto_bytes` / `zerobus_proto_schema_free` — free an encoded buffer / a schema handle.
+
+### Bug Fixes
+
+### Documentation
+
+### Internal Changes
+
+### Behavior Changes
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v1.2.1
 
 ### Major Changes

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -1,17 +1,10 @@
 # NEXT CHANGELOG
 
-## Release v1.3.0
+## Release v1.4.0
 
 ### Major Changes
 
 ### New Features and Improvements
-
-- **C-builder API for SDK construction**: `zerobus_sdk_builder_new`, per-option setters (`_endpoint`, `_unity_catalog_url`, `_sdk_identifier`, `_application_name`, `_disable_tls`), and `_build` / `_free`. Mirrors the Rust `ZerobusSdkBuilder`; new options are added as setters without ABI breaks. Legacy `zerobus_sdk_new` is retained and delegates to the builder.
-- **Dynamic protobuf from a Unity Catalog schema**: a pure-C consumer can now build a protobuf descriptor from UC table metadata and encode records without a companion Rust crate. New opaque type `CZerobusProtoSchema` and functions:
-  - `zerobus_proto_schema_from_uc_json` — build a schema handle from UC table-metadata JSON (the body of `GET /api/2.1/unity-catalog/tables/{name}`).
-  - `zerobus_proto_schema_descriptor_bytes` — borrow the serialized `DescriptorProto` to pass straight to `zerobus_sdk_create_stream` (byte-identical to the descriptor the encoder uses).
-  - `zerobus_proto_schema_encode_json` — encode one JSON record into protobuf bytes; unknown keys are ignored. `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` columns are integers (days / micros since epoch), `BINARY` is a base64 string, `DECIMAL` is a string, and large 64-bit integers are accepted as JSON strings (the protobuf-JSON canonical form) to avoid precision loss in producers that emit numbers as IEEE-754 doubles. Top-level non-nullable scalar/struct columns are proto2 `required`; a record missing one is rejected (ARRAY/MAP map to `repeated`, which has no presence, so an omitted one encodes as empty).
-  - `zerobus_free_proto_bytes` / `zerobus_proto_schema_free` — free an encoded buffer / a schema handle.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Finalizes the FFI **v1.3.0** release. `rust/ffi/Cargo.toml` is already at `1.3.0` (bumped earlier in #358), so this PR is the changelog roll-over that precedes tagging `ffi/v1.3.0`:

- Move the accumulated `NEXT_CHANGELOG.md` entries into `CHANGELOG.md` under `## Release v1.3.0`.
- Reset `NEXT_CHANGELOG.md` to an empty template headed `## Release v1.4.0`.

v1.3.0 ships the C-builder API (`zerobus_sdk_builder_*`, #358) and the dynamic-protobuf API (`CZerobusProtoSchema` + `zerobus_proto_schema_*`, #371). No code or ABI change in this PR.

**WHY:** Finalizing the changelog is the prerequisite to tagging the release. Unlike v1.2.0 (which needed follow-up #306 to bump the version), `Cargo.toml` is already at `1.3.0`, so no version bump is required here.

## How is this tested?

N/A — changelog-only change. Verified the crate still builds and all 52 FFI unit tests pass (`cargo build -p zerobus-ffi`, `cargo test -p zerobus-ffi`).