### PR TITLE
[Rust SDK] Fix generating VARIANT types in nested schemas

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+- Fixed the `GenerateProto` tool rejecting `VARIANT` columns with `Unsupported column type` (and `Unsupported array/map element type` when nested). `VARIANT` now maps to `string` (unshredded JSON-encoded text) at the top level and inside `ARRAY`/`MAP`, matching the other SDKs.
 - Fixed the default `recoveryRetries`, which was `3` instead of the `4` used by the Rust core and every other SDK (Go, TypeScript, C++). A stream left with the default now makes 4 recovery attempts on transient failures instead of 3, matching the documented cross-SDK behavior. Callers that set `recoveryRetries` explicitly are unaffected. (#438)
 
 ### Documentation

--- a/java/src/main/java/com/databricks/zerobus/tools/GenerateProto.java
+++ b/java/src/main/java/com/databricks/zerobus/tools/GenerateProto.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  * --client-secret &lt;secret&gt; --table &lt;catalog.schema.table&gt; --output &lt;output.proto&gt;
  * [--proto-msg &lt;message_name&gt;]
  *
- * <p>Type mappings: INT -&gt; int32 STRING -&gt; string FLOAT -&gt; float LONG/BIGINT -&gt; int64
+ * <p>Type mappings: INT -&gt; int32 STRING/VARIANT -&gt; string FLOAT -&gt; float LONG/BIGINT -&gt; int64
  * SHORT/SMALLINT -&gt; int32 DOUBLE -&gt; double BOOLEAN -&gt; bool BINARY -&gt; bytes DATE -&gt;
  * int32 TIMESTAMP -&gt; int64 ARRAY&lt;type&gt; -&gt; repeated type MAP&lt;key_type, value_type&gt;
  * -&gt; map&lt;key_type, value_type&gt;
@@ -55,6 +55,7 @@ public class GenerateProto {
           + "  Delta            -> Proto2\n"
           + "  INT              -> int32\n"
           + "  STRING           -> string\n"
+          + "  VARIANT          -> string\n"
           + "  FLOAT            -> float\n"
           + "  LONG             -> int64\n"
           + "  SHORT            -> int32\n"
@@ -286,6 +287,7 @@ public class GenerateProto {
         protoType = "int64";
         break;
       case "STRING":
+      case "VARIANT":
         protoType = "string";
         break;
       case "FLOAT":
@@ -365,6 +367,7 @@ public class GenerateProto {
       case "TIMESTAMP":
         return "int64";
       case "STRING":
+      case "VARIANT":
         return "string";
       case "FLOAT":
         return "float";

--- a/java/src/main/java/com/databricks/zerobus/tools/GenerateProto.java
+++ b/java/src/main/java/com/databricks/zerobus/tools/GenerateProto.java
@@ -26,10 +26,10 @@ import java.util.regex.Pattern;
  * --client-secret &lt;secret&gt; --table &lt;catalog.schema.table&gt; --output &lt;output.proto&gt;
  * [--proto-msg &lt;message_name&gt;]
  *
- * <p>Type mappings: INT -&gt; int32 STRING/VARIANT -&gt; string FLOAT -&gt; float LONG/BIGINT -&gt; int64
- * SHORT/SMALLINT -&gt; int32 DOUBLE -&gt; double BOOLEAN -&gt; bool BINARY -&gt; bytes DATE -&gt;
- * int32 TIMESTAMP -&gt; int64 ARRAY&lt;type&gt; -&gt; repeated type MAP&lt;key_type, value_type&gt;
- * -&gt; map&lt;key_type, value_type&gt;
+ * <p>Type mappings: INT -&gt; int32 STRING/VARIANT -&gt; string FLOAT -&gt; float LONG/BIGINT -&gt;
+ * int64 SHORT/SMALLINT -&gt; int32 DOUBLE -&gt; double BOOLEAN -&gt; bool BINARY -&gt; bytes DATE
+ * -&gt; int32 TIMESTAMP -&gt; int64 ARRAY&lt;type&gt; -&gt; repeated type MAP&lt;key_type,
+ * value_type&gt; -&gt; map&lt;key_type, value_type&gt;
  */
 public class GenerateProto {
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Fixed `VARIANT` columns nested inside a `STRUCT`, `ARRAY`, or `MAP` failing with `unknown primitive type 'variant'` when building a descriptor from a Unity Catalog schema. Nested `VARIANT` now maps to `string` (unshredded JSON-encoded text) at any depth, matching the top-level behavior. Applies to both the protobuf and Arrow Flight schema paths (`descriptor_from_uc_columns` / `arrow_schema_from_uc_columns`), and so also fixes the Go and C++ SDKs, which build descriptors through the C FFI.
+
 ### Documentation
 
 - Reworked ingestion docs to lead with the high-throughput pattern (ingest in a loop, then `flush()` once) and explicitly warn against calling `wait_for_offset()` after every record. Updated the README, crate- and method-level doc comments (`ingest_record_offset`, `ingest_records_offset`, `wait_for_offset`, `flush`), and the `json`/`proto` single-record examples accordingly.

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Fixed `VARIANT` columns nested inside a `STRUCT`, `ARRAY`, or `MAP` failing with `unknown primitive type 'variant'` when building a descriptor from a Unity Catalog schema. Nested `VARIANT` now maps to `string` (unshredded JSON-encoded text) at any depth, matching the top-level behavior. Applies to both the protobuf and Arrow Flight schema paths (`descriptor_from_uc_columns` / `arrow_schema_from_uc_columns`), and so also fixes the Go and C++ SDKs, which build descriptors through the C FFI.
+- Fixed `VARIANT` columns nested inside a `STRUCT`, `ARRAY`, or `MAP` failing with `unknown primitive type 'variant'` when building a descriptor from a Unity Catalog schema. Nested `VARIANT` now maps to `string` (unshredded JSON-encoded text) at any depth, matching the top-level behavior. Applies to both the protobuf and Arrow Flight schema paths (`descriptor_from_uc_columns` / `arrow_schema_from_uc_columns`).
 
 ### Documentation
 

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -397,7 +397,8 @@ fn type_ref_to_complex(tref: &TypeRef, level: usize) -> Result<ComplexType, Stri
 
 fn parse_primitive_type(s: &str) -> Result<PrimitiveType, String> {
     Ok(match s {
-        "string" => PrimitiveType::String,
+        // VARIANT is carried as an unshredded JSON-encoded string.
+        "string" | "variant" => PrimitiveType::String,
         "long" => PrimitiveType::Long,
         "integer" => PrimitiveType::Integer,
         "short" => PrimitiveType::Short,
@@ -978,6 +979,38 @@ mod tests {
     }
 
     #[test]
+    fn nested_variant_maps_to_string() {
+        // VARIANT nested in STRUCT/ARRAY/MAP arrives as the lowercase "variant"
+        // token in type_json and must map to proto `string`, like the top level.
+        let type_json = r#"{
+            "type":"struct",
+            "fields":[
+                {"name":"v","type":"variant","nullable":true,"metadata":{}},
+                {"name":"tags","type":{"type":"array","elementType":"variant","containsNull":true},"nullable":true,"metadata":{}},
+                {"name":"props","type":{"type":"map","keyType":"string","valueType":"variant","valueContainsNull":true},"nullable":true,"metadata":{}}
+            ]
+        }"#;
+        let cols = vec![complex_col("payload", "STRUCT", type_json, 0)];
+        let d = descriptor_from_uc_columns(&cols, "m").unwrap();
+
+        let nested = d
+            .nested_type
+            .iter()
+            .find(|n| n.name() == field(&d, "payload").type_name.as_deref().unwrap())
+            .expect("nested struct message not emitted");
+        assert_eq!(field(nested, "v").r#type(), ProtoType::String);
+        assert_eq!(field(nested, "tags").r#type(), ProtoType::String);
+        assert_eq!(field(nested, "tags").label(), Label::Repeated);
+        let entry_name = field(nested, "props").type_name.as_deref().unwrap();
+        let entry = nested
+            .nested_type
+            .iter()
+            .find(|n| n.name() == entry_name)
+            .expect("map entry message missing");
+        assert_eq!(field(entry, "value").r#type(), ProtoType::String);
+    }
+
+    #[test]
     fn map_with_struct_value_emits_value_and_entry() {
         let type_json = r#"{
             "type":"map",
@@ -1409,6 +1442,20 @@ mod tests {
                         &DataType::Timestamp(TimeUnit::Microsecond, None)
                     );
                 }
+                other => panic!("expected Struct, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn nested_variant_maps_to_large_utf8() {
+            let type_json = r#"{
+                "type":"struct",
+                "fields":[{"name":"v","type":"variant","nullable":true,"metadata":{}}]
+            }"#;
+            let cols = vec![complex_col("payload", "STRUCT", type_json, 0)];
+            let s = arrow_schema_from_uc_columns(&cols).unwrap();
+            match arrow_field(&s, "payload").data_type() {
+                DataType::Struct(fs) => assert_eq!(fs[0].data_type(), &DataType::LargeUtf8),
                 other => panic!("expected Struct, got {:?}", other),
             }
         }

--- a/rust/third_party/arrow-flight/src/lib.rs
+++ b/rust/third_party/arrow-flight/src/lib.rs
@@ -186,7 +186,7 @@ fn limited_fmt(f: &mut fmt::Formatter<'_>, value: &[u8], limit: usize) -> fmt::R
     if value.len() > limit {
         write!(f, "{:?}", &value[..limit])
     } else {
-        write!(f, "{:?}", &value)
+        write!(f, "{:?}", value)
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

VARIANT columns nested inside a STRUCT, ARRAY, or MAP failed when building a descriptor from a Unity Catalog table schema:
- Rust core: unknown primitive type 'variant'
- Java GenerateProto: Unsupported column type (and Unsupported array/map element type when nested)

Top-level VARIANT was already handled; only the nested code paths were missing the mapping.

TODO:
Improve Java's `GenerateProto` to handle structs

## How is this tested?

- `nested_variant_maps_to_string` — VARIANT nested in STRUCT/ARRAY/MAP → proto string
- `nested_variant_maps_to_large_utf8` — Arrow Flight path → LargeUtf8

Also tested ingesting data