### PR TITLE
[C++] Arrow Flight stream (Beta)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,6 +67,7 @@ include(BuildRustFfi)
 add_library(zerobus_cpp
     src/sdk.cpp
     src/stream.cpp
+    src/arrow_stream.cpp
     src/proto_schema.cpp
     src/headers_callback.cpp)
 add_library(zerobus::zerobus ALIAS zerobus_cpp)

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -1,0 +1,79 @@
+#ifndef ZEROBUS_ARROW_STREAM_HPP
+#define ZEROBUS_ARROW_STREAM_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "zerobus/headers_provider.hpp"
+
+namespace zerobus {
+
+struct CArrowStream;  // opaque FFI handle (defined in zerobus.h)
+class Sdk;
+
+/// An Arrow Flight ingestion stream (Beta).
+///
+/// Records are supplied as Arrow IPC stream bytes (schema + one record batch).
+/// Created via `Sdk::create_arrow_stream`. Move-only; the destructor closes and
+/// frees the stream. The API is stabilising but may still change before GA.
+///
+/// As with `Stream`, prefer calling `close()` explicitly: it surfaces close
+/// errors (the destructor swallows them) and flushes synchronously, which can
+/// block up to `flush_timeout_ms` (default 5 minutes) if the server is
+/// unresponsive. Letting the object fall out of scope drags that blocking close
+/// into the destructor.
+///
+/// Thread safety: not safe for concurrent use from multiple threads.
+class ArrowStream {
+ public:
+  ~ArrowStream();
+
+  ArrowStream(ArrowStream&& other) noexcept;
+  ArrowStream& operator=(ArrowStream&& other) noexcept;
+  ArrowStream(const ArrowStream&) = delete;
+  ArrowStream& operator=(const ArrowStream&) = delete;
+
+  /// Ingest one Arrow RecordBatch supplied as Arrow IPC stream bytes (a
+  /// self-contained IPC stream: schema message + one record batch message).
+  /// Returns the logical offset assigned to the batch.
+  std::int64_t ingest_batch(const std::uint8_t* ipc_bytes, std::size_t len);
+  std::int64_t ingest_batch(const std::vector<std::uint8_t>& ipc_bytes);
+
+  /// Block until the batch at `offset` has been acknowledged.
+  void wait_for_offset(std::int64_t offset);
+
+  /// Flush all pending batches and wait for their acknowledgment.
+  void flush();
+
+  /// Return all unacknowledged batches from a closed or failed stream, each as
+  /// a self-contained Arrow IPC stream (schema + one batch). Remains callable
+  /// after a failed `close()`, which keeps the handle alive so recovery is
+  /// possible.
+  std::vector<std::vector<std::uint8_t>> get_unacked_batches();
+
+  /// Gracefully close the stream, flushing pending batches first. Idempotent.
+  ///
+  /// On success the stream becomes unusable. If the close fails it throws
+  /// `ZerobusException` but keeps the handle alive, so the caller can still
+  /// recover buffered batches via `get_unacked_batches()` and/or retry
+  /// `close()`; the destructor frees the handle as a last resort.
+  void close();
+
+  /// Whether the stream has been closed (queried from the FFI when live).
+  bool is_closed() const noexcept;
+
+ private:
+  friend class Sdk;
+  ArrowStream(CArrowStream* handle, std::shared_ptr<HeadersProvider> provider)
+      : handle_(handle), provider_(std::move(provider)) {}
+
+  CArrowStream* handle_;
+  std::shared_ptr<HeadersProvider> provider_;
+};
+
+}  // namespace zerobus
+
+#endif  // ZEROBUS_ARROW_STREAM_HPP

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -29,8 +29,10 @@ class Sdk;
 /// Thread safety: not safe for concurrent use from multiple threads.
 ///
 /// Only the IPC-bytes ingest path is wrapped. The FFI's
-/// `zerobus_arrow_stream_ingest_batch_via_record_batch` takes an opaque
-/// `RecordBatch*` no C++ caller can construct, so it is intentionally omitted.
+/// `zerobus_arrow_stream_ingest_batch_via_record_batch` takes the same IPC bytes
+/// and is a functional duplicate of `zerobus_arrow_stream_ingest_batch` (both
+/// deserialise the bytes and re-encode with the stream's compression settings),
+/// so it is intentionally omitted as redundant.
 class ArrowStream {
  public:
   ~ArrowStream();

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -27,6 +27,10 @@ class Sdk;
 /// into the destructor.
 ///
 /// Thread safety: not safe for concurrent use from multiple threads.
+///
+/// Only the IPC-bytes ingest path is wrapped. The FFI's
+/// `zerobus_arrow_stream_ingest_batch_via_record_batch` takes an opaque
+/// `RecordBatch*` no C++ caller can construct, so it is intentionally omitted.
 class ArrowStream {
  public:
   ~ArrowStream();
@@ -36,13 +40,25 @@ class ArrowStream {
   ArrowStream(const ArrowStream&) = delete;
   ArrowStream& operator=(const ArrowStream&) = delete;
 
-  /// Ingest one Arrow RecordBatch supplied as Arrow IPC stream bytes (a
-  /// self-contained IPC stream: schema message + one record batch message).
-  /// Returns the logical offset assigned to the batch.
+  /// Ingest one Arrow RecordBatch as a self-contained Arrow IPC stream (schema
+  /// message + one record batch message). Returns the assigned logical offset.
+  ///
+  /// Asynchronous: this only queues the batch. Queue many, then `flush()` once;
+  /// do not call `wait_for_offset` per batch (one round-trip each kills
+  /// throughput). The offset is a handle to wait on later, not a cue to wait.
+  ///
+  /// @code
+  ///   for (const auto& batch : batches) {
+  ///     stream.ingest_batch(batch);  // queue only — do NOT wait here
+  ///   }
+  ///   stream.flush();                // wait once for all pending acks
+  /// @endcode
   std::int64_t ingest_batch(const std::uint8_t* ipc_bytes, std::size_t len);
   std::int64_t ingest_batch(const std::vector<std::uint8_t>& ipc_bytes);
 
-  /// Block until the batch at `offset` has been acknowledged.
+  /// Block until the batch at `offset` has been acknowledged. Reserve for
+  /// low-volume cases; in hot paths `flush()` once instead (see
+  /// `ingest_batch`).
   void wait_for_offset(std::int64_t offset);
 
   /// Flush all pending batches and wait for their acknowledgment.
@@ -62,7 +78,10 @@ class ArrowStream {
   /// `close()`; the destructor frees the handle as a last resort.
   void close();
 
-  /// Whether the stream has been closed (queried from the FFI when live).
+  /// Whether the stream has been closed. Unlike `Stream::is_closed()` (a pure
+  /// `handle == nullptr` check), while the handle is live this also queries the
+  /// core, so it can report `true` for a stream the core closed on its own. The
+  /// query is conservative: it reports `true` if it cannot answer.
   bool is_closed() const noexcept;
 
  private:

--- a/cpp/include/zerobus/arrow_stream.hpp
+++ b/cpp/include/zerobus/arrow_stream.hpp
@@ -28,11 +28,9 @@ class Sdk;
 ///
 /// Thread safety: not safe for concurrent use from multiple threads.
 ///
-/// Only the IPC-bytes ingest path is wrapped. The FFI's
-/// `zerobus_arrow_stream_ingest_batch_via_record_batch` takes the same IPC bytes
-/// and is a functional duplicate of `zerobus_arrow_stream_ingest_batch` (both
-/// deserialise the bytes and re-encode with the stream's compression settings),
-/// so it is intentionally omitted as redundant.
+/// Only the IPC-bytes ingest path is wrapped;
+/// `zerobus_arrow_stream_ingest_batch_via_record_batch` is a functional
+/// duplicate of `zerobus_arrow_stream_ingest_batch`, so it is omitted.
 class ArrowStream {
  public:
   ~ArrowStream();

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -46,17 +46,21 @@ struct StreamOptions {
 };
 
 /// Arrow IPC compression codec. Matches the `ipc_compression` field encoding
-/// in `CArrowStreamConfigurationOptions` (-1 = None, 0 = LZ4_FRAME, 1 = ZSTD).
+/// in `CArrowStreamConfigurationOptions` (-1 = none, 0 = LZ4_FRAME, 1 = ZSTD).
+///
+/// Named `NoCompression`, not `None`, to avoid X11's `#define None 0L`, which
+/// the preprocessor expands even inside an `enum class`.
 enum class IpcCompression : std::int32_t {
-  None = -1,
+  NoCompression = -1,
   Lz4Frame = 0,
   Zstd = 1,
 };
 
 /// Configuration for an Arrow Flight ingestion stream (Beta).
 ///
-/// Defaults mirror `zerobus_arrow_get_default_config()`; keep them in sync by
-/// hand (not yet pinned by `config_defaults_test`).
+/// The scalar defaults below are hand-kept in sync with the Rust core and sent
+/// to the FFI verbatim (see `to_c()`). `arrow_config_defaults_test` fails the
+/// build if they drift from `zerobus_arrow_get_default_config()`.
 struct ArrowStreamOptions {
   /// Maximum number of in-flight (unacknowledged) batches.
   std::size_t max_inflight_batches = 1'000;
@@ -75,7 +79,7 @@ struct ArrowStreamOptions {
   /// Connection establishment timeout.
   std::uint64_t connection_timeout_ms = 30'000;
   /// Arrow IPC compression codec.
-  IpcCompression ipc_compression = IpcCompression::None;
+  IpcCompression ipc_compression = IpcCompression::NoCompression;
   /// Max wait during a server-initiated pause before recovering. `nullopt` =
   /// full server duration; `0` = recover immediately; `x` = min(x, server).
   std::optional<std::uint64_t> stream_paused_max_wait_time_ms;

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -14,7 +14,7 @@ enum class RecordType : std::int32_t {
   Json = 2,
 };
 
-/// Configuration for a (non-Arrow) ingestion stream.
+/// Configuration for a gRPC ingestion stream.
 ///
 /// The scalar defaults below are hand-kept in sync with the Rust core and sent
 /// to the FFI verbatim (see `to_c()`). `config_defaults_test` fails the build

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -55,10 +55,8 @@ enum class IpcCompression : std::int32_t {
 
 /// Configuration for an Arrow Flight ingestion stream (Beta).
 ///
-/// Defaults mirror the FFI's `zerobus_arrow_get_default_config()` (which in
-/// turn draws from the Rust core's `stream_options::defaults`). Unlike
-/// `StreamOptions`, these defaults are not yet pinned by `config_defaults_test`,
-/// so keep them in sync with the FFI by hand.
+/// Defaults mirror `zerobus_arrow_get_default_config()`; keep them in sync by
+/// hand (not yet pinned by `config_defaults_test`).
 struct ArrowStreamOptions {
   /// Maximum number of in-flight (unacknowledged) batches.
   std::size_t max_inflight_batches = 1'000;
@@ -78,10 +76,8 @@ struct ArrowStreamOptions {
   std::uint64_t connection_timeout_ms = 30'000;
   /// Arrow IPC compression codec.
   IpcCompression ipc_compression = IpcCompression::None;
-  /// Max time to wait during a server-initiated pause before recovering:
-  /// - `nullopt`: wait the full server-specified duration (most graceful).
-  /// - `0`: recover immediately, closing the stream right away.
-  /// - `x > 0`: wait up to min(x, server_duration) milliseconds.
+  /// Max wait during a server-initiated pause before recovering. `nullopt` =
+  /// full server duration; `0` = recover immediately; `x` = min(x, server).
   std::optional<std::uint64_t> stream_paused_max_wait_time_ms;
 };
 

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -14,7 +14,7 @@ enum class RecordType : std::int32_t {
   Json = 2,
 };
 
-/// Configuration for an ingestion stream.
+/// Configuration for a (non-Arrow) ingestion stream.
 ///
 /// The scalar defaults below are hand-kept in sync with the Rust core and sent
 /// to the FFI verbatim (see `to_c()`). `config_defaults_test` fails the build
@@ -43,6 +43,41 @@ struct StreamOptions {
   /// Max time to wait for a headers-provider callback to return.
   /// `nullopt` leaves the FFI default in place.
   std::optional<std::uint64_t> callback_max_wait_time_ms;
+};
+
+/// Arrow IPC compression codec. Matches the `ipc_compression` field encoding
+/// in `CArrowStreamConfigurationOptions` (-1 = None, 0 = LZ4_FRAME, 1 = ZSTD).
+enum class IpcCompression : std::int32_t {
+  None = -1,
+  Lz4Frame = 0,
+  Zstd = 1,
+};
+
+/// Configuration for an Arrow Flight ingestion stream (Beta).
+///
+/// Defaults mirror the Rust core's `zerobus_arrow_get_default_config()`.
+struct ArrowStreamOptions {
+  /// Maximum number of in-flight (unacknowledged) batches.
+  std::size_t max_inflight_batches = 1'000;
+  /// Whether automatic stream recovery is enabled.
+  bool recovery = true;
+  /// Total time budget for a recovery attempt.
+  std::uint64_t recovery_timeout_ms = 15'000;
+  /// Backoff between recovery retries.
+  std::uint64_t recovery_backoff_ms = 2'000;
+  /// Number of recovery retries before giving up.
+  std::uint32_t recovery_retries = 4;
+  /// How long to wait for a server ack before considering the stream stalled.
+  std::uint64_t server_lack_of_ack_timeout_ms = 60'000;
+  /// Time budget for `flush()`.
+  std::uint64_t flush_timeout_ms = 300'000;
+  /// Connection establishment timeout.
+  std::uint64_t connection_timeout_ms = 30'000;
+  /// Arrow IPC compression codec.
+  IpcCompression ipc_compression = IpcCompression::None;
+  /// Max time to wait during a server-initiated pause before recovering.
+  /// `nullopt` = wait the full server-specified duration.
+  std::optional<std::int64_t> stream_paused_max_wait_time_ms;
 };
 
 }  // namespace zerobus

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -55,7 +55,10 @@ enum class IpcCompression : std::int32_t {
 
 /// Configuration for an Arrow Flight ingestion stream (Beta).
 ///
-/// Defaults mirror the Rust core's `zerobus_arrow_get_default_config()`.
+/// Defaults mirror the FFI's `zerobus_arrow_get_default_config()` (which in
+/// turn draws from the Rust core's `stream_options::defaults`). Unlike
+/// `StreamOptions`, these defaults are not yet pinned by `config_defaults_test`,
+/// so keep them in sync with the FFI by hand.
 struct ArrowStreamOptions {
   /// Maximum number of in-flight (unacknowledged) batches.
   std::size_t max_inflight_batches = 1'000;
@@ -75,9 +78,11 @@ struct ArrowStreamOptions {
   std::uint64_t connection_timeout_ms = 30'000;
   /// Arrow IPC compression codec.
   IpcCompression ipc_compression = IpcCompression::None;
-  /// Max time to wait during a server-initiated pause before recovering.
-  /// `nullopt` = wait the full server-specified duration.
-  std::optional<std::int64_t> stream_paused_max_wait_time_ms;
+  /// Max time to wait during a server-initiated pause before recovering:
+  /// - `nullopt`: wait the full server-specified duration (most graceful).
+  /// - `0`: recover immediately, closing the stream right away.
+  /// - `x > 0`: wait up to min(x, server_duration) milliseconds.
+  std::optional<std::uint64_t> stream_paused_max_wait_time_ms;
 };
 
 }  // namespace zerobus

--- a/cpp/include/zerobus/sdk.hpp
+++ b/cpp/include/zerobus/sdk.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "zerobus/arrow_stream.hpp"
 #include "zerobus/config.hpp"
 #include "zerobus/headers_provider.hpp"
 #include "zerobus/stream.hpp"
@@ -92,6 +93,23 @@ class Sdk {
   Stream create_stream(const TableProperties& table,
                        std::shared_ptr<HeadersProvider> headers_provider,
                        const StreamOptions& options = {});
+
+  /// Create an Arrow Flight stream (Beta) authenticated with OAuth client
+  /// credentials. `schema_ipc_bytes` is an Arrow IPC stream encoding only the
+  /// schema (an empty IPC stream with just the schema message).
+  ArrowStream create_arrow_stream(
+      const std::string& table_name,
+      const std::vector<std::uint8_t>& schema_ipc_bytes,
+      const std::string& client_id, const std::string& client_secret,
+      const ArrowStreamOptions& options = {});
+
+  /// Create an Arrow Flight stream (Beta) authenticated with a custom headers
+  /// provider.
+  ArrowStream create_arrow_stream(
+      const std::string& table_name,
+      const std::vector<std::uint8_t>& schema_ipc_bytes,
+      std::shared_ptr<HeadersProvider> headers_provider,
+      const ArrowStreamOptions& options = {});
 
  private:
   friend class SdkBuilder;

--- a/cpp/include/zerobus/zerobus.hpp
+++ b/cpp/include/zerobus/zerobus.hpp
@@ -8,6 +8,7 @@
 /// which in turn wraps the Rust core. All operations report failure by throwing
 /// `zerobus::ZerobusException`.
 
+#include "zerobus/arrow_stream.hpp"
 #include "zerobus/config.hpp"
 #include "zerobus/error.hpp"
 #include "zerobus/headers_provider.hpp"

--- a/cpp/src/arrow_stream.cpp
+++ b/cpp/src/arrow_stream.cpp
@@ -1,0 +1,139 @@
+// Implementation of ArrowStream (declared in zerobus/arrow_stream.hpp), the
+// Beta Arrow Flight ingestion path.
+//
+// Each method forwards to the zerobus_arrow_stream_* C FFI entry points and
+// routes failures through detail::ResultGuard. get_unacked_batches copies the
+// FFI-owned batch payloads out before freeing the returned array. The
+// destructor closes best-effort (swallowing errors); close() surfaces them.
+// Public API documentation lives on the header.
+#include "zerobus/arrow_stream.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "detail/ffi_util.hpp"
+
+namespace zerobus {
+
+// Best-effort graceful close in the destructor (errors are swallowed — a
+// destructor must not throw), then free the Rust-owned handle.
+ArrowStream::~ArrowStream() {
+  if (handle_ != nullptr) {
+    detail::ResultGuard guard;
+    zerobus_arrow_stream_close(handle_, guard.ptr());
+    zerobus_arrow_stream_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+// Move carries the handle and the headers-provider together, nulling the source
+// so the handle is closed/freed exactly once.
+ArrowStream::ArrowStream(ArrowStream&& other) noexcept
+    : handle_(other.handle_), provider_(std::move(other.provider_)) {
+  other.handle_ = nullptr;
+}
+
+ArrowStream& ArrowStream::operator=(ArrowStream&& other) noexcept {
+  if (this != &other) {
+    // Close + free any stream we already hold before adopting other's.
+    if (handle_ != nullptr) {
+      detail::ResultGuard guard;
+      zerobus_arrow_stream_close(handle_, guard.ptr());
+      zerobus_arrow_stream_free(handle_);
+    }
+    handle_ = other.handle_;
+    provider_ = std::move(other.provider_);
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+// Ingest one batch (schema + records as Arrow IPC bytes); returns the assigned
+// offset. Like the Stream ingest path, failure comes back via the ResultGuard.
+std::int64_t ArrowStream::ingest_batch(const std::uint8_t* ipc_bytes,
+                                       std::size_t len) {
+  detail::ResultGuard guard;
+  std::int64_t offset =
+      zerobus_arrow_stream_ingest_batch(handle_, ipc_bytes, len, guard.ptr());
+  guard.throw_if_error();
+  return offset;
+}
+
+// Vector overload forwarding to the (pointer, length) form.
+std::int64_t ArrowStream::ingest_batch(
+    const std::vector<std::uint8_t>& ipc_bytes) {
+  return ingest_batch(ipc_bytes.data(), ipc_bytes.size());
+}
+
+void ArrowStream::wait_for_offset(std::int64_t offset) {
+  detail::ResultGuard guard;
+  zerobus_arrow_stream_wait_for_offset(handle_, offset, guard.ptr());
+  guard.throw_if_error();
+}
+
+void ArrowStream::flush() {
+  detail::ResultGuard guard;
+  zerobus_arrow_stream_flush(handle_, guard.ptr());
+  guard.throw_if_error();
+}
+
+// Copy each unacked batch out of the FFI-owned array (parallel batches/lengths
+// arrays) into owning vectors, then free the array — the borrowed bytes are
+// only valid until that free.
+std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
+  detail::ResultGuard guard;
+  CArrowBatchArray array =
+      zerobus_arrow_stream_get_unacked_batches(handle_, guard.ptr());
+  guard.throw_if_error();
+
+  std::vector<std::vector<std::uint8_t>> out;
+  if (array.batches != nullptr && array.count > 0) {
+    out.reserve(array.count);
+    for (std::size_t i = 0; i < array.count; ++i) {
+      const std::uint8_t* bytes = array.batches[i];
+      std::size_t len = array.lengths[i];
+      std::vector<std::uint8_t> batch;
+      if (bytes != nullptr && len > 0) {
+        batch.assign(bytes, bytes + len);
+      }
+      out.push_back(std::move(batch));
+    }
+  }
+  zerobus_arrow_free_batch_array(array);
+  return out;
+}
+
+// Explicit close: surfaces a failed flush/close by throwing (the destructor
+// does not). Idempotent via the null-handle guard.
+//
+// On failure the handle is deliberately kept (not freed, handle_ left non-null)
+// so the caller can still recover buffered batches via get_unacked_batches()
+// and retry close(); the destructor frees it as a last resort. Only a
+// successful close frees the handle and marks the stream closed. (Mirrors
+// Stream::close().)
+void ArrowStream::close() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  detail::ResultGuard guard;
+  bool ok = zerobus_arrow_stream_close(handle_, guard.ptr());
+  if (!ok) {
+    // Keep handle_ alive for recovery, then surface the error.
+    guard.throw_if_error();
+    // Fallback if close reported failure without setting an error message.
+    throw ZerobusException("failed to close Arrow stream", false);
+  }
+  zerobus_arrow_stream_free(handle_);
+  handle_ = nullptr;
+}
+
+// Once close()/destruction has nulled the handle the stream is closed; while it
+// is still live, defer to the core's own closed state via the FFI.
+bool ArrowStream::is_closed() const noexcept {
+  if (handle_ == nullptr) {
+    return true;
+  }
+  return zerobus_arrow_stream_is_closed(handle_);
+}
+
+}  // namespace zerobus

--- a/cpp/src/arrow_stream.cpp
+++ b/cpp/src/arrow_stream.cpp
@@ -15,6 +15,38 @@
 
 namespace zerobus {
 
+namespace {
+
+// Reject use of a released handle (after a successful close() or a move) with a
+// clear message instead of the low-level FFI null-pointer error. (Mirrors
+// stream.cpp.)
+void ensure_open(const CArrowStream* handle) {
+  if (handle == nullptr) {
+    throw ZerobusException("Stream has been closed", false);
+  }
+}
+
+// Reject a negative offset from an ingest call: it means the FFI returned a
+// sentinel with success set, never a usable offset. (Mirrors stream.cpp.)
+std::int64_t checked_offset(std::int64_t offset) {
+  if (offset < 0) {
+    throw ZerobusException("unexpected negative offset from Zerobus FFI",
+                           false);
+  }
+  return offset;
+}
+
+// Frees the FFI-owned array on scope exit, so it is released even if a copy
+// below throws. (Mirrors RecordArrayGuard in stream.cpp.)
+struct BatchArrayGuard {
+  CArrowBatchArray array;
+  ~BatchArrayGuard() { zerobus_arrow_free_batch_array(array); }
+  BatchArrayGuard(const BatchArrayGuard&) = delete;
+  BatchArrayGuard& operator=(const BatchArrayGuard&) = delete;
+};
+
+}  // namespace
+
 // Best-effort graceful close in the destructor (errors are swallowed — a
 // destructor must not throw), then free the Rust-owned handle.
 ArrowStream::~ArrowStream() {
@@ -52,11 +84,12 @@ ArrowStream& ArrowStream::operator=(ArrowStream&& other) noexcept {
 // offset. Like the Stream ingest path, failure comes back via the ResultGuard.
 std::int64_t ArrowStream::ingest_batch(const std::uint8_t* ipc_bytes,
                                        std::size_t len) {
+  ensure_open(handle_);
   detail::ResultGuard guard;
   std::int64_t offset =
       zerobus_arrow_stream_ingest_batch(handle_, ipc_bytes, len, guard.ptr());
   guard.throw_if_error();
-  return offset;
+  return checked_offset(offset);
 }
 
 // Vector overload forwarding to the (pointer, length) form.
@@ -66,12 +99,19 @@ std::int64_t ArrowStream::ingest_batch(
 }
 
 void ArrowStream::wait_for_offset(std::int64_t offset) {
+  ensure_open(handle_);
+  // Reject negative offsets before the FFI (matches Stream).
+  if (offset < 0) {
+    throw ZerobusException("wait_for_offset called with a negative offset",
+                           false);
+  }
   detail::ResultGuard guard;
   zerobus_arrow_stream_wait_for_offset(handle_, offset, guard.ptr());
   guard.throw_if_error();
 }
 
 void ArrowStream::flush() {
+  ensure_open(handle_);
   detail::ResultGuard guard;
   zerobus_arrow_stream_flush(handle_, guard.ptr());
   guard.throw_if_error();
@@ -81,10 +121,15 @@ void ArrowStream::flush() {
 // arrays) into owning vectors, then free the array — the borrowed bytes are
 // only valid until that free.
 std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
+  // Still callable after a failed close() (handle_ kept alive) so recovery
+  // works; only a successful close or a move is rejected.
+  ensure_open(handle_);
   detail::ResultGuard guard;
   CArrowBatchArray array =
       zerobus_arrow_stream_get_unacked_batches(handle_, guard.ptr());
   guard.throw_if_error();
+  // Own the array before the copy so it is freed on any exit path.
+  BatchArrayGuard array_guard{array};
 
   std::vector<std::vector<std::uint8_t>> out;
   if (array.batches != nullptr && array.count > 0) {
@@ -99,7 +144,6 @@ std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
       out.push_back(std::move(batch));
     }
   }
-  zerobus_arrow_free_batch_array(array);
   return out;
 }
 

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -46,6 +46,13 @@ inline CStreamConfigurationOptions to_c(const StreamOptions& opts) {
 
 /// Build the C Arrow stream-config struct from `ArrowStreamOptions`.
 inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
+  // The core builds a bounded Tokio channel with this capacity
+  // (`mpsc::channel(max_inflight_batches)` in `arrow_stream.rs`), which panics
+  // on a capacity of 0. Reject it here with an actionable message rather than
+  // letting the FFI panic guard surface the opaque panic text.
+  if (opts.max_inflight_batches == 0) {
+    throw ZerobusException("max_inflight_batches must be at least 1", false);
+  }
   CArrowStreamConfigurationOptions c = zerobus_arrow_get_default_config();
   c.max_inflight_batches = opts.max_inflight_batches;
   c.recovery = opts.recovery;

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -53,10 +53,13 @@ inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
   c.flush_timeout_ms = opts.flush_timeout_ms;
   c.connection_timeout_ms = opts.connection_timeout_ms;
   c.ipc_compression = static_cast<std::int32_t>(opts.ipc_compression);
-  // -1 sentinel = "wait full server duration" (no explicit cap).
+  // The C field is signed with -1 as the "wait full server duration" sentinel;
+  // `nullopt` maps to it. A present value is non-negative (unsigned in the
+  // option), so cast to the signed field explicitly rather than letting the
+  // ternary fold both branches to unsigned.
   c.stream_paused_max_wait_time_ms =
       opts.stream_paused_max_wait_time_ms.has_value()
-          ? *opts.stream_paused_max_wait_time_ms
+          ? static_cast<std::int64_t>(*opts.stream_paused_max_wait_time_ms)
           : -1;
   return c;
 }

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -41,6 +41,26 @@ inline CStreamConfigurationOptions to_c(const StreamOptions& opts) {
   return c;
 }
 
+/// Build the C Arrow stream-config struct from `ArrowStreamOptions`.
+inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
+  CArrowStreamConfigurationOptions c = zerobus_arrow_get_default_config();
+  c.max_inflight_batches = opts.max_inflight_batches;
+  c.recovery = opts.recovery;
+  c.recovery_timeout_ms = opts.recovery_timeout_ms;
+  c.recovery_backoff_ms = opts.recovery_backoff_ms;
+  c.recovery_retries = opts.recovery_retries;
+  c.server_lack_of_ack_timeout_ms = opts.server_lack_of_ack_timeout_ms;
+  c.flush_timeout_ms = opts.flush_timeout_ms;
+  c.connection_timeout_ms = opts.connection_timeout_ms;
+  c.ipc_compression = static_cast<std::int32_t>(opts.ipc_compression);
+  // -1 sentinel = "wait full server duration" (no explicit cap).
+  c.stream_paused_max_wait_time_ms =
+      opts.stream_paused_max_wait_time_ms.has_value()
+          ? *opts.stream_paused_max_wait_time_ms
+          : -1;
+  return c;
+}
+
 }  // namespace detail
 }  // namespace zerobus
 

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -1,6 +1,9 @@
 #ifndef ZEROBUS_DETAIL_CONFIG_CONVERT_HPP
 #define ZEROBUS_DETAIL_CONFIG_CONVERT_HPP
 
+#include <cstdint>
+#include <limits>
+
 #include "detail/ffi_util.hpp"
 #include "zerobus/config.hpp"
 
@@ -53,12 +56,21 @@ inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
   c.flush_timeout_ms = opts.flush_timeout_ms;
   c.connection_timeout_ms = opts.connection_timeout_ms;
   c.ipc_compression = static_cast<std::int32_t>(opts.ipc_compression);
-  // `nullopt` maps to the signed field's -1 sentinel ("full server duration").
-  // Cast explicitly so the ternary doesn't fold both branches to unsigned.
-  c.stream_paused_max_wait_time_ms =
-      opts.stream_paused_max_wait_time_ms.has_value()
-          ? static_cast<std::int64_t>(*opts.stream_paused_max_wait_time_ms)
-          : -1;
+  // `nullopt` maps to the -1 sentinel ("full server duration"). Reject values
+  // above INT64_MAX so they can't wrap to a negative int64 and be misread as
+  // -1.
+  if (opts.stream_paused_max_wait_time_ms.has_value()) {
+    std::uint64_t v = *opts.stream_paused_max_wait_time_ms;
+    if (v >
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+      throw ZerobusException(
+          "stream_paused_max_wait_time_ms exceeds the maximum supported value",
+          false);
+    }
+    c.stream_paused_max_wait_time_ms = static_cast<std::int64_t>(v);
+  } else {
+    c.stream_paused_max_wait_time_ms = -1;
+  }
   return c;
 }
 

--- a/cpp/src/detail/config_convert.hpp
+++ b/cpp/src/detail/config_convert.hpp
@@ -53,10 +53,8 @@ inline CArrowStreamConfigurationOptions to_c(const ArrowStreamOptions& opts) {
   c.flush_timeout_ms = opts.flush_timeout_ms;
   c.connection_timeout_ms = opts.connection_timeout_ms;
   c.ipc_compression = static_cast<std::int32_t>(opts.ipc_compression);
-  // The C field is signed with -1 as the "wait full server duration" sentinel;
-  // `nullopt` maps to it. A present value is non-negative (unsigned in the
-  // option), so cast to the signed field explicitly rather than letting the
-  // ternary fold both branches to unsigned.
+  // `nullopt` maps to the signed field's -1 sentinel ("full server duration").
+  // Cast explicitly so the ternary doesn't fold both branches to unsigned.
   c.stream_paused_max_wait_time_ms =
       opts.stream_paused_max_wait_time_ms.has_value()
           ? static_cast<std::int64_t>(*opts.stream_paused_max_wait_time_ms)

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -25,15 +25,6 @@ const std::uint8_t* descriptor_ptr(const std::vector<std::uint8_t>& d) {
   return d.empty() ? nullptr : d.data();
 }
 
-// Pointer to the bytes, or null when empty. Used for the Arrow schema, whose
-// emptiness is validated separately before this is called.
-const std::uint8_t* non_empty_ptr(const std::vector<std::uint8_t>& bytes) {
-  if (bytes.empty()) {
-    return nullptr;
-  }
-  return bytes.data();
-}
-
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -227,10 +218,11 @@ ArrowStream Sdk::create_arrow_stream(
   }
   detail::ResultGuard guard;
   CArrowStreamConfigurationOptions copts = detail::to_c(options);
-  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  // Non-empty checked above, so data() is non-null.
   CArrowStream* stream = zerobus_sdk_create_arrow_stream(
-      handle_, detail::checked_c_str(table_name, "table_name"), schema_ptr,
-      schema_ipc_bytes.size(), detail::checked_c_str(client_id, "client_id"),
+      handle_, detail::checked_c_str(table_name, "table_name"),
+      schema_ipc_bytes.data(), schema_ipc_bytes.size(),
+      detail::checked_c_str(client_id, "client_id"),
       detail::checked_c_str(client_secret, "client_secret"), &copts,
       guard.ptr());
   if (stream == nullptr) {
@@ -257,11 +249,12 @@ ArrowStream Sdk::create_arrow_stream(
   }
   detail::ResultGuard guard;
   CArrowStreamConfigurationOptions copts = detail::to_c(options);
-  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  // Non-empty checked above, so data() is non-null.
   CArrowStream* stream = zerobus_sdk_create_arrow_stream_with_headers_provider(
-      handle_, detail::checked_c_str(table_name, "table_name"), schema_ptr,
-      schema_ipc_bytes.size(), detail::zerobus_cpp_headers_trampoline,
-      headers_provider.get(), &copts, guard.ptr());
+      handle_, detail::checked_c_str(table_name, "table_name"),
+      schema_ipc_bytes.data(), schema_ipc_bytes.size(),
+      detail::zerobus_cpp_headers_trampoline, headers_provider.get(), &copts,
+      guard.ptr());
   if (stream == nullptr) {
     guard.throw_if_error();
     throw ZerobusException("failed to create Arrow stream", false);

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -2,8 +2,8 @@
 //
 // Each method forwards to the C FFI (zerobus.h): the builder accumulates
 // configuration on an opaque CZerobusSdkBuilder and build() consumes it into a
-// CZerobusSdk, while create_stream hands the configured options across the
-// boundary. Every fallible call routes its CResult through
+// CZerobusSdk, while create_stream / create_arrow_stream hand the configured
+// options across the boundary. Every fallible call routes its CResult through
 // detail::ResultGuard, which converts failure into a ZerobusException and frees
 // the C error string. Public API documentation lives on the declarations in the
 // header; comments here cover only implementation details.
@@ -23,6 +23,15 @@ namespace {
 // Pointer to the descriptor bytes, or null for a JSON stream.
 const std::uint8_t* descriptor_ptr(const std::vector<std::uint8_t>& d) {
   return d.empty() ? nullptr : d.data();
+}
+
+// Pointer to the bytes, or null when empty. Used for the Arrow schema, whose
+// emptiness is validated separately before this is called.
+const std::uint8_t* non_empty_ptr(const std::vector<std::uint8_t>& bytes) {
+  if (bytes.empty()) {
+    return nullptr;
+  }
+  return bytes.data();
 }
 
 }  // namespace
@@ -202,6 +211,62 @@ Stream Sdk::create_stream(const TableProperties& table,
     throw ZerobusException("failed to create stream", false);
   }
   return Stream(stream, std::move(headers_provider));
+}
+
+// Create an OAuth-authenticated Arrow Flight stream (Beta). The schema IPC
+// bytes are required (an Arrow stream has no JSON fallback), so reject an empty
+// schema before crossing the FFI rather than letting the core fail less
+// clearly.
+ArrowStream Sdk::create_arrow_stream(
+    const std::string& table_name,
+    const std::vector<std::uint8_t>& schema_ipc_bytes,
+    const std::string& client_id, const std::string& client_secret,
+    const ArrowStreamOptions& options) {
+  if (schema_ipc_bytes.empty()) {
+    throw ZerobusException("schema_ipc_bytes must not be empty", false);
+  }
+  detail::ResultGuard guard;
+  CArrowStreamConfigurationOptions copts = detail::to_c(options);
+  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  CArrowStream* stream = zerobus_sdk_create_arrow_stream(
+      handle_, detail::checked_c_str(table_name, "table_name"), schema_ptr,
+      schema_ipc_bytes.size(), detail::checked_c_str(client_id, "client_id"),
+      detail::checked_c_str(client_secret, "client_secret"), &copts,
+      guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Arrow stream", false);
+  }
+  return ArrowStream(stream, nullptr);
+}
+
+// Arrow Flight stream (Beta) authenticated by a custom headers provider. Both
+// the provider and the schema bytes are validated up front; as with the proto
+// path, the Stream keeps the provider's shared_ptr alive for the callback's
+// lifetime.
+ArrowStream Sdk::create_arrow_stream(
+    const std::string& table_name,
+    const std::vector<std::uint8_t>& schema_ipc_bytes,
+    std::shared_ptr<HeadersProvider> headers_provider,
+    const ArrowStreamOptions& options) {
+  if (headers_provider == nullptr) {
+    throw ZerobusException("headers_provider must not be null", false);
+  }
+  if (schema_ipc_bytes.empty()) {
+    throw ZerobusException("schema_ipc_bytes must not be empty", false);
+  }
+  detail::ResultGuard guard;
+  CArrowStreamConfigurationOptions copts = detail::to_c(options);
+  const std::uint8_t* schema_ptr = non_empty_ptr(schema_ipc_bytes);
+  CArrowStream* stream = zerobus_sdk_create_arrow_stream_with_headers_provider(
+      handle_, detail::checked_c_str(table_name, "table_name"), schema_ptr,
+      schema_ipc_bytes.size(), detail::zerobus_cpp_headers_trampoline,
+      headers_provider.get(), &copts, guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Arrow stream", false);
+  }
+  return ArrowStream(stream, std::move(headers_provider));
 }
 
 }  // namespace zerobus

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -242,8 +242,8 @@ ArrowStream Sdk::create_arrow_stream(
 
 // Arrow Flight stream (Beta) authenticated by a custom headers provider. Both
 // the provider and the schema bytes are validated up front; as with the proto
-// path, the Stream keeps the provider's shared_ptr alive for the callback's
-// lifetime.
+// path, the ArrowStream keeps the provider's shared_ptr alive for the
+// callback's lifetime.
 ArrowStream Sdk::create_arrow_stream(
     const std::string& table_name,
     const std::vector<std::uint8_t>& schema_ipc_bytes,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -22,4 +22,5 @@ endfunction()
 
 zerobus_add_test(config_defaults_test)
 zerobus_add_test(arrow_config_defaults_test)
+zerobus_add_test(arrow_config_convert_test)
 zerobus_add_test(embedded_nul_test)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -21,4 +21,5 @@ function(zerobus_add_test name)
 endfunction()
 
 zerobus_add_test(config_defaults_test)
+zerobus_add_test(arrow_config_defaults_test)
 zerobus_add_test(embedded_nul_test)

--- a/cpp/tests/arrow_config_convert_test.cpp
+++ b/cpp/tests/arrow_config_convert_test.cpp
@@ -1,6 +1,7 @@
-// Covers to_c(ArrowStreamOptions)'s stream_paused_max_wait_time_ms handling:
-// set-value round-trip and the >INT64_MAX rejection (arrow_config_defaults_test
-// only pins the nullopt -> -1 default).
+// Covers to_c(ArrowStreamOptions)'s client-side validation and optional-field
+// handling: the stream_paused_max_wait_time_ms set-value round-trip and
+// >INT64_MAX rejection, and the max_inflight_batches == 0 rejection
+// (arrow_config_defaults_test only pins the nullopt -> -1 default).
 
 #include <cstdint>
 #include <cstdio>
@@ -79,6 +80,33 @@ int main() {
     }
     if (!threw) {
       fail("stream_paused_max_wait_time_ms > INT64_MAX was NOT rejected");
+    }
+  }
+
+  // max_inflight_batches == 0 must be rejected client-side: the core builds a
+  // bounded Tokio channel with this capacity, which panics on 0.
+  {
+    zerobus::ArrowStreamOptions opts{};
+    opts.max_inflight_batches = 0;
+    bool threw = false;
+    try {
+      zerobus::detail::to_c(opts);
+    } catch (const zerobus::ZerobusException&) {
+      threw = true;
+    }
+    if (!threw) {
+      fail("max_inflight_batches == 0 was NOT rejected");
+    }
+  }
+
+  // A positive max_inflight_batches round-trips unchanged.
+  {
+    zerobus::ArrowStreamOptions opts{};
+    opts.max_inflight_batches = 42;
+    const zerobus::CArrowStreamConfigurationOptions c =
+        zerobus::detail::to_c(opts);
+    if (c.max_inflight_batches != 42) {
+      fail("set max_inflight_batches did not round-trip to 42");
     }
   }
 

--- a/cpp/tests/arrow_config_convert_test.cpp
+++ b/cpp/tests/arrow_config_convert_test.cpp
@@ -67,8 +67,10 @@ int main() {
   // Above INT64_MAX must throw, not wrap to a negative int64.
   {
     zerobus::ArrowStreamOptions opts{};
-    opts.stream_paused_max_wait_time_ms =
-        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1;
+    const auto too_large =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) +
+        1;
+    opts.stream_paused_max_wait_time_ms = too_large;
     bool threw = false;
     try {
       zerobus::detail::to_c(opts);

--- a/cpp/tests/arrow_config_convert_test.cpp
+++ b/cpp/tests/arrow_config_convert_test.cpp
@@ -1,7 +1,6 @@
-// Exercises the one piece of real logic in to_c(ArrowStreamOptions): the
-// stream_paused_max_wait_time_ms optional handling. arrow_config_defaults_test
-// only pins the default-constructed (nullopt -> -1) case, so the "value set"
-// round-trip and the ">INT64_MAX rejection" branch are covered here.
+// Covers to_c(ArrowStreamOptions)'s stream_paused_max_wait_time_ms handling:
+// set-value round-trip and the >INT64_MAX rejection (arrow_config_defaults_test
+// only pins the nullopt -> -1 default).
 
 #include <cstdint>
 #include <cstdio>
@@ -44,8 +43,7 @@ int main() {
     }
   }
 
-  // INT64_MAX is the largest accepted value: it must not be rejected and must
-  // round-trip (not wrap to a negative int64 misread as the -1 sentinel).
+  // INT64_MAX is the largest accepted value: round-trips, not rejected.
   {
     zerobus::ArrowStreamOptions opts{};
     opts.stream_paused_max_wait_time_ms =
@@ -66,7 +64,7 @@ int main() {
     }
   }
 
-  // A value above INT64_MAX must throw rather than wrap to a negative int64.
+  // Above INT64_MAX must throw, not wrap to a negative int64.
   {
     zerobus::ArrowStreamOptions opts{};
     opts.stream_paused_max_wait_time_ms =

--- a/cpp/tests/arrow_config_convert_test.cpp
+++ b/cpp/tests/arrow_config_convert_test.cpp
@@ -1,0 +1,91 @@
+// Exercises the one piece of real logic in to_c(ArrowStreamOptions): the
+// stream_paused_max_wait_time_ms optional handling. arrow_config_defaults_test
+// only pins the default-constructed (nullopt -> -1) case, so the "value set"
+// round-trip and the ">INT64_MAX rejection" branch are covered here.
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <optional>
+
+#include "detail/config_convert.hpp"
+#include "zerobus/error.hpp"
+
+namespace {
+
+int g_failures = 0;
+
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_failures;
+}
+
+}  // namespace
+
+int main() {
+  // A set value round-trips unchanged.
+  {
+    zerobus::ArrowStreamOptions opts{};
+    opts.stream_paused_max_wait_time_ms = 5000;
+    const zerobus::CArrowStreamConfigurationOptions c =
+        zerobus::detail::to_c(opts);
+    if (c.stream_paused_max_wait_time_ms != 5000) {
+      fail("set stream_paused_max_wait_time_ms did not round-trip to 5000");
+    }
+  }
+
+  // nullopt maps to the -1 sentinel ("full server duration").
+  {
+    zerobus::ArrowStreamOptions opts{};  // stream_paused_max_wait_time_ms unset
+    const zerobus::CArrowStreamConfigurationOptions c =
+        zerobus::detail::to_c(opts);
+    if (c.stream_paused_max_wait_time_ms != -1) {
+      fail("nullopt stream_paused_max_wait_time_ms did not map to -1 sentinel");
+    }
+  }
+
+  // INT64_MAX is the largest accepted value: it must not be rejected and must
+  // round-trip (not wrap to a negative int64 misread as the -1 sentinel).
+  {
+    zerobus::ArrowStreamOptions opts{};
+    opts.stream_paused_max_wait_time_ms =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+    bool threw = false;
+    try {
+      const zerobus::CArrowStreamConfigurationOptions c =
+          zerobus::detail::to_c(opts);
+      if (c.stream_paused_max_wait_time_ms !=
+          std::numeric_limits<std::int64_t>::max()) {
+        fail("INT64_MAX stream_paused_max_wait_time_ms did not round-trip");
+      }
+    } catch (const zerobus::ZerobusException&) {
+      threw = true;
+    }
+    if (threw) {
+      fail("INT64_MAX stream_paused_max_wait_time_ms was wrongly rejected");
+    }
+  }
+
+  // A value above INT64_MAX must throw rather than wrap to a negative int64.
+  {
+    zerobus::ArrowStreamOptions opts{};
+    opts.stream_paused_max_wait_time_ms =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1;
+    bool threw = false;
+    try {
+      zerobus::detail::to_c(opts);
+    } catch (const zerobus::ZerobusException&) {
+      threw = true;
+    }
+    if (!threw) {
+      fail("stream_paused_max_wait_time_ms > INT64_MAX was NOT rejected");
+    }
+  }
+
+  if (g_failures != 0) {
+    std::fprintf(stderr, "%d check(s) failed.\n", g_failures);
+    return 1;
+  }
+  std::printf("arrow config conversion handles the optional wait-time field\n");
+  return 0;
+}

--- a/cpp/tests/arrow_config_defaults_test.cpp
+++ b/cpp/tests/arrow_config_defaults_test.cpp
@@ -14,7 +14,8 @@ int g_failures = 0;
 
 // Report but don't abort, so one run lists every drifted field.
 // Signed int64 (not uint64): the -1 sentinels (ipc_compression,
-// stream_paused_max_wait_time_ms) compare cleanly, and every field is < INT64_MAX.
+// stream_paused_max_wait_time_ms) compare cleanly, and every field is
+// < INT64_MAX.
 template <typename A, typename B>
 void check_eq(const char* field, A actual, B expected) {
   if (static_cast<std::int64_t>(actual) !=

--- a/cpp/tests/arrow_config_defaults_test.cpp
+++ b/cpp/tests/arrow_config_defaults_test.cpp
@@ -13,6 +13,10 @@ namespace {
 int g_failures = 0;
 
 // Report but don't abort, so a single run lists every drifted field at once.
+// Compare through signed int64 (not uint64 like config_defaults_test): the Arrow
+// config's ipc_compression and stream_paused_max_wait_time_ms default to -1, and
+// a signed cast compares those sentinels cleanly. max_inflight_batches (1'000)
+// is far below INT64_MAX, so the cast is exact for every current field.
 template <typename A, typename B>
 void check_eq(const char* field, A actual, B expected) {
   if (static_cast<std::int64_t>(actual) !=

--- a/cpp/tests/arrow_config_defaults_test.cpp
+++ b/cpp/tests/arrow_config_defaults_test.cpp
@@ -12,11 +12,9 @@ namespace {
 
 int g_failures = 0;
 
-// Report but don't abort, so a single run lists every drifted field at once.
-// Compare through signed int64 (not uint64 like config_defaults_test): the Arrow
-// config's ipc_compression and stream_paused_max_wait_time_ms default to -1, and
-// a signed cast compares those sentinels cleanly. max_inflight_batches (1'000)
-// is far below INT64_MAX, so the cast is exact for every current field.
+// Report but don't abort, so one run lists every drifted field.
+// Signed int64 (not uint64): the -1 sentinels (ipc_compression,
+// stream_paused_max_wait_time_ms) compare cleanly, and every field is < INT64_MAX.
 template <typename A, typename B>
 void check_eq(const char* field, A actual, B expected) {
   if (static_cast<std::int64_t>(actual) !=

--- a/cpp/tests/arrow_config_defaults_test.cpp
+++ b/cpp/tests/arrow_config_defaults_test.cpp
@@ -1,0 +1,67 @@
+// Arrow analogue of config_defaults_test: `to_c()` overwrites every scalar with
+// the C++ literal, so a stale literal would silently ship a wrong default. This
+// pins `to_c(ArrowStreamOptions{})` to `zerobus_arrow_get_default_config()`,
+// turning drift into a build failure.
+
+#include <cstdint>
+#include <cstdio>
+
+#include "detail/config_convert.hpp"
+
+namespace {
+
+int g_failures = 0;
+
+// Report but don't abort, so a single run lists every drifted field at once.
+template <typename A, typename B>
+void check_eq(const char* field, A actual, B expected) {
+  if (static_cast<std::int64_t>(actual) !=
+      static_cast<std::int64_t>(expected)) {
+    std::fprintf(stderr,
+                 "FAIL: %s: ArrowStreamOptions{} default (%lld) != "
+                 "zerobus_arrow_get_default_config() (%lld)\n",
+                 field, static_cast<long long>(actual),
+                 static_cast<long long>(expected));
+    ++g_failures;
+  }
+}
+
+}  // namespace
+
+int main() {
+  const zerobus::ArrowStreamOptions opts{};
+  const zerobus::CArrowStreamConfigurationOptions from_cpp =
+      zerobus::detail::to_c(opts);
+  const zerobus::CArrowStreamConfigurationOptions from_ffi =
+      zerobus::zerobus_arrow_get_default_config();
+
+  check_eq("max_inflight_batches", from_cpp.max_inflight_batches,
+           from_ffi.max_inflight_batches);
+  check_eq("recovery", from_cpp.recovery, from_ffi.recovery);
+  check_eq("recovery_timeout_ms", from_cpp.recovery_timeout_ms,
+           from_ffi.recovery_timeout_ms);
+  check_eq("recovery_backoff_ms", from_cpp.recovery_backoff_ms,
+           from_ffi.recovery_backoff_ms);
+  check_eq("recovery_retries", from_cpp.recovery_retries,
+           from_ffi.recovery_retries);
+  check_eq("server_lack_of_ack_timeout_ms",
+           from_cpp.server_lack_of_ack_timeout_ms,
+           from_ffi.server_lack_of_ack_timeout_ms);
+  check_eq("flush_timeout_ms", from_cpp.flush_timeout_ms,
+           from_ffi.flush_timeout_ms);
+  check_eq("connection_timeout_ms", from_cpp.connection_timeout_ms,
+           from_ffi.connection_timeout_ms);
+  check_eq("ipc_compression", from_cpp.ipc_compression,
+           from_ffi.ipc_compression);
+  check_eq("stream_paused_max_wait_time_ms",
+           from_cpp.stream_paused_max_wait_time_ms,
+           from_ffi.stream_paused_max_wait_time_ms);
+
+  if (g_failures != 0) {
+    std::fprintf(stderr, "%d field(s) diverged from the FFI defaults.\n",
+                 g_failures);
+    return 1;
+  }
+  std::printf("arrow config defaults match FFI defaults\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds the C++ Arrow Flight ingestion stream (Beta) on top of the current core, and fixes a set of doc/type inconsistencies found while reviewing it.

### Arrow Flight stream (Beta)
- New `ArrowStream` class (`arrow_stream.hpp`/`.cpp`): move-only handle over the `zerobus_arrow_stream_*` FFI, with `ingest_batch`, `wait_for_offset`, `flush`, `get_unacked_batches`, `close`, and `is_closed`.
- `Sdk::create_arrow_stream` overloads for OAuth client-credentials and custom headers-provider auth.
- `ArrowStreamOptions` config struct + `IpcCompression` enum, converted to the C config via `to_c()`.

### Doc/type fixes
- Correct an `ArrowStream` reference in the `create_arrow_stream` comment (was "Stream").
- Document all three `stream_paused_max_wait_time_ms` cases (`nullopt` / `0` / `> 0`) to match the FFI header and Rust core.
- Change `stream_paused_max_wait_time_ms` to `std::optional<std::uint64_t>` to match the core's `Option<u64>`, and cast the sentinel explicitly in `to_c()` so the ternary doesn't fold both branches to unsigned.
- Correct the header note on why `zerobus_arrow_stream_ingest_batch_via_record_batch` is omitted: it is a functional duplicate of `zerobus_arrow_stream_ingest_batch` (same IPC-bytes signature, both deserialise then re-encode), not a method taking an unconstructable `RecordBatch*`.

### Tests (config-conversion unit tests only)
This PR includes only server-free unit tests of the config-conversion logic — the layer that ships in this diff:
- `arrow_config_defaults_test` pins every `to_c(ArrowStreamOptions{})` scalar to `zerobus_arrow_get_default_config()`, turning default drift into a build failure.
- `arrow_config_convert_test` covers the `stream_paused_max_wait_time_ms` conversion logic: set-value round-trip, `nullopt` → `-1` sentinel, the `INT64_MAX` boundary, and the `> INT64_MAX` overflow rejection.

## Scope / follow-ups

This is an incremental split of the C++ SDK, so some artifacts land in later stacked PRs rather than here:

- **README, `NEXT_CHANGELOG.md`/`CHANGELOG.md`, and runnable examples** for the Arrow path are deferred to the following stacked PRs. The `cpp/` tree has no changelog/README/`examples/` yet; they will be bootstrapped alongside the rest of the SDK docs.
- **Behavioral / lifecycle tests** (live-`ArrowStream` coverage: move single-close, `close()` idempotency, post-close operation guards, `get_unacked_batches` after a failed close) are deferred to the same later PRs, since they exercise a live stream and generally require a server. The unit tests above intentionally cover only the config-conversion logic introduced in this diff.

## Notes
- The API is Beta and may change before GA.
- `stream_paused_max_wait_time_ms` changing from signed to unsigned is a source-level change to the (unreleased) Beta config struct.
