### PR TITLE
[Rust][FFI] Move header helpers to common.rs

### DIFF
--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Internal Changes
 
+- Move the header-callback helpers `zerobus_alloc_header_array`, `zerobus_alloc_cstring`, and `zerobus_free_headers` from `arrow.rs` into the shared `common.rs` module, next to the `CHeader`/`CHeaders` types they serve. No behavior, signature, or ABI change; their declarations move ahead of the Arrow functions in the generated `zerobus.h`.
+
 ### Behavior Changes
 
 ### Breaking Changes

--- a/rust/ffi/src/arrow.rs
+++ b/rust/ffi/src/arrow.rs
@@ -6,7 +6,6 @@ use bytes::Bytes;
 use databricks_zerobus_ingest_sdk::{
     HeadersProvider, RecordBatch, StreamBuilder, ZerobusArrowStream, ZerobusError, ZerobusResult,
 };
-use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Arc;
@@ -649,81 +648,4 @@ pub extern "C" fn zerobus_arrow_get_default_config() -> CArrowStreamConfiguratio
         ipc_compression: -1,
         stream_paused_max_wait_time_ms: -1,
     }
-}
-
-/// Allocate a zeroed `CHeader` array of `count` elements for a headers callback
-/// to populate and return in a `CHeaders`.
-///
-/// The array is allocated by the same allocator `zerobus_free_headers` releases
-/// it with (`libc::calloc` / `libc::free`), so a non-Rust callback can build a
-/// `CHeaders` without its own allocator having to match Rust's. This matters on
-/// Windows, where the C/C++ caller and this statically linked library can
-/// resolve to different CRT heaps; allocating here keeps the alloc/free pair on
-/// one heap and avoids the cross-heap free that would otherwise corrupt memory.
-///
-/// Zero-initialised so a partially populated array is safe to pass to
-/// `zerobus_free_headers` (unset key/value pointers are null and skipped).
-/// Returns null if `count` is 0 or the allocation fails.
-// Not wrapped in `ffi_guard`: a pure `calloc` that returns null on failure,
-// with no panic-capable operation.
-#[no_mangle]
-pub extern "C" fn zerobus_alloc_header_array(count: usize) -> *mut CHeader {
-    if count == 0 {
-        return ptr::null_mut();
-    }
-    unsafe { libc::calloc(count, std::mem::size_of::<CHeader>()) as *mut CHeader }
-}
-
-/// Duplicate `len` bytes from `data` into a NUL-terminated C string for a
-/// headers callback to store in a `CHeader` key/value or a `CHeaders`
-/// error_message.
-///
-/// Allocated as a Rust `CString`, matching the `CString::from_raw` that
-/// `zerobus_free_headers` frees it with — the string is allocated and freed by
-/// the same allocator inside this library (see `zerobus_alloc_header_array` for
-/// why that matters). `len` of 0 yields an empty string (a valid non-null
-/// pointer). Returns null on allocation failure or if the input contains an
-/// interior NUL byte (which a C string cannot represent).
-// Not wrapped in `ffi_guard`: null-checks its input and returns null on any
-// failure (`CString::new` reports interior NULs as `Err`), with no
-// panic-capable operation.
-#[no_mangle]
-pub extern "C" fn zerobus_alloc_cstring(data: *const u8, len: usize) -> *mut c_char {
-    let bytes: &[u8] = if len == 0 {
-        &[]
-    } else if data.is_null() {
-        return ptr::null_mut();
-    } else {
-        unsafe { std::slice::from_raw_parts(data, len) }
-    };
-    match CString::new(bytes) {
-        Ok(s) => s.into_raw(),
-        Err(_) => ptr::null_mut(),
-    }
-}
-
-/// Free headers returned from callback
-#[no_mangle]
-pub extern "C" fn zerobus_free_headers(headers: CHeaders) {
-    ffi_guard(ptr::null_mut(), (), move || {
-        if !headers.headers.is_null() {
-            unsafe {
-                let headers_slice = std::slice::from_raw_parts_mut(headers.headers, headers.count);
-                for header in headers_slice {
-                    if !header.key.is_null() {
-                        let _ = CString::from_raw(header.key);
-                    }
-                    if !header.value.is_null() {
-                        let _ = CString::from_raw(header.value);
-                    }
-                }
-                libc::free(headers.headers as *mut std::ffi::c_void);
-            }
-        }
-        if !headers.error_message.is_null() {
-            unsafe {
-                let _ = CString::from_raw(headers.error_message);
-            }
-        }
-    })
 }

--- a/rust/ffi/src/common.rs
+++ b/rust/ffi/src/common.rs
@@ -248,7 +248,7 @@ impl HeadersProvider for CallbackHeadersProvider {
                     .to_string_lossy()
                     .into_owned()
             };
-            crate::zerobus_free_headers(c_headers);
+            zerobus_free_headers(c_headers);
             return Err(ZerobusError::InvalidArgument(format!(
                 "Headers provider error: {}",
                 error_str
@@ -274,9 +274,86 @@ impl HeadersProvider for CallbackHeadersProvider {
             }
         }
 
-        crate::zerobus_free_headers(c_headers);
+        zerobus_free_headers(c_headers);
         Ok(headers)
     }
+}
+
+/// Allocate a zeroed `CHeader` array of `count` elements for a headers callback
+/// to populate and return in a `CHeaders`.
+///
+/// The array is allocated by the same allocator `zerobus_free_headers` releases
+/// it with (`libc::calloc` / `libc::free`), so a non-Rust callback can build a
+/// `CHeaders` without its own allocator having to match Rust's. This matters on
+/// Windows, where the C/C++ caller and this statically linked library can
+/// resolve to different CRT heaps; allocating here keeps the alloc/free pair on
+/// one heap and avoids the cross-heap free that would otherwise corrupt memory.
+///
+/// Zero-initialised so a partially populated array is safe to pass to
+/// `zerobus_free_headers` (unset key/value pointers are null and skipped).
+/// Returns null if `count` is 0 or the allocation fails.
+// Not wrapped in `ffi_guard`: a pure `calloc` that returns null on failure,
+// with no panic-capable operation.
+#[no_mangle]
+pub extern "C" fn zerobus_alloc_header_array(count: usize) -> *mut CHeader {
+    if count == 0 {
+        return ptr::null_mut();
+    }
+    unsafe { libc::calloc(count, std::mem::size_of::<CHeader>()) as *mut CHeader }
+}
+
+/// Duplicate `len` bytes from `data` into a NUL-terminated C string for a
+/// headers callback to store in a `CHeader` key/value or a `CHeaders`
+/// error_message.
+///
+/// Allocated as a Rust `CString`, matching the `CString::from_raw` that
+/// `zerobus_free_headers` frees it with - the string is allocated and freed by
+/// the same allocator inside this library (see `zerobus_alloc_header_array` for
+/// why that matters). `len` of 0 yields an empty string (a valid non-null
+/// pointer). Returns null on allocation failure or if the input contains an
+/// interior NUL byte (which a C string cannot represent).
+// Not wrapped in `ffi_guard`: null-checks its input and returns null on any
+// failure (`CString::new` reports interior NULs as `Err`), with no
+// panic-capable operation.
+#[no_mangle]
+pub extern "C" fn zerobus_alloc_cstring(data: *const u8, len: usize) -> *mut c_char {
+    let bytes: &[u8] = if len == 0 {
+        &[]
+    } else if data.is_null() {
+        return ptr::null_mut();
+    } else {
+        unsafe { std::slice::from_raw_parts(data, len) }
+    };
+    match CString::new(bytes) {
+        Ok(s) => s.into_raw(),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Free headers returned from callback
+#[no_mangle]
+pub extern "C" fn zerobus_free_headers(headers: CHeaders) {
+    ffi_guard(ptr::null_mut(), (), move || {
+        if !headers.headers.is_null() {
+            unsafe {
+                let headers_slice = std::slice::from_raw_parts_mut(headers.headers, headers.count);
+                for header in headers_slice {
+                    if !header.key.is_null() {
+                        let _ = CString::from_raw(header.key);
+                    }
+                    if !header.value.is_null() {
+                        let _ = CString::from_raw(header.value);
+                    }
+                }
+                libc::free(headers.headers as *mut std::ffi::c_void);
+            }
+        }
+        if !headers.error_message.is_null() {
+            unsafe {
+                let _ = CString::from_raw(headers.error_message);
+            }
+        }
+    })
 }
 
 /// Function pointer type for the ack-success callback.

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -5,12 +5,15 @@
 extern crate libc;
 
 // Module declaration order is load-bearing. cbindgen emits functions in source
-// walk order (module declaration order, then top-to-bottom within each module),
-// and `ffi/zerobus.h` must stay byte-identical for the Go/Java ABI. The exported
-// functions must concatenate as: arrow fns + `zerobus_free_headers` (arrow) →
-// builder fns → sdk fns → stream fns ending with `zerobus_free_error_message`
-// and `zerobus_get_default_config` → proto fns. `common` declares the shared
-// types and has no exported functions.
+// walk order (module declaration order, then top-to-bottom within each module).
+// The generated `ffi/zerobus.h` declares the exported functions in that order;
+// C symbols link by name, so the order is not an ABI contract, but keeping it
+// stable minimises header churn. The exported functions concatenate as: the
+// shared header helpers from `common` (`zerobus_alloc_header_array`,
+// `zerobus_alloc_cstring`, `zerobus_free_headers`) → arrow fns → builder fns →
+// sdk fns → stream fns ending with `zerobus_free_error_message` and
+// `zerobus_get_default_config` → proto fns. `common` also declares the shared
+// types and the header helpers listed above.
 //
 // A comment between each declaration breaks rustfmt's contiguous-`mod` grouping,
 // so it cannot alphabetize them and reorder the generated header.

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -19,6 +19,23 @@ namespace zerobus {
 #endif  // __cplusplus
 
 /**
+ * A single header key-value pair for C FFI
+ */
+typedef struct CHeader {
+  char *key;
+  char *value;
+} CHeader;
+
+/**
+ * A collection of headers returned from Go callback
+ */
+typedef struct CHeaders {
+  struct CHeader *headers;
+  uintptr_t count;
+  char *error_message;
+} CHeaders;
+
+/**
  * Opaque handle for an Arrow Flight stream.
  */
 typedef struct CArrowStream {
@@ -59,23 +76,6 @@ typedef struct CResult {
   char *error_message;
   bool is_retryable;
 } CResult;
-
-/**
- * A single header key-value pair for C FFI
- */
-typedef struct CHeader {
-  char *key;
-  char *value;
-} CHeader;
-
-/**
- * A collection of headers returned from Go callback
- */
-typedef struct CHeaders {
-  struct CHeader *headers;
-  uintptr_t count;
-  char *error_message;
-} CHeaders;
 
 /**
  * Function pointer type for the headers provider callback
@@ -177,6 +177,42 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Allocate a zeroed `CHeader` array of `count` elements for a headers callback
+ * to populate and return in a `CHeaders`.
+ *
+ * The array is allocated by the same allocator `zerobus_free_headers` releases
+ * it with (`libc::calloc` / `libc::free`), so a non-Rust callback can build a
+ * `CHeaders` without its own allocator having to match Rust's. This matters on
+ * Windows, where the C/C++ caller and this statically linked library can
+ * resolve to different CRT heaps; allocating here keeps the alloc/free pair on
+ * one heap and avoids the cross-heap free that would otherwise corrupt memory.
+ *
+ * Zero-initialised so a partially populated array is safe to pass to
+ * `zerobus_free_headers` (unset key/value pointers are null and skipped).
+ * Returns null if `count` is 0 or the allocation fails.
+ */
+struct CHeader *zerobus_alloc_header_array(uintptr_t count);
+
+/**
+ * Duplicate `len` bytes from `data` into a NUL-terminated C string for a
+ * headers callback to store in a `CHeader` key/value or a `CHeaders`
+ * error_message.
+ *
+ * Allocated as a Rust `CString`, matching the `CString::from_raw` that
+ * `zerobus_free_headers` frees it with - the string is allocated and freed by
+ * the same allocator inside this library (see `zerobus_alloc_header_array` for
+ * why that matters). `len` of 0 yields an empty string (a valid non-null
+ * pointer). Returns null on allocation failure or if the input contains an
+ * interior NUL byte (which a C string cannot represent).
+ */
+char *zerobus_alloc_cstring(const uint8_t *data, uintptr_t len);
+
+/**
+ * Free headers returned from callback
+ */
+void zerobus_free_headers(struct CHeaders headers);
+
+/**
  * Creates an Arrow Flight stream authenticated with OAuth client credentials.
  *
  * `schema_ipc_bytes` must point to Arrow IPC stream bytes encoding only the schema
@@ -275,42 +311,6 @@ bool zerobus_arrow_stream_is_closed(struct CArrowStream *stream);
  * Returns the default Arrow stream configuration options.
  */
 struct CArrowStreamConfigurationOptions zerobus_arrow_get_default_config(void);
-
-/**
- * Allocate a zeroed `CHeader` array of `count` elements for a headers callback
- * to populate and return in a `CHeaders`.
- *
- * The array is allocated by the same allocator `zerobus_free_headers` releases
- * it with (`libc::calloc` / `libc::free`), so a non-Rust callback can build a
- * `CHeaders` without its own allocator having to match Rust's. This matters on
- * Windows, where the C/C++ caller and this statically linked library can
- * resolve to different CRT heaps; allocating here keeps the alloc/free pair on
- * one heap and avoids the cross-heap free that would otherwise corrupt memory.
- *
- * Zero-initialised so a partially populated array is safe to pass to
- * `zerobus_free_headers` (unset key/value pointers are null and skipped).
- * Returns null if `count` is 0 or the allocation fails.
- */
-struct CHeader *zerobus_alloc_header_array(uintptr_t count);
-
-/**
- * Duplicate `len` bytes from `data` into a NUL-terminated C string for a
- * headers callback to store in a `CHeader` key/value or a `CHeaders`
- * error_message.
- *
- * Allocated as a Rust `CString`, matching the `CString::from_raw` that
- * `zerobus_free_headers` frees it with — the string is allocated and freed by
- * the same allocator inside this library (see `zerobus_alloc_header_array` for
- * why that matters). `len` of 0 yields an empty string (a valid non-null
- * pointer). Returns null on allocation failure or if the input contains an
- * interior NUL byte (which a C string cannot represent).
- */
-char *zerobus_alloc_cstring(const uint8_t *data, uintptr_t len);
-
-/**
- * Free headers returned from callback
- */
-void zerobus_free_headers(struct CHeaders headers);
 
 /**
  * Allocates a new SDK builder. Must be terminated by exactly one of


### PR DESCRIPTION
Fixes #468.

Follow-up from a deferred review nit on #420 ([discussion](https://github.com/databricks/zerobus-sdk/pull/420#discussion_r3513892190)): the header-callback helpers in `rust/ffi/src/arrow.rs` aren't Arrow-specific, so they belong in the shared FFI module.

## What changed

Moved `zerobus_alloc_header_array`, `zerobus_alloc_cstring`, and `zerobus_free_headers` out of `arrow.rs` into `common.rs`, placing them next to the `CHeader`/`CHeaders` types and the `CallbackHeadersProvider` machinery they serve. The functions, signatures, and semantics are byte-for-byte identical — this is a pure relocation.

Along with the move:
- Dropped the now-unused `use std::ffi::CString;` from `arrow.rs`.
- Switched the two `crate::zerobus_free_headers(...)` call sites in `common.rs` to the now-local path.
- Rewrote the load-bearing cbindgen module-ordering comment in `lib.rs`. It previously stated `common` had no exported functions and that `zerobus.h` must stay byte-identical; both are now updated to reflect that `common` leads with the three header helpers and that C symbols link by name (declaration order is header churn, not an ABI contract).
- Regenerated `zerobus.h` via the `build.rs` cbindgen step. The three declarations now precede the Arrow functions; their content is unchanged.

## No behavior / ABI change

C symbols resolve by name at link time, so the reordering in `zerobus.h` does not affect the Go/Java ABI.

## Testing

- `make fmt` clean; `cargo build` clean (no unused-import warnings).
- `cargo test -p zerobus-ffi` — 71/71 pass, including `test_every_extern_c_entry_point_is_guarded` (guard-coverage scan already covers `common.rs`).
- `cargo clippy -p zerobus-ffi` — only a pre-existing `module_inception` warning in `tests.rs`, unrelated to this change.

Added an Internal Changes entry to `rust/ffi/NEXT_CHANGELOG.md`.
