### PR TITLE
[Go] Add darwin library cross-builds via cargo-zigbuild

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -18,6 +18,16 @@ jobs:
             target: aarch64-unknown-linux-gnu
             lib_dir: linux_arm64
             cross: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-apple-darwin
+            lib_dir: darwin_amd64
+            cross: false
+            zigbuild: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-apple-darwin
+            lib_dir: darwin_arm64
+            cross: false
+            zigbuild: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-gnu
             lib_dir: windows_amd64
@@ -63,8 +73,23 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (darwin cross-builds)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (darwin cross-builds)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build FFI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI library (zigbuild)
+        if: matrix.zigbuild
+        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Prepare artifact
         shell: bash


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `darwin_amd64` and `darwin_arm64` to the `release-go.yml` build matrix,
cross-compiled from a Linux runner via `cargo-zigbuild`.

## How is this tested?

N/A