### PR TITLE
[C++] Arrow Flight stream (Beta), split from #415

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -1,0 +1,88 @@
+name: C++ CI
+
+on:
+  workflow_call:
+    inputs:
+      use_local_sdk:
+        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
+        type: boolean
+        default: false
+
+jobs:
+  fmt:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    defaults:
+      run:
+        working-directory: cpp
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+      - name: Check formatting
+        run: make fmt-check
+
+  test:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    defaults:
+      run:
+        working-directory: cpp
+        shell: bash
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Get JFrog OIDC token
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"
+      - name: Configure Cargo registry
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Patch Rust workspace to use local SDK
+        if: inputs.use_local_sdk
+        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "sdk" }\n' >> ../rust/Cargo.toml
+
+      - name: Build (SDK, tests, examples)
+        run: make build
+
+      - name: Run tests
+        run: make test
+
+  sanitize:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    defaults:
+      run:
+        working-directory: cpp
+        shell: bash
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Get JFrog OIDC token
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"
+      - name: Configure Cargo registry
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Patch Rust workspace to use local SDK
+        if: inputs.use_local_sdk
+        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "sdk" }\n' >> ../rust/Cargo.toml
+
+      # Build the SDK, tests, and examples with AddressSanitizer and run the
+      # existing suite under it. This catches the memory bugs a thin FFI wrapper
+      # is prone to (use-after-free, double-free, buffer overflow) without adding
+      # any dependency. Debug build for readable stack traces.
+      - name: Build + test with AddressSanitizer
+        env:
+          # The Rust core's global tokio runtime is intentionally never torn
+          # down, so the leak detector would flag it as a false positive.
+          # Disable leak detection; keep the use-after-free/double-free checks.
+          ASAN_OPTIONS: detect_leaks=0
+        run: make test SANITIZE=address BUILD_TYPE=Debug

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -81,8 +81,13 @@ jobs:
       # any dependency. Debug build for readable stack traces.
       - name: Build + test with AddressSanitizer
         env:
-          # The Rust core's global tokio runtime is intentionally never torn
-          # down, so the leak detector would flag it as a false positive.
-          # Disable leak detection; keep the use-after-free/double-free checks.
-          ASAN_OPTIONS: detect_leaks=0
+          # Keep LeakSanitizer on so wrapper leaks (a missed
+          # zerobus_free_error_message, a leaked CHeader array or proto-bytes
+          # buffer) are caught alongside the use-after-free/double-free checks —
+          # that is the whole point of this job. The Rust core's global tokio
+          # runtime and header-key cache are intentionally never torn down, so
+          # they are suppressed narrowly via the file below rather than by
+          # disabling leak detection wholesale.
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/cpp/lsan_suppressions.txt
         run: make test SANITIZE=address BUILD_TYPE=Debug

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    needs: [changes, rust, java, typescript, python, go]
+    needs: [changes, rust, java, typescript, python, go, cpp]
     if: always()
     steps:
       - run: |
@@ -20,7 +20,8 @@ jobs:
             "${{ needs.java.result }}" \
             "${{ needs.typescript.result }}" \
             "${{ needs.python.result }}" \
-            "${{ needs.go.result }}"; do
+            "${{ needs.go.result }}" \
+            "${{ needs.cpp.result }}"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "Job failed or was cancelled: $result"
               exit 1
@@ -37,6 +38,7 @@ jobs:
       typescript: ${{ steps.filter.outputs.typescript }}
       python: ${{ steps.filter.outputs.python }}
       go: ${{ steps.filter.outputs.go }}
+      cpp: ${{ steps.filter.outputs.cpp }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -58,6 +60,9 @@ jobs:
             go:
               - 'go/**'
               - '.github/workflows/ci-go.yml'
+            cpp:
+              - 'cpp/**'
+              - '.github/workflows/ci-cpp.yml'
 
   # Blocking jobs — required for merge
   rust:
@@ -100,6 +105,14 @@ jobs:
       contents: read
     uses: ./.github/workflows/ci-go.yml
 
+  cpp:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/ci-cpp.yml
+
   # Non-blocking cross-SDK jobs — run all SDK tests against the local Rust
   # source when rust/** changes, to catch breakage before a new FFI release.
   # These are intentionally excluded from `gate` so they don't block merging.
@@ -110,6 +123,16 @@ jobs:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-go.yml
+    with:
+      use_local_sdk: true
+
+  cross-sdk-cpp:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/ci-cpp.yml
     with:
       use_local_sdk: true
 

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+Standard: c++17
+ColumnLimit: 80

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,133 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(zerobus_cpp
+    VERSION 0.1.0
+    DESCRIPTION "Zerobus C++ SDK (wrapper over the Zerobus C FFI)"
+    LANGUAGES CXX)
+
+# Detect whether we are the top-level project (controls test/example defaults).
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(ZEROBUS_IS_TOP_LEVEL ON)
+else()
+  set(ZEROBUS_IS_TOP_LEVEL OFF)
+endif()
+
+option(ZEROBUS_BUILD_TESTS "Build the Zerobus C++ SDK tests" ${ZEROBUS_IS_TOP_LEVEL})
+option(ZEROBUS_BUILD_EXAMPLES "Build the Zerobus C++ SDK examples" ${ZEROBUS_IS_TOP_LEVEL})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+# ---------------------------------------------------------------------------
+# Sanitizers (off by default)
+# ---------------------------------------------------------------------------
+# Build the SDK, tests, and examples with a runtime sanitizer so the existing
+# test suite also catches the memory/threading bugs a thin FFI wrapper is prone
+# to (use-after-free, double-free, leaks, data races). No extra dependencies —
+# the sanitizers ship with GCC/Clang. Enable with e.g. -DZEROBUS_SANITIZE=address
+# (others: thread, undefined). The flags must apply to compiling AND linking and
+# to every target, so they are set globally here, before any target is defined.
+set(ZEROBUS_SANITIZE "" CACHE STRING
+    "Runtime sanitizer to build with: address, thread, undefined (empty = none)")
+
+if(ZEROBUS_SANITIZE)
+  if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    message(FATAL_ERROR
+        "ZEROBUS_SANITIZE requires GCC or Clang (got ${CMAKE_CXX_COMPILER_ID})")
+  endif()
+  message(STATUS "Zerobus: building with -fsanitize=${ZEROBUS_SANITIZE}")
+  # -fno-omit-frame-pointer + -g give readable stack traces in reports.
+  add_compile_options(-fsanitize=${ZEROBUS_SANITIZE} -fno-omit-frame-pointer -g)
+  add_link_options(-fsanitize=${ZEROBUS_SANITIZE})
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(BuildRustFfi)
+
+# ---------------------------------------------------------------------------
+# Library target
+# ---------------------------------------------------------------------------
+add_library(zerobus_cpp
+    src/sdk.cpp
+    src/stream.cpp
+    src/proto_schema.cpp
+    src/headers_callback.cpp)
+add_library(zerobus::zerobus ALIAS zerobus_cpp)
+
+target_compile_features(zerobus_cpp PUBLIC cxx_std_17)
+
+target_include_directories(zerobus_cpp
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Linking the FFI library PUBLIC propagates both the zerobus.h include directory
+# and the platform system libraries the Rust static library needs.
+target_link_libraries(zerobus_cpp PUBLIC zerobus::ffi)
+
+if(DEFINED ZEROBUS_FFI_BUILD_TARGET)
+  add_dependencies(zerobus_cpp ${ZEROBUS_FFI_BUILD_TARGET})
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(zerobus_cpp PRIVATE -Wall -Wextra)
+endif()
+
+set_target_properties(zerobus_cpp PROPERTIES
+    OUTPUT_NAME zerobus_cpp
+    POSITION_INDEPENDENT_CODE ON
+    # Export under the same name as the in-build alias (zerobus::zerobus) so
+    # consumers link the same target whether they use the build tree or the
+    # installed package. Without this the export namespace would prepend to the
+    # real target name, yielding zerobus::zerobus_cpp.
+    EXPORT_NAME zerobus)
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# Copy the compiled library and headers into the standard install layout, and
+# record zerobus_cpp as a member of the "zerobus-targets" export set.
+install(TARGETS zerobus_cpp
+    EXPORT zerobus-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Bundle the Rust C FFI archive that zerobus_cpp statically links. Without it a
+# consumer could locate the C++ library but would have no symbols to satisfy its
+# FFI calls. zerobus-config.cmake recreates the zerobus::ffi target from this.
+get_target_property(_zerobus_ffi_location zerobus_ffi IMPORTED_LOCATION)
+install(FILES "${_zerobus_ffi_location}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Piece #1a: write zerobus-targets.cmake, which recreates the zerobus::zerobus
+# target (library path, include dir, dependencies) in a consumer's build.
+install(EXPORT zerobus-targets
+    NAMESPACE zerobus::
+    FILE zerobus-targets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerobus)
+
+# Piece #1b: generate the entry-point file find_package(zerobus) looks for,
+# plus a version file so consumers can request a compatible version.
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/zerobus-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/zerobus-config.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerobus)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/zerobus-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/zerobus-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/zerobus-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerobus)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -55,6 +55,7 @@ include(BuildRustFfi)
 add_library(zerobus_cpp
     src/sdk.cpp
     src/stream.cpp
+    src/arrow_stream.cpp
     src/proto_schema.cpp
     src/headers_callback.cpp)
 add_library(zerobus::zerobus ALIAS zerobus_cpp)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,0 +1,64 @@
+# Makefile for the Zerobus C++ SDK.
+#
+# Thin convenience wrappers around CMake/CTest and clang-format, mirroring the
+# build/test/lint/fmt verbs used by the other SDKs in this monorepo.
+
+BUILD_DIR ?= build
+BUILD_TYPE ?= Release
+JOBS ?= 4
+
+# Optional runtime sanitizer, e.g. `make test SANITIZE=address` (or thread,
+# undefined). Empty by default, so normal builds are unaffected.
+SANITIZE ?=
+SANITIZE_FLAG := $(if $(SANITIZE),-DZEROBUS_SANITIZE=$(SANITIZE),)
+
+# All hand-written C++ sources (excludes the CMake build tree and fetched deps).
+SOURCES := $(shell find include src tests examples -name '*.cpp' -o -name '*.hpp' 2>/dev/null)
+
+.PHONY: help configure build build-ffi test lint fmt fmt-check clean examples check
+
+help:
+	@echo "Available targets:"
+	@echo "  make build      - Configure and build the SDK, tests, and examples"
+	@echo "  make build-ffi  - Build only the underlying Rust C FFI library"
+	@echo "  make test       - Build and run the test suite (ctest)"
+	@echo "  make examples   - Build the example binaries"
+	@echo "  make fmt        - Format all C++ sources with clang-format"
+	@echo "  make fmt-check  - Check formatting without modifying files"
+	@echo "  make lint       - Run lint checks (formatting + compiler warnings)"
+	@echo "  make check      - Run fmt-check and lint"
+	@echo "  make clean      - Remove the build directory"
+	@echo ""
+	@echo "  Add SANITIZE=address (or thread/undefined) to build+test with a sanitizer,"
+	@echo "  e.g. 'make test SANITIZE=address'."
+
+configure:
+	cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(SANITIZE_FLAG)
+
+build: configure
+	cmake --build $(BUILD_DIR) -j $(JOBS)
+
+# Build just the Rust FFI static library (cargo build --release in rust/ffi).
+build-ffi:
+	cd ../rust/ffi && cargo build --release
+
+test: build
+	cd $(BUILD_DIR) && ctest --output-on-failure
+
+examples: build
+	@echo "Examples built under $(BUILD_DIR)/examples/"
+
+fmt:
+	clang-format -i $(SOURCES)
+
+fmt-check:
+	clang-format --dry-run --Werror $(SOURCES)
+
+# Without clang-tidy available everywhere, lint = formatting + the compiler's
+# own -Wall -Wextra (enabled in CMakeLists for the library target).
+lint: fmt-check build
+
+check: fmt-check lint
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/cpp/cmake/BuildRustFfi.cmake
+++ b/cpp/cmake/BuildRustFfi.cmake
@@ -1,0 +1,70 @@
+# Builds the Zerobus C FFI static library from the local Rust source and exposes
+# it as an imported target `zerobus::ffi`.
+#
+# Mirrors go/build_rust.sh: invokes `cargo build --release` in `rust/ffi`, which
+# produces `rust/target/release/libzerobus_ffi.a` and regenerates `zerobus.h`
+# (via the crate's cbindgen build script). The header directory is added to the
+# imported target's interface includes.
+#
+# Override the prebuilt library and header instead of building from source by
+# setting -DZEROBUS_FFI_LIBRARY=<path-to-.a> and -DZEROBUS_FFI_HEADER_DIR=<dir>.
+
+set(ZEROBUS_REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/.." CACHE PATH
+    "Path to the zerobus-sdk monorepo root")
+set(ZEROBUS_FFI_CRATE_DIR "${ZEROBUS_REPO_ROOT}/rust/ffi")
+set(ZEROBUS_RUST_TARGET_DIR "${ZEROBUS_REPO_ROOT}/rust/target")
+
+if(WIN32)
+  set(_zb_ffi_lib_name "zerobus_ffi.lib")
+else()
+  set(_zb_ffi_lib_name "libzerobus_ffi.a")
+endif()
+
+add_library(zerobus_ffi STATIC IMPORTED GLOBAL)
+add_library(zerobus::ffi ALIAS zerobus_ffi)
+
+if(DEFINED ZEROBUS_FFI_LIBRARY)
+  # Use a prebuilt/vendored static library.
+  if(NOT DEFINED ZEROBUS_FFI_HEADER_DIR)
+    set(ZEROBUS_FFI_HEADER_DIR "${ZEROBUS_FFI_CRATE_DIR}")
+  endif()
+  set_target_properties(zerobus_ffi PROPERTIES
+      IMPORTED_LOCATION "${ZEROBUS_FFI_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ZEROBUS_FFI_HEADER_DIR}")
+  message(STATUS "Zerobus: using prebuilt FFI library ${ZEROBUS_FFI_LIBRARY}")
+else()
+  # Build from local Rust source via cargo.
+  find_program(CARGO_EXECUTABLE cargo REQUIRED
+      DOC "Path to the cargo build tool")
+
+  set(_zb_ffi_lib "${ZEROBUS_RUST_TARGET_DIR}/release/${_zb_ffi_lib_name}")
+
+  add_custom_command(
+      OUTPUT "${_zb_ffi_lib}"
+      COMMAND "${CARGO_EXECUTABLE}" build --release
+      WORKING_DIRECTORY "${ZEROBUS_FFI_CRATE_DIR}"
+      COMMENT "Building Zerobus C FFI (cargo build --release)"
+      VERBATIM)
+  add_custom_target(zerobus_ffi_build DEPENDS "${_zb_ffi_lib}")
+
+  set_target_properties(zerobus_ffi PROPERTIES
+      IMPORTED_LOCATION "${_zb_ffi_lib}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ZEROBUS_FFI_CRATE_DIR}")
+  # Consumers must build the cargo target first; the imported target itself
+  # cannot carry the dependency, so callers add it to their own targets.
+  set(ZEROBUS_FFI_BUILD_TARGET zerobus_ffi_build CACHE INTERNAL "")
+endif()
+
+# System libraries the Rust static library needs at link time. These mirror the
+# CGO LDFLAGS in go/ffi.go.
+if(APPLE)
+  target_link_libraries(zerobus_ffi INTERFACE
+      "-framework CoreFoundation" "-framework Security" iconv)
+elseif(WIN32)
+  target_link_libraries(zerobus_ffi INTERFACE
+      ws2_32 userenv bcrypt ntdll)
+else()  # Linux / other Unix
+  find_package(Threads REQUIRED)
+  target_link_libraries(zerobus_ffi INTERFACE
+      Threads::Threads ${CMAKE_DL_LIBS} m resolv)
+endif()

--- a/cpp/cmake/zerobus-config.cmake.in
+++ b/cpp/cmake/zerobus-config.cmake.in
@@ -1,0 +1,48 @@
+# Config file loaded by find_package(zerobus). configure_package_config_file()
+# expands @PACKAGE_INIT@ into a small preamble that defines PACKAGE_PREFIX_DIR
+# (the directory this package was installed into).
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# The C++ SDK statically links the Rust C FFI archive (libzerobus_ffi.a). That
+# archive is bundled in this package, but the imported target that the SDK links
+# against (zerobus::ffi) only existed in the SDK's own build tree. Recreate it
+# here so the exported zerobus::zerobus target can resolve its FFI symbols, and
+# re-apply the system libraries the Rust static library needs at link time.
+if(NOT TARGET zerobus::ffi)
+  add_library(zerobus::ffi STATIC IMPORTED)
+
+  find_library(ZEROBUS_FFI_LIBRARY
+      NAMES zerobus_ffi
+      HINTS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@"
+      NO_DEFAULT_PATH)
+  if(NOT ZEROBUS_FFI_LIBRARY)
+    set(zerobus_FOUND FALSE)
+    set(zerobus_NOT_FOUND_MESSAGE
+        "Zerobus FFI archive not found under ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+    return()
+  endif()
+  set_target_properties(zerobus::ffi PROPERTIES
+      IMPORTED_LOCATION "${ZEROBUS_FFI_LIBRARY}")
+
+  # Mirror BuildRustFfi.cmake: the Rust static library pulls in these platform
+  # system libraries at link time.
+  if(APPLE)
+    set_property(TARGET zerobus::ffi APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        "-framework CoreFoundation" "-framework Security" iconv)
+  elseif(WIN32)
+    set_property(TARGET zerobus::ffi APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        ws2_32 userenv bcrypt ntdll)
+  else()  # Linux / other Unix
+    find_dependency(Threads)
+    set_property(TARGET zerobus::ffi APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        Threads::Threads ${CMAKE_DL_LIBS} m resolv)
+  endif()
+endif()
+
+# Recreate the zerobus::zerobus target itself (declares the installed library +
+# headers). This references zerobus::ffi defined above.
+include("${CMAKE_CURRENT_LIST_DIR}/zerobus-targets.cmake")
+
+check_required_components(zerobus)

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -1,0 +1,70 @@
+#ifndef ZEROBUS_ARROW_STREAM_HPP
+#define ZEROBUS_ARROW_STREAM_HPP
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "zerobus/headers_provider.hpp"
+
+namespace zerobus {
+
+struct CArrowStream;  // opaque FFI handle (defined in zerobus.h)
+class Sdk;
+
+/// An Arrow Flight ingestion stream (Beta).
+///
+/// Records are supplied as Arrow IPC stream bytes (schema + one record batch).
+/// Created via `Sdk::create_arrow_stream`. Move-only; the destructor closes and
+/// frees the stream. The API is stabilising but may still change before GA.
+///
+/// As with `Stream`, prefer calling `close()` explicitly: it surfaces close
+/// errors (the destructor swallows them) and flushes synchronously, which can
+/// block up to `flush_timeout_ms` (default 5 minutes) if the server is
+/// unresponsive. Letting the object fall out of scope drags that blocking close
+/// into the destructor.
+///
+/// Thread safety: not safe for concurrent use from multiple threads.
+class ArrowStream {
+ public:
+  ~ArrowStream();
+
+  ArrowStream(ArrowStream&& other) noexcept;
+  ArrowStream& operator=(ArrowStream&& other) noexcept;
+  ArrowStream(const ArrowStream&) = delete;
+  ArrowStream& operator=(const ArrowStream&) = delete;
+
+  /// Ingest one Arrow RecordBatch supplied as Arrow IPC stream bytes (a
+  /// self-contained IPC stream: schema message + one record batch message).
+  /// Returns the logical offset assigned to the batch.
+  std::int64_t ingest_batch(const std::uint8_t* ipc_bytes, std::size_t len);
+  std::int64_t ingest_batch(const std::vector<std::uint8_t>& ipc_bytes);
+
+  /// Block until the batch at `offset` has been acknowledged.
+  void wait_for_offset(std::int64_t offset);
+
+  /// Flush all pending batches and wait for their acknowledgment.
+  void flush();
+
+  /// Return all unacknowledged batches from a closed or failed stream, each as
+  /// a self-contained Arrow IPC stream (schema + one batch).
+  std::vector<std::vector<std::uint8_t>> get_unacked_batches();
+
+  /// Gracefully close the stream, flushing pending batches first. Idempotent.
+  void close();
+
+  /// Whether the stream has been closed (queried from the FFI when live).
+  bool is_closed() const noexcept;
+
+ private:
+  friend class Sdk;
+  ArrowStream(CArrowStream* handle, std::shared_ptr<HeadersProvider> provider)
+      : handle_(handle), provider_(std::move(provider)) {}
+
+  CArrowStream* handle_;
+  std::shared_ptr<HeadersProvider> provider_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_ARROW_STREAM_HPP

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -1,8 +1,10 @@
 #ifndef ZEROBUS_ARROW_STREAM_HPP
 #define ZEROBUS_ARROW_STREAM_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "zerobus/headers_provider.hpp"
@@ -47,10 +49,17 @@ class ArrowStream {
   void flush();
 
   /// Return all unacknowledged batches from a closed or failed stream, each as
-  /// a self-contained Arrow IPC stream (schema + one batch).
+  /// a self-contained Arrow IPC stream (schema + one batch). Remains callable
+  /// after a failed `close()`, which keeps the handle alive so recovery is
+  /// possible.
   std::vector<std::vector<std::uint8_t>> get_unacked_batches();
 
   /// Gracefully close the stream, flushing pending batches first. Idempotent.
+  ///
+  /// On success the stream becomes unusable. If the close fails it throws
+  /// `ZerobusException` but keeps the handle alive, so the caller can still
+  /// recover buffered batches via `get_unacked_batches()` and/or retry
+  /// `close()`; the destructor frees the handle as a last resort.
   void close();
 
   /// Whether the stream has been closed (queried from the FFI when live).

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -1,0 +1,50 @@
+#ifndef ZEROBUS_CONFIG_HPP
+#define ZEROBUS_CONFIG_HPP
+
+#include <cstdint>
+#include <optional>
+
+namespace zerobus {
+
+/// Wire format of a record. Matches `CStreamConfigurationOptions.record_type`.
+enum class RecordType : std::int32_t {
+  Unspecified = 0,
+  Proto = 1,
+  Json = 2,
+};
+
+/// Configuration for an ingestion stream.
+///
+/// Defaults mirror the Rust core's `zerobus_get_default_config()`. The actual
+/// C struct passed to the FFI is seeded from the live FFI defaults and then
+/// overridden field-by-field with the values below, so unknown future fields
+/// keep their FFI defaults.
+struct StreamOptions {
+  /// Maximum number of in-flight (unacknowledged) requests.
+  std::size_t max_inflight_requests = 1'000'000;
+  /// Whether automatic stream recovery is enabled.
+  bool recovery = true;
+  /// Total time budget for a recovery attempt.
+  std::uint64_t recovery_timeout_ms = 15'000;
+  /// Backoff between recovery retries.
+  std::uint64_t recovery_backoff_ms = 2'000;
+  /// Number of recovery retries before giving up.
+  std::uint32_t recovery_retries = 4;
+  /// How long to wait for a server ack before considering the stream stalled.
+  std::uint64_t server_lack_of_ack_timeout_ms = 60'000;
+  /// Time budget for `flush()`.
+  std::uint64_t flush_timeout_ms = 300'000;
+  /// Record wire format. Must match the stream's table (proto vs JSON).
+  RecordType record_type = RecordType::Proto;
+  /// Max time to wait during a server-initiated pause before recovering.
+  /// `nullopt` = wait the full server-specified duration; `0` = recover
+  /// immediately; `>0` = wait up to min(this, server duration).
+  std::optional<std::uint64_t> stream_paused_max_wait_time_ms;
+  /// Max time to wait for a headers-provider callback to return.
+  /// `nullopt` leaves the FFI default in place.
+  std::optional<std::uint64_t> callback_max_wait_time_ms;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_CONFIG_HPP

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -13,7 +13,7 @@ enum class RecordType : std::int32_t {
   Json = 2,
 };
 
-/// Configuration for an ingestion stream.
+/// Configuration for a (non-Arrow) ingestion stream.
 ///
 /// Defaults mirror the Rust core's `zerobus_get_default_config()`. The actual
 /// C struct passed to the FFI is seeded from the live FFI defaults and then
@@ -43,6 +43,41 @@ struct StreamOptions {
   /// Max time to wait for a headers-provider callback to return.
   /// `nullopt` leaves the FFI default in place.
   std::optional<std::uint64_t> callback_max_wait_time_ms;
+};
+
+/// Arrow IPC compression codec. Matches the `ipc_compression` field encoding
+/// in `CArrowStreamConfigurationOptions` (-1 = None, 0 = LZ4_FRAME, 1 = ZSTD).
+enum class IpcCompression : std::int32_t {
+  None = -1,
+  Lz4Frame = 0,
+  Zstd = 1,
+};
+
+/// Configuration for an Arrow Flight ingestion stream (Beta).
+///
+/// Defaults mirror the Rust core's `zerobus_arrow_get_default_config()`.
+struct ArrowStreamOptions {
+  /// Maximum number of in-flight (unacknowledged) batches.
+  std::size_t max_inflight_batches = 1'000;
+  /// Whether automatic stream recovery is enabled.
+  bool recovery = true;
+  /// Total time budget for a recovery attempt.
+  std::uint64_t recovery_timeout_ms = 15'000;
+  /// Backoff between recovery retries.
+  std::uint64_t recovery_backoff_ms = 2'000;
+  /// Number of recovery retries before giving up.
+  std::uint32_t recovery_retries = 4;
+  /// How long to wait for a server ack before considering the stream stalled.
+  std::uint64_t server_lack_of_ack_timeout_ms = 60'000;
+  /// Time budget for `flush()`.
+  std::uint64_t flush_timeout_ms = 300'000;
+  /// Connection establishment timeout.
+  std::uint64_t connection_timeout_ms = 30'000;
+  /// Arrow IPC compression codec.
+  IpcCompression ipc_compression = IpcCompression::None;
+  /// Max time to wait during a server-initiated pause before recovering.
+  /// `nullopt` = wait the full server-specified duration.
+  std::optional<std::int64_t> stream_paused_max_wait_time_ms;
 };
 
 }  // namespace zerobus

--- a/cpp/include/zerobus/error.hpp
+++ b/cpp/include/zerobus/error.hpp
@@ -1,0 +1,30 @@
+#ifndef ZEROBUS_ERROR_HPP
+#define ZEROBUS_ERROR_HPP
+
+#include <stdexcept>
+#include <string>
+
+namespace zerobus {
+
+/// Exception thrown by all Zerobus SDK operations on failure.
+///
+/// Mirrors the `CResult` carried across the C FFI boundary: a human-readable
+/// message plus a retryability flag. `is_retryable()` reflects the Rust core's
+/// `ZerobusError::is_retryable()` classification — callers may retry the
+/// operation when it returns `true`.
+class ZerobusException : public std::runtime_error {
+ public:
+  ZerobusException(std::string message, bool is_retryable)
+      : std::runtime_error(std::move(message)), is_retryable_(is_retryable) {}
+
+  /// Whether the underlying error is transient and the operation may be
+  /// retried.
+  bool is_retryable() const noexcept { return is_retryable_; }
+
+ private:
+  bool is_retryable_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_ERROR_HPP

--- a/cpp/include/zerobus/headers_provider.hpp
+++ b/cpp/include/zerobus/headers_provider.hpp
@@ -1,0 +1,38 @@
+#ifndef ZEROBUS_HEADERS_PROVIDER_HPP
+#define ZEROBUS_HEADERS_PROVIDER_HPP
+
+#include <map>
+#include <string>
+
+namespace zerobus {
+
+/// Supplies authentication headers for a stream on demand.
+///
+/// Implement this interface to provide custom authentication (e.g. a rotating
+/// bearer token) instead of static OAuth client credentials. The Rust core
+/// invokes `get_headers()` whenever it needs fresh headers, possibly from an
+/// internal worker thread.
+///
+/// Thread safety: the core guards against *concurrent* invocations and will
+/// surface an error if two calls overlap, but `get_headers()` may still be
+/// called from a different thread than the one that created the stream.
+/// Implementations should therefore be thread-safe with respect to their own
+/// state.
+///
+/// Lifetime: a provider passed to `Sdk::create_stream` must remain alive for as
+/// long as the resulting `Stream`. The `Stream` holds a `shared_ptr` to it, so
+/// passing a `shared_ptr` is sufficient.
+class HeadersProvider {
+ public:
+  virtual ~HeadersProvider() = default;
+
+  /// Return the headers to attach to stream requests.
+  ///
+  /// Throwing from this method propagates the exception message back to the
+  /// Rust core as a headers-provider error, which fails the pending operation.
+  virtual std::map<std::string, std::string> get_headers() = 0;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_HEADERS_PROVIDER_HPP

--- a/cpp/include/zerobus/headers_provider.hpp
+++ b/cpp/include/zerobus/headers_provider.hpp
@@ -22,6 +22,13 @@ namespace zerobus {
 /// Lifetime: a provider passed to `Sdk::create_stream` must remain alive for as
 /// long as the resulting `Stream`. The `Stream` holds a `shared_ptr` to it, so
 /// passing a `shared_ptr` is sufficient.
+///
+/// WARNING — this lifetime guarantee does not extend to the `Stream`'s
+/// fire-and-forget (`_nowait`) ingestion APIs. Those spawn detached background
+/// tasks that the core does not join on `close()` or destruction, so a task may
+/// invoke `get_headers()` after the `Stream` has dropped its `shared_ptr` and
+/// destroyed this provider. Do not combine a `HeadersProvider` with the
+/// `_nowait` APIs; use the blocking ingest variants instead.
 class HeadersProvider {
  public:
   virtual ~HeadersProvider() = default;

--- a/cpp/include/zerobus/headers_provider.hpp
+++ b/cpp/include/zerobus/headers_provider.hpp
@@ -22,13 +22,6 @@ namespace zerobus {
 /// Lifetime: a provider passed to `Sdk::create_stream` must remain alive for as
 /// long as the resulting `Stream`. The `Stream` holds a `shared_ptr` to it, so
 /// passing a `shared_ptr` is sufficient.
-///
-/// WARNING — this lifetime guarantee does not extend to the `Stream`'s
-/// fire-and-forget (`_nowait`) ingestion APIs. Those spawn detached background
-/// tasks that the core does not join on `close()` or destruction, so a task may
-/// invoke `get_headers()` after the `Stream` has dropped its `shared_ptr` and
-/// destroyed this provider. Do not combine a `HeadersProvider` with the
-/// `_nowait` APIs; use the blocking ingest variants instead.
 class HeadersProvider {
  public:
   virtual ~HeadersProvider() = default;

--- a/cpp/include/zerobus/proto_schema.hpp
+++ b/cpp/include/zerobus/proto_schema.hpp
@@ -1,0 +1,56 @@
+#ifndef ZEROBUS_PROTO_SCHEMA_HPP
+#define ZEROBUS_PROTO_SCHEMA_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace zerobus {
+
+struct CZerobusProtoSchema;  // opaque FFI handle (defined in zerobus.h)
+
+/// Builds a protobuf descriptor and encodes JSON records straight from Unity
+/// Catalog table metadata — no pre-generated `.proto` file required.
+///
+/// Construct one with `from_uc_json()` passing the JSON body of
+/// `GET /api/2.1/unity-catalog/tables/{name}`. Use `descriptor_bytes()` as the
+/// `TableProperties::descriptor_proto` for a proto stream, then `encode_json()`
+/// to turn each record's JSON into protobuf bytes for ingestion.
+///
+/// See the FFI README / `zerobus.h` for the JSON value shaping rules per Unity
+/// Catalog column type (DATE/TIMESTAMP as integers, BINARY as base64, etc.).
+///
+/// Thread safety: a single handle may be used by concurrent readers
+/// (`descriptor_bytes()`, `encode_json()`). Destruction must not race any such
+/// call; this class is move-only and not copyable.
+class ProtoSchema {
+ public:
+  /// Build a schema from Unity Catalog table metadata JSON. Throws
+  /// `ZerobusException` on parse/build failure.
+  static ProtoSchema from_uc_json(const std::string& uc_table_json);
+
+  ~ProtoSchema();
+
+  ProtoSchema(ProtoSchema&& other) noexcept;
+  ProtoSchema& operator=(ProtoSchema&& other) noexcept;
+  ProtoSchema(const ProtoSchema&) = delete;
+  ProtoSchema& operator=(const ProtoSchema&) = delete;
+
+  /// The serialized protobuf `DescriptorProto` for this table. Pass to
+  /// `TableProperties::descriptor_proto`.
+  std::vector<std::uint8_t> descriptor_bytes() const;
+
+  /// Encode a single JSON record into protobuf bytes. Unknown keys are ignored.
+  /// Throws `ZerobusException` if the record cannot be encoded (e.g. a missing
+  /// required column or a malformed value).
+  std::vector<std::uint8_t> encode_json(const std::string& record_json) const;
+
+ private:
+  explicit ProtoSchema(CZerobusProtoSchema* handle) : handle_(handle) {}
+
+  CZerobusProtoSchema* handle_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_PROTO_SCHEMA_HPP

--- a/cpp/include/zerobus/record.hpp
+++ b/cpp/include/zerobus/record.hpp
@@ -1,0 +1,40 @@
+#ifndef ZEROBUS_RECORD_HPP
+#define ZEROBUS_RECORD_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace zerobus {
+
+/// A record recovered from a stream that was closed or failed before all
+/// records were acknowledged. Returned by `Stream::get_unacked_records()`.
+///
+/// Owns its payload bytes (copied out of the FFI-owned buffer before the
+/// underlying `CRecordArray` is freed).
+class UnackedRecord {
+ public:
+  UnackedRecord(bool is_json, std::vector<std::uint8_t> data)
+      : is_json_(is_json), data_(std::move(data)) {}
+
+  /// Whether this record was a JSON record (otherwise protobuf bytes).
+  bool is_json() const noexcept { return is_json_; }
+
+  /// The raw record payload: UTF-8 JSON bytes if `is_json()`, otherwise
+  /// protobuf-encoded bytes.
+  const std::vector<std::uint8_t>& data() const noexcept { return data_; }
+
+  /// Convenience: the payload interpreted as a JSON string. Only meaningful
+  /// when `is_json()` is true.
+  std::string as_string() const {
+    return std::string(data_.begin(), data_.end());
+  }
+
+ private:
+  bool is_json_;
+  std::vector<std::uint8_t> data_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_RECORD_HPP

--- a/cpp/include/zerobus/sdk.hpp
+++ b/cpp/include/zerobus/sdk.hpp
@@ -1,0 +1,104 @@
+#ifndef ZEROBUS_SDK_HPP
+#define ZEROBUS_SDK_HPP
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "zerobus/config.hpp"
+#include "zerobus/headers_provider.hpp"
+#include "zerobus/stream.hpp"
+
+namespace zerobus {
+
+struct CZerobusSdk;  // opaque FFI handle (defined in zerobus.h)
+
+/// Identifies the target table and (for proto streams) its schema.
+struct TableProperties {
+  /// Fully-qualified table name: `catalog.schema.table`.
+  std::string table_name;
+  /// Serialized protobuf `DescriptorProto`. Leave empty for a JSON stream.
+  std::vector<std::uint8_t> descriptor_proto;
+};
+
+class Sdk;
+
+/// Fluent builder for `Sdk`. Obtain one from `Sdk::builder()`.
+///
+/// At minimum, set `endpoint()`. The Unity Catalog URL is required for the
+/// OAuth client-credentials path but optional when a custom `HeadersProvider`
+/// supplies authentication.
+class SdkBuilder {
+ public:
+  SdkBuilder();
+  ~SdkBuilder();
+
+  SdkBuilder(SdkBuilder&& other) noexcept;
+  SdkBuilder& operator=(SdkBuilder&& other) noexcept;
+  SdkBuilder(const SdkBuilder&) = delete;
+  SdkBuilder& operator=(const SdkBuilder&) = delete;
+
+  /// Zerobus gRPC endpoint URL (required).
+  SdkBuilder& endpoint(const std::string& value);
+  /// Unity Catalog URL. Optional when using a custom headers provider.
+  SdkBuilder& unity_catalog_url(const std::string& value);
+  /// Override the SDK prefix of the `user-agent` header. Defaults to
+  /// `zerobus-sdk-cpp/<version>`.
+  SdkBuilder& sdk_identifier(const std::string& value);
+  /// Append an application identifier to the `user-agent` header.
+  SdkBuilder& application_name(const std::string& value);
+  /// Select a plaintext (non-TLS) gRPC channel. TLS is on by default.
+  SdkBuilder& disable_tls();
+
+  /// Consume the builder and construct the `Sdk`. Throws `ZerobusException` on
+  /// failure. The builder must not be used afterwards.
+  Sdk build();
+
+ private:
+  void* builder_;  // CZerobusSdkBuilder* (opaque)
+};
+
+/// Entry point to the Zerobus SDK: an authenticated connection factory that
+/// creates ingestion streams.
+///
+/// Move-only; the destructor frees the underlying FFI resources. A single `Sdk`
+/// may create many streams.
+class Sdk {
+ public:
+  /// Start building an `Sdk`. Preferred over `create()`.
+  static SdkBuilder builder();
+
+  /// Convenience constructor mirroring the simpler `zerobus_sdk_new` path: TLS
+  /// on, default user agent. Prefer `builder()` for full control.
+  static Sdk create(const std::string& endpoint,
+                    const std::string& unity_catalog_url);
+
+  ~Sdk();
+
+  Sdk(Sdk&& other) noexcept;
+  Sdk& operator=(Sdk&& other) noexcept;
+  Sdk(const Sdk&) = delete;
+  Sdk& operator=(const Sdk&) = delete;
+
+  /// Create a proto/JSON stream authenticated with OAuth client credentials.
+  Stream create_stream(const TableProperties& table,
+                       const std::string& client_id,
+                       const std::string& client_secret,
+                       const StreamOptions& options = {});
+
+  /// Create a proto/JSON stream authenticated with a custom headers provider.
+  Stream create_stream(const TableProperties& table,
+                       std::shared_ptr<HeadersProvider> headers_provider,
+                       const StreamOptions& options = {});
+
+ private:
+  friend class SdkBuilder;
+  explicit Sdk(CZerobusSdk* handle) : handle_(handle) {}
+
+  CZerobusSdk* handle_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_SDK_HPP

--- a/cpp/include/zerobus/sdk.hpp
+++ b/cpp/include/zerobus/sdk.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "zerobus/arrow_stream.hpp"
 #include "zerobus/config.hpp"
 #include "zerobus/headers_provider.hpp"
 #include "zerobus/stream.hpp"
@@ -91,6 +92,23 @@ class Sdk {
   Stream create_stream(const TableProperties& table,
                        std::shared_ptr<HeadersProvider> headers_provider,
                        const StreamOptions& options = {});
+
+  /// Create an Arrow Flight stream (Beta) authenticated with OAuth client
+  /// credentials. `schema_ipc_bytes` is an Arrow IPC stream encoding only the
+  /// schema (an empty IPC stream with just the schema message).
+  ArrowStream create_arrow_stream(
+      const std::string& table_name,
+      const std::vector<std::uint8_t>& schema_ipc_bytes,
+      const std::string& client_id, const std::string& client_secret,
+      const ArrowStreamOptions& options = {});
+
+  /// Create an Arrow Flight stream (Beta) authenticated with a custom headers
+  /// provider.
+  ArrowStream create_arrow_stream(
+      const std::string& table_name,
+      const std::vector<std::uint8_t>& schema_ipc_bytes,
+      std::shared_ptr<HeadersProvider> headers_provider,
+      const ArrowStreamOptions& options = {});
 
  private:
   friend class SdkBuilder;

--- a/cpp/include/zerobus/stream.hpp
+++ b/cpp/include/zerobus/stream.hpp
@@ -56,28 +56,6 @@ class Stream {
   /// Ingest a batch of JSON records. Returns the offset of the last record.
   std::int64_t ingest_json_records(const std::vector<std::string>& records);
 
-  /// Fire-and-forget single-record ingestion. Returns immediately; only
-  /// argument-validation errors are reported (as exceptions). Ingestion errors
-  /// are silently dropped. The stream must outlive the background work.
-  ///
-  /// WARNING — do not combine the `_nowait` APIs with a custom
-  /// `HeadersProvider`. A fire-and-forget task is detached: neither `close()`
-  /// nor the destructor drains it, and a task that still needs fresh headers
-  /// may call back into the provider after the `Stream` (and the `shared_ptr`
-  /// keeping the provider alive) is destroyed — a use-after-free. The FFI
-  /// exposes no way to drain these tasks, so there is no safe ordering. With a
-  /// `HeadersProvider`, use only the blocking ingest variants, which complete
-  /// before they return.
-  void ingest_proto_record_nowait(const std::uint8_t* data, std::size_t len);
-  void ingest_proto_record_nowait(const std::vector<std::uint8_t>& data);
-  void ingest_json_record_nowait(const std::string& json);
-
-  /// Fire-and-forget batch ingestion. Copies the payloads before returning, so
-  /// the caller's buffers may be released immediately.
-  void ingest_proto_records_nowait(
-      const std::vector<std::vector<std::uint8_t>>& records);
-  void ingest_json_records_nowait(const std::vector<std::string>& records);
-
   /// Block until the record at `offset` has been acknowledged by the server.
   void wait_for_offset(std::int64_t offset);
 

--- a/cpp/include/zerobus/stream.hpp
+++ b/cpp/include/zerobus/stream.hpp
@@ -59,6 +59,15 @@ class Stream {
   /// Fire-and-forget single-record ingestion. Returns immediately; only
   /// argument-validation errors are reported (as exceptions). Ingestion errors
   /// are silently dropped. The stream must outlive the background work.
+  ///
+  /// WARNING — do not combine the `_nowait` APIs with a custom
+  /// `HeadersProvider`. A fire-and-forget task is detached: neither `close()`
+  /// nor the destructor drains it, and a task that still needs fresh headers
+  /// may call back into the provider after the `Stream` (and the `shared_ptr`
+  /// keeping the provider alive) is destroyed — a use-after-free. The FFI
+  /// exposes no way to drain these tasks, so there is no safe ordering. With a
+  /// `HeadersProvider`, use only the blocking ingest variants, which complete
+  /// before they return.
   void ingest_proto_record_nowait(const std::uint8_t* data, std::size_t len);
   void ingest_proto_record_nowait(const std::vector<std::uint8_t>& data);
   void ingest_json_record_nowait(const std::string& json);

--- a/cpp/include/zerobus/stream.hpp
+++ b/cpp/include/zerobus/stream.hpp
@@ -1,0 +1,107 @@
+#ifndef ZEROBUS_STREAM_HPP
+#define ZEROBUS_STREAM_HPP
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "zerobus/headers_provider.hpp"
+#include "zerobus/record.hpp"
+
+namespace zerobus {
+
+struct CZerobusStream;  // opaque FFI handle (defined in zerobus.h)
+class Sdk;
+
+/// A unidirectional ingestion stream to a single Zerobus table.
+///
+/// Created via `Sdk::create_stream`. Move-only; the destructor closes the
+/// stream gracefully (best effort) and frees the underlying FFI resources.
+///
+/// Prefer calling `close()` explicitly rather than relying on the destructor:
+/// - `close()` flushes pending records and surfaces any error by throwing,
+///   whereas the destructor swallows it.
+/// - Closing flushes synchronously and can block up to the stream's
+///   `flush_timeout_ms` (default 5 minutes) if the server is unresponsive. A
+///   `Stream` that falls out of scope therefore drags that blocking close into
+///   the destructor at an unpredictable point. Call `close()` at a controlled
+///   point in your code instead.
+///
+/// Thread safety: not safe for concurrent use from multiple threads. Serialize
+/// access externally, matching the Java and Rust core contracts.
+class Stream {
+ public:
+  ~Stream();
+
+  Stream(Stream&& other) noexcept;
+  Stream& operator=(Stream&& other) noexcept;
+  Stream(const Stream&) = delete;
+  Stream& operator=(const Stream&) = delete;
+
+  /// Ingest a single protobuf-encoded record. Returns the logical offset
+  /// assigned to the record. Throws `ZerobusException` on failure.
+  std::int64_t ingest_proto_record(const std::uint8_t* data, std::size_t len);
+  std::int64_t ingest_proto_record(const std::vector<std::uint8_t>& data);
+
+  /// Ingest a single JSON record. Returns the assigned logical offset.
+  std::int64_t ingest_json_record(const std::string& json);
+
+  /// Ingest a batch of protobuf records. Returns the offset of the last record
+  /// in the batch. Prefer batch APIs over per-record calls in hot paths — each
+  /// FFI crossing has a fixed cost.
+  std::int64_t ingest_proto_records(
+      const std::vector<std::vector<std::uint8_t>>& records);
+
+  /// Ingest a batch of JSON records. Returns the offset of the last record.
+  std::int64_t ingest_json_records(const std::vector<std::string>& records);
+
+  /// Fire-and-forget single-record ingestion. Returns immediately; only
+  /// argument-validation errors are reported (as exceptions). Ingestion errors
+  /// are silently dropped. The stream must outlive the background work.
+  void ingest_proto_record_nowait(const std::uint8_t* data, std::size_t len);
+  void ingest_proto_record_nowait(const std::vector<std::uint8_t>& data);
+  void ingest_json_record_nowait(const std::string& json);
+
+  /// Fire-and-forget batch ingestion. Copies the payloads before returning, so
+  /// the caller's buffers may be released immediately.
+  void ingest_proto_records_nowait(
+      const std::vector<std::vector<std::uint8_t>>& records);
+  void ingest_json_records_nowait(const std::vector<std::string>& records);
+
+  /// Block until the record at `offset` has been acknowledged by the server.
+  void wait_for_offset(std::int64_t offset);
+
+  /// Flush all pending records and wait for their acknowledgment.
+  void flush();
+
+  /// Return all unacknowledged records from a closed or failed stream, for the
+  /// caller to re-ingest on a fresh stream.
+  std::vector<UnackedRecord> get_unacked_records();
+
+  /// Gracefully close the stream, flushing pending records first. Idempotent:
+  /// safe to call more than once. After this returns the stream is unusable.
+  ///
+  /// Blocks until the flush completes or the stream's `flush_timeout_ms`
+  /// elapses (default 5 minutes), so call it at a controlled point rather than
+  /// leaving it to the destructor. Throws `ZerobusException` if the close
+  /// fails.
+  void close();
+
+  /// Whether `close()` has already been called (locally observed).
+  bool is_closed() const noexcept { return handle_ == nullptr; }
+
+ private:
+  friend class Sdk;
+  Stream(CZerobusStream* handle, std::shared_ptr<HeadersProvider> provider)
+      : handle_(handle), provider_(std::move(provider)) {}
+
+  CZerobusStream* handle_;
+  // Kept alive for the stream's lifetime; the FFI callback holds a raw pointer
+  // into this object.
+  std::shared_ptr<HeadersProvider> provider_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_STREAM_HPP

--- a/cpp/include/zerobus/version.hpp
+++ b/cpp/include/zerobus/version.hpp
@@ -1,0 +1,17 @@
+#ifndef ZEROBUS_VERSION_HPP
+#define ZEROBUS_VERSION_HPP
+
+#define ZEROBUS_CPP_VERSION_MAJOR 0
+#define ZEROBUS_CPP_VERSION_MINOR 1
+#define ZEROBUS_CPP_VERSION_PATCH 0
+#define ZEROBUS_CPP_VERSION "0.1.0"
+
+namespace zerobus {
+
+/// The Zerobus C++ SDK version string (e.g. "0.1.0"). Sent as the default
+/// `user-agent` SDK identifier prefix (`zerobus-sdk-cpp/<version>`).
+inline const char* version() { return ZEROBUS_CPP_VERSION; }
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_VERSION_HPP

--- a/cpp/include/zerobus/zerobus.hpp
+++ b/cpp/include/zerobus/zerobus.hpp
@@ -8,6 +8,7 @@
 /// which in turn wraps the Rust core. All operations report failure by throwing
 /// `zerobus::ZerobusException`.
 
+#include "zerobus/arrow_stream.hpp"
 #include "zerobus/config.hpp"
 #include "zerobus/error.hpp"
 #include "zerobus/headers_provider.hpp"

--- a/cpp/include/zerobus/zerobus.hpp
+++ b/cpp/include/zerobus/zerobus.hpp
@@ -1,0 +1,20 @@
+#ifndef ZEROBUS_HPP
+#define ZEROBUS_HPP
+
+/// Umbrella header for the Zerobus C++ SDK. Include this to pull in the full
+/// public API.
+///
+/// The SDK is a thin, RAII C++ wrapper over the Zerobus C FFI (`zerobus.h`),
+/// which in turn wraps the Rust core. All operations report failure by throwing
+/// `zerobus::ZerobusException`.
+
+#include "zerobus/config.hpp"
+#include "zerobus/error.hpp"
+#include "zerobus/headers_provider.hpp"
+#include "zerobus/proto_schema.hpp"
+#include "zerobus/record.hpp"
+#include "zerobus/sdk.hpp"
+#include "zerobus/stream.hpp"
+#include "zerobus/version.hpp"
+
+#endif  // ZEROBUS_HPP

--- a/cpp/lsan_suppressions.txt
+++ b/cpp/lsan_suppressions.txt
@@ -1,0 +1,14 @@
+# LeakSanitizer suppressions for the C++ SDK test suite.
+#
+# These cover allocations the Rust FFI core intentionally keeps for the whole
+# process lifetime — they are reachable, not lost, so flagging them as leaks is
+# a false positive. The suppressions are deliberately narrow: they match only
+# the offending globals, leaving real wrapper leaks (a missed
+# zerobus_free_error_message, a leaked CHeader array, a leaked proto-bytes
+# buffer) detectable.
+#
+# `RUNTIME` and `HEADER_KEY_CACHE` are `once_cell::sync::Lazy` globals in
+# rust/ffi/src/common.rs that are never dropped; the tokio runtime they hold
+# spins up worker threads whose allocations stay live until exit.
+leak:once_cell
+leak:tokio

--- a/cpp/src/arrow_stream.cpp
+++ b/cpp/src/arrow_stream.cpp
@@ -1,0 +1,132 @@
+// Implementation of ArrowStream (declared in zerobus/arrow_stream.hpp), the
+// Beta Arrow Flight ingestion path.
+//
+// Each method forwards to the zerobus_arrow_stream_* C FFI entry points and
+// routes failures through detail::ResultGuard. get_unacked_batches copies the
+// FFI-owned batch payloads out before freeing the returned array. The
+// destructor closes best-effort (swallowing errors); close() surfaces them.
+// Public API documentation lives on the header.
+#include "zerobus/arrow_stream.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "detail/ffi_util.hpp"
+
+namespace zerobus {
+
+// Best-effort graceful close in the destructor (errors are swallowed — a
+// destructor must not throw), then free the Rust-owned handle.
+ArrowStream::~ArrowStream() {
+  if (handle_ != nullptr) {
+    detail::ResultGuard guard;
+    zerobus_arrow_stream_close(handle_, guard.ptr());
+    zerobus_arrow_stream_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+// Move carries the handle and the headers-provider together, nulling the source
+// so the handle is closed/freed exactly once.
+ArrowStream::ArrowStream(ArrowStream&& other) noexcept
+    : handle_(other.handle_), provider_(std::move(other.provider_)) {
+  other.handle_ = nullptr;
+}
+
+ArrowStream& ArrowStream::operator=(ArrowStream&& other) noexcept {
+  if (this != &other) {
+    // Close + free any stream we already hold before adopting other's.
+    if (handle_ != nullptr) {
+      detail::ResultGuard guard;
+      zerobus_arrow_stream_close(handle_, guard.ptr());
+      zerobus_arrow_stream_free(handle_);
+    }
+    handle_ = other.handle_;
+    provider_ = std::move(other.provider_);
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+// Ingest one batch (schema + records as Arrow IPC bytes); returns the assigned
+// offset. Like the Stream ingest path, failure comes back via the ResultGuard.
+std::int64_t ArrowStream::ingest_batch(const std::uint8_t* ipc_bytes,
+                                       std::size_t len) {
+  detail::ResultGuard guard;
+  std::int64_t offset =
+      zerobus_arrow_stream_ingest_batch(handle_, ipc_bytes, len, guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+// Vector overload forwarding to the (pointer, length) form.
+std::int64_t ArrowStream::ingest_batch(
+    const std::vector<std::uint8_t>& ipc_bytes) {
+  return ingest_batch(ipc_bytes.data(), ipc_bytes.size());
+}
+
+void ArrowStream::wait_for_offset(std::int64_t offset) {
+  detail::ResultGuard guard;
+  zerobus_arrow_stream_wait_for_offset(handle_, offset, guard.ptr());
+  guard.throw_if_error();
+}
+
+void ArrowStream::flush() {
+  detail::ResultGuard guard;
+  zerobus_arrow_stream_flush(handle_, guard.ptr());
+  guard.throw_if_error();
+}
+
+// Copy each unacked batch out of the FFI-owned array (parallel batches/lengths
+// arrays) into owning vectors, then free the array — the borrowed bytes are
+// only valid until that free.
+std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
+  detail::ResultGuard guard;
+  CArrowBatchArray array =
+      zerobus_arrow_stream_get_unacked_batches(handle_, guard.ptr());
+  guard.throw_if_error();
+
+  std::vector<std::vector<std::uint8_t>> out;
+  if (array.batches != nullptr && array.count > 0) {
+    out.reserve(array.count);
+    for (std::size_t i = 0; i < array.count; ++i) {
+      const std::uint8_t* bytes = array.batches[i];
+      std::size_t len = array.lengths[i];
+      std::vector<std::uint8_t> batch;
+      if (bytes != nullptr && len > 0) {
+        batch.assign(bytes, bytes + len);
+      }
+      out.push_back(std::move(batch));
+    }
+  }
+  zerobus_arrow_free_batch_array(array);
+  return out;
+}
+
+// Explicit close: surfaces a failed flush/close by throwing (the destructor
+// does not). Idempotent; the handle is captured and nulled before the FFI call
+// so it is freed exactly once whether or not the close succeeds.
+void ArrowStream::close() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  CArrowStream* h = handle_;
+  handle_ = nullptr;
+  detail::ResultGuard guard;
+  bool ok = zerobus_arrow_stream_close(h, guard.ptr());
+  zerobus_arrow_stream_free(h);
+  if (!ok) {
+    guard.throw_if_error();
+  }
+}
+
+// Once close()/destruction has nulled the handle the stream is closed; while it
+// is still live, defer to the core's own closed state via the FFI.
+bool ArrowStream::is_closed() const noexcept {
+  if (handle_ == nullptr) {
+    return true;
+  }
+  return zerobus_arrow_stream_is_closed(handle_);
+}
+
+}  // namespace zerobus

--- a/cpp/src/arrow_stream.cpp
+++ b/cpp/src/arrow_stream.cpp
@@ -104,20 +104,27 @@ std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
 }
 
 // Explicit close: surfaces a failed flush/close by throwing (the destructor
-// does not). Idempotent; the handle is captured and nulled before the FFI call
-// so it is freed exactly once whether or not the close succeeds.
+// does not). Idempotent via the null-handle guard.
+//
+// On failure the handle is deliberately kept (not freed, handle_ left non-null)
+// so the caller can still recover buffered batches via get_unacked_batches()
+// and retry close(); the destructor frees it as a last resort. Only a
+// successful close frees the handle and marks the stream closed. (Mirrors
+// Stream::close().)
 void ArrowStream::close() {
   if (handle_ == nullptr) {
     return;
   }
-  CArrowStream* h = handle_;
-  handle_ = nullptr;
   detail::ResultGuard guard;
-  bool ok = zerobus_arrow_stream_close(h, guard.ptr());
-  zerobus_arrow_stream_free(h);
+  bool ok = zerobus_arrow_stream_close(handle_, guard.ptr());
   if (!ok) {
+    // Keep handle_ alive for recovery, then surface the error.
     guard.throw_if_error();
+    // Fallback if close reported failure without setting an error message.
+    throw ZerobusException("failed to close Arrow stream", false);
   }
+  zerobus_arrow_stream_free(handle_);
+  handle_ = nullptr;
 }
 
 // Once close()/destruction has nulled the handle the stream is closed; while it

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -38,6 +38,26 @@ inline CStreamConfigurationOptions to_c(const StreamOptions& opts) {
   return c;
 }
 
+/// Build the C Arrow stream-config struct from `ArrowStreamOptions`.
+inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
+  CArrowStreamConfigurationOptions c = zerobus_arrow_get_default_config();
+  c.max_inflight_batches = opts.max_inflight_batches;
+  c.recovery = opts.recovery;
+  c.recovery_timeout_ms = opts.recovery_timeout_ms;
+  c.recovery_backoff_ms = opts.recovery_backoff_ms;
+  c.recovery_retries = opts.recovery_retries;
+  c.server_lack_of_ack_timeout_ms = opts.server_lack_of_ack_timeout_ms;
+  c.flush_timeout_ms = opts.flush_timeout_ms;
+  c.connection_timeout_ms = opts.connection_timeout_ms;
+  c.ipc_compression = static_cast<std::int32_t>(opts.ipc_compression);
+  // -1 sentinel = "wait full server duration" (no explicit cap).
+  c.stream_paused_max_wait_time_ms =
+      opts.stream_paused_max_wait_time_ms.has_value()
+          ? *opts.stream_paused_max_wait_time_ms
+          : -1;
+  return c;
+}
+
 }  // namespace detail
 }  // namespace zerobus
 

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -1,0 +1,44 @@
+#ifndef ZEROBUS_DETAIL_CONFIG_CONVERT_HPP
+#define ZEROBUS_DETAIL_CONFIG_CONVERT_HPP
+
+#include "detail/ffi_util.hpp"
+#include "zerobus/config.hpp"
+
+namespace zerobus {
+namespace detail {
+
+/// Build the C stream-config struct. Seeds from the live FFI defaults (so any
+/// field this wrapper doesn't know about keeps its default) then overrides each
+/// known field. Unlike the Go wrapper there is no zero-value ambiguity for
+/// `recovery`: it is always written explicitly.
+inline CStreamConfigurationOptions to_c(const StreamOptions& opts) {
+  CStreamConfigurationOptions c = zerobus_get_default_config();
+  c.max_inflight_requests = opts.max_inflight_requests;
+  c.recovery = opts.recovery;
+  c.recovery_timeout_ms = opts.recovery_timeout_ms;
+  c.recovery_backoff_ms = opts.recovery_backoff_ms;
+  c.recovery_retries = opts.recovery_retries;
+  c.server_lack_of_ack_timeout_ms = opts.server_lack_of_ack_timeout_ms;
+  c.flush_timeout_ms = opts.flush_timeout_ms;
+  c.record_type = static_cast<std::int32_t>(opts.record_type);
+  if (opts.stream_paused_max_wait_time_ms.has_value()) {
+    c.has_stream_paused_max_wait_time_ms = true;
+    c.stream_paused_max_wait_time_ms = *opts.stream_paused_max_wait_time_ms;
+  } else {
+    c.has_stream_paused_max_wait_time_ms = false;
+    c.stream_paused_max_wait_time_ms = 0;
+  }
+  if (opts.callback_max_wait_time_ms.has_value()) {
+    c.has_callback_max_wait_time_ms = true;
+    c.callback_max_wait_time_ms = *opts.callback_max_wait_time_ms;
+  } else {
+    c.has_callback_max_wait_time_ms = false;
+    c.callback_max_wait_time_ms = 0;
+  }
+  return c;
+}
+
+}  // namespace detail
+}  // namespace zerobus
+
+#endif  // ZEROBUS_DETAIL_CONFIG_CONVERT_HPP

--- a/cpp/src/detail/ffi_util.hpp
+++ b/cpp/src/detail/ffi_util.hpp
@@ -1,0 +1,66 @@
+#ifndef ZEROBUS_DETAIL_FFI_UTIL_HPP
+#define ZEROBUS_DETAIL_FFI_UTIL_HPP
+
+// The cbindgen-generated C header. It declares everything inside
+// `namespace zerobus { extern "C" { ... } }`, so the C symbols are referenced
+// from this SDK's `zerobus` namespace unqualified.
+#include <string>
+#include <utility>
+
+#include "zerobus.h"
+#include "zerobus/error.hpp"
+
+namespace zerobus {
+namespace detail {
+
+/// Owns a `CResult` for the duration of one FFI call and converts failure into
+/// a `ZerobusException`. The error string allocated by the Rust core is always
+/// freed (via `zerobus_free_error_message`) before throwing.
+class ResultGuard {
+ public:
+  ResultGuard() : result_{} {}
+
+  ~ResultGuard() {
+    // Defensive: if the message was set but never consumed (e.g. the caller
+    // chose not to call throw_if_error after an FFI call that wrote one),
+    // still free it to avoid a leak.
+    if (result_.error_message != nullptr) {
+      zerobus_free_error_message(result_.error_message);
+      result_.error_message = nullptr;
+    }
+  }
+
+  ResultGuard(const ResultGuard&) = delete;
+  ResultGuard& operator=(const ResultGuard&) = delete;
+
+  CResult* ptr() { return &result_; }
+
+  /// Throw a ZerobusException if the FFI reported failure. Frees the C error
+  /// string either way. Safe to call multiple times.
+  void throw_if_error() {
+    if (!result_.success) {
+      std::string message = result_.error_message != nullptr
+                                ? std::string(result_.error_message)
+                                : std::string("unknown Zerobus error");
+      bool retryable = result_.is_retryable;
+      if (result_.error_message != nullptr) {
+        zerobus_free_error_message(result_.error_message);
+        result_.error_message = nullptr;
+      }
+      throw ZerobusException(std::move(message), retryable);
+    }
+    // Success: there should be no message, but free defensively.
+    if (result_.error_message != nullptr) {
+      zerobus_free_error_message(result_.error_message);
+      result_.error_message = nullptr;
+    }
+  }
+
+ private:
+  CResult result_;
+};
+
+}  // namespace detail
+}  // namespace zerobus
+
+#endif  // ZEROBUS_DETAIL_FFI_UTIL_HPP

--- a/cpp/src/detail/headers_callback.hpp
+++ b/cpp/src/detail/headers_callback.hpp
@@ -1,0 +1,20 @@
+#ifndef ZEROBUS_DETAIL_HEADERS_CALLBACK_HPP
+#define ZEROBUS_DETAIL_HEADERS_CALLBACK_HPP
+
+#include "detail/ffi_util.hpp"
+
+namespace zerobus {
+namespace detail {
+
+/// C trampoline matching `HeadersProviderCallback`. `user_data` must point to a
+/// live `HeadersProvider`. Invokes `get_headers()` and marshals the result into
+/// a `CHeaders` whose buffers are allocated so the Rust core's
+/// `zerobus_free_headers` can release them (keys/values via the C string
+/// allocator, the array via `malloc`). Exceptions are caught and reported via
+/// `CHeaders.error_message`.
+extern "C" CHeaders zerobus_cpp_headers_trampoline(void* user_data);
+
+}  // namespace detail
+}  // namespace zerobus
+
+#endif  // ZEROBUS_DETAIL_HEADERS_CALLBACK_HPP

--- a/cpp/src/headers_callback.cpp
+++ b/cpp/src/headers_callback.cpp
@@ -1,0 +1,105 @@
+// The extern "C" trampoline that lets the Rust core call back into a C++
+// HeadersProvider (declared in detail/headers_callback.hpp).
+//
+// The core invokes get_headers() through this function and the result is
+// marshalled into a CHeaders whose buffers are allocated so the core's
+// zerobus_free_headers can release them: the array via calloc and each
+// key/value via a malloc'd C string, matching the Go wrapper's contract (see
+// zerobus_free_headers in rust/ffi/src/arrow.rs). Exceptions never cross the
+// boundary — they are caught and reported as CHeaders.error_message.
+#include "detail/headers_callback.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+
+#include "zerobus/headers_provider.hpp"
+
+namespace zerobus {
+namespace detail {
+
+namespace {
+
+// Duplicate a std::string into a NUL-terminated, malloc-allocated C string.
+// The Rust core frees these via the C string allocator (its default global
+// allocator delegates to malloc/free), matching the Go wrapper's C.CString use.
+char* dup_cstring(const std::string& s) {
+  char* out = static_cast<char*>(std::malloc(s.size() + 1));
+  if (out == nullptr) {
+    return nullptr;
+  }
+  std::memcpy(out, s.data(), s.size());
+  out[s.size()] = '\0';
+  return out;
+}
+
+CHeaders make_error(const std::string& message) {
+  CHeaders headers{};
+  headers.headers = nullptr;
+  headers.count = 0;
+  headers.error_message = dup_cstring(message);
+  return headers;
+}
+
+void free_marshaled_headers(CHeader* headers, std::size_t count) {
+  if (headers == nullptr) {
+    return;
+  }
+  for (std::size_t i = 0; i < count; ++i) {
+    std::free(headers[i].key);
+    std::free(headers[i].value);
+  }
+  std::free(headers);
+}
+
+}  // namespace
+
+extern "C" CHeaders zerobus_cpp_headers_trampoline(void* user_data) {
+  if (user_data == nullptr) {
+    return make_error("null headers provider");
+  }
+  auto* provider = static_cast<HeadersProvider*>(user_data);
+
+  std::map<std::string, std::string> headers;
+  try {
+    headers = provider->get_headers();
+  } catch (const std::exception& e) {
+    return make_error(e.what());
+  } catch (...) {
+    return make_error("headers provider threw a non-std::exception");
+  }
+
+  CHeaders result{};
+  result.error_message = nullptr;
+  result.count = 0;
+  result.headers = nullptr;
+
+  if (headers.empty()) {
+    return result;
+  }
+
+  auto* arr =
+      static_cast<CHeader*>(std::calloc(headers.size(), sizeof(CHeader)));
+  if (arr == nullptr) {
+    return make_error("out of memory marshalling headers");
+  }
+
+  std::size_t i = 0;
+  for (const auto& kv : headers) {
+    arr[i].key = dup_cstring(kv.first);
+    arr[i].value = dup_cstring(kv.second);
+    if (arr[i].key == nullptr || arr[i].value == nullptr) {
+      free_marshaled_headers(arr, i + 1);
+      return make_error("out of memory marshalling headers");
+    }
+    ++i;
+  }
+
+  result.headers = arr;
+  result.count = headers.size();
+  return result;
+}
+
+}  // namespace detail
+}  // namespace zerobus

--- a/cpp/src/proto_schema.cpp
+++ b/cpp/src/proto_schema.cpp
@@ -1,0 +1,93 @@
+// Implementation of ProtoSchema (declared in zerobus/proto_schema.hpp).
+//
+// Wraps the zerobus_proto_schema_* C FFI: from_uc_json builds the schema handle
+// from Unity Catalog table metadata, descriptor_bytes copies out the borrowed
+// descriptor bytes, and encode_json copies out (then frees, via
+// zerobus_free_proto_bytes) the FFI-allocated protobuf buffer. Public API
+// documentation lives on the header.
+#include "zerobus/proto_schema.hpp"
+
+#include <utility>
+
+#include "detail/ffi_util.hpp"
+
+namespace zerobus {
+
+// Build the schema handle from Unity Catalog table metadata JSON. A null handle
+// signals failure; throw the FFI's error if it set one, else a generic message.
+ProtoSchema ProtoSchema::from_uc_json(const std::string& uc_table_json) {
+  detail::ResultGuard guard;
+  CZerobusProtoSchema* handle =
+      zerobus_proto_schema_from_uc_json(uc_table_json.c_str(), guard.ptr());
+  if (handle == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to build proto schema from UC JSON", false);
+  }
+  return ProtoSchema(handle);
+}
+
+// Free the Rust-owned schema handle.
+ProtoSchema::~ProtoSchema() {
+  if (handle_ != nullptr) {
+    zerobus_proto_schema_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+// Handle-stealing move; the source is nulled so the handle is freed once.
+ProtoSchema::ProtoSchema(ProtoSchema&& other) noexcept
+    : handle_(other.handle_) {
+  other.handle_ = nullptr;
+}
+
+ProtoSchema& ProtoSchema::operator=(ProtoSchema&& other) noexcept {
+  if (this != &other) {
+    if (handle_ != nullptr) {
+      zerobus_proto_schema_free(handle_);
+    }
+    handle_ = other.handle_;
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+// Return the table's serialized DescriptorProto. The FFI hands back a pointer
+// borrowed from the schema (not a fresh allocation), so this copies it into an
+// owned vector and there is nothing to free. An empty/absent descriptor yields
+// an empty vector. Const and safe to call from concurrent readers.
+std::vector<std::uint8_t> ProtoSchema::descriptor_bytes() const {
+  std::uintptr_t len = 0;
+  const std::uint8_t* bytes =
+      zerobus_proto_schema_descriptor_bytes(handle_, &len);
+  if (bytes == nullptr || len == 0) {
+    return {};
+  }
+  // Copy out of the SDK-owned buffer; the borrow is only valid until free.
+  return std::vector<std::uint8_t>(bytes, bytes + len);
+}
+
+// Encode one JSON record to protobuf bytes using this schema. Unlike
+// descriptor_bytes(), the FFI allocates the output buffer and transfers
+// ownership, so we copy it out and then release it with
+// zerobus_free_proto_bytes (even on the empty-result path). A false return
+// means encoding failed.
+std::vector<std::uint8_t> ProtoSchema::encode_json(
+    const std::string& record_json) const {
+  detail::ResultGuard guard;
+  std::uint8_t* out_data = nullptr;
+  std::uintptr_t out_len = 0;
+  bool ok = zerobus_proto_schema_encode_json(handle_, record_json.c_str(),
+                                             &out_data, &out_len, guard.ptr());
+  if (!ok) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to encode JSON record", false);
+  }
+  std::vector<std::uint8_t> result;
+  if (out_data != nullptr && out_len > 0) {
+    result.assign(out_data, out_data + out_len);
+  }
+  zerobus_free_proto_bytes(out_data, out_len);
+  return result;
+}
+
+}  // namespace zerobus

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -1,0 +1,210 @@
+// Implementation of Sdk and SdkBuilder (declared in zerobus/sdk.hpp).
+//
+// Each method forwards to the C FFI (zerobus.h): the builder accumulates
+// configuration on an opaque CZerobusSdkBuilder and build() consumes it into a
+// CZerobusSdk, while create_stream hands the configured options across the
+// boundary. Every fallible call routes its CResult through
+// detail::ResultGuard, which converts failure into a ZerobusException and frees
+// the C error string. Public API documentation lives on the declarations in the
+// header; comments here cover only implementation details.
+#include "zerobus/sdk.hpp"
+
+#include <utility>
+
+#include "detail/config_convert.hpp"
+#include "detail/ffi_util.hpp"
+#include "detail/headers_callback.hpp"
+#include "zerobus/version.hpp"
+
+namespace zerobus {
+
+namespace {
+
+// Pointer to the descriptor bytes, or null for a JSON stream.
+const std::uint8_t* descriptor_ptr(const std::vector<std::uint8_t>& d) {
+  return d.empty() ? nullptr : d.data();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// SdkBuilder
+// ---------------------------------------------------------------------------
+
+// Allocate a fresh FFI builder and stamp the default user-agent prefix. The
+// builder handle is declared as a plain void* in the header (see sdk.hpp), so
+// every use casts it back to the opaque CZerobusSdkBuilder* from zerobus.h.
+SdkBuilder::SdkBuilder() : builder_(zerobus_sdk_builder_new()) {
+  auto* b = static_cast<CZerobusSdkBuilder*>(builder_);
+  std::string id = std::string("zerobus-sdk-cpp/") + ZEROBUS_CPP_VERSION;
+  zerobus_sdk_builder_sdk_identifier(b, id.c_str());
+}
+
+// Free the builder unless it was already consumed by build() (which nulls it).
+SdkBuilder::~SdkBuilder() {
+  if (builder_ != nullptr) {
+    zerobus_sdk_builder_free(static_cast<CZerobusSdkBuilder*>(builder_));
+    builder_ = nullptr;
+  }
+}
+
+// Move steals the opaque pointer and nulls the source, so the FFI handle is
+// owned — and ultimately freed — by exactly one SdkBuilder.
+SdkBuilder::SdkBuilder(SdkBuilder&& other) noexcept : builder_(other.builder_) {
+  other.builder_ = nullptr;
+}
+
+SdkBuilder& SdkBuilder::operator=(SdkBuilder&& other) noexcept {
+  if (this != &other) {
+    // Free any builder we already hold before taking over other's.
+    if (builder_ != nullptr) {
+      zerobus_sdk_builder_free(static_cast<CZerobusSdkBuilder*>(builder_));
+    }
+    builder_ = other.builder_;
+    other.builder_ = nullptr;
+  }
+  return *this;
+}
+
+// The configuration setters below each forward their value to the matching
+// zerobus_sdk_builder_* FFI call and return *this so calls can be chained. They
+// are infallible at this layer; an invalid value (e.g. a malformed endpoint)
+// surfaces later, when build() is called.
+SdkBuilder& SdkBuilder::endpoint(const std::string& value) {
+  zerobus_sdk_builder_endpoint(static_cast<CZerobusSdkBuilder*>(builder_),
+                               value.c_str());
+  return *this;
+}
+
+SdkBuilder& SdkBuilder::unity_catalog_url(const std::string& value) {
+  zerobus_sdk_builder_unity_catalog_url(
+      static_cast<CZerobusSdkBuilder*>(builder_), value.c_str());
+  return *this;
+}
+
+SdkBuilder& SdkBuilder::sdk_identifier(const std::string& value) {
+  zerobus_sdk_builder_sdk_identifier(static_cast<CZerobusSdkBuilder*>(builder_),
+                                     value.c_str());
+  return *this;
+}
+
+SdkBuilder& SdkBuilder::application_name(const std::string& value) {
+  zerobus_sdk_builder_application_name(
+      static_cast<CZerobusSdkBuilder*>(builder_), value.c_str());
+  return *this;
+}
+
+SdkBuilder& SdkBuilder::disable_tls() {
+  zerobus_sdk_builder_disable_tls(static_cast<CZerobusSdkBuilder*>(builder_));
+  return *this;
+}
+
+// Consume the builder into an Sdk. The FFI takes ownership of the builder and
+// frees it on both the success and failure paths, so we null builder_ up front
+// to keep the destructor from double-freeing it.
+Sdk SdkBuilder::build() {
+  detail::ResultGuard guard;
+  CZerobusSdk* sdk = zerobus_sdk_builder_build(
+      static_cast<CZerobusSdkBuilder*>(builder_), guard.ptr());
+  builder_ = nullptr;
+  if (sdk == nullptr) {
+    // A null handle means failure: throw the FFI's error if it set one.
+    guard.throw_if_error();
+    // Fallback if the FFI returned null without an error message.
+    throw ZerobusException("failed to build Zerobus SDK", false);
+  }
+  return Sdk(sdk);
+}
+
+// ---------------------------------------------------------------------------
+// Sdk
+// ---------------------------------------------------------------------------
+
+SdkBuilder Sdk::builder() { return SdkBuilder(); }
+
+// Convenience path equivalent to building with only endpoint + UC URL set. Like
+// build(), a null handle signals failure.
+Sdk Sdk::create(const std::string& endpoint,
+                const std::string& unity_catalog_url) {
+  detail::ResultGuard guard;
+  CZerobusSdk* sdk =
+      zerobus_sdk_new(endpoint.c_str(), unity_catalog_url.c_str(), guard.ptr());
+  if (sdk == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Zerobus SDK", false);
+  }
+  return Sdk(sdk);
+}
+
+// Release the Rust-owned SDK handle. Streams hold their own handles, so an Sdk
+// may be destroyed independently of the streams it created.
+Sdk::~Sdk() {
+  if (handle_ != nullptr) {
+    zerobus_sdk_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+// Same handle-stealing move contract as SdkBuilder: the source is nulled so the
+// handle is freed exactly once.
+Sdk::Sdk(Sdk&& other) noexcept : handle_(other.handle_) {
+  other.handle_ = nullptr;
+}
+
+Sdk& Sdk::operator=(Sdk&& other) noexcept {
+  if (this != &other) {
+    if (handle_ != nullptr) {
+      zerobus_sdk_free(handle_);
+    }
+    handle_ = other.handle_;
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+// Create an OAuth-authenticated proto/JSON stream. The descriptor pointer is
+// null for a JSON stream (descriptor_ptr() maps an empty vector to null), and
+// the StreamOptions are converted to the C struct just for this call. The
+// resulting Stream owns no headers provider, hence the null second argument.
+Stream Sdk::create_stream(const TableProperties& table,
+                          const std::string& client_id,
+                          const std::string& client_secret,
+                          const StreamOptions& options) {
+  detail::ResultGuard guard;
+  CStreamConfigurationOptions copts = detail::to_c(options);
+  CZerobusStream* stream = zerobus_sdk_create_stream(
+      handle_, table.table_name.c_str(), descriptor_ptr(table.descriptor_proto),
+      table.descriptor_proto.size(), client_id.c_str(), client_secret.c_str(),
+      &copts, guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create stream", false);
+  }
+  return Stream(stream, nullptr);
+}
+
+// Same as above but authenticated by a custom headers provider. We validate the
+// pointer here (the FFI would otherwise receive a null callback target), pass
+// the raw provider pointer as the trampoline's user_data, and hand the
+// shared_ptr to the Stream so the provider outlives every callback the core
+// makes through it.
+Stream Sdk::create_stream(const TableProperties& table,
+                          std::shared_ptr<HeadersProvider> headers_provider,
+                          const StreamOptions& options) {
+  if (headers_provider == nullptr) {
+    throw ZerobusException("headers_provider must not be null", false);
+  }
+  detail::ResultGuard guard;
+  CStreamConfigurationOptions copts = detail::to_c(options);
+  CZerobusStream* stream = zerobus_sdk_create_stream_with_headers_provider(
+      handle_, table.table_name.c_str(), descriptor_ptr(table.descriptor_proto),
+      table.descriptor_proto.size(), detail::zerobus_cpp_headers_trampoline,
+      headers_provider.get(), &copts, guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create stream", false);
+  }
+  return Stream(stream, std::move(headers_provider));
+}
+
+}  // namespace zerobus

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -2,8 +2,8 @@
 //
 // Each method forwards to the C FFI (zerobus.h): the builder accumulates
 // configuration on an opaque CZerobusSdkBuilder and build() consumes it into a
-// CZerobusSdk, while create_stream hands the configured options across the
-// boundary. Every fallible call routes its CResult through
+// CZerobusSdk, while create_stream / create_arrow_stream hand the configured
+// options across the boundary. Every fallible call routes its CResult through
 // detail::ResultGuard, which converts failure into a ZerobusException and frees
 // the C error string. Public API documentation lives on the declarations in the
 // header; comments here cover only implementation details.
@@ -23,6 +23,15 @@ namespace {
 // Pointer to the descriptor bytes, or null for a JSON stream.
 const std::uint8_t* descriptor_ptr(const std::vector<std::uint8_t>& d) {
   return d.empty() ? nullptr : d.data();
+}
+
+// Pointer to the bytes, or null when empty. Used for the Arrow schema, whose
+// emptiness is validated separately before this is called.
+const std::uint8_t* non_empty_ptr(const std::vector<std::uint8_t>& bytes) {
+  if (bytes.empty()) {
+    return nullptr;
+  }
+  return bytes.data();
 }
 
 }  // namespace
@@ -205,6 +214,60 @@ Stream Sdk::create_stream(const TableProperties& table,
     throw ZerobusException("failed to create stream", false);
   }
   return Stream(stream, std::move(headers_provider));
+}
+
+// Create an OAuth-authenticated Arrow Flight stream (Beta). The schema IPC
+// bytes are required (an Arrow stream has no JSON fallback), so reject an empty
+// schema before crossing the FFI rather than letting the core fail less
+// clearly.
+ArrowStream Sdk::create_arrow_stream(
+    const std::string& table_name,
+    const std::vector<std::uint8_t>& schema_ipc_bytes,
+    const std::string& client_id, const std::string& client_secret,
+    const ArrowStreamOptions& options) {
+  if (schema_ipc_bytes.empty()) {
+    throw ZerobusException("schema_ipc_bytes must not be empty", false);
+  }
+  detail::ResultGuard guard;
+  CArrowStreamConfigurationOptions copts = detail::to_c(options);
+  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  CArrowStream* stream = zerobus_sdk_create_arrow_stream(
+      handle_, table_name.c_str(), schema_ptr, schema_ipc_bytes.size(),
+      client_id.c_str(), client_secret.c_str(), &copts, guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Arrow stream", false);
+  }
+  return ArrowStream(stream, nullptr);
+}
+
+// Arrow Flight stream (Beta) authenticated by a custom headers provider. Both
+// the provider and the schema bytes are validated up front; as with the proto
+// path, the Stream keeps the provider's shared_ptr alive for the callback's
+// lifetime.
+ArrowStream Sdk::create_arrow_stream(
+    const std::string& table_name,
+    const std::vector<std::uint8_t>& schema_ipc_bytes,
+    std::shared_ptr<HeadersProvider> headers_provider,
+    const ArrowStreamOptions& options) {
+  if (headers_provider == nullptr) {
+    throw ZerobusException("headers_provider must not be null", false);
+  }
+  if (schema_ipc_bytes.empty()) {
+    throw ZerobusException("schema_ipc_bytes must not be empty", false);
+  }
+  detail::ResultGuard guard;
+  CArrowStreamConfigurationOptions copts = detail::to_c(options);
+  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  CArrowStream* stream = zerobus_sdk_create_arrow_stream_with_headers_provider(
+      handle_, table_name.c_str(), schema_ptr, schema_ipc_bytes.size(),
+      detail::zerobus_cpp_headers_trampoline, headers_provider.get(), &copts,
+      guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Arrow stream", false);
+  }
+  return ArrowStream(stream, std::move(headers_provider));
 }
 
 }  // namespace zerobus

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -1,0 +1,234 @@
+// Implementation of Stream (declared in zerobus/stream.hpp).
+//
+// A thin forwarding layer over the zerobus_stream_* C FFI entry points. The
+// file-local helpers build the small parallel pointer/length arrays the batch
+// entry points expect, and every fallible call routes its CResult through
+// detail::ResultGuard. The destructor and move-assignment close best-effort
+// (swallowing errors), whereas close() surfaces them. Public API documentation
+// lives on the header; comments here cover only implementation details.
+#include "zerobus/stream.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "detail/ffi_util.hpp"
+
+namespace zerobus {
+
+namespace {
+
+// An empty payload still needs a valid, non-null pointer to pass across the FFI
+// (paired with length 0); hand out the address of a static sentinel byte rather
+// than nullptr or a dangling data() result.
+const std::uint8_t* ptr_or_sentinel(const std::vector<std::uint8_t>& bytes) {
+  static const std::uint8_t kEmptyPayloadSentinel = 0;
+  return bytes.empty() ? &kEmptyPayloadSentinel : bytes.data();
+}
+
+// Build the parallel pointer/length arrays the batch FFI entry points expect.
+struct ProtoBatchView {
+  std::vector<const std::uint8_t*> ptrs;
+  std::vector<std::uintptr_t> lens;
+};
+
+ProtoBatchView make_proto_batch(
+    const std::vector<std::vector<std::uint8_t>>& records) {
+  ProtoBatchView v;
+  v.ptrs.reserve(records.size());
+  v.lens.reserve(records.size());
+  for (const auto& r : records) {
+    v.ptrs.push_back(ptr_or_sentinel(r));
+    v.lens.push_back(r.size());
+  }
+  return v;
+}
+
+// JSON records cross the FFI as an array of NUL-terminated C strings, so unlike
+// the proto path there is no parallel length array — only the pointers.
+struct JsonBatchView {
+  std::vector<const char*> ptrs;
+};
+
+JsonBatchView make_json_batch(const std::vector<std::string>& records) {
+  JsonBatchView v;
+  v.ptrs.reserve(records.size());
+  for (const auto& r : records) {
+    v.ptrs.push_back(r.c_str());
+  }
+  return v;
+}
+
+}  // namespace
+
+Stream::~Stream() {
+  if (handle_ != nullptr) {
+    // Best-effort graceful close; never throw from a destructor.
+    detail::ResultGuard guard;
+    zerobus_stream_close(handle_, guard.ptr());
+    zerobus_stream_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+// Move transfers both the handle and the headers-provider that must outlive it,
+// nulling the source handle so only one Stream ever closes/frees it.
+Stream::Stream(Stream&& other) noexcept
+    : handle_(other.handle_), provider_(std::move(other.provider_)) {
+  other.handle_ = nullptr;
+}
+
+Stream& Stream::operator=(Stream&& other) noexcept {
+  if (this != &other) {
+    // Close + free any stream we currently hold before adopting other's; the
+    // close is best-effort here since assignment cannot throw usefully.
+    if (handle_ != nullptr) {
+      detail::ResultGuard guard;
+      zerobus_stream_close(handle_, guard.ptr());
+      zerobus_stream_free(handle_);
+    }
+    handle_ = other.handle_;
+    provider_ = std::move(other.provider_);
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+// The ingest methods below share one shape: route a CResult through a
+// ResultGuard, call the matching zerobus_stream_* entry point, then
+// throw_if_error(). The blocking variants return the server-assigned offset;
+// the _nowait variants return void and only report argument-validation errors.
+
+std::int64_t Stream::ingest_proto_record(const std::uint8_t* data,
+                                         std::size_t len) {
+  detail::ResultGuard guard;
+  std::int64_t offset =
+      zerobus_stream_ingest_proto_record(handle_, data, len, guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+// Vector overload: adapt to the (pointer, length) form, substituting the
+// sentinel so an empty record still passes a non-null pointer.
+std::int64_t Stream::ingest_proto_record(
+    const std::vector<std::uint8_t>& data) {
+  return ingest_proto_record(ptr_or_sentinel(data), data.size());
+}
+
+std::int64_t Stream::ingest_json_record(const std::string& json) {
+  detail::ResultGuard guard;
+  std::int64_t offset =
+      zerobus_stream_ingest_json_record(handle_, json.c_str(), guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+std::int64_t Stream::ingest_proto_records(
+    const std::vector<std::vector<std::uint8_t>>& records) {
+  ProtoBatchView v = make_proto_batch(records);
+  detail::ResultGuard guard;
+  std::int64_t offset = zerobus_stream_ingest_proto_records(
+      handle_, v.ptrs.data(), v.lens.data(), v.ptrs.size(), guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+std::int64_t Stream::ingest_json_records(
+    const std::vector<std::string>& records) {
+  JsonBatchView v = make_json_batch(records);
+  detail::ResultGuard guard;
+  std::int64_t offset = zerobus_stream_ingest_json_records(
+      handle_, v.ptrs.data(), v.ptrs.size(), guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+void Stream::ingest_proto_record_nowait(const std::uint8_t* data,
+                                        std::size_t len) {
+  detail::ResultGuard guard;
+  zerobus_stream_ingest_proto_record_nowait(handle_, data, len, guard.ptr());
+  guard.throw_if_error();
+}
+
+void Stream::ingest_proto_record_nowait(const std::vector<std::uint8_t>& data) {
+  ingest_proto_record_nowait(ptr_or_sentinel(data), data.size());
+}
+
+void Stream::ingest_json_record_nowait(const std::string& json) {
+  detail::ResultGuard guard;
+  zerobus_stream_ingest_json_record_nowait(handle_, json.c_str(), guard.ptr());
+  guard.throw_if_error();
+}
+
+void Stream::ingest_proto_records_nowait(
+    const std::vector<std::vector<std::uint8_t>>& records) {
+  ProtoBatchView v = make_proto_batch(records);
+  detail::ResultGuard guard;
+  zerobus_stream_ingest_proto_records_nowait(
+      handle_, v.ptrs.data(), v.lens.data(), v.ptrs.size(), guard.ptr());
+  guard.throw_if_error();
+}
+
+void Stream::ingest_json_records_nowait(
+    const std::vector<std::string>& records) {
+  JsonBatchView v = make_json_batch(records);
+  detail::ResultGuard guard;
+  zerobus_stream_ingest_json_records_nowait(handle_, v.ptrs.data(),
+                                            v.ptrs.size(), guard.ptr());
+  guard.throw_if_error();
+}
+
+void Stream::wait_for_offset(std::int64_t offset) {
+  detail::ResultGuard guard;
+  zerobus_stream_wait_for_offset(handle_, offset, guard.ptr());
+  guard.throw_if_error();
+}
+
+void Stream::flush() {
+  detail::ResultGuard guard;
+  zerobus_stream_flush(handle_, guard.ptr());
+  guard.throw_if_error();
+}
+
+// Copy each record out of the FFI-owned array into owning UnackedRecords, then
+// free the array — the borrowed buffers are only valid until that free, so the
+// copy must happen first.
+std::vector<UnackedRecord> Stream::get_unacked_records() {
+  detail::ResultGuard guard;
+  CRecordArray array = zerobus_stream_get_unacked_records(handle_, guard.ptr());
+  // On error the array is empty; surface the error first.
+  guard.throw_if_error();
+
+  std::vector<UnackedRecord> out;
+  if (array.records != nullptr && array.len > 0) {
+    out.reserve(array.len);
+    for (std::size_t i = 0; i < array.len; ++i) {
+      const CRecord& rec = array.records[i];
+      std::vector<std::uint8_t> data;
+      if (rec.data != nullptr && rec.data_len > 0) {
+        data.assign(rec.data, rec.data + rec.data_len);
+      }
+      out.emplace_back(rec.is_json, std::move(data));
+    }
+  }
+  zerobus_free_record_array(array);
+  return out;
+}
+
+// Explicit close: unlike the destructor, this surfaces a failed flush/close by
+// throwing. Idempotent via the null-handle guard. The handle is freed whether
+// or not the close succeeds, so it is captured and nulled before the FFI call.
+void Stream::close() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  CZerobusStream* h = handle_;
+  handle_ = nullptr;  // Mark closed up front; the handle is freed regardless.
+  detail::ResultGuard guard;
+  bool ok = zerobus_stream_close(h, guard.ptr());
+  zerobus_stream_free(h);
+  if (!ok) {
+    guard.throw_if_error();
+  }
+}
+
+}  // namespace zerobus

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -95,8 +95,7 @@ Stream& Stream::operator=(Stream&& other) noexcept {
 
 // The ingest methods below share one shape: route a CResult through a
 // ResultGuard, call the matching zerobus_stream_* entry point, then
-// throw_if_error(). The blocking variants return the server-assigned offset;
-// the _nowait variants return void and only report argument-validation errors.
+// throw_if_error(), returning the server-assigned offset.
 
 std::int64_t Stream::ingest_proto_record(const std::uint8_t* data,
                                          std::size_t len) {
@@ -140,41 +139,6 @@ std::int64_t Stream::ingest_json_records(
       handle_, v.ptrs.data(), v.ptrs.size(), guard.ptr());
   guard.throw_if_error();
   return offset;
-}
-
-void Stream::ingest_proto_record_nowait(const std::uint8_t* data,
-                                        std::size_t len) {
-  detail::ResultGuard guard;
-  zerobus_stream_ingest_proto_record_nowait(handle_, data, len, guard.ptr());
-  guard.throw_if_error();
-}
-
-void Stream::ingest_proto_record_nowait(const std::vector<std::uint8_t>& data) {
-  ingest_proto_record_nowait(ptr_or_sentinel(data), data.size());
-}
-
-void Stream::ingest_json_record_nowait(const std::string& json) {
-  detail::ResultGuard guard;
-  zerobus_stream_ingest_json_record_nowait(handle_, json.c_str(), guard.ptr());
-  guard.throw_if_error();
-}
-
-void Stream::ingest_proto_records_nowait(
-    const std::vector<std::vector<std::uint8_t>>& records) {
-  ProtoBatchView v = make_proto_batch(records);
-  detail::ResultGuard guard;
-  zerobus_stream_ingest_proto_records_nowait(
-      handle_, v.ptrs.data(), v.lens.data(), v.ptrs.size(), guard.ptr());
-  guard.throw_if_error();
-}
-
-void Stream::ingest_json_records_nowait(
-    const std::vector<std::string>& records) {
-  JsonBatchView v = make_json_batch(records);
-  detail::ResultGuard guard;
-  zerobus_stream_ingest_json_records_nowait(handle_, v.ptrs.data(),
-                                            v.ptrs.size(), guard.ptr());
-  guard.throw_if_error();
 }
 
 void Stream::wait_for_offset(std::int64_t offset) {


### PR DESCRIPTION
## Summary

Adds the Arrow Flight ingestion surface (Beta) to the C++ SDK, peeled out of
the core SDK PR (split 4/6 from #415) so the core reviews as the GA proto/JSON
ingestion path only.

This PR adds:
- `ArrowStream` class — `include/zerobus/arrow_stream.hpp` + `src/arrow_stream.cpp`
- Arrow stream config — `IpcCompression` + `ArrowStreamOptions` in `config.hpp`
  and the Arrow `to_c` in `detail/config_convert.hpp`
- The two `Sdk::create_arrow_stream` overloads (OAuth + custom headers provider)
  and the `non_empty_ptr` helper they use
- The umbrella-header include and the CMake source entry

No core proto/JSON behavior changes — the diff vs the base branch is Arrow-only
(8 files, +343/−3).

### Stacking
Stacked on **`split/415/core`** (base of this PR). Part of the #415 split; the
core PR must merge first.

### Beta
Arrow Flight is Beta — the API is stabilising and may still change before GA,
mirroring the Rust core's `arrow-flight` feature gating.
