### PR TITLE
[Rust] Add mux acknowledgment callback bridge

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### New Features and Improvements
 
+- Added the callback bridge used by multiplexed streams to report `MessageId`
+  values while preserving the existing `AckCallback` API. Each sub-stream
+  callback converts its stream-local `OffsetId` into a message ID containing
+  both the sub-stream index and offset.
+
 ### Bug Fixes
 
 ### Documentation
@@ -17,3 +22,7 @@
 ### Deprecations
 
 ### API Changes
+
+- Generalized `AckCallback` over its identifier type while preserving
+  `OffsetId` as the default for existing single-stream callbacks. Multiplexed
+  callbacks use the same trait with `MessageId` as the identifier type.

--- a/rust/sdk/src/callbacks.rs
+++ b/rust/sdk/src/callbacks.rs
@@ -26,7 +26,9 @@ use crate::offset_generator::OffsetId;
 /// Callback trait for receiving acknowledgment notifications.
 ///
 /// Implement this trait to receive callbacks when records/batches are acknowledged
-/// by the server or when errors occur.
+/// by the server or when errors occur. Single streams use the default [`OffsetId`]
+/// identifier. Other stream types can select an identifier that matches their
+/// ingestion API.
 ///
 /// # Thread Safety and Performance
 ///
@@ -58,7 +60,7 @@ use crate::offset_generator::OffsetId;
 ///     }
 /// }
 /// ```
-pub trait AckCallback: Send + Sync {
+pub trait AckCallback<Id = OffsetId>: Send + Sync {
     /// Called when a record/batch is successfully acknowledged by the server.
     ///
     /// **Note**: This runs synchronously in a dedicated callback handler task.
@@ -66,8 +68,8 @@ pub trait AckCallback: Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `offset_id` - The logical offset ID that was acknowledged
-    fn on_ack(&self, offset_id: OffsetId);
+    /// * `id` - The identifier that was acknowledged
+    fn on_ack(&self, id: Id);
 
     /// Called when an error occurs for a specific record/batch.
     ///
@@ -76,11 +78,12 @@ pub trait AckCallback: Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `offset_id` - The logical offset ID that encountered an error
+    /// * `id` - The identifier that encountered an error
     /// * `error_message` - Human-readable error description
-    fn on_error(&self, offset_id: OffsetId, error_message: &str);
+    fn on_error(&self, id: Id, error_message: &str);
 }
 
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/sdk/src/multiplexed_stream.rs
+++ b/rust/sdk/src/multiplexed_stream.rs
@@ -18,12 +18,14 @@
 //! [`get_unacked_records`](MultiplexedStream::get_unacked_records) or
 //! [`get_unacked_batches`](MultiplexedStream::get_unacked_batches).
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
 use futures::future::join_all;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
-use crate::{EncodedBatch, EncodedRecord, OffsetId, ZerobusError, ZerobusResult, ZerobusStream};
+use crate::{
+    AckCallback, EncodedBatch, EncodedRecord, OffsetId, ZerobusError, ZerobusResult, ZerobusStream,
+};
 
 /// Number of bits reserved for the stream index.
 /// 6 bits supports up to 64 sub-streams.
@@ -79,6 +81,43 @@ impl MessageId {
     pub fn from_raw(raw: i64) -> Self {
         Self(raw)
     }
+}
+
+struct MultiplexedAckCallbackAdapter {
+    stream_index: usize,
+    callback: Arc<dyn AckCallback<MessageId>>,
+}
+
+impl AckCallback for MultiplexedAckCallbackAdapter {
+    fn on_ack(&self, offset_id: OffsetId) {
+        self.callback
+            .on_ack(MessageId::new(self.stream_index, offset_id));
+    }
+
+    fn on_error(&self, offset_id: OffsetId, error_message: &str) {
+        self.callback
+            .on_error(MessageId::new(self.stream_index, offset_id), error_message);
+    }
+}
+
+/// Creates the callback installed on one multiplexed sub-stream.
+///
+/// The adapter captures the sub-stream index and converts each stream-local
+/// [`OffsetId`] into the [`MessageId`] exposed by [`MultiplexedStream`].
+#[allow(dead_code)]
+pub(crate) fn multiplexed_ack_callback(
+    stream_index: usize,
+    callback: Arc<dyn AckCallback<MessageId>>,
+) -> Arc<dyn AckCallback> {
+    assert!(
+        stream_index < (1 << STREAM_BITS),
+        "MultiplexedStream supports at most {} sub-streams",
+        1 << STREAM_BITS
+    );
+    Arc::new(MultiplexedAckCallbackAdapter {
+        stream_index,
+        callback,
+    })
 }
 
 /// Distributes ingestion round-robin across a fixed set of [`ZerobusStream`]s.
@@ -438,6 +477,26 @@ impl Drop for MultiplexedStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingMultiplexedCallback {
+        acks: Mutex<Vec<MessageId>>,
+        errors: Mutex<Vec<(MessageId, String)>>,
+    }
+
+    impl AckCallback<MessageId> for RecordingMultiplexedCallback {
+        fn on_ack(&self, message_id: MessageId) {
+            self.acks.lock().unwrap().push(message_id);
+        }
+
+        fn on_error(&self, message_id: MessageId, error_message: &str) {
+            self.errors
+                .lock()
+                .unwrap()
+                .push((message_id, error_message.to_string()));
+        }
+    }
 
     #[test]
     #[should_panic(expected = "MultiplexedStream requires at least one sub-stream")]
@@ -471,5 +530,32 @@ mod tests {
         assert_ne!(a, b);
         assert_eq!(a.sub_offset(), b.sub_offset());
         assert_ne!(a.stream_index(), b.stream_index());
+    }
+
+    #[test]
+    fn test_multiplexed_ack_callback_routes_substream_ids() {
+        let callback = Arc::new(RecordingMultiplexedCallback::default());
+        let stream_0 = multiplexed_ack_callback(0, callback.clone());
+        let stream_1 = multiplexed_ack_callback(1, callback.clone());
+
+        stream_0.on_ack(42);
+        stream_1.on_ack(42);
+        stream_1.on_error(43, "test error");
+
+        assert_eq!(
+            callback.acks.lock().unwrap().as_slice(),
+            &[MessageId::new(0, 42), MessageId::new(1, 42)]
+        );
+        assert_eq!(
+            callback.errors.lock().unwrap().as_slice(),
+            &[(MessageId::new(1, 43), "test error".to_string())]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "MultiplexedStream supports at most 64 sub-streams")]
+    fn test_multiplexed_ack_callback_rejects_invalid_stream_index() {
+        let callback = Arc::new(RecordingMultiplexedCallback::default());
+        multiplexed_ack_callback(64, callback);
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implements the acknowledgment callback bridge required by multiplexed streams.

- Generalize `AckCallback` over its identifier type while preserving `OffsetId` as the default, so existing individual-stream callback implementations remain unchanged.
- Add a crate-private multiplexed callback adapter that captures one sub-stream index.
- Convert each acknowledged stream-local `OffsetId` into the `MessageId` exposed by `MultiplexedStream`.
- Forward both successful acknowledgments and errors through `AckCallback<MessageId>`.
- Validate that callback adapters are only created for supported sub-stream indices.

The multiplexed stream builder is being added separately in #433. Its only callback-specific responsibility will be to install one adapter per sub-stream:

```rust
let callback = multiplexed_ack_callback(stream_index, callback.clone());
grpc_config.ack_callback = Some(callback);
```

This gives multiplexed streams the same user-facing callback API as individual streams, except the identifier is `MessageId` instead of `OffsetId`:

```rust
impl AckCallback<MessageId> for MyCallback {
    fn on_ack(&self, message_id: MessageId) {
        println!("Acknowledged {message_id}");
    }

    fn on_error(&self, message_id: MessageId, error_message: &str) {
        eprintln!("Error for {message_id}: {error_message}");
    }
}
```

Each adapter already knows which sub-stream it belongs to, so callback delivery requires no lookup, routing table, or locking. It only packs the captured stream index and acknowledged offset into a `MessageId` before invoking the user callback.

## How is this tested?

- Verifies callbacks from different sub-streams produce different `MessageId` values for the same stream-local offset.
- Verifies errors preserve both the correct `MessageId` and error message.
- Verifies invalid sub-stream indices are rejected.
- `cargo test -p databricks-zerobus-ingest-sdk`
- `cargo clippy -p databricks-zerobus-ingest-sdk --all-targets -- -D warnings`
- `cargo fmt --all --check`
