### PR TITLE
[All] Fix license classification in NOTICE files (MIT / Apache / BSD)

### DIFF
--- a/go/NOTICE
+++ b/go/NOTICE
@@ -24,15 +24,15 @@ This Go SDK wraps the Zerobus Rust SDK via C FFI. The compiled native library in
 - **bytes**: Copyright (c) 2018 Carl Lerche (https://github.com/tokio-rs/bytes)
 - **smallvec**: Copyright (c) 2018 The Servo Project Developers (https://github.com/servo/rust-smallvec)
 - **once_cell**: Copyright (c) 2018 Aleksey Kladov (https://github.com/matklad/once_cell)
+- **tokio-retry**: Copyright (c) 2018 Sam Rijs (https://github.com/srijs/rust-tokio-retry)
+- **hyper-http-proxy**: Copyright (c) 2019 Trent Mick (https://github.com/tafia/hyper-http-proxy)
+- **hyper-util**: Copyright (c) 2023 Sean McArthur (https://github.com/hyperium/hyper-util)
 
 ### Apache License 2.0
 
 - **prost**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
 - **prost-types**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
-- **tokio-retry**: Copyright (c) 2018 Sam Rijs (https://github.com/srijs/rust-tokio-retry)
 - **reqwest**: Copyright (c) 2016 Sean McArthur (https://github.com/seanmonstar/reqwest)
-- **hyper-http-proxy**: Copyright (c) 2019 Trent Mick (https://github.com/tafia/hyper-http-proxy)
-- **hyper-util**: Copyright (c) 2023 Sean McArthur (https://github.com/hyperium/hyper-util)
 - **arrow-ipc**: Copyright (c) 2020 Apache Arrow contributors (https://github.com/apache/arrow-rs)
 
 ## Go Dependencies

--- a/java/NOTICE
+++ b/java/NOTICE
@@ -8,15 +8,17 @@ This Software includes the following open source components:
 
 ## Apache License 2.0
 
-### Protocol Buffers (protobuf-java)
-Copyright 2008 Google Inc.
-https://github.com/protocolbuffers/protobuf
-License: https://github.com/protocolbuffers/protobuf/blob/main/LICENSE
-
 ### Apache Arrow (arrow-vector) — optional, provided scope
 Copyright 2016 The Apache Software Foundation
 https://github.com/apache/arrow
 License: https://github.com/apache/arrow/blob/main/LICENSE.txt
+
+## BSD 3-Clause License
+
+### Protocol Buffers (protobuf-java)
+Copyright 2008 Google Inc.
+https://github.com/protocolbuffers/protobuf
+License: https://github.com/protocolbuffers/protobuf/blob/main/LICENSE
 
 ## MIT License
 

--- a/rust/NOTICE
+++ b/rust/NOTICE
@@ -19,7 +19,6 @@ This Software includes the following open source components:
 - **serde_json**: Copyright (c) 2014 David Tolnay (https://github.com/serde-rs/json)
 - **bytes**: Copyright (c) 2018 Carl Lerche (https://github.com/tokio-rs/bytes)
 - **smallvec**: Copyright (c) 2018 The Servo Project Developers (https://github.com/servo/rust-smallvec)
-- **self_cell**: Copyright (c) 2020 Lukas Bergdoll (https://github.com/Voultapher/self_cell)
 - **tokio-retry**: Copyright (c) 2018 Sam Rijs (https://github.com/srijs/rust-tokio-retry)
 - **hyper-http-proxy**: Copyright (c) 2019 Trent Mick (https://github.com/tafia/hyper-http-proxy)
 - **hyper-util**: Copyright (c) 2023 Sean McArthur (https://github.com/hyperium/hyper-util)
@@ -28,6 +27,7 @@ This Software includes the following open source components:
 
 - **prost**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
 - **prost-types**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
+- **self_cell**: Copyright (c) 2020 Lukas Bergdoll (https://github.com/Voultapher/self_cell)
 - **reqwest**: Copyright (c) 2016 Sean McArthur (https://github.com/seanmonstar/reqwest)
 
 ## Optional: Arrow Flight support (Apache License 2.0)

--- a/rust/NOTICE
+++ b/rust/NOTICE
@@ -20,15 +20,15 @@ This Software includes the following open source components:
 - **bytes**: Copyright (c) 2018 Carl Lerche (https://github.com/tokio-rs/bytes)
 - **smallvec**: Copyright (c) 2018 The Servo Project Developers (https://github.com/servo/rust-smallvec)
 - **self_cell**: Copyright (c) 2020 Lukas Bergdoll (https://github.com/Voultapher/self_cell)
+- **tokio-retry**: Copyright (c) 2018 Sam Rijs (https://github.com/srijs/rust-tokio-retry)
+- **hyper-http-proxy**: Copyright (c) 2019 Trent Mick (https://github.com/tafia/hyper-http-proxy)
+- **hyper-util**: Copyright (c) 2023 Sean McArthur (https://github.com/hyperium/hyper-util)
 
 ## Apache License 2.0
 
 - **prost**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
 - **prost-types**: Copyright (c) 2017 Dan Burkert (https://github.com/tokio-rs/prost)
-- **tokio-retry**: Copyright (c) 2018 Sam Rijs (https://github.com/srijs/rust-tokio-retry)
 - **reqwest**: Copyright (c) 2016 Sean McArthur (https://github.com/seanmonstar/reqwest)
-- **hyper-http-proxy**: Copyright (c) 2019 Trent Mick (https://github.com/tafia/hyper-http-proxy)
-- **hyper-util**: Copyright (c) 2023 Sean McArthur (https://github.com/hyperium/hyper-util)
 
 ## Optional: Arrow Flight support (Apache License 2.0)
 


### PR DESCRIPTION
Fixes #485.

## Summary

Several third-party components were listed under the wrong license section in the `NOTICE` files. All classifications below were re-verified against the authoritative source (`cargo metadata` for Rust crates; upstream project license for Java deps), not just the upstream repo landing page.

### Rust crates (`go/NOTICE`, `rust/NOTICE`)

`tokio-retry`, `hyper-http-proxy`, and `hyper-util` are **MIT**-licensed but were listed under **Apache License 2.0**. Moved all three into the MIT section of both files.

- `tokio-retry 0.3.0` — MIT
- `hyper-http-proxy 1.1.0` — MIT
- `hyper-util 0.1.20` — MIT

`reqwest` (also in the Apache section) is `MIT OR Apache-2.0`, so listing it under Apache remains valid — left unchanged.

Surfaced by @teodordelibasic-db in review of #417.

### `self_cell` (`rust/NOTICE`)

`self_cell` was listed under **MIT**, but `self_cell 1.2` is **`Apache-2.0 OR GPL-2.0-only`** — MIT is not one of its options. Moved it to the Apache License 2.0 section. (`self_cell` is only pulled in via the optional `zeroparser` feature.)

### `protobuf-java` (`java/NOTICE`)

Google Protocol Buffers (`protobuf-java 4.33.0`) was listed under **Apache License 2.0**, but it is **BSD 3-Clause**. Moved it into a new BSD 3-Clause section, matching the already-correct classification of the same component in `python/NOTICE`.

## Scope / audit

All five wrapper `NOTICE` files were audited against `cargo metadata` / upstream licenses:

- **`go/NOTICE`, `rust/NOTICE`** — fixed the three MIT crates; `rust/NOTICE` additionally fixes `self_cell`.
- **`java/NOTICE`** — fixed `protobuf-java` (Apache → BSD 3-Clause).
- **`python/NOTICE`, `typescript/NOTICE`** — audited; remaining listings are all dual-licensed `MIT OR Apache-2.0` crates, valid wherever listed. No changes needed. (`protobuf` was already correctly under BSD 3-Clause in `python/NOTICE`.)
- **`cpp/NOTICE`** — already classifies the three MIT crates correctly (lands via a separate PR); not on `main` yet.

Docs-only change; no code or build impact.

### Not changed (noted for reviewers)

`arrow-array` is `Apache-2.0 AND MIT` (conjunctive) and is listed under Apache-only in `python/NOTICE` / `typescript/NOTICE`. Strictly both licenses apply, so an Apache-only listing is arguably incomplete — but it's consistent across files and minor, so it's left out of this PR's scope.