### PR TITLE
[Java] Expose applicationName parameter in ZerobusSdk constructor

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -9,9 +9,11 @@
 - Added native library support for Linux musl (Alpine) on x86_64 and aarch64. The libc flavor is detected automatically at runtime; override with `-Dzerobus.libc=musl|glibc`.
 - Added `ZerobusSdk.streamBuilder()`, a fluent builder for creating streams that mirrors the Rust SDK's `stream_builder()`. It supports JSON, Protocol Buffer, and Arrow Flight streams through a single chainable API and is now the recommended way to create streams. See `StreamBuilder`.
 - `ZerobusSdk` now has a three-argument constructor accepting an optional `applicationName`
-  parameter. When set, it is appended to the HTTP `user-agent` header sent on every request
-  (e.g. `zerobus-sdk-java/1.3.0 my-app/1.0`), enabling server-side attribution per
-  customer application. The existing two-argument constructor is unchanged.
+  parameter. When set, it is appended to the HTTP `user-agent` header on gRPC requests to the
+  Zerobus service (it is not sent on requests to the login service that mint the OAuth token),
+  so callers can be identified in server-side telemetry. The wire value becomes
+  `zerobus-sdk-java/<version> <applicationName>` (e.g. `zerobus-sdk-java/1.3.0 my-app/1.0`).
+  The existing two-argument constructor is unchanged.
 
 ### Bug Fixes
 
@@ -39,3 +41,6 @@
 - Added `StreamBuilder` and its typed sub-builders (`StreamBuilder.JsonStreamBuilder`,
   `StreamBuilder.ProtoStreamBuilder`, `StreamBuilder.ArrowStreamBuilder`), returned by
   `ZerobusSdk.streamBuilder()`.
+- Added a three-argument `ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint, String
+  applicationName)` constructor. The existing two-argument constructor delegates to it with a
+  `null` application name.

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Added native library support for Linux musl (Alpine) on x86_64 and aarch64. The libc flavor is detected automatically at runtime; override with `-Dzerobus.libc=musl|glibc`.
 - Added `ZerobusSdk.streamBuilder()`, a fluent builder for creating streams that mirrors the Rust SDK's `stream_builder()`. It supports JSON, Protocol Buffer, and Arrow Flight streams through a single chainable API and is now the recommended way to create streams. See `StreamBuilder`.
+- `ZerobusSdk` now has a three-argument constructor accepting an optional `applicationName`
+  parameter. When set, it is appended to the HTTP `user-agent` header sent on every request
+  (e.g. `zerobus-sdk-java/1.3.0 my-app/1.0`), enabling server-side attribution per
+  customer application. The existing two-argument constructor is unchanged.
 
 ### Bug Fixes
 

--- a/java/README.md
+++ b/java/README.md
@@ -1011,12 +1011,14 @@ try {
 
 Main entry point for the SDK.
 
-**Constructor:**
+**Constructors:**
 ```java
 ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint)
+ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint, String applicationName)
 ```
 - `serverEndpoint` - The Zerobus gRPC endpoint (e.g., `https://<workspace-id>.zerobus.region.cloud.databricks.com`)
 - `unityCatalogEndpoint` - The Unity Catalog endpoint (your workspace URL)
+- `applicationName` (optional) - Application identifier appended to the HTTP `user-agent` header, conventionally `"<product>/<version>"` (e.g. `"my-app/1.0"`). Pass `null` to omit.
 
 **Methods:**
 

--- a/java/src/main/java/com/databricks/zerobus/ZerobusSdk.java
+++ b/java/src/main/java/com/databricks/zerobus/ZerobusSdk.java
@@ -98,9 +98,24 @@ public class ZerobusSdk implements AutoCloseable {
    * @throws ZerobusException if the SDK cannot be initialized
    */
   public ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint) {
+    this(serverEndpoint, unityCatalogEndpoint, null);
+  }
+
+  /**
+   * Creates a new ZerobusSdk instance with an optional application identifier.
+   *
+   * @param serverEndpoint The gRPC endpoint URL for the Zerobus service.
+   * @param unityCatalogEndpoint The Unity Catalog endpoint URL.
+   * @param applicationName Optional application identifier appended to the HTTP {@code user-agent}
+   *     header, conventionally {@code "<product>/<version>"} (e.g. {@code "my-app/1.0"}). When set,
+   *     the header becomes {@code "zerobus-sdk-java/<version> <applicationName>"}. Pass {@code
+   *     null} to omit.
+   * @throws ZerobusException if the SDK cannot be initialized
+   */
+  public ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint, String applicationName) {
     this.serverEndpoint = serverEndpoint;
     this.unityCatalogEndpoint = unityCatalogEndpoint;
-    this.nativeHandle = nativeCreate(serverEndpoint, unityCatalogEndpoint);
+    this.nativeHandle = nativeCreate(serverEndpoint, unityCatalogEndpoint, applicationName);
     if (this.nativeHandle == 0) {
       throw new RuntimeException("Failed to create native SDK instance");
     }
@@ -759,7 +774,8 @@ public class ZerobusSdk implements AutoCloseable {
 
   // Native methods implemented in Rust
 
-  private static native long nativeCreate(String serverEndpoint, String unityCatalogEndpoint);
+  private static native long nativeCreate(
+      String serverEndpoint, String unityCatalogEndpoint, String applicationName);
 
   private static native void nativeDestroy(long handle);
 

--- a/java/src/test/java/com/databricks/zerobus/ZerobusSdkTest.java
+++ b/java/src/test/java/com/databricks/zerobus/ZerobusSdkTest.java
@@ -1,0 +1,56 @@
+package com.databricks.zerobus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ZerobusSdk} construction. Construction only parses the endpoints, so dummy
+ * URLs suffice; runs against the staged JNI library in CI and skips on bare local runs.
+ */
+public class ZerobusSdkTest {
+
+  private static final String SERVER_ENDPOINT =
+      "https://1234567890.zerobus.us-west-2.cloud.databricks.com";
+  private static final String UNITY_CATALOG_ENDPOINT =
+      "https://test-workspace.cloud.databricks.com";
+
+  /**
+   * Skips the test unless the native library is loadable (needed to construct {@link ZerobusSdk}).
+   */
+  private static void assumeNativeLibrary() {
+    boolean available;
+    try {
+      NativeLoader.ensureLoaded();
+      available = true;
+    } catch (UnsatisfiedLinkError | ExceptionInInitializerError e) {
+      available = false;
+    }
+    assumeTrue(available, "Native library required to construct ZerobusSdk");
+  }
+
+  @Test
+  void constructsWithoutApplicationName() {
+    assumeNativeLibrary();
+    try (ZerobusSdk sdk = new ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT)) {
+      assertNotNull(sdk);
+    }
+  }
+
+  @Test
+  void constructsWithNullApplicationName() {
+    assumeNativeLibrary();
+    try (ZerobusSdk sdk = new ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, null)) {
+      assertNotNull(sdk);
+    }
+  }
+
+  @Test
+  void constructsWithApplicationName() {
+    assumeNativeLibrary();
+    try (ZerobusSdk sdk = new ZerobusSdk(SERVER_ENDPOINT, UNITY_CATALOG_ENDPOINT, "my-app/1.0")) {
+      assertNotNull(sdk);
+    }
+  }
+}

--- a/rust/jni/src/sdk.rs
+++ b/rust/jni/src/sdk.rs
@@ -51,7 +51,7 @@ impl NativeSdkHandle {
 ///
 /// # JNI Signature
 /// ```java
-/// private static native long nativeCreate(String serverEndpoint, String unityCatalogEndpoint);
+/// private static native long nativeCreate(String serverEndpoint, String unityCatalogEndpoint, String applicationName);
 /// ```
 #[no_mangle]
 pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'local>(
@@ -59,6 +59,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'loca
     _class: JClass<'local>,
     server_endpoint: JString<'local>,
     unity_catalog_endpoint: JString<'local>,
+    application_name: JString<'local>,
 ) -> jlong {
     // Extract the endpoint strings
     let server_endpoint: String = match env.get_string(&server_endpoint) {
@@ -77,14 +78,29 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'loca
         }
     };
 
+    let application_name: Option<String> = if application_name.is_null() {
+        None
+    } else {
+        match env.get_string(&application_name) {
+            Ok(s) => Some(s.into()),
+            Err(e) => {
+                throw_zerobus_exception(&mut env, &format!("Invalid application name: {}", e));
+                return 0;
+            }
+        }
+    };
+
     // Create the SDK
     let sdk_identifier = format!("zerobus-sdk-java/{}", env!("CARGO_PKG_VERSION"));
-    match ZerobusSdk::builder()
+    let builder = ZerobusSdk::builder()
         .endpoint(server_endpoint)
         .unity_catalog_url(unity_catalog_endpoint)
-        .sdk_identifier(sdk_identifier)
-        .build()
-    {
+        .sdk_identifier(sdk_identifier);
+    let builder = match application_name {
+        Some(name) => builder.application_name(name),
+        None => builder,
+    };
+    match builder.build() {
         Ok(sdk) => NativeSdkHandle::new(sdk).into_raw(),
         Err(e) => {
             throw_from_zerobus_error(&mut env, &e);


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Added a three-argument `ZerobusSdk(String serverEndpoint, String unityCatalogEndpoint, String applicationName)` constructor. The existing two-argument constructor is unchanged and delegates to the new one with null.
- The `applicationName` value is passed through JNI to the Rust builder's `.application_name()`, appending it to the HTTP `user-agent` header (e.g. `zerobus-sdk-java/1.3.0 my-app/1.0`).
- Updated `nativeCreate` JNI signature in both Java and Rust to carry the new nullable parameter.

## Why

The `applicationName` feature already exists in the Rust and Python SDKs (and was just added to TypeScript in [#460](https://github.com/databricks/zerobus-sdk/pull/460)). This brings Java to parity.

## How is this tested?

- Rust JNI crate builds cleanly (cargo build in rust/jni/).
- Maven not available in the dev environment; Java compilation not verified locally.
- Not tested end-to-end against a live Zerobus service.