### PR TITLE
[C++] Add C++ to issue-template SDK dropdowns (split 2/6 from #415)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,6 +13,7 @@ body:
         - Java
         - Python
         - Go
+        - C++
         - All
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -13,6 +13,7 @@ body:
         - Java
         - Python
         - Go
+        - C++
         - All
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -13,6 +13,7 @@ body:
         - Java
         - Python
         - Go
+        - C++
         - All
     validations:
       required: true


### PR DESCRIPTION
## Summary

Add **C++** to the SDK dropdown in the bug, feature, and task issue forms so
issues can be filed against the C++ SDK. The value yields the `[C++]` title
prefix via `issue-label.yml`, matching the commit convention.

Part of the #415 split (2/6). Independent — can merge in any order.
