### PR TITLE
[Typescript] Fix SDK identifier in user-agent header and expose applicationName

### DIFF
--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### New Features and Improvements
 
+- `ZerobusSdk` constructor now accepts an optional `applicationName` parameter.
+  When set, it is appended to the HTTP `user-agent` header sent on every request
+  (e.g. `zerobus-sdk-ts/1.2.0 my-app/1.0`), enabling server-side attribution.
+  The SDK now also correctly identifies itself as `zerobus-sdk-ts` rather than
+  falling back to the underlying `zerobus-sdk-rs` identifier.
+
 ### Bug Fixes
 
 ### Documentation

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### New Features and Improvements
 
-- `ZerobusSdk` constructor now accepts an optional `applicationName` parameter.
-  When set, it is appended to the HTTP `user-agent` header sent on every request
+- `ZerobusSdk` constructor now accepts an optional `options` object
+  (`ZerobusSdkOptions`) as its third argument. Its `applicationName` field is
+  appended to the HTTP `user-agent` header sent on every request
   (e.g. `zerobus-sdk-ts/1.2.0 my-app/1.0`), enabling server-side attribution.
   The SDK now also correctly identifies itself as `zerobus-sdk-ts` rather than
   falling back to the underlying `zerobus-sdk-rs` identifier.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -808,13 +808,14 @@ Main entry point for the SDK.
 **Constructor:**
 
 ```typescript
-new ZerobusSdk(zerobusEndpoint: string, unityCatalogUrl: string, applicationName?: string)
+new ZerobusSdk(zerobusEndpoint: string, unityCatalogUrl: string, options?: ZerobusSdkOptions)
 ```
 
 **Parameters:**
 - `zerobusEndpoint` (string) - The Zerobus gRPC endpoint (e.g., `https://<workspace-id>.zerobus.<region>.cloud.databricks.com` for AWS, or `https://<workspace-id>.zerobus.<region>.azuredatabricks.net` for Azure)
 - `unityCatalogUrl` (string) - The Unity Catalog endpoint (your workspace URL)
-- `applicationName` (string, optional) - Application identifier appended to the HTTP `user-agent` header, conventionally `"<product>/<version>"` (e.g. `"my-app/1.0"`).
+- `options` (ZerobusSdkOptions, optional) - Additional SDK configuration:
+  - `applicationName` (string, optional) - Application identifier appended to the HTTP `user-agent` header, conventionally `"<product>/<version>"` (e.g. `"my-app/1.0"`). The header becomes `zerobus-sdk-ts/<version> <applicationName>`, enabling server-side attribution.
 
 **Methods:**
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -808,12 +808,13 @@ Main entry point for the SDK.
 **Constructor:**
 
 ```typescript
-new ZerobusSdk(zerobusEndpoint: string, unityCatalogUrl: string)
+new ZerobusSdk(zerobusEndpoint: string, unityCatalogUrl: string, applicationName?: string)
 ```
 
 **Parameters:**
 - `zerobusEndpoint` (string) - The Zerobus gRPC endpoint (e.g., `https://<workspace-id>.zerobus.<region>.cloud.databricks.com` for AWS, or `https://<workspace-id>.zerobus.<region>.azuredatabricks.net` for Azure)
 - `unityCatalogUrl` (string) - The Unity Catalog endpoint (your workspace URL)
+- `applicationName` (string, optional) - Application identifier appended to the HTTP `user-agent` header, conventionally `"<product>/<version>"` (e.g. `"my-app/1.0"`).
 
 **Methods:**
 

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -836,6 +836,13 @@ impl RustHeadersProvider for TsOAuthHeadersProvider {
     }
 }
 
+#[napi(object)]
+#[derive(Default)]
+pub struct ZerobusSdkOptions {
+    /// Identifier appended to the `user-agent` header
+    pub application_name: Option<String>,
+}
+
 /// The main SDK for interacting with the Databricks Zerobus service.
 ///
 /// This is the entry point for creating ingestion streams to Delta tables.
@@ -846,7 +853,7 @@ impl RustHeadersProvider for TsOAuthHeadersProvider {
 /// const sdk = new ZerobusSdk(
 ///   "https://workspace-id.zerobus.region.cloud.databricks.com",
 ///   "https://workspace.cloud.databricks.com",
-///   "my-app/1.0"
+///   { applicationName: "my-app/1.0" }
 /// );
 ///
 /// const stream = await sdk.createStream(
@@ -874,10 +881,8 @@ impl ZerobusSdk {
     ///   (e.g., "https://workspace-id.zerobus.region.cloud.databricks.com")
     /// * `unity_catalog_url` - The Unity Catalog endpoint URL
     ///   (e.g., "https://workspace.cloud.databricks.com")
-    /// * `application_name` - Optional application identifier appended to the
-    ///   HTTP `user-agent` header, conventionally `"<product>/<version>"`.
-    ///   The SDK prefix `zerobus-sdk-ts/<version>` is always present; this
-    ///   value is appended after it (e.g. `"zerobus-sdk-ts/1.2.0 my-app/1.0"`).
+    /// * `options` - Optional SDK configuration (see `ZerobusSdkOptions`),
+    ///   including `applicationName` for server-side attribution.
     ///
     /// # Errors
     ///
@@ -887,7 +892,7 @@ impl ZerobusSdk {
     pub fn new(
         zerobus_endpoint: String,
         unity_catalog_url: String,
-        application_name: Option<String>,
+        options: Option<ZerobusSdkOptions>,
     ) -> Result<Self> {
         let workspace_id = zerobus_endpoint
             .strip_prefix("https://")
@@ -900,11 +905,13 @@ impl ZerobusSdk {
                 )
             })?;
 
+        let options = options.unwrap_or_default();
+
         let builder = RustZerobusSdk::builder()
             .endpoint(&zerobus_endpoint)
             .unity_catalog_url(&unity_catalog_url)
             .sdk_identifier(TS_SDK_USER_AGENT);
-        let builder = match application_name {
+        let builder = match options.application_name {
             Some(name) => builder.application_name(name),
             None => builder,
         };
@@ -983,19 +990,19 @@ impl ZerobusSdk {
         // Decode the optional protobuf descriptor up-front so we can hand it
         // to the builder's `.compiled_proto()` setter; the builder constructs
         // the (now-private) `TableProperties` itself.
-        let descriptor_proto: Option<prost_types::DescriptorProto> =
-            if let Some(ref desc_str) = table_properties.descriptor_proto {
-                let bytes = base64_decode(desc_str).map_err(|e| {
-                    Error::from_reason(format!("Failed to decode descriptor: {}", e))
+        let descriptor_proto: Option<prost_types::DescriptorProto> = if let Some(ref desc_str) =
+            table_properties.descriptor_proto
+        {
+            let bytes = base64_decode(desc_str)
+                .map_err(|e| Error::from_reason(format!("Failed to decode descriptor: {}", e)))?;
+            let dp: prost_types::DescriptorProto =
+                prost::Message::decode(&bytes[..]).map_err(|e| {
+                    Error::from_reason(format!("Failed to parse descriptor proto: {}", e))
                 })?;
-                let dp: prost_types::DescriptorProto = prost::Message::decode(&bytes[..])
-                    .map_err(|e| {
-                        Error::from_reason(format!("Failed to parse descriptor proto: {}", e))
-                    })?;
-                Some(dp)
-            } else {
-                None
-            };
+            Some(dp)
+        } else {
+            None
+        };
 
         let opts = options.unwrap_or(StreamConfigurationOptions {
             max_inflight_requests: None,
@@ -1474,9 +1481,7 @@ impl ZerobusArrowStream {
                 stream_ref
                     .ingest_ipc_batch(Bytes::from(buffer_vec))
                     .await
-                    .map_err(|e| {
-                        napi::Error::from_reason(format!("Failed to ingest batch: {}", e))
-                    })
+                    .map_err(|e| napi::Error::from_reason(format!("Failed to ingest batch: {}", e)))
             },
             |env, offset_id| {
                 let global: JsGlobal = env.get_global()?;

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -748,11 +748,6 @@ impl StaticHeadersProvider {
             ));
         }
 
-        // Add TS user agent if not provided
-        if !map.contains_key("user-agent") {
-            map.insert("user-agent", TS_SDK_USER_AGENT.to_string());
-        }
-
         Ok(Self { headers: map })
     }
 }
@@ -837,7 +832,6 @@ impl RustHeadersProvider for TsOAuthHeadersProvider {
         let mut headers = HashMap::new();
         headers.insert("authorization", format!("Bearer {}", token));
         headers.insert("x-databricks-zerobus-table-name", self.table_name.clone());
-        headers.insert("user-agent", TS_SDK_USER_AGENT.to_string());
         Ok(headers)
     }
 }
@@ -851,7 +845,8 @@ impl RustHeadersProvider for TsOAuthHeadersProvider {
 /// ```typescript
 /// const sdk = new ZerobusSdk(
 ///   "https://workspace-id.zerobus.region.cloud.databricks.com",
-///   "https://workspace.cloud.databricks.com"
+///   "https://workspace.cloud.databricks.com",
+///   "my-app/1.0"
 /// );
 ///
 /// const stream = await sdk.createStream(
@@ -879,13 +874,21 @@ impl ZerobusSdk {
     ///   (e.g., "https://workspace-id.zerobus.region.cloud.databricks.com")
     /// * `unity_catalog_url` - The Unity Catalog endpoint URL
     ///   (e.g., "https://workspace.cloud.databricks.com")
+    /// * `application_name` - Optional application identifier appended to the
+    ///   HTTP `user-agent` header, conventionally `"<product>/<version>"`.
+    ///   The SDK prefix `zerobus-sdk-ts/<version>` is always present; this
+    ///   value is appended after it (e.g. `"zerobus-sdk-ts/1.2.0 my-app/1.0"`).
     ///
     /// # Errors
     ///
     /// - Invalid endpoint URLs
     /// - Failed to extract workspace ID from the endpoint
     #[napi(constructor)]
-    pub fn new(zerobus_endpoint: String, unity_catalog_url: String) -> Result<Self> {
+    pub fn new(
+        zerobus_endpoint: String,
+        unity_catalog_url: String,
+        application_name: Option<String>,
+    ) -> Result<Self> {
         let workspace_id = zerobus_endpoint
             .strip_prefix("https://")
             .or_else(|| zerobus_endpoint.strip_prefix("http://"))
@@ -897,9 +900,15 @@ impl ZerobusSdk {
                 )
             })?;
 
-        let inner = RustZerobusSdk::builder()
+        let builder = RustZerobusSdk::builder()
             .endpoint(&zerobus_endpoint)
             .unity_catalog_url(&unity_catalog_url)
+            .sdk_identifier(TS_SDK_USER_AGENT);
+        let builder = match application_name {
+            Some(name) => builder.application_name(name),
+            None => builder,
+        };
+        let inner = builder
             .build()
             .map_err(|e| Error::from_reason(format!("Failed to create SDK: {}", e)))?;
 

--- a/typescript/test/unit.test.ts
+++ b/typescript/test/unit.test.ts
@@ -27,6 +27,24 @@ describe('ZerobusSdk', () => {
             );
             assert.ok(sdk);
         });
+
+        it('should accept an options object with applicationName', () => {
+            const sdk = new ZerobusSdk(
+                'https://1234567890.zerobus.us-west-2.cloud.databricks.com',
+                'https://test-workspace.cloud.databricks.com',
+                { applicationName: 'my-app/1.0' }
+            );
+            assert.ok(sdk);
+        });
+
+        it('should accept an empty options object', () => {
+            const sdk = new ZerobusSdk(
+                'https://1234567890.zerobus.us-west-2.cloud.databricks.com',
+                'https://test-workspace.cloud.databricks.com',
+                {}
+            );
+            assert.ok(sdk);
+        });
     });
 
     describe('configuration validation', () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

- `ZerobusSdk` constructor now correctly sets `zerobus-sdk-ts/<version>` as the SDK identifier in the HTTP user-agent header, instead of falling back to `zerobus-sdk-rs`.
- Added optional `applicationName` constructor parameter, appended to the user-agent (e.g. `zerobus-sdk-ts/1.2.0 my-app/1.0`).
- Removed dead `user-agent` insertions from the headers providers, which were never effective at the transport level.

## Why

Without explicitly setting the SDK identifier, the server cannot distinguish TypeScript traffic from direct Rust usage, making per-language telemetry impossible. The applicationName feature already exists in Rust and Python - this brings TypeScript to parity.

## How is this tested?

- Built locally (`npm run build`) - compiles and NAPI-RS generates updated TypeScript types correctly.
- `npm run test:unit`
- Integration tests run against staging (shinkansen_eastus1.default.air_quality) — all passed
- Confirmed the user-agent header value on the wire: added a temporary `eprintln!` in the constructor and observed `zerobus-sdk-ts/1.1.0 irina-test/1.0` in the test output