### PR TITLE
[Rust][FFI] Fix darwin release builds by building static-lib only

### DIFF
--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -41,17 +41,17 @@ jobs:
           - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: x86_64-apple-darwin
             static_lib: libzerobus_ffi.a
-            dynamic_lib: libzerobus_ffi.dylib
             artifact_dir: darwin-x86_64
             cross: false
             zigbuild: true
+            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: aarch64-apple-darwin
             static_lib: libzerobus_ffi.a
-            dynamic_lib: libzerobus_ffi.dylib
             artifact_dir: darwin-aarch64
             cross: false
             zigbuild: true
+            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
             static_lib: zerobus_ffi.lib
@@ -121,17 +121,25 @@ jobs:
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Build FFI library (zigbuild)
-        if: matrix.zigbuild
+        if: matrix.zigbuild && !matrix.static_only
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
         run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI static library (zigbuild, static only)
+        if: matrix.zigbuild && matrix.static_only
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo zigbuild rustc --release -p zerobus-ffi --target ${{ matrix.target }} --crate-type staticlib
 
       - name: Prepare artifacts
         shell: bash
         run: |
           mkdir -p artifacts/${{ matrix.artifact_dir }}
           cp target/${{ matrix.target }}/release/${{ matrix.static_lib }} artifacts/${{ matrix.artifact_dir }}/
-          cp target/${{ matrix.target }}/release/${{ matrix.dynamic_lib }} artifacts/${{ matrix.artifact_dir }}/
+          if [ -n "${{ matrix.dynamic_lib }}" ]; then
+            cp target/${{ matrix.target }}/release/${{ matrix.dynamic_lib }} artifacts/${{ matrix.artifact_dir }}/
+          fi
           cp ffi/zerobus.h artifacts/${{ matrix.artifact_dir }}/
 
       - name: Upload artifact


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR changes the `release-ffi.yml` workflow so that for macOS, only static libraries (`libzerobus_ffi.a`) are build instead of building dynamic libs as well.

When the `static_only: true` flag is set, the targets are built via `cargo zigbuild rustc … --crate-type staticlib`.

The darwin cross-builds added in #429 fail at the link step for dynamic libs:

```
error: unable to find framework 'Security'. searched paths:  none
error: unable to find framework 'CoreFoundation'. searched paths:  none
error: linking with `zigcc-aarch64-apple-darwin` failed: exit status: 1
```

The Rust SDK transitively links Apple's `Security` and `CoreFoundation` frameworks (via `rustls-native-certs`), which live in the macOS SDK absent on the Linux runner, and not bundled by zig. This only affects the `cdylib` (`.dylib`), which requires a link step. The static lib is just an archive of object files with no link, so it builds cleanly and defers framework resolution to the consumer's link on an actual Mac.

Building the staticlib alone is sufficient for the Go SDK, which statically links `libzerobus_ffi.a` and already supplies `-framework Security -framework CoreFoundation` in its own cgo `LDFLAGS`, resolving them at build time on macOS. The tradeoff is that the FFI release no longer ships a darwin `.dylib`; if an external consumer ever needs one, that requires vendoring the macOS SDK into the build and can be added later.

## How is this tested?

Validated the crate-type override locally on a Linux host (no zig needed — the `--crate-type staticlib` behavior is toolchain-agnostic):

```
$ cargo rustc --release -p zerobus-ffi --crate-type staticlib
$ ls target/release/libzerobus_ffi.*
libzerobus_ffi.a    libzerobus_ffi.d      # no .so / .dylib emitted
$ nm target/release/libzerobus_ffi.a | grep -c zerobus_sdk_builder_endpoint
1
```

Confirms the staticlib-only build emits just the `.a` and the archive retains the FFI symbols. The full darwin cross-build itself will be exercised when the workflow next runs against this branch.