### PR TITLE
[Java][Python] Default recovery_retries to 4 (#438)

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+- Fixed the default `recoveryRetries`, which was `3` instead of the `4` used by the Rust core and every other SDK (Go, TypeScript, C++). A stream left with the default now makes 4 recovery attempts on transient failures instead of 3, matching the documented cross-SDK behavior. Callers that set `recoveryRetries` explicitly are unaffected. (#438)
+
 ### Documentation
 
 - Reworked README and Javadoc to steer users toward the high-throughput ingestion pattern: ingest with `ingestRecordOffset()` in a loop without waiting, then `flush()` (or `waitForOffset()` on the last offset) once. Added a performance callout warning against waiting for an acknowledgment after every record, documented `AckCallback` as the non-blocking alternative, and rewrote the Quick Start example to use the offset-based API instead of the deprecated `ingestRecord().join()` loop.

--- a/java/src/main/java/com/databricks/zerobus/StreamConfigurationOptions.java
+++ b/java/src/main/java/com/databricks/zerobus/StreamConfigurationOptions.java
@@ -32,7 +32,7 @@ public class StreamConfigurationOptions {
   private boolean recovery = true;
   private int recoveryTimeoutMs = 15000;
   private int recoveryBackoffMs = 2000;
-  private int recoveryRetries = 3;
+  private int recoveryRetries = 4;
   private int flushTimeoutMs = 300000;
   private int serverLackOfAckTimeoutMs = 60000;
   private Optional<Consumer<IngestRecordResponse>> ackCallback = Optional.empty();
@@ -182,7 +182,7 @@ public class StreamConfigurationOptions {
    *   <li>recovery: true
    *   <li>recoveryTimeoutMs: 15000
    *   <li>recoveryBackoffMs: 2000
-   *   <li>recoveryRetries: 3
+   *   <li>recoveryRetries: 4
    *   <li>flushTimeoutMs: 300000
    *   <li>serverLackOfAckTimeoutMs: 60000
    *   <li>ackCallback: empty

--- a/java/src/test/java/com/databricks/zerobus/StreamConfigurationOptionsTest.java
+++ b/java/src/test/java/com/databricks/zerobus/StreamConfigurationOptionsTest.java
@@ -21,7 +21,7 @@ public class StreamConfigurationOptionsTest {
     assertTrue(options.recovery());
     assertEquals(15000, options.recoveryTimeoutMs());
     assertEquals(2000, options.recoveryBackoffMs());
-    assertEquals(3, options.recoveryRetries());
+    assertEquals(4, options.recoveryRetries());
     assertEquals(300000, options.flushTimeoutMs());
     assertEquals(60000, options.serverLackOfAckTimeoutMs());
     assertFalse(options.ackCallback().isPresent());

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Bug Fixes
 
+- Fixed the default `recovery_retries`, which was `3` instead of the `4` used by the Rust core and every other SDK (Go, TypeScript, C++). A stream left with the default now makes 4 recovery attempts on transient failures instead of 3, matching the documented cross-SDK behavior. Callers that pass `recovery_retries` explicitly are unaffected. (#438)
+
 ### Documentation
 
 - README: documented the `application_name` constructor argument.

--- a/python/README.md
+++ b/python/README.md
@@ -305,7 +305,7 @@ stream = sdk.create_stream(client_id, client_secret, table_properties, options)
 | `recovery` | `bool` | `True` | Enable automatic stream recovery |
 | `recovery_timeout_ms` | `int` | `15000` | Timeout for recovery operations (ms) |
 | `recovery_backoff_ms` | `int` | `2000` | Delay between recovery attempts (ms) |
-| `recovery_retries` | `int` | `3` | Maximum number of recovery attempts |
+| `recovery_retries` | `int` | `4` | Maximum number of recovery attempts |
 | `flush_timeout_ms` | `int` | `300000` | Timeout for flush operations (ms) |
 | `server_lack_of_ack_timeout_ms` | `int` | `60000` | Server acknowledgment timeout (ms) |
 | `stream_paused_max_wait_time_ms` | `Optional[int]` | `None` | Max wait during graceful stream close. `None` = full server duration, `0` = immediate, `x` = min(x, server_duration) |

--- a/python/examples/async_example_arrow.py
+++ b/python/examples/async_example_arrow.py
@@ -99,7 +99,7 @@ async def main():
             recovery=True,
             recovery_timeout_ms=15000,
             recovery_backoff_ms=2000,
-            recovery_retries=3,
+            recovery_retries=4,
         )
         logger.info("Arrow stream configuration created")
 

--- a/python/examples/sync_example_arrow.py
+++ b/python/examples/sync_example_arrow.py
@@ -98,7 +98,7 @@ def main():
             recovery=True,
             recovery_timeout_ms=15000,
             recovery_backoff_ms=2000,
-            recovery_retries=3,
+            recovery_retries=4,
         )
         logger.info("Arrow stream configuration created")
 

--- a/python/examples/sync_example_json.py
+++ b/python/examples/sync_example_json.py
@@ -129,7 +129,7 @@ def main():
             recovery=True,
             recovery_timeout_ms=15000,
             recovery_backoff_ms=2000,
-            recovery_retries=3,
+            recovery_retries=4,
         )
         logger.info("✓ Stream configuration created")
 

--- a/python/examples/sync_example_proto.py
+++ b/python/examples/sync_example_proto.py
@@ -129,7 +129,7 @@ def main():
             recovery=True,
             recovery_timeout_ms=15000,
             recovery_backoff_ms=2000,
-            recovery_retries=3,
+            recovery_retries=4,
         )
         logger.info("✓ Stream configuration created (Protobuf mode)")
 

--- a/python/rust/src/common.rs
+++ b/python/rust/src/common.rs
@@ -327,7 +327,7 @@ impl Default for StreamConfigurationOptions {
             recovery: true,
             recovery_timeout_ms: 15_000,
             recovery_backoff_ms: 2_000,
-            recovery_retries: 3,
+            recovery_retries: 4,
             server_lack_of_ack_timeout_ms: 60_000,
             flush_timeout_ms: 300_000,
             record_type: RecordType { value: 1 }, // PROTO

--- a/python/zerobus/_zerobus_core.pyi
+++ b/python/zerobus/_zerobus_core.pyi
@@ -96,7 +96,7 @@ class StreamConfigurationOptions:
     """Backoff time in milliseconds between recovery attempts (default: 2000)"""
 
     recovery_retries: int
-    """Number of retries for stream recovery (default: 3)"""
+    """Number of retries for stream recovery (default: 4)"""
 
     server_lack_of_ack_timeout_ms: int
     """Number of ms in which, if we do not receive an acknowledgement, the server is considered unresponsive (default: 60000)"""
@@ -122,7 +122,7 @@ class StreamConfigurationOptions:
         recovery: bool = True,
         recovery_timeout_ms: int = 15000,
         recovery_backoff_ms: int = 2000,
-        recovery_retries: int = 3,
+        recovery_retries: int = 4,
         server_lack_of_ack_timeout_ms: int = 60000,
         flush_timeout_ms: int = 300000,
         record_type: RecordType = ...,
@@ -138,7 +138,7 @@ class StreamConfigurationOptions:
             recovery: Enable automatic stream recovery (default: True)
             recovery_timeout_ms: Recovery operation timeout in ms (default: 15000)
             recovery_backoff_ms: Delay between recovery attempts in ms (default: 2000)
-            recovery_retries: Maximum number of recovery attempts (default: 3)
+            recovery_retries: Maximum number of recovery attempts (default: 4)
             server_lack_of_ack_timeout_ms: Server acknowledgment timeout in ms (default: 60000)
             flush_timeout_ms: Flush operation timeout in ms (default: 300000)
             record_type: Serialization format (default: RecordType.PROTO)

--- a/python/zerobus/sdk/shared/config.py
+++ b/python/zerobus/sdk/shared/config.py
@@ -57,7 +57,7 @@ Args:
         attempt of recovery). Default: 15000
     recovery_backoff_ms: Backoff time in milliseconds between recovery attempts.
         Default: 2000
-    recovery_retries: Number of retries for stream recovery. Default: 3
+    recovery_retries: Number of retries for stream recovery. Default: 4
     server_lack_of_ack_timeout_ms: The number of ms in which, if we do not
         receive an acknowledgement, the server is considered unresponsive.
         Default: 60000


### PR DESCRIPTION
## Summary

Fixes #438.

The **Java** and **Python** SDKs defaulted `recovery_retries` to **3**, while the Rust core and every other wrapper (Go, TypeScript, C++) use **4**. A stream left with the default gave up after 3 recovery attempts on Java/Python but 4 everywhere else — an unintended cross-SDK divergence that arrived when those SDKs moved into the monorepo carrying their pre-existing default. No comment, changelog, or commit message ever justified `3`.

This aligns both wrappers with the core's documented intent.

| SDK | before | after |
|---|---|---|
| Rust core (ground truth) | 4 | 4 |
| Go / TypeScript / C++ | 4 | 4 |
| **Java** | **3** ❌ | **4** ✅ |
| **Python** | **3** ❌ | **4** ✅ |

## Changes

**Behavior (default 3 → 4):**
- Java: `StreamConfigurationOptions.java` field (the builder derives from it via `getDefault()`).
- Python: `python/rust/src/common.rs` `Default` impl.

**Docs / stub / test kept in sync:**
- Java Javadoc default list + the default-values unit test (`StreamConfigurationOptionsTest`).
- Python type stub `_zerobus_core.pyi` (attribute doc, `__init__` signature, Args doc), `config.py` docstring, `README.md` options table.
- The four `python/examples/*.py` that explicitly passed `recovery_retries=3` (consistency only — explicit overrides, not the default).

**Changelogs:** Bug Fixes entries in `java/NEXT_CHANGELOG.md` and `python/NEXT_CHANGELOG.md`.

## Notes

- **User-visible default change:** streams attempt 4 recoveries instead of 3 when the option is left unset. It's a convergence to the documented core intent, not a surprise. Callers that set `recovery_retries` explicitly are unaffected.
- **Drift audit (per the issue's optional ask):** every other default field in both option structs was checked against the core — `recovery_retries` was the only drift. Python's Arrow config already used `4` and is untouched.
- **JNI path:** `rust/jni/src/options.rs` reads `recoveryRetries` from the Java object (no hardcoded default), so the Java field fix fully covers it.
- Reviewed with `llm review`: 0 findings.
