### PR TITLE
[Rust][FFI] Add native library support for Linux musl (Alpine)

### DIFF
--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -22,6 +22,20 @@ jobs:
             dynamic_lib: libzerobus_ffi.so
             artifact_dir: linux-aarch64
             cross: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            dynamic_lib: libzerobus_ffi.so
+            artifact_dir: linux-musl-x86_64
+            cross: false
+            zigbuild: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            dynamic_lib: libzerobus_ffi.so
+            artifact_dir: linux-musl-aarch64
+            cross: false
+            zigbuild: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
             static_lib: zerobus_ffi.lib
@@ -69,8 +83,25 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (musl cross-builds)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac # v2.0.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (musl cross-builds)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build FFI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI library (zigbuild)
+        if: matrix.zigbuild
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
+        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Prepare artifacts
         shell: bash

--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install Zig (musl cross-builds)
         if: matrix.zigbuild
-        uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac # v2.0.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.13.0
 

--- a/.github/workflows/release-jni.yml
+++ b/.github/workflows/release-jni.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install Zig (musl cross-builds)
         if: matrix.zigbuild
-        uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac # v2.0.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.13.0
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements
 
-- Build the FFI library for Linux musl targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`), enabling C/C++ and Go-on-Alpine consumers to link `libzerobus_ffi.a` / `libzerobus_ffi.so` on musl-based (Alpine) containers. Artifacts ship in the `linux-musl-x86_64` / `linux-musl-aarch64` directories. Mirrors the JNI musl support added in #347.
+- Build the FFI library for Linux musl targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`), enabling C/C++ and Go-on-Alpine consumers to link `libzerobus_ffi.a` / `libzerobus_ffi.so` on musl-based (Alpine) containers. Artifacts ship in the `linux-musl-x86_64` / `linux-musl-aarch64` directories.
 
 ### Bug Fixes
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+- Build the FFI library for Linux musl targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`), enabling C/C++ and Go-on-Alpine consumers to link `libzerobus_ffi.a` / `libzerobus_ffi.so` on musl-based (Alpine) containers. Artifacts ship in the `linux-musl-x86_64` / `linux-musl-aarch64` directories. Mirrors the JNI musl support added in #347.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/ffi/README.md
+++ b/rust/ffi/README.md
@@ -22,6 +22,16 @@ cargo build -p zerobus-ffi --release
 rustup target add aarch64-unknown-linux-gnu
 cargo build -p zerobus-ffi --release --target aarch64-unknown-linux-gnu
 
+# Linux musl (Alpine), x86_64 and ARM64 — cross-compiled with cargo-zigbuild.
+# Built with -C target-feature=-crt-static so the libs link musl dynamically,
+# which is correct for dynamically-linked Alpine hosts.
+cargo install cargo-zigbuild
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+RUSTFLAGS="-C target-feature=-crt-static" \
+  cargo zigbuild -p zerobus-ffi --release --target x86_64-unknown-linux-musl
+RUSTFLAGS="-C target-feature=-crt-static" \
+  cargo zigbuild -p zerobus-ffi --release --target aarch64-unknown-linux-musl
+
 # macOS ARM64 (Apple Silicon)
 rustup target add aarch64-apple-darwin
 cargo build -p zerobus-ffi --release --target aarch64-apple-darwin


### PR DESCRIPTION
## What changes are proposed in this pull request?

**WHAT:** Builds the C FFI library (`rust/ffi`) for Linux musl targets so it works on Alpine / musl-based containers:

- Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` matrix rows to `.github/workflows/release-ffi.yml`, cross-compiled with `cargo-zigbuild` on the existing `databricks-protected-runner-group / linux-ubuntu-latest` runners (no dedicated Alpine runner). Builds with `RUSTFLAGS=-C target-feature=-crt-static` so the libs link musl dynamically, which is correct for dynamically-linked Alpine hosts. The crate's `crate-type = ["staticlib", "cdylib"]` means one `cargo zigbuild` run emits both `libzerobus_ffi.a` and `libzerobus_ffi.so`. Artifacts upload as `ffi-linux-musl-x86_64` / `ffi-linux-musl-aarch64`.
- Documents the musl cross-compile in `rust/ffi/README.md`.
- Adds a `rust/ffi/NEXT_CHANGELOG.md` entry.

**WHY:** The FFI library was previously built only for glibc targets, so the glibc-linked artifacts do not load or link on Alpine. This is the FFI counterpart to #324 (Java request), which was implemented for JNI in #347 but left the FFI build unchanged — so direct C/C++ consumers on Alpine were still unsupported. This PR mirrors the #347 workflow approach for FFI.

The Java side of #347 also had a runtime `NativeLoader` (it bundles all platforms in one JAR and selects the lib at load time). The FFI library has no runtime loader — C/C++ consumers link the `linux-musl-*` directory they download directly — so there is no analogous code to add here. Per scope decision, the `release-go.yml` / Go-on-Alpine path (which needs cgo build-tag plumbing to distinguish musl from glibc) is left to a separate change.

Fixes #411

## How is this tested?

Triggered & passed - https://github.com/databricks/zerobus-sdk/actions/runs/28018404039

CI/packaging change only — no unit-testable code paths. Validated the `release-ffi.yml` YAML parses and that the new matrix rows reuse the existing `Prepare artifacts` / `Upload artifact` steps (keyed off `matrix.artifact_dir` / `static_lib` / `dynamic_lib`). The workflow is `workflow_dispatch`-triggered; a manual `release-ffi.yml` run is the end-to-end verification, mirroring how #347 was validated via a triggered `release-jni.yml` run.
