### PR TITLE
[C++] SDK examples (split 6/6 from #415)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -98,6 +98,10 @@ if(ZEROBUS_BUILD_TESTS)
   add_subdirectory(tests)
 endif()
 
+if(ZEROBUS_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
 # ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Each example is a standalone executable linking the SDK. They read connection
+# settings from environment variables at runtime (see each file's header).
+set(ZEROBUS_EXAMPLES
+    json_single
+    json_batch
+    proto_uc_schema
+    headers_provider
+    arrow_stream)
+
+foreach(example ${ZEROBUS_EXAMPLES})
+  add_executable(${example} ${example}.cpp)
+  target_link_libraries(${example} PRIVATE zerobus::zerobus)
+endforeach()

--- a/cpp/examples/arrow_stream.cpp
+++ b/cpp/examples/arrow_stream.cpp
@@ -1,0 +1,71 @@
+// Ingest Arrow RecordBatches over an Arrow Flight stream (Beta).
+//
+// Records cross the FFI as Arrow IPC stream bytes. Producing those bytes
+// requires the Arrow C++ library, which this SDK does not depend on, so this
+// example reads pre-encoded IPC bytes from files:
+//   ZEROBUS_ARROW_SCHEMA_IPC   file with an IPC stream encoding only the schema
+//   ZEROBUS_ARROW_BATCH_IPC    file with an IPC stream (schema + one batch)
+// See json_single.cpp for the connection environment variables.
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+std::string env(const char* name) {
+  const char* v = std::getenv(name);
+  return v != nullptr ? std::string(v) : std::string();
+}
+
+std::vector<std::uint8_t> read_file(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("cannot open " + path);
+  }
+  return std::vector<std::uint8_t>(std::istreambuf_iterator<char>(in),
+                                   std::istreambuf_iterator<char>());
+}
+}  // namespace
+
+int main() {
+  try {
+    std::vector<std::uint8_t> schema_ipc =
+        read_file(env("ZEROBUS_ARROW_SCHEMA_IPC"));
+    std::vector<std::uint8_t> batch_ipc =
+        read_file(env("ZEROBUS_ARROW_BATCH_IPC"));
+
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(env("ZEROBUS_SERVER_ENDPOINT"))
+                           .unity_catalog_url(env("DATABRICKS_WORKSPACE_URL"))
+                           .application_name("zerobus-cpp-arrow-example")
+                           .build();
+
+    zerobus::ArrowStreamOptions options;
+    options.ipc_compression = zerobus::IpcCompression::Zstd;
+
+    zerobus::ArrowStream stream = sdk.create_arrow_stream(
+        env("ZEROBUS_TABLE_NAME"), schema_ipc, env("DATABRICKS_CLIENT_ID"),
+        env("DATABRICKS_CLIENT_SECRET"), options);
+
+    std::int64_t offset = stream.ingest_batch(batch_ipc);
+    std::cout << "ingested batch at offset " << offset << "\n";
+
+    stream.flush();
+    stream.close();
+    std::cout << "done\n";
+    return 0;
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "zerobus error: " << e.what()
+              << " (retryable=" << (e.is_retryable() ? "true" : "false")
+              << ")\n";
+    return 1;
+  } catch (const std::exception& e) {
+    std::cerr << "error: " << e.what() << "\n";
+    return 1;
+  }
+}

--- a/cpp/examples/headers_provider.cpp
+++ b/cpp/examples/headers_provider.cpp
@@ -1,0 +1,72 @@
+// Authenticate a stream with a custom HeadersProvider instead of static OAuth
+// client credentials. Implement get_headers() to supply (and refresh) whatever
+// authorization headers your environment requires.
+//
+// Required environment variables:
+//   DATABRICKS_TOKEN          bearer token supplied via the HeadersProvider
+// See json_single.cpp for the remaining connection environment variables (the
+// client id/secret are not used on this path).
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+std::string env(const char* name) {
+  const char* v = std::getenv(name);
+  return v != nullptr ? std::string(v) : std::string();
+}
+
+// Supplies a bearer token. In a real implementation, refresh the token here as
+// needed; get_headers() is called by the core whenever fresh headers are
+// needed.
+class BearerTokenProvider : public zerobus::HeadersProvider {
+ public:
+  explicit BearerTokenProvider(std::string token) : token_(std::move(token)) {}
+
+  std::map<std::string, std::string> get_headers() override {
+    return {{"Authorization", "Bearer " + token_}};
+  }
+
+ private:
+  std::string token_;
+};
+}  // namespace
+
+int main() {
+  try {
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(env("ZEROBUS_SERVER_ENDPOINT"))
+                           .application_name("zerobus-cpp-headers-example")
+                           .build();
+
+    zerobus::TableProperties table;
+    table.table_name = env("ZEROBUS_TABLE_NAME");
+
+    zerobus::StreamOptions options;
+    options.record_type = zerobus::RecordType::Json;
+
+    auto provider =
+        std::make_shared<BearerTokenProvider>(env("DATABRICKS_TOKEN"));
+
+    zerobus::Stream stream = sdk.create_stream(table, provider, options);
+
+    std::int64_t offset =
+        stream.ingest_json_record(R"({"id": 1, "payload": "via headers"})");
+    std::cout << "ingested at offset " << offset << "\n";
+
+    stream.flush();
+    stream.close();
+    std::cout << "done\n";
+    return 0;
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "zerobus error: " << e.what()
+              << " (retryable=" << (e.is_retryable() ? "true" : "false")
+              << ")\n";
+    return 1;
+  }
+}

--- a/cpp/examples/json_batch.cpp
+++ b/cpp/examples/json_batch.cpp
@@ -1,0 +1,58 @@
+// Ingest a batch of JSON records. Batch APIs amortize the per-call FFI cost and
+// should be preferred in hot paths.
+//
+// See json_single.cpp for the required environment variables.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+std::string env(const char* name) {
+  const char* v = std::getenv(name);
+  return v != nullptr ? std::string(v) : std::string();
+}
+}  // namespace
+
+int main() {
+  try {
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(env("ZEROBUS_SERVER_ENDPOINT"))
+                           .unity_catalog_url(env("DATABRICKS_WORKSPACE_URL"))
+                           .application_name("zerobus-cpp-json-batch-example")
+                           .build();
+
+    zerobus::TableProperties table;
+    table.table_name = env("ZEROBUS_TABLE_NAME");
+
+    zerobus::StreamOptions options;
+    options.record_type = zerobus::RecordType::Json;
+
+    zerobus::Stream stream =
+        sdk.create_stream(table, env("DATABRICKS_CLIENT_ID"),
+                          env("DATABRICKS_CLIENT_SECRET"), options);
+
+    std::vector<std::string> records;
+    for (int i = 0; i < 100; ++i) {
+      records.push_back(R"({"id": )" + std::to_string(i) +
+                        R"(, "payload": "batch"})");
+    }
+
+    std::int64_t last_offset = stream.ingest_json_records(records);
+    std::cout << "ingested " << records.size()
+              << " records, last offset = " << last_offset << "\n";
+
+    stream.flush();
+    stream.close();
+    std::cout << "done\n";
+    return 0;
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "zerobus error: " << e.what()
+              << " (retryable=" << (e.is_retryable() ? "true" : "false")
+              << ")\n";
+    return 1;
+  }
+}

--- a/cpp/examples/json_single.cpp
+++ b/cpp/examples/json_single.cpp
@@ -1,0 +1,56 @@
+// Ingest a single JSON record using OAuth client credentials.
+//
+// Required environment variables:
+//   ZEROBUS_SERVER_ENDPOINT   gRPC endpoint
+//   DATABRICKS_WORKSPACE_URL  Unity Catalog / workspace URL
+//   DATABRICKS_CLIENT_ID      OAuth client id
+//   DATABRICKS_CLIENT_SECRET  OAuth client secret
+//   ZEROBUS_TABLE_NAME        Target table: catalog.schema.table
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+std::string env(const char* name) {
+  const char* v = std::getenv(name);
+  return v != nullptr ? std::string(v) : std::string();
+}
+}  // namespace
+
+int main() {
+  try {
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(env("ZEROBUS_SERVER_ENDPOINT"))
+                           .unity_catalog_url(env("DATABRICKS_WORKSPACE_URL"))
+                           .application_name("zerobus-cpp-json-single-example")
+                           .build();
+
+    zerobus::TableProperties table;
+    table.table_name = env("ZEROBUS_TABLE_NAME");
+    // Empty descriptor_proto => JSON stream.
+
+    zerobus::StreamOptions options;
+    options.record_type = zerobus::RecordType::Json;
+
+    zerobus::Stream stream =
+        sdk.create_stream(table, env("DATABRICKS_CLIENT_ID"),
+                          env("DATABRICKS_CLIENT_SECRET"), options);
+
+    std::int64_t offset =
+        stream.ingest_json_record(R"({"id": 1, "payload": "hello from C++"})");
+    std::cout << "ingested at offset " << offset << "\n";
+
+    stream.flush();
+    stream.close();
+    std::cout << "done\n";
+    return 0;
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "zerobus error: " << e.what()
+              << " (retryable=" << (e.is_retryable() ? "true" : "false")
+              << ")\n";
+    return 1;
+  }
+}

--- a/cpp/examples/proto_uc_schema.cpp
+++ b/cpp/examples/proto_uc_schema.cpp
@@ -1,0 +1,64 @@
+// Ingest protobuf records whose descriptor is built directly from Unity Catalog
+// table metadata — no pre-generated .proto file or protoc needed.
+//
+// Fetch GET /api/2.1/unity-catalog/tables/{name} and pass its JSON body via the
+// ZEROBUS_UC_TABLE_JSON environment variable (or adapt this to read a file).
+// See json_single.cpp for the connection environment variables.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+std::string env(const char* name) {
+  const char* v = std::getenv(name);
+  return v != nullptr ? std::string(v) : std::string();
+}
+}  // namespace
+
+int main() {
+  try {
+    // Build the protobuf schema (descriptor + encoder) from UC table metadata.
+    zerobus::ProtoSchema schema =
+        zerobus::ProtoSchema::from_uc_json(env("ZEROBUS_UC_TABLE_JSON"));
+
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(env("ZEROBUS_SERVER_ENDPOINT"))
+                           .unity_catalog_url(env("DATABRICKS_WORKSPACE_URL"))
+                           .application_name("zerobus-cpp-proto-example")
+                           .build();
+
+    zerobus::TableProperties table;
+    table.table_name = env("ZEROBUS_TABLE_NAME");
+    table.descriptor_proto = schema.descriptor_bytes();  // => proto stream
+
+    zerobus::StreamOptions options;  // record_type defaults to Proto
+    zerobus::Stream stream =
+        sdk.create_stream(table, env("DATABRICKS_CLIENT_ID"),
+                          env("DATABRICKS_CLIENT_SECRET"), options);
+
+    // Encode JSON records into protobuf bytes using the UC-derived schema.
+    std::vector<std::vector<std::uint8_t>> batch;
+    for (int i = 0; i < 10; ++i) {
+      batch.push_back(schema.encode_json(R"({"id": )" + std::to_string(i) +
+                                         R"(, "payload": "proto"})"));
+    }
+
+    std::int64_t last_offset = stream.ingest_proto_records(batch);
+    std::cout << "ingested " << batch.size()
+              << " proto records, last offset = " << last_offset << "\n";
+
+    stream.flush();
+    stream.close();
+    std::cout << "done\n";
+    return 0;
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "zerobus error: " << e.what()
+              << " (retryable=" << (e.is_retryable() ? "true" : "false")
+              << ")\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

Runnable C++ SDK examples (`examples/`) — JSON single/batch, proto-from-UC-schema,
custom headers provider, Arrow Flight — and the `add_subdirectory(examples)`
wiring.

Part of the #415 split (6/6).

### Merge order
**Stacked on #5 (tests).** Merge last.

Draft until the stack is reviewed.
