### PR TITLE
[Rust] Dynamic protobuf (proto from UC)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "databricks-zerobus-ingest-sdk",
  "prost",
  "prost-reflect",
+ "serde_json",
  "tokio",
 ]
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### New Features and Improvements
 
+- Token caching for the default OAuth path. Tokens obtained via `.oauth(...)` are now cached per table on the `ZerobusSdk` instance and reused across stream creations and recoveries until they near expiry, instead of minting a fresh token on every stream. This reduces load on the Unity Catalog token endpoint for clients that create many short-lived streams. Caching is on by default and can be tuned via `ZerobusSdkBuilder::token_cache_enabled` and `ZerobusSdkBuilder::token_refresh_buffer`.
+- On a server-side authentication rejection during stream creation, the cached token is invalidated so the next attempt re-mints (re-checking grants at Unity Catalog), rather than reusing a rejected token until the refresh window.
+- `OAuthHeadersProvider::new` now caches tokens for the lifetime of the returned provider (previously it minted a fresh token on every call). Behavior is unchanged for the common path of constructing streams through `ZerobusSdk`, which already shares a cache.
+- Dynamic protobuf ingestion: ingest on the efficient proto path without a compiled `.proto` or generated Rust types. The canonical record contract is a **JSON value encoded against the descriptor** (consistent with the C/FFI encode path), turned into protobuf wire bytes client-side. Three pieces ship together:
+  - `StreamBuilder::proto_from_uc()` — fetches the table's schema from Unity Catalog at stream creation and derives the protobuf descriptor (no local `.proto`).
+  - `schema::TableDescriptorBuilder` — build a descriptor in code from Databricks column types when there is no Unity Catalog metadata.
+  - `DynamicProtoEncoder` (via `ZerobusStream::encoder()`) — encode JSON records (string, `serde_json::Value`, or any `serde::Serialize`) into protobuf bytes against the stream's descriptor, then ingest them through the existing `ingest_record_offset` / `ingest_records_offset` API.
+
 ### Bug Fixes
 
 ### Documentation
@@ -17,3 +25,13 @@
 ### Deprecations
 
 ### API Changes
+
+- Added `ZerobusSdkBuilder::token_cache_enabled(bool)` to enable or disable OAuth token caching (default enabled).
+- Added `ZerobusSdkBuilder::token_refresh_buffer(Duration)` to configure how long before a cached token's expiry it is refreshed (default 5 minutes).
+- Added `HeadersProvider::invalidate` with a default no-op implementation; the SDK calls it when the server rejects the supplied credentials so a provider can drop cached auth state. Existing trait implementations are unaffected.
+- Added `StreamBuilder::proto_from_uc()` to create a proto stream whose descriptor is fetched from Unity Catalog at `build()` time.
+- Added `ZerobusStream::encoder()`, returning a `DynamicProtoEncoder` bound to the stream's descriptor.
+- Added `DynamicProtoEncoder` (module `dynamic`) with `new`, `encode`, `encode_value`, `encode_record`, `descriptor`, and `descriptor_bytes`.
+- Added `schema::TableDescriptorBuilder` for constructing a `DescriptorProto` in code, plus `schema::fetch_uc_table_schema` and `schema::descriptor_from_uc` for fetching a table's schema/descriptor from the Unity Catalog REST API.
+- Added `DefaultTokenFactory::get_workspace_token` to mint an `all-apis` token for Unity Catalog REST calls.
+- `prost-reflect` is now a regular dependency of the SDK crate (previously a dev-dependency).

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -12,7 +12,7 @@
 - Dynamic protobuf ingestion: ingest on the efficient proto path without a compiled `.proto` or generated Rust types. The canonical record contract is a **JSON value encoded against the descriptor** (consistent with the C/FFI encode path), turned into protobuf wire bytes client-side. Three pieces ship together:
   - `StreamBuilder::proto_from_uc()` — fetches the table's schema from Unity Catalog at stream creation and derives the protobuf descriptor (no local `.proto`).
   - `schema::TableDescriptorBuilder` — build a descriptor in code from Databricks column types when there is no Unity Catalog metadata.
-  - `DynamicProtoEncoder` (via `ZerobusStream::encoder()`) — encode JSON records (string, `serde_json::Value`, or any `serde::Serialize`) into protobuf bytes against the stream's descriptor, then ingest them through the existing `ingest_record_offset` / `ingest_records_offset` API.
+  - `DynamicProtoEncoder` (via `ZerobusStream::encoder()`) — encode JSON records (a string or `serde_json::Value`) into protobuf bytes against the stream's descriptor, then ingest them through the existing `ingest_record_offset` / `ingest_records_offset` API.
 
 ### Bug Fixes
 
@@ -31,7 +31,7 @@
 - Added `HeadersProvider::invalidate` with a default no-op implementation; the SDK calls it when the server rejects the supplied credentials so a provider can drop cached auth state. Existing trait implementations are unaffected.
 - Added `StreamBuilder::proto_from_uc()` to create a proto stream whose descriptor is fetched from Unity Catalog at `build()` time.
 - Added `ZerobusStream::encoder()`, returning a `DynamicProtoEncoder` bound to the stream's descriptor.
-- Added `DynamicProtoEncoder` (module `dynamic`) with `new`, `encode`, `encode_value`, `encode_record`, `descriptor`, and `descriptor_bytes`.
+- Added `DynamicProtoEncoder` (module `dynamic`) with `new`, `encode`, and `encode_value`.
 - Added `schema::TableDescriptorBuilder` for constructing a `DescriptorProto` in code, plus `schema::fetch_uc_table_schema` and `schema::descriptor_from_uc` for fetching a table's schema/descriptor from the Unity Catalog REST API.
 - Added `DefaultTokenFactory::get_workspace_token` to mint an `all-apis` token for Unity Catalog REST calls.
 - `prost-reflect` is now a regular dependency of the SDK crate (previously a dev-dependency).

--- a/rust/README.md
+++ b/rust/README.md
@@ -522,7 +522,7 @@ let descriptor = TableDescriptorBuilder::new("orders")
     .build()?;
 ```
 
-`encoder` also takes a `serde_json::Value` (`encode_value`) or any `serde::Serialize` (`encode_record`). Some Databricks types need shaping in the JSON (`DATE`/`TIMESTAMP` as integers, `BINARY` as base64, `DECIMAL` as a string) — see the `dynamic` module docs.
+`encoder.encode` takes a JSON string and `encode_value` a `serde_json::Value`. Some Databricks types need shaping in the JSON (`DATE`/`TIMESTAMP` as integers, `BINARY` as base64, `DECIMAL` as a string) — see the `dynamic` module docs.
 
 ### 5. Ingest Data
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -218,7 +218,7 @@ zerobus_rust_sdk/
 |                  |                   |
 |      +-----------+-----------+       |
 |      v                       v       |
-| +----------+          +----------+   | 
+| +----------+          +----------+   |
 | |  Sender  |          | Receiver |   | Parallel tasks
 | |  Task    |          |  Task    |   |
 | +----------+          +----------+   |
@@ -328,7 +328,7 @@ For JSON-based ingestion, you can skip the schema generation step and directly p
 ### 1. Generate Protocol Buffer Schema (Protocol Buffers approach only)
 
 > **Important Note**: The schema generation tool and examples are **only available in the GitHub repository**. The crate published on [crates.io](https://crates.io/crates/databricks-zerobus-ingest-sdk) contains only the core Zerobus ingestion SDK logic. To generate protobuf schemas or see working examples, clone the repository:
-> 
+>
 > ```bash
 > git clone https://github.com/databricks/zerobus-sdk.git
 > cd zerobus-sdk/rust
@@ -491,6 +491,38 @@ let mut stream = sdk
 ```
 
 Setters can be called in any order. The builder validates at `build()` time that both authentication and format have been configured.
+
+#### Dynamic Protocol Buffers Stream (no compiled `.proto`)
+
+Use the proto path without a `.proto` file or generated types: the SDK fetches the descriptor at runtime and encodes **JSON** records to protobuf bytes client-side.
+
+```rust
+let mut stream = sdk
+    .stream_builder().table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .proto_from_uc()            // fetch the descriptor from Unity Catalog
+    .build()
+    .await?;
+
+let encoder = stream.encoder()?;    // build once, reuse
+let offset = stream
+    .ingest_record_offset(encoder.encode(r#"{"id": 1, "customer_name": "Alice"}"#)?)
+    .await?;
+stream.wait_for_offset(offset).await?;
+```
+
+Or build the descriptor in code when there is no Unity Catalog metadata, and pass it to `.compiled_proto(descriptor)` instead. Encoding is identical.
+
+```rust
+use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
+
+let descriptor = TableDescriptorBuilder::new("orders")
+    .column("id", "BIGINT", false)
+    .column("customer_name", "STRING", true)
+    .build()?;
+```
+
+`encoder` also takes a `serde_json::Value` (`encode_value`) or any `serde::Serialize` (`encode_record`). Some Databricks types need shaping in the JSON (`DATE`/`TIMESTAMP` as integers, `BINARY` as base64, `DECIMAL` as a string) — see the `dynamic` module docs.
 
 ### 5. Ingest Data
 
@@ -690,12 +722,12 @@ match stream.close().await {
         let unacked = stream.get_unacked_records().await?;
         let total_records = unacked.count();
         println!("Failed to ack {} records", total_records);
-        
+
         // Option 2: Get records grouped by batch (preserves batch structure)
         let unacked_batches = stream.get_unacked_batches().await?;
         let total_records: usize = unacked_batches.iter().map(|batch| batch.get_record_count()).sum();
         println!("Failed to ack {} records in {} batches", total_records, unacked_batches.len());
-        
+
         // Retry with a new stream
     }
     Ok(_) => println!("Stream closed successfully"),

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -40,6 +40,7 @@ The SDK supports two serialization formats and two ingestion methods:
 | [JSON Batch](json/README.md#batch-example) | JSON | Batch | `cargo run -p rust-examples-json --example json_batch` |
 | [Proto Single](proto/README.md#single-record-example) | Protocol Buffers | Single-record | `cargo run -p rust-examples-proto --example proto_single` |
 | [Proto Batch](proto/README.md#batch-example) | Protocol Buffers | Batch | `cargo run -p rust-examples-proto --example proto_batch` |
+| [Proto Dynamic](proto/README.md) | Protocol Buffers (dynamic, no `.proto`) | Single-record | `cargo run -p rust-examples-proto --example proto_dynamic` |
 | [Arrow](arrow/README.md) | Arrow Flight (Beta) | `RecordBatch` | `cargo run -p example_arrow` |
 
 ## Prerequisites

--- a/rust/examples/proto/Cargo.toml
+++ b/rust/examples/proto/Cargo.toml
@@ -12,9 +12,14 @@ path = "batch.rs"
 name = "proto_single"
 path = "single.rs"
 
+[[example]]
+name = "proto_dynamic"
+path = "dynamic.rs"
+
 [dependencies]
 databricks-zerobus-ingest-sdk = { path = "../../sdk" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 chrono.workspace = true
 prost.workspace = true
 prost-reflect.workspace = true
+serde_json.workspace = true

--- a/rust/examples/proto/README.md
+++ b/rust/examples/proto/README.md
@@ -28,6 +28,7 @@ Protocol Buffers examples provide type safety and better performance. **No schem
 **Available examples:**
 - **`single.rs`** - Ingest records one at a time using `ingest_record_offset()` / `ingest_record()`
 - **`batch.rs`** - Ingest multiple records at once using `ingest_records_offset()` / `ingest_records()`
+- **`dynamic.rs`** - Ingest on the proto path with **no compiled `.proto`**: the descriptor is fetched from Unity Catalog (or built in code)
 
 ## Three Ways to Pass Data
 
@@ -176,6 +177,48 @@ if let Some(offset) = stream.ingest_records_offset(batch).await? {
 - **All-or-nothing**: The entire batch succeeds or fails as a unit
 - **Single acknowledgment**: One offset ID for the whole batch
 - **Empty batches**: Returns `None` (no-op)
+
+## Dynamic Example (no compiled `.proto`)
+
+`dynamic.rs` ingests on the efficient proto path without authoring a `.proto`
+file or generating Rust types. The descriptor is obtained at runtime and records
+are supplied as JSON, encoded to protobuf bytes client-side by the stream's
+`encoder()`.
+
+### Running the Example
+
+1. Configure credentials in `dynamic.rs` (see [Prerequisites](../README.md#prerequisites))
+
+2. Run the example:
+   ```bash
+   cargo run -p rust-examples-proto --example proto_dynamic
+   ```
+
+### Code Highlights
+
+```rust
+// Fetch the descriptor from Unity Catalog at stream creation — no .proto needed.
+let mut stream = sdk
+    .stream_builder()
+    .table(TABLE_NAME)
+    .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+    .proto_from_uc()
+    .build()
+    .await?;
+
+// Build the encoder once, then encode JSON records against the descriptor.
+let encoder = stream.encoder()?;
+let offset = stream
+    .ingest_record_offset(encoder.encode(r#"{"id": 1, "customer_name": "Alice"}"#)?)
+    .await?;
+stream.wait_for_offset(offset).await?;
+```
+
+When there is no Unity Catalog metadata, build the descriptor in code with
+`schema::TableDescriptorBuilder` and pass it to `.compiled_proto(...)` instead;
+the encoding step is identical. A few Databricks column types need shaping in the
+JSON you supply (`DATE`/`TIMESTAMP` as integers, `BINARY` as base64, `DECIMAL` as
+a string) — see the SDK's `dynamic` module docs.
 
 ## Adapting for Your Custom Table
 

--- a/rust/examples/proto/dynamic.rs
+++ b/rust/examples/proto/dynamic.rs
@@ -1,0 +1,143 @@
+//! Dynamic protobuf ingestion: no compiled `.proto`, no generated Rust types.
+//!
+//! Two descriptor sources are shown:
+//!  1. `.proto_from_uc()` — the SDK fetches the table's schema from Unity Catalog
+//!     at stream creation and derives the protobuf descriptor (the default,
+//!     used in `main`).
+//!  2. `TableDescriptorBuilder` — build the descriptor in code when you already
+//!     know the schema and have no Unity Catalog metadata (see
+//!     `ingest_with_in_code_descriptor`).
+//!
+//! In both cases records are supplied as JSON and encoded to protobuf bytes by
+//! the stream's `encoder()`, then ingested on the proto path.
+
+use std::error::Error;
+
+use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
+use databricks_zerobus_ingest_sdk::{ZerobusSdk, ZerobusStream};
+
+// Change constants to match your data.
+const TABLE_NAME: &str = "<your_table_name>";
+const DATABRICKS_CLIENT_ID: &str = "<your_databricks_client_id>";
+const DATABRICKS_CLIENT_SECRET: &str = "<your_databricks_client_secret>";
+
+// Uncomment the appropriate lines for your cloud.
+
+// For AWS:
+const DATABRICKS_WORKSPACE_URL: &str = "https://<your-workspace>.cloud.databricks.com";
+const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.databricks.com";
+
+// For Azure:
+// const DATABRICKS_WORKSPACE_URL: &str = "https://<your-workspace>.azuredatabricks.net";
+// const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.azuredatabricks.net";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let sdk = ZerobusSdk::builder()
+        .endpoint(SERVER_ENDPOINT)
+        .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
+        .build()?;
+
+    // No `.proto` file and no generated types: the descriptor is fetched from
+    // Unity Catalog at `build()` time.
+    let mut stream = sdk
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .proto_from_uc()
+        .max_inflight_requests(100)
+        .build()
+        .await?;
+
+    ingest_dynamic_records(&mut stream).await?;
+
+    stream.close().await?;
+    println!("Stream closed successfully");
+
+    Ok(())
+}
+
+/// Encode JSON records against the UC-derived descriptor and ingest them.
+async fn ingest_dynamic_records(stream: &mut ZerobusStream) -> Result<(), Box<dyn Error>> {
+    // Build the encoder once from the stream's descriptor and reuse it.
+    let encoder = stream.encoder()?;
+
+    // Delta TIMESTAMP is int64 microseconds since epoch UTC.
+    let now = chrono::Utc::now().timestamp_micros();
+
+    // 1. Encode a JSON string. The `Vec<u8>` it returns is protobuf wire bytes,
+    //    exactly what a compiled `.proto` type's `encode_to_vec()` would yield.
+    let record = format!(
+        r#"{{
+            "id": 1,
+            "customer_name": "Alice Smith",
+            "product_name": "Wireless Mouse",
+            "quantity": 2,
+            "price": 25.99,
+            "status": "pending",
+            "created_at": {now},
+            "updated_at": {now}
+        }}"#
+    );
+    let offset = stream
+        .ingest_record_offset(encoder.encode(&record)?)
+        .await?;
+    println!("[JSON string] Record sent with offset ID: {offset}");
+    stream.wait_for_offset(offset).await?;
+    println!("[JSON string] Record acknowledged with offset ID: {offset}");
+
+    // 2. Encode a `serde_json::Value` built with the `json!` macro.
+    let value = serde_json::json!({
+        "id": 2,
+        "customer_name": "Bob Johnson",
+        "product_name": "Mechanical Keyboard",
+        "quantity": 1,
+        "price": 89.99,
+        "status": "shipped",
+        "created_at": now,
+        "updated_at": now,
+    });
+    let offset = stream
+        .ingest_record_offset(encoder.encode_value(&value)?)
+        .await?;
+    println!("[JSON value] Record sent with offset ID: {offset}");
+    stream.wait_for_offset(offset).await?;
+    println!("[JSON value] Record acknowledged with offset ID: {offset}");
+
+    Ok(())
+}
+
+/// Alternative descriptor source: build it in code with `TableDescriptorBuilder`
+/// (no Unity Catalog round-trip), open the stream with `.compiled_proto(...)`,
+/// then encode records the same way.
+///
+/// Not called by `main`; shown as a reference for the no-UC path.
+#[allow(dead_code)]
+async fn ingest_with_in_code_descriptor(sdk: &ZerobusSdk) -> Result<(), Box<dyn Error>> {
+    let descriptor = TableDescriptorBuilder::new("table_Orders")
+        .column("id", "BIGINT", false)
+        .column("customer_name", "STRING", true)
+        .column("product_name", "STRING", true)
+        .column("quantity", "INT", true)
+        .column("price", "DOUBLE", true)
+        .column("status", "STRING", true)
+        .column("created_at", "TIMESTAMP", true)
+        .column("updated_at", "TIMESTAMP", true)
+        .build()?;
+
+    let mut stream = sdk
+        .stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .compiled_proto(descriptor)
+        .build()
+        .await?;
+
+    let encoder = stream.encoder()?;
+    let offset = stream
+        .ingest_record_offset(encoder.encode(r#"{"id": 100, "customer_name": "Carol"}"#)?)
+        .await?;
+    stream.wait_for_offset(offset).await?;
+    stream.close().await?;
+    Ok(())
+}

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -38,6 +38,7 @@ hyper-util.workspace = true
 smallvec.workspace = true
 bytes.workspace = true
 self_cell = { version = "1.2", optional = true }
+prost-reflect = { workspace = true, features = ["serde"] }
 
 # Arrow Flight dependencies
 arrow-flight = { workspace = true, optional = true }
@@ -51,7 +52,6 @@ tracing-subscriber.workspace = true
 # zeroparser e2e + bench dev-deps
 criterion = { version = "0.5", default-features = false, features = ["html_reports"] }
 plotters = { version = "0.3", default-features = false, features = ["svg_backend"] }
-prost-reflect = { workspace = true, features = ["serde"] }
 rstest = "0.24"
 strum = { version = "0.27", features = ["derive"] }
 

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -219,6 +219,13 @@ impl<'a> StreamBuilder<'a> {
     /// [`headers_provider`](Self::headers_provider) it reuses the provider's
     /// `authorization` header. The principal needs `SELECT` on the table.
     ///
+    /// Each `build()` performs these UC calls fresh and uncached (a workspace-token
+    /// mint plus the schema fetch), on top of the cached write token. For workloads
+    /// that churn many short-lived streams to the same table, fetch the descriptor
+    /// once with [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc),
+    /// reuse it via [`compiled_proto`](Self::compiled_proto), and obtain the encoder
+    /// from each resulting stream.
+    ///
     /// # Example
     ///
     /// ```rust,ignore

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use crate::callbacks::AckCallback;
 use crate::databricks::zerobus::RecordType;
+use crate::default_token_factory::DefaultTokenFactory;
 #[cfg(feature = "testing")]
 use crate::headers_provider::NoAuthHeadersProvider;
 use crate::headers_provider::{HeadersProvider, OAuthHeadersProvider};
@@ -49,6 +50,7 @@ enum AuthConfig {
 enum FormatConfig {
     Json,
     CompiledProto(Box<prost_types::DescriptorProto>),
+    ProtoFromUc,
     #[cfg(feature = "arrow-flight")]
     Arrow(Arc<ArrowSchema>),
 }
@@ -114,6 +116,7 @@ impl fmt::Debug for StreamBuilder<'_> {
         let format_kind = match &self.format {
             Some(FormatConfig::Json) => "Json",
             Some(FormatConfig::CompiledProto(_)) => "CompiledProto",
+            Some(FormatConfig::ProtoFromUc) => "ProtoFromUc",
             #[cfg(feature = "arrow-flight")]
             Some(FormatConfig::Arrow(_)) => "Arrow",
             None => "None",
@@ -189,8 +192,50 @@ impl<'a> StreamBuilder<'a> {
     }
 
     /// Select compiled protobuf record format.
+    ///
+    /// Use this when you already hold a [`prost_types::DescriptorProto`] — from a
+    /// compiled `.proto`, from
+    /// [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder),
+    /// or from [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc).
+    /// To ingest without a compiled `.proto`, obtain a
+    /// [`DynamicProtoEncoder`](crate::DynamicProtoEncoder) via
+    /// [`ZerobusStream::encoder`](crate::ZerobusStream::encoder).
     pub fn compiled_proto(mut self, descriptor: prost_types::DescriptorProto) -> Self {
         self.format = Some(FormatConfig::CompiledProto(Box::new(descriptor)));
+        self
+    }
+
+    /// Select dynamic protobuf, fetching the table's descriptor from Unity
+    /// Catalog at `build()` time.
+    ///
+    /// No compiled `.proto` is required: the SDK fetches the table's schema from
+    /// Unity Catalog, derives a protobuf descriptor, and opens a proto stream
+    /// with it. Supply records as JSON and encode them with the stream's
+    /// [`encoder`](crate::ZerobusStream::encoder), which is bound to the same
+    /// descriptor.
+    ///
+    /// The fetch uses an `all-apis` token: with [`oauth`](Self::oauth) the SDK
+    /// mints one from the client credentials; with
+    /// [`headers_provider`](Self::headers_provider) it reuses the provider's
+    /// `authorization` header. The principal needs `SELECT` on the table.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let stream = sdk
+    ///     .stream_builder()
+    ///     .table("catalog.schema.table")
+    ///     .oauth("client-id", "client-secret")
+    ///     .proto_from_uc()
+    ///     .build()
+    ///     .await?;
+    /// let encoder = stream.encoder()?;
+    /// let offset = stream
+    ///     .ingest_record_offset(encoder.encode(r#"{"id": 1}"#)?)
+    ///     .await?;
+    /// ```
+    pub fn proto_from_uc(mut self) -> Self {
+        self.format = Some(FormatConfig::ProtoFromUc);
         self
     }
 
@@ -358,10 +403,52 @@ impl<'a> StreamBuilder<'a> {
         }
         if self.format.is_none() {
             return Err(ZerobusError::InvalidArgument(
-                "record format is required: call .json(), .compiled_proto(), or .arrow()".into(),
+                "record format is required: call .json(), .compiled_proto(), .proto_from_uc(), \
+                 or .arrow()"
+                    .into(),
             ));
         }
         Ok(())
+    }
+
+    /// Resolve an `all-apis` token for the Unity Catalog REST API used by
+    /// [`proto_from_uc`](Self::proto_from_uc) to fetch the table schema.
+    ///
+    /// With OAuth credentials the SDK mints a workspace token (the Zerobus
+    /// write token is not accepted by the REST API). With a custom headers
+    /// provider it reuses the `authorization` header that provider supplies.
+    async fn resolve_uc_api_token(&self) -> ZerobusResult<String> {
+        match self.auth.as_ref() {
+            Some(AuthConfig::OAuth {
+                client_id,
+                client_secret,
+            }) => {
+                DefaultTokenFactory::get_workspace_token(
+                    &self.sdk.unity_catalog_url,
+                    client_id,
+                    client_secret,
+                )
+                .await
+            }
+            Some(AuthConfig::HeadersProvider(provider)) => {
+                let headers = provider.get_headers().await?;
+                let auth = headers.get("authorization").ok_or_else(|| {
+                    ZerobusError::InvalidArgument(
+                        "headers provider did not supply an 'authorization' header required to \
+                         fetch the Unity Catalog schema for proto_from_uc()"
+                            .to_string(),
+                    )
+                })?;
+                Ok(auth.strip_prefix("Bearer ").unwrap_or(auth).to_string())
+            }
+            // No credentials in the no-auth testing path; the (mock) Unity
+            // Catalog endpoint is expected not to require authorization.
+            #[cfg(feature = "testing")]
+            Some(AuthConfig::NoAuth) => Ok(String::new()),
+            None => Err(ZerobusError::InvalidArgument(
+                "authentication is required: call .oauth() or .headers_provider()".into(),
+            )),
+        }
     }
 
     /// Resolve the headers provider from the stored auth config.
@@ -393,9 +480,22 @@ impl<'a> StreamBuilder<'a> {
         self.validate()?;
         let headers_provider = self.resolve_headers_provider()?;
 
-        let (record_type, descriptor_proto) = match self.format {
+        // Take the format out so the `proto_from_uc` arm can borrow `&self`
+        // (for the UC fetch) without tripping a partial-move of `self.format`.
+        let format = self.format.take();
+        let (record_type, descriptor_proto) = match format {
             Some(FormatConfig::Json) => (RecordType::Json, None),
             Some(FormatConfig::CompiledProto(desc)) => (RecordType::Proto, Some(*desc)),
+            Some(FormatConfig::ProtoFromUc) => {
+                let token = self.resolve_uc_api_token().await?;
+                let descriptor = crate::schema::descriptor_from_uc(
+                    &self.sdk.unity_catalog_url,
+                    &self.table_name,
+                    &token,
+                )
+                .await?;
+                (RecordType::Proto, Some(descriptor))
+            }
             #[cfg(feature = "arrow-flight")]
             Some(FormatConfig::Arrow(_)) => {
                 return Err(ZerobusError::InvalidArgument(
@@ -404,7 +504,8 @@ impl<'a> StreamBuilder<'a> {
             }
             None => {
                 return Err(ZerobusError::InvalidArgument(
-                    "record format is required: call .json() or .compiled_proto() before .build()"
+                    "record format is required: call .json(), .compiled_proto(), or \
+                     .proto_from_uc() before .build()"
                         .into(),
                 ));
             }
@@ -526,6 +627,21 @@ mod tests {
             .table("catalog.schema.table")
             .headers_provider(provider)
             .compiled_proto(prost_types::DescriptorProto::default());
+    }
+
+    #[test]
+    fn proto_from_uc_builder() {
+        let sdk = test_sdk();
+        let builder = sdk
+            .stream_builder()
+            .table("catalog.schema.table")
+            .oauth("cid", "csec")
+            .proto_from_uc()
+            .max_inflight_requests(100);
+        // Validation passes (table + auth + format all set) without opening a stream.
+        builder.validate().unwrap();
+        let debug_str = format!("{:?}", builder);
+        assert!(debug_str.contains("ProtoFromUc"));
     }
 
     #[test]

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -205,45 +205,14 @@ impl<'a> StreamBuilder<'a> {
         self
     }
 
-    /// Select dynamic protobuf, fetching the table's descriptor from Unity
-    /// Catalog at `build()` time.
+    /// Select dynamic protobuf: the descriptor is fetched from Unity Catalog at
+    /// `build()` time (no compiled `.proto`); supply records as JSON via the
+    /// stream's [`encoder`](crate::ZerobusStream::encoder).
     ///
-    /// No compiled `.proto` is required: the SDK fetches the table's schema from
-    /// Unity Catalog, derives a protobuf descriptor, and opens a proto stream
-    /// with it. Supply records as JSON and encode them with the stream's
-    /// [`encoder`](crate::ZerobusStream::encoder), which is bound to the same
-    /// descriptor.
-    ///
-    /// The fetch uses an `all-apis` token: with [`oauth`](Self::oauth) the SDK
-    /// mints one from the client credentials; with
-    /// [`headers_provider`](Self::headers_provider) it reuses the provider's
-    /// `authorization` header, which must therefore be a token the Unity Catalog
-    /// REST API accepts (a workspace `all-apis` token, not a Zerobus
-    /// write-scoped one) or the schema fetch fails. The principal needs `SELECT`
-    /// on the table.
-    ///
-    /// Each `build()` performs these UC calls fresh and uncached (a workspace-token
-    /// mint plus the schema fetch), on top of the cached write token. For workloads
-    /// that churn many short-lived streams to the same table, fetch the descriptor
-    /// once with [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc),
-    /// reuse it via [`compiled_proto`](Self::compiled_proto), and obtain the encoder
-    /// from each resulting stream.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// let stream = sdk
-    ///     .stream_builder()
-    ///     .table("catalog.schema.table")
-    ///     .oauth("client-id", "client-secret")
-    ///     .proto_from_uc()
-    ///     .build()
-    ///     .await?;
-    /// let encoder = stream.encoder()?;
-    /// let offset = stream
-    ///     .ingest_record_offset(encoder.encode(r#"{"id": 1}"#)?)
-    ///     .await?;
-    /// ```
+    /// The fetch is uncached and needs an `all-apis` token with `SELECT` — minted
+    /// from [`oauth`](Self::oauth), or taken from a
+    /// [`headers_provider`](Self::headers_provider)'s `authorization` header (which
+    /// must then be UC-REST-scoped, not Zerobus-write-scoped).
     pub fn proto_from_uc(mut self) -> Self {
         self.format = Some(FormatConfig::ProtoFromUc);
         self
@@ -421,12 +390,8 @@ impl<'a> StreamBuilder<'a> {
         Ok(())
     }
 
-    /// Resolve an `all-apis` token for the Unity Catalog REST API used by
-    /// [`proto_from_uc`](Self::proto_from_uc) to fetch the table schema.
-    ///
-    /// With OAuth credentials the SDK mints a workspace token (the Zerobus
-    /// write token is not accepted by the REST API). With a custom headers
-    /// provider it reuses the `authorization` header that provider supplies.
+    /// Resolve an `all-apis` token for the UC REST schema fetch: mint one from
+    /// OAuth credentials, or reuse the headers provider's `authorization` header.
     async fn resolve_uc_api_token(&self) -> ZerobusResult<String> {
         match self.auth.as_ref() {
             Some(AuthConfig::OAuth {
@@ -490,8 +455,7 @@ impl<'a> StreamBuilder<'a> {
         self.validate()?;
         let headers_provider = self.resolve_headers_provider()?;
 
-        // Take the format out so the `proto_from_uc` arm can borrow `&self`
-        // (for the UC fetch) without tripping a partial-move of `self.format`.
+        // Take the format out so the `proto_from_uc` arm can borrow `&self`.
         let format = self.format.take();
         let (record_type, descriptor_proto) = match format {
             Some(FormatConfig::Json) => (RecordType::Json, None),

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -217,7 +217,10 @@ impl<'a> StreamBuilder<'a> {
     /// The fetch uses an `all-apis` token: with [`oauth`](Self::oauth) the SDK
     /// mints one from the client credentials; with
     /// [`headers_provider`](Self::headers_provider) it reuses the provider's
-    /// `authorization` header. The principal needs `SELECT` on the table.
+    /// `authorization` header, which must therefore be a token the Unity Catalog
+    /// REST API accepts (a workspace `all-apis` token, not a Zerobus
+    /// write-scoped one) or the schema fetch fails. The principal needs `SELECT`
+    /// on the table.
     ///
     /// Each `build()` performs these UC calls fresh and uncached (a workspace-token
     /// mint plus the schema fetch), on top of the cached write token. For workloads
@@ -795,6 +798,53 @@ mod tests {
         let provider = builder.resolve_headers_provider().unwrap();
         let headers = provider.get_headers().await.unwrap();
         assert_eq!(headers.get("x-test").unwrap(), "value");
+    }
+
+    #[tokio::test]
+    async fn resolve_uc_api_token_from_headers_provider() {
+        // A provider whose `authorization` header is configurable (or absent).
+        struct AuthProvider(Option<&'static str>);
+        #[async_trait::async_trait]
+        impl HeadersProvider for AuthProvider {
+            async fn get_headers(&self) -> crate::ZerobusResult<HashMap<&'static str, String>> {
+                let mut h = HashMap::new();
+                if let Some(v) = self.0 {
+                    h.insert("authorization", v.to_string());
+                }
+                Ok(h)
+            }
+        }
+
+        let sdk = test_sdk();
+
+        // `Bearer ` prefix is stripped.
+        let token = sdk
+            .stream_builder()
+            .table("c.s.t")
+            .headers_provider(Arc::new(AuthProvider(Some("Bearer abc"))))
+            .resolve_uc_api_token()
+            .await
+            .unwrap();
+        assert_eq!(token, "abc");
+
+        // A bare token is returned as-is.
+        let token = sdk
+            .stream_builder()
+            .table("c.s.t")
+            .headers_provider(Arc::new(AuthProvider(Some("rawtoken"))))
+            .resolve_uc_api_token()
+            .await
+            .unwrap();
+        assert_eq!(token, "rawtoken");
+
+        // A provider with no `authorization` header is an error.
+        let err = sdk
+            .stream_builder()
+            .table("c.s.t")
+            .headers_provider(Arc::new(AuthProvider(None)))
+            .resolve_uc_api_token()
+            .await;
+        assert!(matches!(err, Err(ZerobusError::InvalidArgument(_))));
     }
 
     #[cfg(feature = "testing")]

--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -103,7 +103,7 @@ impl DefaultTokenFactory {
     ) -> ZerobusResult<String> {
         let client = reqwest::Client::new();
         let params = [("grant_type", "client_credentials"), ("scope", "all-apis")];
-        let token_endpoint = format!("{}/oidc/v1/token", uc_endpoint);
+        let token_endpoint = format!("{}/oidc/v1/token", uc_endpoint.trim_end_matches('/'));
         let resp = client
             .post(&token_endpoint)
             .basic_auth(client_id, Some(client_secret))

--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -84,6 +84,53 @@ impl DefaultTokenFactory {
         .map(|fetched| fetched.token)
     }
 
+    /// Obtains an OAuth 2.0 access token for calling Databricks workspace REST
+    /// APIs (such as the Unity Catalog tables endpoint).
+    ///
+    /// Unlike [`get_token`](Self::get_token), this token is *not* downscoped to
+    /// the Zerobus direct-write API — it is a plain `all-apis` client-credentials
+    /// token, which is what the Unity Catalog REST API requires. Used by the
+    /// dynamic-protobuf path to fetch a table's schema at stream creation.
+    ///
+    /// # Errors
+    ///
+    /// * [`ZerobusError::TokenFetchError`] on network or `5xx` errors (retryable).
+    /// * [`ZerobusError::InvalidUCTokenError`] on `4xx` or an unparseable response.
+    pub async fn get_workspace_token(
+        uc_endpoint: &str,
+        client_id: &str,
+        client_secret: &str,
+    ) -> ZerobusResult<String> {
+        let client = reqwest::Client::new();
+        let params = [("grant_type", "client_credentials"), ("scope", "all-apis")];
+        let token_endpoint = format!("{}/oidc/v1/token", uc_endpoint);
+        let resp = client
+            .post(&token_endpoint)
+            .basic_auth(client_id, Some(client_secret))
+            .form(&params)
+            .send()
+            .await
+            .map_err(Self::handle_http_error)?;
+
+        if !resp.status().is_success() {
+            let status_code = resp.status().as_u16();
+            let error_body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "Failed to read error body".to_string());
+            return Err(Self::classify_status_code(status_code, error_body));
+        }
+
+        let body: serde_json::Value = resp.json().await.map_err(|e| {
+            ZerobusError::InvalidUCTokenError(format!("Parse failed with error: {}", e))
+        })?;
+
+        body["access_token"]
+            .as_str()
+            .ok_or_else(|| ZerobusError::InvalidUCTokenError("access_token missing".to_string()))
+            .map(|s| s.to_string())
+    }
+
     /// Obtains an OAuth 2.0 access token along with its reported lifetime.
     ///
     /// This is the caching-aware variant of [`get_token`](Self::get_token): in

--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -84,13 +84,10 @@ impl DefaultTokenFactory {
         .map(|fetched| fetched.token)
     }
 
-    /// Obtains an OAuth 2.0 access token for calling Databricks workspace REST
-    /// APIs (such as the Unity Catalog tables endpoint).
-    ///
-    /// Unlike [`get_token`](Self::get_token), this token is *not* downscoped to
-    /// the Zerobus direct-write API — it is a plain `all-apis` client-credentials
-    /// token, which is what the Unity Catalog REST API requires. Used by the
-    /// dynamic-protobuf path to fetch a table's schema at stream creation.
+    /// Mint a plain `all-apis` client-credentials token for Databricks workspace
+    /// REST APIs (e.g. the Unity Catalog tables endpoint) — unlike
+    /// [`get_token`](Self::get_token), it is not downscoped to the Zerobus
+    /// write API. Used by the dynamic-protobuf path to fetch a table's schema.
     ///
     /// # Errors
     ///

--- a/rust/sdk/src/dynamic.rs
+++ b/rust/sdk/src/dynamic.rs
@@ -288,6 +288,55 @@ mod tests {
     }
 
     #[test]
+    fn encoder_output_matches_compiled_prost_message() {
+        // The wire output must byte-match a compiled prost message with the same
+        // schema — the core "bytes match what the server validates" guarantee,
+        // checked against an independent encoder (prost codegen, not our pool).
+        #[derive(Clone, PartialEq, prost::Message)]
+        struct AirQuality {
+            #[prost(string, optional, tag = "1")]
+            device_name: Option<String>,
+            #[prost(int32, optional, tag = "2")]
+            temp: Option<i32>,
+            #[prost(int32, optional, tag = "3")]
+            humidity: Option<i32>,
+        }
+
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
+        let dynamic = encoder
+            .encode(r#"{"device_name": "s", "temp": 22, "humidity": 65}"#)
+            .unwrap();
+        let compiled = AirQuality {
+            device_name: Some("s".into()),
+            temp: Some(22),
+            humidity: Some(65),
+        }
+        .encode_to_vec();
+        assert_eq!(dynamic, compiled);
+    }
+
+    #[test]
+    fn nested_required_field_is_not_validated_client_side() {
+        // finish() enforces presence only for top-level required columns; a
+        // required field nested in a STRUCT is delegated to the server. This pins
+        // that documented boundary: `addr` is present but its required child
+        // `zip` is omitted, and the record still encodes here.
+        let descriptor = TableDescriptorBuilder::new("m")
+            .complex_column(
+                "addr",
+                "STRUCT",
+                r#"{"type":"struct","fields":[
+                    {"name":"zip","type":"integer","nullable":false,"metadata":{}}
+                ]}"#,
+                true,
+            )
+            .build()
+            .unwrap();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        assert!(encoder.encode(r#"{"addr": {}}"#).is_ok());
+    }
+
+    #[test]
     fn encodes_repeated_and_struct_via_json() {
         // ARRAY<long> -> repeated; STRUCT -> nested message. Both arrive as JSON.
         let descriptor = TableDescriptorBuilder::new("evt")

--- a/rust/sdk/src/dynamic.rs
+++ b/rust/sdk/src/dynamic.rs
@@ -1,57 +1,30 @@
 //! Dynamic protobuf encoding: turn JSON records into protobuf wire bytes against
 //! a descriptor obtained at runtime, with no compiled `.proto` types.
 //!
-//! This is the keystone of the SDK's *dynamic protobuf* path. A user who has a
-//! [`prost_types::DescriptorProto`] — fetched from Unity Catalog (see
-//! [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc)) or built in
-//! code (see [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder))
-//! — can encode records supplied as JSON and ingest them on the efficient proto
-//! path, without generating Rust types from a `.proto` file.
+//! Build a [`DescriptorProto`] from Unity Catalog (see
+//! [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc)) or in code
+//! (see [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder)),
+//! then encode records supplied as JSON and ingest them on the proto path. This
+//! is the canonical dynamic-record contract across the Zerobus SDKs: a JSON value
+//! encoded against the descriptor, turned into protobuf bytes client-side.
 //!
-//! # Canonical record contract
-//!
-//! Across all Zerobus SDKs the canonical way to supply a record dynamically is a
-//! **JSON value encoded against the descriptor**. The C/FFI path established this
-//! contract; this module is its native-Rust counterpart. The SDK turns each JSON
-//! record into protobuf wire bytes client-side and ships those bytes on the proto
-//! stream — the validated, compact path the typed SDK already optimizes for.
-//!
-//! # Value-encoding rules
-//!
-//! Records follow protobuf's JSON mapping. A few Databricks column types need
-//! shaping in the JSON you provide:
-//!
-//! - `DATE` / `TIMESTAMP` / `TIMESTAMP_NTZ`: integers (days / microseconds since
-//!   the Unix epoch), **not** ISO-8601 strings.
-//! - `BINARY`: a base64-encoded string, not a JSON array of bytes.
-//! - `DECIMAL`: a string (e.g. `"123.45"`) to preserve precision/scale.
-//! - `VARIANT`: a JSON-encoded string (a string whose contents are the variant's
-//!   JSON).
-//! - `ARRAY` / `MAP` / `STRUCT`: JSON array / object / object respectively.
-//! - `LONG` / `BIGINT` above 2^53: pass as a JSON string, otherwise the value
-//!   loses precision as a JSON number.
-//!
-//! Unknown keys are ignored, so records that carry extra non-column metadata are
-//! accepted. Presence is enforced for top-level non-nullable scalar and struct
-//! columns (proto2 `required`): a record omitting one is rejected. `ARRAY`/`MAP`
-//! columns map to `repeated`, which has no presence, so an omitted one encodes as
-//! empty rather than failing.
-//!
-//! # Example
+//! Records follow protobuf's JSON mapping; a few Databricks column types need
+//! shaping in the JSON you supply: `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` as integers
+//! (days / micros since epoch), `BINARY` as base64, `DECIMAL` as a string,
+//! `VARIANT` as a JSON-encoded string, and `LONG` above 2^53 as a string. Unknown
+//! keys are ignored; a missing non-nullable top-level column (proto2 `required`)
+//! is rejected.
 //!
 //! ```no_run
 //! use databricks_zerobus_ingest_sdk::dynamic::DynamicProtoEncoder;
 //! use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
-//!
 //! # fn main() -> Result<(), databricks_zerobus_ingest_sdk::ZerobusError> {
 //! let descriptor = TableDescriptorBuilder::new("orders")
 //!     .column("id", "BIGINT", false)
 //!     .column("name", "STRING", true)
 //!     .build()?;
-//!
 //! let encoder = DynamicProtoEncoder::new(&descriptor)?;
 //! let bytes = encoder.encode(r#"{"id": 1, "name": "Alice"}"#)?;
-//! // `bytes` is protobuf wire format; ingest it on a proto stream.
 //! # Ok(())
 //! # }
 //! ```
@@ -61,47 +34,29 @@ use prost_reflect::{
     Cardinality, DescriptorPool, DeserializeOptions, DynamicMessage, MessageDescriptor,
 };
 use prost_types::DescriptorProto;
-use serde::Serialize;
 
 use crate::{ZerobusError, ZerobusResult, ZerobusStream};
 
-/// Synthetic file name for the single-message descriptor pool. Has no package,
-/// so the message's fully-qualified name is its bare name.
-const SYNTHETIC_FILE_NAME: &str = "zerobus_dynamic.proto";
-
 /// Encodes JSON records into protobuf wire bytes against a runtime descriptor.
 ///
-/// Build one from a [`DescriptorProto`] with [`DynamicProtoEncoder::new`], then
-/// reuse it to encode many records — constructing it parses the descriptor into a
-/// reflection pool, so build it once per stream and keep it around rather than
-/// per record.
-///
-/// See the [module docs](crate::dynamic) for the JSON value-encoding rules.
-///
-/// Cloning is cheap: the reflection handle is reference-counted internally.
+/// Build once with [`new`](Self::new) and reuse — construction parses the
+/// descriptor into a reflection pool. Cloning is cheap (the handle is
+/// reference-counted). See the [module docs](crate::dynamic) for the JSON
+/// value-encoding rules.
 #[derive(Debug, Clone)]
 pub struct DynamicProtoEncoder {
-    /// The descriptor this encoder validates against. Kept so callers can recover
-    /// the exact bytes the stream was (or should be) created with.
-    descriptor: DescriptorProto,
-    /// Reflection handle used to deserialize JSON into a dynamic message.
     message: MessageDescriptor,
 }
 
 impl DynamicProtoEncoder {
-    /// Build an encoder for the given message descriptor.
-    ///
-    /// The descriptor is typically obtained from
-    /// [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc) (Unity
-    /// Catalog) or [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder)
-    /// (in code). It must be the same descriptor the stream is created with, so
-    /// the wire bytes this encoder produces match what the server validates.
+    /// Build an encoder for the given message descriptor. It must be the same
+    /// descriptor the stream is created with, so the bytes it produces match what
+    /// the server validates.
     ///
     /// # Errors
     ///
-    /// [`ZerobusError::InvalidArgument`] if the descriptor cannot be assembled
-    /// into a reflection pool (e.g. it references a nested type it does not
-    /// define).
+    /// [`ZerobusError::InvalidArgument`] if the descriptor has no name or cannot
+    /// be assembled into a reflection pool.
     pub fn new(descriptor: &DescriptorProto) -> ZerobusResult<Self> {
         let message_name = descriptor.name().to_string();
         if message_name.is_empty() {
@@ -109,9 +64,10 @@ impl DynamicProtoEncoder {
                 "descriptor has no message name".to_string(),
             ));
         }
-
+        // Wrap the message in a synthetic, package-less file so its
+        // fully-qualified name is just the bare message name.
         let file = prost_types::FileDescriptorProto {
-            name: Some(SYNTHETIC_FILE_NAME.to_string()),
+            name: Some("zerobus_dynamic.proto".to_string()),
             message_type: vec![descriptor.clone()],
             ..Default::default()
         };
@@ -119,48 +75,22 @@ impl DynamicProtoEncoder {
         pool.add_file_descriptor_proto(file).map_err(|e| {
             ZerobusError::InvalidArgument(format!("failed to build descriptor pool: {e}"))
         })?;
-        // No package on the synthetic file, so the fully-qualified name is the
-        // bare message name.
         let message = pool.get_message_by_name(&message_name).ok_or_else(|| {
-            ZerobusError::InvalidArgument(format!(
-                "message '{message_name}' not found in descriptor pool"
-            ))
+            ZerobusError::InvalidArgument(format!("message '{message_name}' not found"))
         })?;
-
-        Ok(Self {
-            descriptor: descriptor.clone(),
-            message,
-        })
+        Ok(Self { message })
     }
 
-    /// The descriptor this encoder was built from.
-    ///
-    /// Use [`descriptor_bytes`](Self::descriptor_bytes) when you need the exact
-    /// serialized form to create a stream with.
-    pub fn descriptor(&self) -> &DescriptorProto {
-        &self.descriptor
-    }
-
-    /// The serialized `DescriptorProto` bytes, byte-identical to what the encoder
-    /// validates against. Pass these when creating the stream so client-side
-    /// encoding and server-side validation agree.
-    pub fn descriptor_bytes(&self) -> Vec<u8> {
-        self.descriptor.encode_to_vec()
-    }
-
-    /// Encode a single JSON record (as a string) into protobuf wire bytes.
+    /// Encode a JSON record (a string) into protobuf wire bytes.
     ///
     /// # Errors
     ///
     /// [`ZerobusError::InvalidArgument`] if the JSON is malformed, has trailing
-    /// content, does not match the descriptor's field types, or omits a required
-    /// (non-nullable top-level scalar/struct) column.
+    /// content, mismatches a field type, or omits a required column.
     pub fn encode(&self, record_json: &str) -> ZerobusResult<Vec<u8>> {
-        let mut deserializer = serde_json::Deserializer::from_str(record_json);
-        let message = self.deserialize(&mut deserializer)?;
-        // Reject extra bytes after the first JSON value rather than silently
-        // ignoring them.
-        deserializer.end().map_err(|e| {
+        let mut de = serde_json::Deserializer::from_str(record_json);
+        let message = self.deserialize(&mut de)?;
+        de.end().map_err(|e| {
             ZerobusError::InvalidArgument(format!(
                 "unexpected trailing content in record JSON: {e}"
             ))
@@ -168,50 +98,28 @@ impl DynamicProtoEncoder {
         self.finish(message)
     }
 
-    /// Encode a [`serde_json::Value`] into protobuf wire bytes.
-    ///
-    /// Useful when a record is already assembled as a JSON value (e.g. built with
-    /// the `serde_json::json!` macro) so it need not be re-serialized to a string.
-    ///
-    /// # Errors
-    ///
-    /// See [`encode`](Self::encode).
+    /// Encode a [`serde_json::Value`] into protobuf wire bytes, avoiding a
+    /// re-serialization when the record is already a JSON value. See
+    /// [`encode`](Self::encode) for the error conditions.
     pub fn encode_value(&self, record: &serde_json::Value) -> ZerobusResult<Vec<u8>> {
         let message = self.deserialize(record)?;
         self.finish(message)
     }
 
-    /// Encode any [`serde::Serialize`] type into protobuf wire bytes by first
-    /// converting it to JSON.
-    ///
-    /// # Errors
-    ///
-    /// [`ZerobusError::InvalidArgument`] if serialization to JSON fails or the
-    /// resulting record does not match the descriptor (see [`encode`](Self::encode)).
-    pub fn encode_record<T: Serialize>(&self, record: &T) -> ZerobusResult<Vec<u8>> {
-        let value = serde_json::to_value(record).map_err(|e| {
-            ZerobusError::InvalidArgument(format!("failed to serialize record to JSON: {e}"))
-        })?;
-        self.encode_value(&value)
-    }
-
-    /// Deserialize JSON from any deserializer into a dynamic message, ignoring
-    /// unknown keys (records often carry extra non-column metadata).
-    fn deserialize<'de, D>(&self, deserializer: D) -> ZerobusResult<DynamicMessage>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    /// Deserialize JSON into a dynamic message, ignoring unknown keys (records
+    /// often carry extra non-column metadata).
+    fn deserialize<'de, D: serde::Deserializer<'de>>(
+        &self,
+        deserializer: D,
+    ) -> ZerobusResult<DynamicMessage> {
         let options = DeserializeOptions::new().deny_unknown_fields(false);
         DynamicMessage::deserialize_with_options(self.message.clone(), deserializer, &options)
             .map_err(|e| ZerobusError::InvalidArgument(format!("failed to encode record: {e}")))
     }
 
-    /// Enforce proto2 `required` presence then serialize to wire bytes.
-    ///
-    /// `prost-reflect` does not enforce presence on encode, so a missing
-    /// top-level required field is rejected here rather than emitting wire bytes
-    /// the server would reject. (`ARRAY`/`MAP` columns are `repeated`, which has
-    /// no presence; nested struct fields are not walked.)
+    /// Enforce proto2 `required` presence (prost-reflect does not on encode) then
+    /// serialize. `repeated` columns (`ARRAY`/`MAP`) have no presence and nested
+    /// struct fields are not walked.
     fn finish(&self, message: DynamicMessage) -> ZerobusResult<Vec<u8>> {
         let missing: Vec<String> = self
             .message
@@ -230,32 +138,22 @@ impl DynamicProtoEncoder {
 }
 
 impl ZerobusStream {
-    /// Build a [`DynamicProtoEncoder`] for this stream's protobuf descriptor.
-    ///
-    /// Returns an encoder bound to the same descriptor the stream was created
-    /// with — whether supplied via
-    /// [`compiled_proto`](crate::StreamBuilder::compiled_proto) or fetched via
-    /// [`proto_from_uc`](crate::StreamBuilder::proto_from_uc) — so JSON records
-    /// encoded by it are guaranteed to match what the server validates.
-    ///
-    /// Constructing an encoder parses the descriptor, so call this once and reuse
-    /// the returned encoder for the lifetime of the stream.
+    /// Build a [`DynamicProtoEncoder`] bound to this stream's protobuf descriptor
+    /// — whether supplied via [`compiled_proto`](crate::StreamBuilder::compiled_proto)
+    /// or fetched via [`proto_from_uc`](crate::StreamBuilder::proto_from_uc) — so
+    /// encoded records are guaranteed to match what the server validates. Build it
+    /// once and reuse.
     ///
     /// # Errors
     ///
     /// [`ZerobusError::InvalidArgument`] if the stream has no descriptor (a JSON
-    /// stream created with [`json`](crate::StreamBuilder::json)) or the descriptor
-    /// cannot be assembled.
-    ///
-    /// # Example
+    /// stream) or the descriptor cannot be assembled.
     ///
     /// ```no_run
     /// # use databricks_zerobus_ingest_sdk::ZerobusStream;
     /// # async fn example(stream: ZerobusStream) -> Result<(), databricks_zerobus_ingest_sdk::ZerobusError> {
     /// let encoder = stream.encoder()?;
-    /// let bytes = encoder.encode(r#"{"id": 1, "name": "Alice"}"#)?;
-    /// let offset = stream.ingest_record_offset(bytes).await?;
-    /// stream.wait_for_offset(offset).await?;
+    /// let offset = stream.ingest_record_offset(encoder.encode(r#"{"id": 1}"#)?).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -281,7 +179,7 @@ mod tests {
     use crate::schema::TableDescriptorBuilder;
     use prost_reflect::Value;
 
-    /// Build the air-quality descriptor used across these tests.
+    /// Build the air-quality descriptor used across these tests (all nullable).
     fn air_quality_descriptor() -> DescriptorProto {
         TableDescriptorBuilder::new("air_quality")
             .column("device_name", "STRING", true)
@@ -291,20 +189,16 @@ mod tests {
             .expect("descriptor builds")
     }
 
-    /// Decode encoded bytes back through the same descriptor for assertions.
     fn decode(encoder: &DynamicProtoEncoder, bytes: &[u8]) -> DynamicMessage {
         DynamicMessage::decode(encoder.message.clone(), bytes).expect("decodes")
     }
 
     #[test]
     fn encode_round_trips_scalar_fields() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
         let bytes = encoder
             .encode(r#"{"device_name": "sensor-1", "temp": 22, "humidity": 65}"#)
             .unwrap();
-
         let decoded = decode(&encoder, &bytes);
         assert_eq!(
             decoded
@@ -318,70 +212,29 @@ mod tests {
             decoded.get_field_by_name("temp").unwrap().as_i32().unwrap(),
             22
         );
-        assert_eq!(
-            decoded
-                .get_field_by_name("humidity")
-                .unwrap()
-                .as_i32()
-                .unwrap(),
-            65
-        );
     }
 
     #[test]
     fn encode_value_matches_encode_string() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
         let from_str = encoder
-            .encode(r#"{"device_name": "s", "temp": 1, "humidity": 2}"#)
+            .encode(r#"{"device_name": "s", "temp": 1}"#)
             .unwrap();
         let from_value = encoder
-            .encode_value(&serde_json::json!({
-                "device_name": "s",
-                "temp": 1,
-                "humidity": 2
-            }))
+            .encode_value(&serde_json::json!({"device_name": "s", "temp": 1}))
             .unwrap();
         assert_eq!(from_str, from_value);
     }
 
     #[test]
-    fn encode_record_accepts_serialize_types() {
-        #[derive(serde::Serialize)]
-        struct Reading {
-            device_name: String,
-            temp: i32,
-            humidity: i32,
-        }
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-
-        let bytes = encoder
-            .encode_record(&Reading {
-                device_name: "s".into(),
-                temp: 7,
-                humidity: 8,
-            })
-            .unwrap();
-        let decoded = decode(&encoder, &bytes);
-        assert_eq!(
-            decoded.get_field_by_name("temp").unwrap().as_i32().unwrap(),
-            7
-        );
-    }
-
-    #[test]
     fn unknown_keys_are_ignored() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
         // `source` is not a column; it must be ignored rather than rejected.
         let bytes = encoder
-            .encode(r#"{"device_name": "s", "temp": 1, "humidity": 2, "source": "kafka"}"#)
+            .encode(r#"{"device_name": "s", "temp": 1, "source": "kafka"}"#)
             .unwrap();
-        let decoded = decode(&encoder, &bytes);
         assert_eq!(
-            decoded
+            decode(&encoder, &bytes)
                 .get_field_by_name("device_name")
                 .unwrap()
                 .as_str()
@@ -392,12 +245,9 @@ mod tests {
 
     #[test]
     fn omitted_optional_field_encodes() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-        // All columns are nullable, so omitting one is fine.
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
         let bytes = encoder.encode(r#"{"device_name": "s"}"#).unwrap();
-        let decoded = decode(&encoder, &bytes);
-        assert!(!decoded.has_field_by_name("temp"));
+        assert!(!decode(&encoder, &bytes).has_field_by_name("temp"));
     }
 
     #[test]
@@ -409,56 +259,26 @@ mod tests {
             .build()
             .unwrap();
         let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-
-        let err = encoder.encode(r#"{"name": "x"}"#).unwrap_err();
-        match err {
+        match encoder.encode(r#"{"name": "x"}"#).unwrap_err() {
             ZerobusError::InvalidArgument(msg) => {
-                assert!(msg.contains("missing required field"), "got: {msg}");
-                assert!(msg.contains("id"), "got: {msg}");
+                assert!(
+                    msg.contains("missing required field") && msg.contains("id"),
+                    "got: {msg}"
+                );
             }
             other => panic!("expected InvalidArgument, got {other:?}"),
         }
     }
 
     #[test]
-    fn malformed_json_is_rejected() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+    fn rejects_invalid_input() {
+        let encoder = DynamicProtoEncoder::new(&air_quality_descriptor()).unwrap();
+        // Malformed JSON.
         assert!(encoder.encode(r#"{"device_name": "#).is_err());
-    }
-
-    #[test]
-    fn trailing_content_is_rejected() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-        let err = encoder
-            .encode(r#"{"device_name": "s"} {"device_name": "t"}"#)
-            .unwrap_err();
-        match err {
-            ZerobusError::InvalidArgument(msg) => {
-                assert!(msg.contains("trailing content"), "got: {msg}")
-            }
-            other => panic!("expected InvalidArgument, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn wrong_field_type_is_rejected() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-        // `temp` is an int; a non-numeric string is not coercible.
-        assert!(encoder
-            .encode(r#"{"device_name": "s", "temp": "hot"}"#)
-            .is_err());
-    }
-
-    #[test]
-    fn descriptor_bytes_round_trip_to_same_descriptor() {
-        let descriptor = air_quality_descriptor();
-        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-        let bytes = encoder.descriptor_bytes();
-        let decoded = DescriptorProto::decode(bytes.as_slice()).unwrap();
-        assert_eq!(&decoded, encoder.descriptor());
+        // Trailing content after the first value.
+        assert!(encoder.encode(r#"{"device_name": "s"} {}"#).is_err());
+        // Wrong field type (`temp` is an int; a non-numeric string is not coercible).
+        assert!(encoder.encode(r#"{"temp": "hot"}"#).is_err());
     }
 
     #[test]
@@ -489,12 +309,14 @@ mod tests {
             .build()
             .unwrap();
         let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
-
         let bytes = encoder
             .encode(r#"{"id": 1, "tags": [10, 20], "addr": {"zip": 94105}}"#)
             .unwrap();
-        let decoded = decode(&encoder, &bytes);
-        match decoded.get_field_by_name("tags").unwrap().as_ref() {
+        match decode(&encoder, &bytes)
+            .get_field_by_name("tags")
+            .unwrap()
+            .as_ref()
+        {
             Value::List(items) => assert_eq!(items.len(), 2),
             other => panic!("expected list, got {other:?}"),
         }

--- a/rust/sdk/src/dynamic.rs
+++ b/rust/sdk/src/dynamic.rs
@@ -1,30 +1,21 @@
 //! Dynamic protobuf encoding: turn JSON records into protobuf wire bytes against
-//! a descriptor obtained at runtime, with no compiled `.proto` types.
+//! a runtime descriptor, with no compiled `.proto`. The descriptor comes from
+//! Unity Catalog ([`descriptor_from_uc`](crate::schema::descriptor_from_uc)) or is
+//! built in code ([`TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder));
+//! records are supplied as JSON. This is the canonical dynamic-record contract
+//! across the Zerobus SDKs.
 //!
-//! Build a [`DescriptorProto`] from Unity Catalog (see
-//! [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc)) or in code
-//! (see [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder)),
-//! then encode records supplied as JSON and ingest them on the proto path. This
-//! is the canonical dynamic-record contract across the Zerobus SDKs: a JSON value
-//! encoded against the descriptor, turned into protobuf bytes client-side.
-//!
-//! Records follow protobuf's JSON mapping; a few Databricks column types need
-//! shaping in the JSON you supply: `DATE`/`TIMESTAMP`/`TIMESTAMP_NTZ` as integers
-//! (days / micros since epoch), `BINARY` as base64, `DECIMAL` as a string,
-//! `VARIANT` as a JSON-encoded string, and `LONG` above 2^53 as a string. Unknown
-//! keys are ignored; a missing non-nullable top-level column (proto2 `required`)
-//! is rejected.
+//! A few Databricks types need shaping in the JSON: `DATE`/`TIMESTAMP`(`_NTZ`) as
+//! integers (days / micros since epoch), `BINARY` as base64, `DECIMAL` and `LONG`
+//! above 2^53 as strings, `VARIANT` as a JSON-encoded string. Unknown keys are
+//! ignored; a missing non-nullable top-level column is rejected.
 //!
 //! ```no_run
-//! use databricks_zerobus_ingest_sdk::dynamic::DynamicProtoEncoder;
-//! use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
+//! # use databricks_zerobus_ingest_sdk::dynamic::DynamicProtoEncoder;
+//! # use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
 //! # fn main() -> Result<(), databricks_zerobus_ingest_sdk::ZerobusError> {
-//! let descriptor = TableDescriptorBuilder::new("orders")
-//!     .column("id", "BIGINT", false)
-//!     .column("name", "STRING", true)
-//!     .build()?;
-//! let encoder = DynamicProtoEncoder::new(&descriptor)?;
-//! let bytes = encoder.encode(r#"{"id": 1, "name": "Alice"}"#)?;
+//! let descriptor = TableDescriptorBuilder::new("orders").column("id", "BIGINT", false).build()?;
+//! let bytes = DynamicProtoEncoder::new(&descriptor)?.encode(r#"{"id": 1}"#)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -64,8 +55,7 @@ impl DynamicProtoEncoder {
                 "descriptor has no message name".to_string(),
             ));
         }
-        // Wrap the message in a synthetic, package-less file so its
-        // fully-qualified name is just the bare message name.
+        // Package-less file so the message's fully-qualified name is its bare name.
         let file = prost_types::FileDescriptorProto {
             name: Some("zerobus_dynamic.proto".to_string()),
             message_type: vec![descriptor.clone()],
@@ -117,9 +107,8 @@ impl DynamicProtoEncoder {
             .map_err(|e| ZerobusError::InvalidArgument(format!("failed to encode record: {e}")))
     }
 
-    /// Enforce proto2 `required` presence (prost-reflect does not on encode) then
-    /// serialize. `repeated` columns (`ARRAY`/`MAP`) have no presence and nested
-    /// struct fields are not walked.
+    /// Enforce top-level proto2 `required` presence (prost-reflect skips it on
+    /// encode), then serialize. Nested fields are not walked.
     fn finish(&self, message: DynamicMessage) -> ZerobusResult<Vec<u8>> {
         let missing: Vec<String> = self
             .message
@@ -138,11 +127,8 @@ impl DynamicProtoEncoder {
 }
 
 impl ZerobusStream {
-    /// Build a [`DynamicProtoEncoder`] bound to this stream's protobuf descriptor
-    /// — whether supplied via [`compiled_proto`](crate::StreamBuilder::compiled_proto)
-    /// or fetched via [`proto_from_uc`](crate::StreamBuilder::proto_from_uc) — so
-    /// encoded records are guaranteed to match what the server validates. Build it
-    /// once and reuse.
+    /// Build a [`DynamicProtoEncoder`] bound to this stream's descriptor, so
+    /// encoded records match what the server validates. Build once and reuse.
     ///
     /// # Errors
     ///
@@ -289,9 +275,7 @@ mod tests {
 
     #[test]
     fn encoder_output_matches_compiled_prost_message() {
-        // The wire output must byte-match a compiled prost message with the same
-        // schema — the core "bytes match what the server validates" guarantee,
-        // checked against an independent encoder (prost codegen, not our pool).
+        // Output must byte-match a compiled prost message (an independent encoder).
         #[derive(Clone, PartialEq, prost::Message)]
         struct AirQuality {
             #[prost(string, optional, tag = "1")]
@@ -317,10 +301,8 @@ mod tests {
 
     #[test]
     fn nested_required_field_is_not_validated_client_side() {
-        // finish() enforces presence only for top-level required columns; a
-        // required field nested in a STRUCT is delegated to the server. This pins
-        // that documented boundary: `addr` is present but its required child
-        // `zip` is omitted, and the record still encodes here.
+        // Nested required fields aren't validated client-side (only top-level):
+        // `addr` is present but its required child `zip` is omitted → still encodes.
         let descriptor = TableDescriptorBuilder::new("m")
             .complex_column(
                 "addr",

--- a/rust/sdk/src/dynamic.rs
+++ b/rust/sdk/src/dynamic.rs
@@ -1,0 +1,502 @@
+//! Dynamic protobuf encoding: turn JSON records into protobuf wire bytes against
+//! a descriptor obtained at runtime, with no compiled `.proto` types.
+//!
+//! This is the keystone of the SDK's *dynamic protobuf* path. A user who has a
+//! [`prost_types::DescriptorProto`] — fetched from Unity Catalog (see
+//! [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc)) or built in
+//! code (see [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder))
+//! — can encode records supplied as JSON and ingest them on the efficient proto
+//! path, without generating Rust types from a `.proto` file.
+//!
+//! # Canonical record contract
+//!
+//! Across all Zerobus SDKs the canonical way to supply a record dynamically is a
+//! **JSON value encoded against the descriptor**. The C/FFI path established this
+//! contract; this module is its native-Rust counterpart. The SDK turns each JSON
+//! record into protobuf wire bytes client-side and ships those bytes on the proto
+//! stream — the validated, compact path the typed SDK already optimizes for.
+//!
+//! # Value-encoding rules
+//!
+//! Records follow protobuf's JSON mapping. A few Databricks column types need
+//! shaping in the JSON you provide:
+//!
+//! - `DATE` / `TIMESTAMP` / `TIMESTAMP_NTZ`: integers (days / microseconds since
+//!   the Unix epoch), **not** ISO-8601 strings.
+//! - `BINARY`: a base64-encoded string, not a JSON array of bytes.
+//! - `DECIMAL`: a string (e.g. `"123.45"`) to preserve precision/scale.
+//! - `VARIANT`: a JSON-encoded string (a string whose contents are the variant's
+//!   JSON).
+//! - `ARRAY` / `MAP` / `STRUCT`: JSON array / object / object respectively.
+//! - `LONG` / `BIGINT` above 2^53: pass as a JSON string, otherwise the value
+//!   loses precision as a JSON number.
+//!
+//! Unknown keys are ignored, so records that carry extra non-column metadata are
+//! accepted. Presence is enforced for top-level non-nullable scalar and struct
+//! columns (proto2 `required`): a record omitting one is rejected. `ARRAY`/`MAP`
+//! columns map to `repeated`, which has no presence, so an omitted one encodes as
+//! empty rather than failing.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use databricks_zerobus_ingest_sdk::dynamic::DynamicProtoEncoder;
+//! use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
+//!
+//! # fn main() -> Result<(), databricks_zerobus_ingest_sdk::ZerobusError> {
+//! let descriptor = TableDescriptorBuilder::new("orders")
+//!     .column("id", "BIGINT", false)
+//!     .column("name", "STRING", true)
+//!     .build()?;
+//!
+//! let encoder = DynamicProtoEncoder::new(&descriptor)?;
+//! let bytes = encoder.encode(r#"{"id": 1, "name": "Alice"}"#)?;
+//! // `bytes` is protobuf wire format; ingest it on a proto stream.
+//! # Ok(())
+//! # }
+//! ```
+
+use prost::Message as _;
+use prost_reflect::{
+    Cardinality, DescriptorPool, DeserializeOptions, DynamicMessage, MessageDescriptor,
+};
+use prost_types::DescriptorProto;
+use serde::Serialize;
+
+use crate::{ZerobusError, ZerobusResult, ZerobusStream};
+
+/// Synthetic file name for the single-message descriptor pool. Has no package,
+/// so the message's fully-qualified name is its bare name.
+const SYNTHETIC_FILE_NAME: &str = "zerobus_dynamic.proto";
+
+/// Encodes JSON records into protobuf wire bytes against a runtime descriptor.
+///
+/// Build one from a [`DescriptorProto`] with [`DynamicProtoEncoder::new`], then
+/// reuse it to encode many records — constructing it parses the descriptor into a
+/// reflection pool, so build it once per stream and keep it around rather than
+/// per record.
+///
+/// See the [module docs](crate::dynamic) for the JSON value-encoding rules.
+///
+/// Cloning is cheap: the reflection handle is reference-counted internally.
+#[derive(Debug, Clone)]
+pub struct DynamicProtoEncoder {
+    /// The descriptor this encoder validates against. Kept so callers can recover
+    /// the exact bytes the stream was (or should be) created with.
+    descriptor: DescriptorProto,
+    /// Reflection handle used to deserialize JSON into a dynamic message.
+    message: MessageDescriptor,
+}
+
+impl DynamicProtoEncoder {
+    /// Build an encoder for the given message descriptor.
+    ///
+    /// The descriptor is typically obtained from
+    /// [`schema::descriptor_from_uc`](crate::schema::descriptor_from_uc) (Unity
+    /// Catalog) or [`schema::TableDescriptorBuilder`](crate::schema::TableDescriptorBuilder)
+    /// (in code). It must be the same descriptor the stream is created with, so
+    /// the wire bytes this encoder produces match what the server validates.
+    ///
+    /// # Errors
+    ///
+    /// [`ZerobusError::InvalidArgument`] if the descriptor cannot be assembled
+    /// into a reflection pool (e.g. it references a nested type it does not
+    /// define).
+    pub fn new(descriptor: &DescriptorProto) -> ZerobusResult<Self> {
+        let message_name = descriptor.name().to_string();
+        if message_name.is_empty() {
+            return Err(ZerobusError::InvalidArgument(
+                "descriptor has no message name".to_string(),
+            ));
+        }
+
+        let file = prost_types::FileDescriptorProto {
+            name: Some(SYNTHETIC_FILE_NAME.to_string()),
+            message_type: vec![descriptor.clone()],
+            ..Default::default()
+        };
+        let mut pool = DescriptorPool::new();
+        pool.add_file_descriptor_proto(file).map_err(|e| {
+            ZerobusError::InvalidArgument(format!("failed to build descriptor pool: {e}"))
+        })?;
+        // No package on the synthetic file, so the fully-qualified name is the
+        // bare message name.
+        let message = pool.get_message_by_name(&message_name).ok_or_else(|| {
+            ZerobusError::InvalidArgument(format!(
+                "message '{message_name}' not found in descriptor pool"
+            ))
+        })?;
+
+        Ok(Self {
+            descriptor: descriptor.clone(),
+            message,
+        })
+    }
+
+    /// The descriptor this encoder was built from.
+    ///
+    /// Use [`descriptor_bytes`](Self::descriptor_bytes) when you need the exact
+    /// serialized form to create a stream with.
+    pub fn descriptor(&self) -> &DescriptorProto {
+        &self.descriptor
+    }
+
+    /// The serialized `DescriptorProto` bytes, byte-identical to what the encoder
+    /// validates against. Pass these when creating the stream so client-side
+    /// encoding and server-side validation agree.
+    pub fn descriptor_bytes(&self) -> Vec<u8> {
+        self.descriptor.encode_to_vec()
+    }
+
+    /// Encode a single JSON record (as a string) into protobuf wire bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`ZerobusError::InvalidArgument`] if the JSON is malformed, has trailing
+    /// content, does not match the descriptor's field types, or omits a required
+    /// (non-nullable top-level scalar/struct) column.
+    pub fn encode(&self, record_json: &str) -> ZerobusResult<Vec<u8>> {
+        let mut deserializer = serde_json::Deserializer::from_str(record_json);
+        let message = self.deserialize(&mut deserializer)?;
+        // Reject extra bytes after the first JSON value rather than silently
+        // ignoring them.
+        deserializer.end().map_err(|e| {
+            ZerobusError::InvalidArgument(format!(
+                "unexpected trailing content in record JSON: {e}"
+            ))
+        })?;
+        self.finish(message)
+    }
+
+    /// Encode a [`serde_json::Value`] into protobuf wire bytes.
+    ///
+    /// Useful when a record is already assembled as a JSON value (e.g. built with
+    /// the `serde_json::json!` macro) so it need not be re-serialized to a string.
+    ///
+    /// # Errors
+    ///
+    /// See [`encode`](Self::encode).
+    pub fn encode_value(&self, record: &serde_json::Value) -> ZerobusResult<Vec<u8>> {
+        let message = self.deserialize(record)?;
+        self.finish(message)
+    }
+
+    /// Encode any [`serde::Serialize`] type into protobuf wire bytes by first
+    /// converting it to JSON.
+    ///
+    /// # Errors
+    ///
+    /// [`ZerobusError::InvalidArgument`] if serialization to JSON fails or the
+    /// resulting record does not match the descriptor (see [`encode`](Self::encode)).
+    pub fn encode_record<T: Serialize>(&self, record: &T) -> ZerobusResult<Vec<u8>> {
+        let value = serde_json::to_value(record).map_err(|e| {
+            ZerobusError::InvalidArgument(format!("failed to serialize record to JSON: {e}"))
+        })?;
+        self.encode_value(&value)
+    }
+
+    /// Deserialize JSON from any deserializer into a dynamic message, ignoring
+    /// unknown keys (records often carry extra non-column metadata).
+    fn deserialize<'de, D>(&self, deserializer: D) -> ZerobusResult<DynamicMessage>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let options = DeserializeOptions::new().deny_unknown_fields(false);
+        DynamicMessage::deserialize_with_options(self.message.clone(), deserializer, &options)
+            .map_err(|e| ZerobusError::InvalidArgument(format!("failed to encode record: {e}")))
+    }
+
+    /// Enforce proto2 `required` presence then serialize to wire bytes.
+    ///
+    /// `prost-reflect` does not enforce presence on encode, so a missing
+    /// top-level required field is rejected here rather than emitting wire bytes
+    /// the server would reject. (`ARRAY`/`MAP` columns are `repeated`, which has
+    /// no presence; nested struct fields are not walked.)
+    fn finish(&self, message: DynamicMessage) -> ZerobusResult<Vec<u8>> {
+        let missing: Vec<String> = self
+            .message
+            .fields()
+            .filter(|f| matches!(f.cardinality(), Cardinality::Required) && !message.has_field(f))
+            .map(|f| f.name().to_string())
+            .collect();
+        if !missing.is_empty() {
+            return Err(ZerobusError::InvalidArgument(format!(
+                "record missing required field(s): {}",
+                missing.join(", ")
+            )));
+        }
+        Ok(message.encode_to_vec())
+    }
+}
+
+impl ZerobusStream {
+    /// Build a [`DynamicProtoEncoder`] for this stream's protobuf descriptor.
+    ///
+    /// Returns an encoder bound to the same descriptor the stream was created
+    /// with — whether supplied via
+    /// [`compiled_proto`](crate::StreamBuilder::compiled_proto) or fetched via
+    /// [`proto_from_uc`](crate::StreamBuilder::proto_from_uc) — so JSON records
+    /// encoded by it are guaranteed to match what the server validates.
+    ///
+    /// Constructing an encoder parses the descriptor, so call this once and reuse
+    /// the returned encoder for the lifetime of the stream.
+    ///
+    /// # Errors
+    ///
+    /// [`ZerobusError::InvalidArgument`] if the stream has no descriptor (a JSON
+    /// stream created with [`json`](crate::StreamBuilder::json)) or the descriptor
+    /// cannot be assembled.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use databricks_zerobus_ingest_sdk::ZerobusStream;
+    /// # async fn example(stream: ZerobusStream) -> Result<(), databricks_zerobus_ingest_sdk::ZerobusError> {
+    /// let encoder = stream.encoder()?;
+    /// let bytes = encoder.encode(r#"{"id": 1, "name": "Alice"}"#)?;
+    /// let offset = stream.ingest_record_offset(bytes).await?;
+    /// stream.wait_for_offset(offset).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn encoder(&self) -> ZerobusResult<DynamicProtoEncoder> {
+        let descriptor = self
+            .table_properties
+            .descriptor_proto
+            .as_ref()
+            .ok_or_else(|| {
+                ZerobusError::InvalidArgument(
+                    "stream has no protobuf descriptor; encoder() requires a proto stream created \
+                     via compiled_proto() or proto_from_uc()"
+                        .to_string(),
+                )
+            })?;
+        DynamicProtoEncoder::new(descriptor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::TableDescriptorBuilder;
+    use prost_reflect::Value;
+
+    /// Build the air-quality descriptor used across these tests.
+    fn air_quality_descriptor() -> DescriptorProto {
+        TableDescriptorBuilder::new("air_quality")
+            .column("device_name", "STRING", true)
+            .column("temp", "INT", true)
+            .column("humidity", "INT", true)
+            .build()
+            .expect("descriptor builds")
+    }
+
+    /// Decode encoded bytes back through the same descriptor for assertions.
+    fn decode(encoder: &DynamicProtoEncoder, bytes: &[u8]) -> DynamicMessage {
+        DynamicMessage::decode(encoder.message.clone(), bytes).expect("decodes")
+    }
+
+    #[test]
+    fn encode_round_trips_scalar_fields() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+
+        let bytes = encoder
+            .encode(r#"{"device_name": "sensor-1", "temp": 22, "humidity": 65}"#)
+            .unwrap();
+
+        let decoded = decode(&encoder, &bytes);
+        assert_eq!(
+            decoded
+                .get_field_by_name("device_name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "sensor-1"
+        );
+        assert_eq!(
+            decoded.get_field_by_name("temp").unwrap().as_i32().unwrap(),
+            22
+        );
+        assert_eq!(
+            decoded
+                .get_field_by_name("humidity")
+                .unwrap()
+                .as_i32()
+                .unwrap(),
+            65
+        );
+    }
+
+    #[test]
+    fn encode_value_matches_encode_string() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+
+        let from_str = encoder
+            .encode(r#"{"device_name": "s", "temp": 1, "humidity": 2}"#)
+            .unwrap();
+        let from_value = encoder
+            .encode_value(&serde_json::json!({
+                "device_name": "s",
+                "temp": 1,
+                "humidity": 2
+            }))
+            .unwrap();
+        assert_eq!(from_str, from_value);
+    }
+
+    #[test]
+    fn encode_record_accepts_serialize_types() {
+        #[derive(serde::Serialize)]
+        struct Reading {
+            device_name: String,
+            temp: i32,
+            humidity: i32,
+        }
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+
+        let bytes = encoder
+            .encode_record(&Reading {
+                device_name: "s".into(),
+                temp: 7,
+                humidity: 8,
+            })
+            .unwrap();
+        let decoded = decode(&encoder, &bytes);
+        assert_eq!(
+            decoded.get_field_by_name("temp").unwrap().as_i32().unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        // `source` is not a column; it must be ignored rather than rejected.
+        let bytes = encoder
+            .encode(r#"{"device_name": "s", "temp": 1, "humidity": 2, "source": "kafka"}"#)
+            .unwrap();
+        let decoded = decode(&encoder, &bytes);
+        assert_eq!(
+            decoded
+                .get_field_by_name("device_name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "s"
+        );
+    }
+
+    #[test]
+    fn omitted_optional_field_encodes() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        // All columns are nullable, so omitting one is fine.
+        let bytes = encoder.encode(r#"{"device_name": "s"}"#).unwrap();
+        let decoded = decode(&encoder, &bytes);
+        assert!(!decoded.has_field_by_name("temp"));
+    }
+
+    #[test]
+    fn missing_required_field_is_rejected() {
+        // A non-nullable scalar column is proto2 `required`; omitting it fails.
+        let descriptor = TableDescriptorBuilder::new("t")
+            .column("id", "BIGINT", false)
+            .column("name", "STRING", true)
+            .build()
+            .unwrap();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+
+        let err = encoder.encode(r#"{"name": "x"}"#).unwrap_err();
+        match err {
+            ZerobusError::InvalidArgument(msg) => {
+                assert!(msg.contains("missing required field"), "got: {msg}");
+                assert!(msg.contains("id"), "got: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_rejected() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        assert!(encoder.encode(r#"{"device_name": "#).is_err());
+    }
+
+    #[test]
+    fn trailing_content_is_rejected() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        let err = encoder
+            .encode(r#"{"device_name": "s"} {"device_name": "t"}"#)
+            .unwrap_err();
+        match err {
+            ZerobusError::InvalidArgument(msg) => {
+                assert!(msg.contains("trailing content"), "got: {msg}")
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_field_type_is_rejected() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        // `temp` is an int; a non-numeric string is not coercible.
+        assert!(encoder
+            .encode(r#"{"device_name": "s", "temp": "hot"}"#)
+            .is_err());
+    }
+
+    #[test]
+    fn descriptor_bytes_round_trip_to_same_descriptor() {
+        let descriptor = air_quality_descriptor();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+        let bytes = encoder.descriptor_bytes();
+        let decoded = DescriptorProto::decode(bytes.as_slice()).unwrap();
+        assert_eq!(&decoded, encoder.descriptor());
+    }
+
+    #[test]
+    fn rejects_descriptor_without_name() {
+        let err = DynamicProtoEncoder::new(&DescriptorProto::default()).unwrap_err();
+        assert!(matches!(err, ZerobusError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn encodes_repeated_and_struct_via_json() {
+        // ARRAY<long> -> repeated; STRUCT -> nested message. Both arrive as JSON.
+        let descriptor = TableDescriptorBuilder::new("evt")
+            .column("id", "BIGINT", true)
+            .complex_column(
+                "tags",
+                "ARRAY",
+                r#"{"type":"array","elementType":"long","containsNull":true}"#,
+                true,
+            )
+            .complex_column(
+                "addr",
+                "STRUCT",
+                r#"{"type":"struct","fields":[
+                    {"name":"zip","type":"integer","nullable":true,"metadata":{}}
+                ]}"#,
+                true,
+            )
+            .build()
+            .unwrap();
+        let encoder = DynamicProtoEncoder::new(&descriptor).unwrap();
+
+        let bytes = encoder
+            .encode(r#"{"id": 1, "tags": [10, 20], "addr": {"zip": 94105}}"#)
+            .unwrap();
+        let decoded = decode(&encoder, &bytes);
+        match decoded.get_field_by_name("tags").unwrap().as_ref() {
+            Value::List(items) => assert_eq!(items.len(), 2),
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -45,6 +45,7 @@ mod builder;
 mod callbacks;
 mod client_warnings;
 mod default_token_factory;
+pub mod dynamic;
 mod errors;
 mod headers_provider;
 mod landing_zone;
@@ -68,6 +69,7 @@ pub use arrow_stream::{ArrowSchema, DataType, Field, RecordBatch, TimeUnit, Zero
 pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
+pub use dynamic::DynamicProtoEncoder;
 pub use errors::ZerobusError;
 #[cfg(feature = "testing")]
 pub use headers_provider::NoAuthHeadersProvider;

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -213,8 +213,7 @@ pub fn descriptor_from_uc_schema(schema: &UcTableSchema) -> Result<DescriptorPro
 }
 
 impl From<SchemaError> for ZerobusError {
-    /// A schema-conversion failure is a malformed-input condition (bad column
-    /// name, unsupported type, invalid `type_json`), so it surfaces as a
+    /// A schema-conversion failure is malformed input, so it maps to the
     /// non-retryable [`ZerobusError::InvalidArgument`].
     fn from(err: SchemaError) -> Self {
         ZerobusError::InvalidArgument(err.to_string())
@@ -226,12 +225,9 @@ impl From<SchemaError> for ZerobusError {
 // ---------------------------------------------------------------------------
 
 /// Fluent builder for a [`DescriptorProto`] assembled in code, for when the
-/// schema is known but there is no `.proto` to compile and no Unity Catalog
-/// metadata to fetch. Columns use the same Databricks type names Unity Catalog
-/// uses, so the output matches [`descriptor_from_uc_columns`]; field numbers
-/// follow the order columns are added (first column → field 1). Pair the result
-/// with [`DynamicProtoEncoder`](crate::dynamic::DynamicProtoEncoder) or
-/// [`StreamBuilder::compiled_proto`](crate::StreamBuilder::compiled_proto).
+/// schema is known but there is no `.proto` and no Unity Catalog metadata. Columns
+/// use Databricks type names (output matches [`descriptor_from_uc_columns`]) and
+/// field numbers follow insertion order.
 ///
 /// ```
 /// use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
@@ -314,19 +310,15 @@ impl TableDescriptorBuilder {
 // ---------------------------------------------------------------------------
 
 /// Fetch a Unity Catalog table's schema via
-/// `GET {unity_catalog_url}/api/2.1/unity-catalog/tables/{table_name}` with
-/// `Authorization: Bearer {token}`. `table_name` is the fully-qualified
-/// `catalog.schema.table`; `token` must be a workspace-API token with `SELECT` on
-/// the table (the Zerobus write token is *not* accepted by the REST API).
+/// `GET {unity_catalog_url}/api/2.1/unity-catalog/tables/{table_name}` with a
+/// `Bearer` token. `table_name` is the fully-qualified `catalog.schema.table`;
+/// `token` must be a workspace-API token with `SELECT` on the table (the Zerobus
+/// write token is *not* accepted by the REST API).
 ///
 /// Prefer [`StreamBuilder::proto_from_uc`](crate::StreamBuilder::proto_from_uc),
-/// which does this automatically at stream creation. Returns
-/// [`ZerobusError::TokenFetchError`] on network/`5xx` (retryable) and
+/// which does this at stream creation. Returns
+/// [`ZerobusError::TokenFetchError`] on network/`5xx` and
 /// [`ZerobusError::InvalidArgument`] on `4xx` or an unparseable body.
-///
-/// The table name is sent percent-encoded as a single path segment, so names
-/// containing URL-significant characters are served correctly and cannot inject
-/// extra path segments, a query, or a fragment.
 pub async fn fetch_uc_table_schema(
     unity_catalog_url: &str,
     table_name: &str,
@@ -340,8 +332,7 @@ pub async fn fetch_uc_table_schema(
         .send()
         .await
         .map_err(|e| {
-            // Network/connect/timeout errors are transient; a status-bearing
-            // error is classified below.
+            // Transient transport errors; status errors are classified below.
             if e.is_timeout() || e.is_connect() {
                 ZerobusError::TokenFetchError(format!("Failed to reach Unity Catalog: {e}"))
             } else {

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -225,34 +225,19 @@ impl From<SchemaError> for ZerobusError {
 // In-code descriptor construction (no Unity Catalog, no `.proto`)
 // ---------------------------------------------------------------------------
 
-/// Fluent builder for a [`DescriptorProto`] assembled in code.
-///
-/// This is the descriptor source to use when the schema is known at compile time
-/// but you would rather not author and compile a `.proto` file, and there is no
-/// Unity Catalog metadata to fetch. Columns are described with the same
-/// Databricks type names Unity Catalog uses (`"BIGINT"`, `"STRING"`, `"STRUCT"`,
-/// …), so the generated descriptor is identical to the one
-/// [`descriptor_from_uc_columns`] would produce. Field numbers are assigned from
-/// the order columns are added (first column → field 1).
-///
-/// Pair the result with [`DynamicProtoEncoder`](crate::dynamic::DynamicProtoEncoder)
-/// to encode JSON records, or pass it to
+/// Fluent builder for a [`DescriptorProto`] assembled in code, for when the
+/// schema is known but there is no `.proto` to compile and no Unity Catalog
+/// metadata to fetch. Columns use the same Databricks type names Unity Catalog
+/// uses, so the output matches [`descriptor_from_uc_columns`]; field numbers
+/// follow the order columns are added (first column → field 1). Pair the result
+/// with [`DynamicProtoEncoder`](crate::dynamic::DynamicProtoEncoder) or
 /// [`StreamBuilder::compiled_proto`](crate::StreamBuilder::compiled_proto).
-///
-/// # Example
 ///
 /// ```
 /// use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
-///
 /// let descriptor = TableDescriptorBuilder::new("orders")
 ///     .column("id", "BIGINT", false)
 ///     .column("customer_name", "STRING", true)
-///     .complex_column(
-///         "tags",
-///         "ARRAY",
-///         r#"{"type":"array","elementType":"string","containsNull":true}"#,
-///         true,
-///     )
 ///     .build()
 ///     .unwrap();
 /// assert_eq!(descriptor.name(), "orders");
@@ -273,10 +258,8 @@ impl TableDescriptorBuilder {
     }
 
     /// Add a simple (non-complex) column by its Databricks type name, e.g.
-    /// `"BIGINT"`, `"STRING"`, `"DOUBLE"`, `"TIMESTAMP"`, `"DATE"`, `"BINARY"`.
-    ///
-    /// For `STRUCT`, `ARRAY`, and `MAP` columns use
-    /// [`complex_column`](Self::complex_column).
+    /// `"BIGINT"`, `"STRING"`, `"TIMESTAMP"`. Use
+    /// [`complex_column`](Self::complex_column) for `STRUCT`/`ARRAY`/`MAP`.
     pub fn column(
         mut self,
         name: impl Into<String>,
@@ -319,12 +302,8 @@ impl TableDescriptorBuilder {
         self
     }
 
-    /// Build the [`DescriptorProto`].
-    ///
-    /// # Errors
-    ///
-    /// [`SchemaError`] if any column has an invalid name, an unsupported type, or
-    /// malformed `type_json`.
+    /// Build the [`DescriptorProto`], erroring if any column has an invalid name,
+    /// an unsupported type, or malformed `type_json`.
     pub fn build(self) -> Result<DescriptorProto, SchemaError> {
         descriptor_from_uc_columns(&self.columns, &self.message_name)
     }
@@ -334,23 +313,16 @@ impl TableDescriptorBuilder {
 // Fetch a table's schema from Unity Catalog over the REST API
 // ---------------------------------------------------------------------------
 
-/// Fetch a Unity Catalog table's schema via the REST API.
-///
-/// Issues `GET {unity_catalog_url}/api/2.1/unity-catalog/tables/{table_name}`
-/// with `Authorization: Bearer {token}`. `table_name` is the fully-qualified
-/// `catalog.schema.table`, and `token` must be a workspace-API token with
-/// `SELECT` on the table (the Zerobus write token minted for ingestion is *not*
-/// sufficient for the REST API).
+/// Fetch a Unity Catalog table's schema via
+/// `GET {unity_catalog_url}/api/2.1/unity-catalog/tables/{table_name}` with
+/// `Authorization: Bearer {token}`. `table_name` is the fully-qualified
+/// `catalog.schema.table`; `token` must be a workspace-API token with `SELECT` on
+/// the table (the Zerobus write token is *not* accepted by the REST API).
 ///
 /// Prefer [`StreamBuilder::proto_from_uc`](crate::StreamBuilder::proto_from_uc),
-/// which performs this fetch automatically at stream creation; use this directly
-/// only when you need the schema outside of stream creation.
-///
-/// # Errors
-///
-/// - [`ZerobusError::TokenFetchError`] on network failures or UC `5xx` (retryable).
-/// - [`ZerobusError::InvalidArgument`] on UC `4xx` (e.g. table not found, denied)
-///   or an unparseable response body.
+/// which does this automatically at stream creation. Returns
+/// [`ZerobusError::TokenFetchError`] on network/`5xx` (retryable) and
+/// [`ZerobusError::InvalidArgument`] on `4xx` or an unparseable body.
 pub async fn fetch_uc_table_schema(
     unity_catalog_url: &str,
     table_name: &str,
@@ -1373,41 +1345,13 @@ mod tests {
         use super::*;
 
         #[test]
-        fn builds_scalar_descriptor_with_positional_field_numbers() {
-            let d = TableDescriptorBuilder::new("orders")
-                .column("id", "BIGINT", false)
-                .column("name", "STRING", true)
-                .build()
-                .unwrap();
-            assert_eq!(d.name(), "orders");
-            assert_eq!(field(&d, "id").r#type(), ProtoType::Int64);
-            assert_eq!(field(&d, "id").label(), Label::Required);
-            assert_eq!(field(&d, "id").number(), 1);
-            assert_eq!(field(&d, "name").label(), Label::Optional);
-            assert_eq!(field(&d, "name").number(), 2);
-        }
-
-        #[test]
         fn matches_descriptor_from_uc_columns() {
             // The builder is a thin front-end over descriptor_from_uc_columns;
-            // the two must produce identical descriptors.
+            // the two must produce identical descriptors (this also pins field
+            // numbering, types, and labels).
             let built = TableDescriptorBuilder::new("m")
                 .column("a", "STRING", true)
                 .column("b", "BIGINT", false)
-                .build()
-                .unwrap();
-            let direct = descriptor_from_uc_columns(
-                &[col("a", "STRING", true, 0), col("b", "BIGINT", false, 1)],
-                "m",
-            )
-            .unwrap();
-            assert_eq!(built, direct);
-        }
-
-        #[test]
-        fn builds_complex_columns() {
-            let d = TableDescriptorBuilder::new("evt")
-                .column("id", "BIGINT", true)
                 .complex_column(
                     "tags",
                     "ARRAY",
@@ -1416,17 +1360,21 @@ mod tests {
                 )
                 .build()
                 .unwrap();
-            assert_eq!(field(&d, "tags").label(), Label::Repeated);
-            assert_eq!(field(&d, "tags").r#type(), ProtoType::String);
-        }
-
-        #[test]
-        fn propagates_invalid_field_name() {
-            let err = TableDescriptorBuilder::new("m")
-                .column("1bad", "STRING", true)
-                .build()
-                .unwrap_err();
-            assert!(matches!(err, SchemaError::InvalidFieldName { .. }));
+            let direct = descriptor_from_uc_columns(
+                &[
+                    col("a", "STRING", true, 0),
+                    col("b", "BIGINT", false, 1),
+                    complex_col(
+                        "tags",
+                        "ARRAY",
+                        r#"{"type":"array","elementType":"string","containsNull":true}"#,
+                        2,
+                    ),
+                ],
+                "m",
+            )
+            .unwrap();
+            assert_eq!(built, direct);
         }
 
         #[test]

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -323,19 +323,19 @@ impl TableDescriptorBuilder {
 /// which does this automatically at stream creation. Returns
 /// [`ZerobusError::TokenFetchError`] on network/`5xx` (retryable) and
 /// [`ZerobusError::InvalidArgument`] on `4xx` or an unparseable body.
+///
+/// The table name is sent percent-encoded as a single path segment, so names
+/// containing URL-significant characters are served correctly and cannot inject
+/// extra path segments, a query, or a fragment.
 pub async fn fetch_uc_table_schema(
     unity_catalog_url: &str,
     table_name: &str,
     token: &str,
 ) -> ZerobusResult<UcTableSchema> {
-    let url = format!(
-        "{}/api/2.1/unity-catalog/tables/{}",
-        unity_catalog_url.trim_end_matches('/'),
-        table_name
-    );
+    let url = uc_table_url(unity_catalog_url, table_name)?;
 
     let response = reqwest::Client::new()
-        .get(&url)
+        .get(url)
         .bearer_auth(token)
         .send()
         .await
@@ -382,6 +382,27 @@ pub async fn descriptor_from_uc(
 ) -> ZerobusResult<DescriptorProto> {
     let schema = fetch_uc_table_schema(unity_catalog_url, table_name, token).await?;
     Ok(descriptor_from_uc_schema(&schema)?)
+}
+
+/// Build the UC "get table" URL, appending `table_name` as a single
+/// percent-encoded path segment so URL-significant characters can't inject path
+/// segments, a query, or a fragment. The `.` separators stay intact and a
+/// trailing slash on the base URL is normalized.
+fn uc_table_url(unity_catalog_url: &str, table_name: &str) -> ZerobusResult<reqwest::Url> {
+    let mut url = reqwest::Url::parse(unity_catalog_url).map_err(|e| {
+        ZerobusError::InvalidUCEndpointError(format!(
+            "invalid Unity Catalog URL '{unity_catalog_url}': {e}"
+        ))
+    })?;
+    url.path_segments_mut()
+        .map_err(|()| {
+            ZerobusError::InvalidUCEndpointError(format!(
+                "Unity Catalog URL '{unity_catalog_url}' cannot be a base"
+            ))
+        })?
+        .pop_if_empty()
+        .extend(["api", "2.1", "unity-catalog", "tables", table_name]);
+    Ok(url)
 }
 
 fn is_complex(type_name: &str) -> bool {
@@ -1381,6 +1402,48 @@ mod tests {
         fn schema_error_converts_to_invalid_argument() {
             let err: ZerobusError = SchemaError::UnsupportedType("WIDGET".into()).into();
             assert!(matches!(err, ZerobusError::InvalidArgument(_)));
+        }
+    }
+
+    mod uc_url {
+        use super::*;
+
+        #[test]
+        fn builds_path_and_normalizes_trailing_slash() {
+            // A trailing slash on the base does not double up; the dotted table
+            // name is preserved verbatim.
+            for base in ["https://host", "https://host/"] {
+                let url = uc_table_url(base, "main.default.my_table").unwrap();
+                assert_eq!(
+                    url.as_str(),
+                    "https://host/api/2.1/unity-catalog/tables/main.default.my_table"
+                );
+            }
+        }
+
+        #[test]
+        fn percent_encodes_name_and_neutralizes_injection() {
+            // URL-significant characters in the name must not reshape the URL:
+            // no injected query/fragment, still exactly one trailing segment.
+            let url = uc_table_url("https://host", "cat.sch.weird/name?x#y").unwrap();
+            assert!(url.query().is_none(), "name must not start a query");
+            assert!(url.fragment().is_none(), "name must not start a fragment");
+            let segments: Vec<&str> = url.path_segments().unwrap().collect();
+            assert_eq!(segments.len(), 5, "no extra path segments injected");
+            assert_eq!(segments[3], "tables");
+            assert!(
+                !segments[4].contains(['/', '?', '#']),
+                "special chars are encoded, got {}",
+                segments[4]
+            );
+        }
+
+        #[test]
+        fn rejects_non_base_url() {
+            assert!(matches!(
+                uc_table_url("not a url", "c.s.t"),
+                Err(ZerobusError::InvalidUCEndpointError(_))
+            ));
         }
     }
 

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -87,6 +87,8 @@ use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
+use crate::{ZerobusError, ZerobusResult};
+
 /// A single column from a Unity Catalog table.
 ///
 /// Field names mirror the Unity Catalog REST API response so the struct can be
@@ -208,6 +210,206 @@ pub fn descriptor_from_uc_columns(
 pub fn descriptor_from_uc_schema(schema: &UcTableSchema) -> Result<DescriptorProto, SchemaError> {
     let message_name = sanitize_message_name(&format!("{}_{}", schema.schema_name, schema.name));
     descriptor_from_uc_columns(&schema.columns, &message_name)
+}
+
+impl From<SchemaError> for ZerobusError {
+    /// A schema-conversion failure is a malformed-input condition (bad column
+    /// name, unsupported type, invalid `type_json`), so it surfaces as a
+    /// non-retryable [`ZerobusError::InvalidArgument`].
+    fn from(err: SchemaError) -> Self {
+        ZerobusError::InvalidArgument(err.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-code descriptor construction (no Unity Catalog, no `.proto`)
+// ---------------------------------------------------------------------------
+
+/// Fluent builder for a [`DescriptorProto`] assembled in code.
+///
+/// This is the descriptor source to use when the schema is known at compile time
+/// but you would rather not author and compile a `.proto` file, and there is no
+/// Unity Catalog metadata to fetch. Columns are described with the same
+/// Databricks type names Unity Catalog uses (`"BIGINT"`, `"STRING"`, `"STRUCT"`,
+/// …), so the generated descriptor is identical to the one
+/// [`descriptor_from_uc_columns`] would produce. Field numbers are assigned from
+/// the order columns are added (first column → field 1).
+///
+/// Pair the result with [`DynamicProtoEncoder`](crate::dynamic::DynamicProtoEncoder)
+/// to encode JSON records, or pass it to
+/// [`StreamBuilder::compiled_proto`](crate::StreamBuilder::compiled_proto).
+///
+/// # Example
+///
+/// ```
+/// use databricks_zerobus_ingest_sdk::schema::TableDescriptorBuilder;
+///
+/// let descriptor = TableDescriptorBuilder::new("orders")
+///     .column("id", "BIGINT", false)
+///     .column("customer_name", "STRING", true)
+///     .complex_column(
+///         "tags",
+///         "ARRAY",
+///         r#"{"type":"array","elementType":"string","containsNull":true}"#,
+///         true,
+///     )
+///     .build()
+///     .unwrap();
+/// assert_eq!(descriptor.name(), "orders");
+/// ```
+#[derive(Debug, Clone)]
+pub struct TableDescriptorBuilder {
+    message_name: String,
+    columns: Vec<UcColumn>,
+}
+
+impl TableDescriptorBuilder {
+    /// Start a builder whose generated message is named `message_name`.
+    pub fn new(message_name: impl Into<String>) -> Self {
+        Self {
+            message_name: message_name.into(),
+            columns: Vec::new(),
+        }
+    }
+
+    /// Add a simple (non-complex) column by its Databricks type name, e.g.
+    /// `"BIGINT"`, `"STRING"`, `"DOUBLE"`, `"TIMESTAMP"`, `"DATE"`, `"BINARY"`.
+    ///
+    /// For `STRUCT`, `ARRAY`, and `MAP` columns use
+    /// [`complex_column`](Self::complex_column).
+    pub fn column(
+        mut self,
+        name: impl Into<String>,
+        databricks_type: impl Into<String>,
+        nullable: bool,
+    ) -> Self {
+        let position = self.columns.len() as i32;
+        self.columns.push(UcColumn {
+            name: name.into(),
+            type_name: databricks_type.into(),
+            type_text: String::new(),
+            type_json: String::new(),
+            nullable,
+            position,
+        });
+        self
+    }
+
+    /// Add a complex column (`STRUCT`, `ARRAY`, or `MAP`).
+    ///
+    /// `type_json` is the Unity Catalog JSON representation of the type (the same
+    /// shape the UC REST API returns), e.g.
+    /// `{"type":"array","elementType":"string","containsNull":true}`.
+    pub fn complex_column(
+        mut self,
+        name: impl Into<String>,
+        databricks_type: impl Into<String>,
+        type_json: impl Into<String>,
+        nullable: bool,
+    ) -> Self {
+        let position = self.columns.len() as i32;
+        self.columns.push(UcColumn {
+            name: name.into(),
+            type_name: databricks_type.into(),
+            type_text: String::new(),
+            type_json: type_json.into(),
+            nullable,
+            position,
+        });
+        self
+    }
+
+    /// Build the [`DescriptorProto`].
+    ///
+    /// # Errors
+    ///
+    /// [`SchemaError`] if any column has an invalid name, an unsupported type, or
+    /// malformed `type_json`.
+    pub fn build(self) -> Result<DescriptorProto, SchemaError> {
+        descriptor_from_uc_columns(&self.columns, &self.message_name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch a table's schema from Unity Catalog over the REST API
+// ---------------------------------------------------------------------------
+
+/// Fetch a Unity Catalog table's schema via the REST API.
+///
+/// Issues `GET {unity_catalog_url}/api/2.1/unity-catalog/tables/{table_name}`
+/// with `Authorization: Bearer {token}`. `table_name` is the fully-qualified
+/// `catalog.schema.table`, and `token` must be a workspace-API token with
+/// `SELECT` on the table (the Zerobus write token minted for ingestion is *not*
+/// sufficient for the REST API).
+///
+/// Prefer [`StreamBuilder::proto_from_uc`](crate::StreamBuilder::proto_from_uc),
+/// which performs this fetch automatically at stream creation; use this directly
+/// only when you need the schema outside of stream creation.
+///
+/// # Errors
+///
+/// - [`ZerobusError::TokenFetchError`] on network failures or UC `5xx` (retryable).
+/// - [`ZerobusError::InvalidArgument`] on UC `4xx` (e.g. table not found, denied)
+///   or an unparseable response body.
+pub async fn fetch_uc_table_schema(
+    unity_catalog_url: &str,
+    table_name: &str,
+    token: &str,
+) -> ZerobusResult<UcTableSchema> {
+    let url = format!(
+        "{}/api/2.1/unity-catalog/tables/{}",
+        unity_catalog_url.trim_end_matches('/'),
+        table_name
+    );
+
+    let response = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| {
+            // Network/connect/timeout errors are transient; a status-bearing
+            // error is classified below.
+            if e.is_timeout() || e.is_connect() {
+                ZerobusError::TokenFetchError(format!("Failed to reach Unity Catalog: {e}"))
+            } else {
+                ZerobusError::InvalidArgument(format!("Unity Catalog request failed: {e}"))
+            }
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let code = status.as_u16();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Failed to read error body".to_string());
+        return Err(if code >= 500 {
+            ZerobusError::TokenFetchError(format!("Unity Catalog server error ({code}): {body}"))
+        } else {
+            ZerobusError::InvalidArgument(format!(
+                "Failed to fetch Unity Catalog table '{table_name}' ({code}): {body}"
+            ))
+        });
+    }
+
+    response.json::<UcTableSchema>().await.map_err(|e| {
+        ZerobusError::InvalidArgument(format!("Failed to parse Unity Catalog table schema: {e}"))
+    })
+}
+
+/// Fetch a Unity Catalog table's schema and build a protobuf [`DescriptorProto`]
+/// for it, with no local `.proto`.
+///
+/// Combines [`fetch_uc_table_schema`] and [`descriptor_from_uc_schema`]. See
+/// [`fetch_uc_table_schema`] for the token requirement and error semantics.
+pub async fn descriptor_from_uc(
+    unity_catalog_url: &str,
+    table_name: &str,
+    token: &str,
+) -> ZerobusResult<DescriptorProto> {
+    let schema = fetch_uc_table_schema(unity_catalog_url, table_name, token).await?;
+    Ok(descriptor_from_uc_schema(&schema)?)
 }
 
 fn is_complex(type_name: &str) -> bool {
@@ -1165,6 +1367,73 @@ mod tests {
         assert_eq!(col.name, "id");
         assert_eq!(col.type_name, "INT");
         assert!(!col.nullable);
+    }
+
+    mod builder {
+        use super::*;
+
+        #[test]
+        fn builds_scalar_descriptor_with_positional_field_numbers() {
+            let d = TableDescriptorBuilder::new("orders")
+                .column("id", "BIGINT", false)
+                .column("name", "STRING", true)
+                .build()
+                .unwrap();
+            assert_eq!(d.name(), "orders");
+            assert_eq!(field(&d, "id").r#type(), ProtoType::Int64);
+            assert_eq!(field(&d, "id").label(), Label::Required);
+            assert_eq!(field(&d, "id").number(), 1);
+            assert_eq!(field(&d, "name").label(), Label::Optional);
+            assert_eq!(field(&d, "name").number(), 2);
+        }
+
+        #[test]
+        fn matches_descriptor_from_uc_columns() {
+            // The builder is a thin front-end over descriptor_from_uc_columns;
+            // the two must produce identical descriptors.
+            let built = TableDescriptorBuilder::new("m")
+                .column("a", "STRING", true)
+                .column("b", "BIGINT", false)
+                .build()
+                .unwrap();
+            let direct = descriptor_from_uc_columns(
+                &[col("a", "STRING", true, 0), col("b", "BIGINT", false, 1)],
+                "m",
+            )
+            .unwrap();
+            assert_eq!(built, direct);
+        }
+
+        #[test]
+        fn builds_complex_columns() {
+            let d = TableDescriptorBuilder::new("evt")
+                .column("id", "BIGINT", true)
+                .complex_column(
+                    "tags",
+                    "ARRAY",
+                    r#"{"type":"array","elementType":"string","containsNull":true}"#,
+                    true,
+                )
+                .build()
+                .unwrap();
+            assert_eq!(field(&d, "tags").label(), Label::Repeated);
+            assert_eq!(field(&d, "tags").r#type(), ProtoType::String);
+        }
+
+        #[test]
+        fn propagates_invalid_field_name() {
+            let err = TableDescriptorBuilder::new("m")
+                .column("1bad", "STRING", true)
+                .build()
+                .unwrap_err();
+            assert!(matches!(err, SchemaError::InvalidFieldName { .. }));
+        }
+
+        #[test]
+        fn schema_error_converts_to_invalid_argument() {
+            let err: ZerobusError = SchemaError::UnsupportedType("WIDGET".into()).into();
+            assert!(matches!(err, ZerobusError::InvalidArgument(_)));
+        }
     }
 
     #[cfg(feature = "arrow-flight")]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #372

Ingest on the protobuf path with no compiled `.proto` and no generated types.
The descriptor is obtained at runtime; records are supplied as JSON and encoded to protobuf bytes client-side. Canonical contract = JSON-against-descriptor.

- `StreamBuilder::proto_from_uc()` — fetch the descriptor from Unity Catalog at `build()`
- `schema::TableDescriptorBuilder` — build a descriptor in code (no UC)
- `DynamicProtoEncoder` via `ZerobusStream::encoder()` — JSON → proto bytes, then ingest through the existing `ingest_record_offset`

Adds tests, a `proto_dynamic` example, README + changelog entries; `prost-reflect` becomes a regular SDK dependency.

## How is this tested?

Manually tested with custom Rust client