### PR TITLE
[PureGo] Add auth provider interfaces and per-table token cache

### DIFF
--- a/purego/README.md
+++ b/purego/README.md
@@ -21,9 +21,11 @@ Implemented packages:
   the `StreamParams.HeadersProvider`. The authorization value is sent verbatim as
   the provider formats it (e.g. `"Bearer <token>"`); the transport does not add a
   scheme prefix.
+- `internal/auth` — the `HeadersProvider` interface and `StaticHeadersProvider`
+  for fixed-header cases, plus a per-`(clientID, secret, table)` token cache
+  with single-flight minting, proactive refresh, and retryable-error fallback.
 
-Planned layers: OAuth/auth, ingest/ack state management, recovery, and the
-public API.
+Planned layers: ingest/ack state management, recovery, and the public API.
 
 ## Regenerating the protobuf bindings
 

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -1,13 +1,9 @@
-// Package auth provides OAuth 2.0 and custom-header authentication for the
-// Zerobus pure-Go SDK.
+// Package auth provides authentication for the Zerobus pure-Go SDK.
 //
-// Authentication is expressed through [HeadersProvider], which supplies the
-// gRPC metadata headers for a stream. The package ships two implementations:
-//   - [OAuthHeadersProvider] — wraps an [OAuthTokenProvider] (Unity Catalog
-//     OAuth 2.0 client credentials flow with per-table token caching and
-//     proactive refresh) and emits the required Zerobus metadata headers.
-//   - [StaticHeadersProvider] — returns a fixed headers map, for tests or
-//     externally managed credentials.
+// Authentication is expressed through [HeadersProvider], which supplies the gRPC
+// metadata headers for a stream. [StaticHeadersProvider] returns a fixed headers
+// map, for tests or externally managed credentials; a per-table token cache
+// backs the Unity Catalog OAuth flow added on top of this package.
 package auth
 
 import (

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -2,8 +2,8 @@
 //
 // Authentication is expressed through [HeadersProvider], which supplies the gRPC
 // metadata headers for a stream. [StaticHeadersProvider] returns a fixed headers
-// map, for tests or externally managed credentials; a per-table token cache
-// backs the Unity Catalog OAuth flow added on top of this package.
+// map, for tests or externally managed credentials; a per-table token cache in
+// this package supports OAuth-based providers built on top of this interface.
 package auth
 
 import (

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -9,6 +9,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 )
 
@@ -46,9 +47,7 @@ func (p *StaticHeadersProvider) GetHeaders(_ context.Context, _ string) (map[str
 		return nil, fmt.Errorf("auth: static headers are empty")
 	}
 	out := make(map[string]string, len(p.headers))
-	for k, v := range p.headers {
-		out[k] = v
-	}
+	maps.Copy(out, p.headers)
 	return out, nil
 }
 

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -1,0 +1,60 @@
+// Package auth provides OAuth 2.0 and custom-header authentication for the
+// Zerobus pure-Go SDK.
+//
+// Authentication is expressed through [HeadersProvider], which supplies the
+// gRPC metadata headers for a stream. The package ships two implementations:
+//   - [OAuthHeadersProvider] — wraps an [OAuthTokenProvider] (Unity Catalog
+//     OAuth 2.0 client credentials flow with per-table token caching and
+//     proactive refresh) and emits the required Zerobus metadata headers.
+//   - [StaticHeadersProvider] — returns a fixed headers map, for tests or
+//     externally managed credentials.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// HeadersProvider provides gRPC metadata headers for stream authentication.
+//
+// GetHeaders returns headers for the given tableName. The transport layer will
+// always enforce the authoritative table-name header from stream-open params.
+// Implementations may include it for parity with other SDKs.
+//
+// Invalidate is called on server auth rejection so any cached credentials can
+// be dropped before the next open attempt.
+type HeadersProvider interface {
+	GetHeaders(ctx context.Context, tableName string) (map[string]string, error)
+	Invalidate(ctx context.Context, tableName string)
+}
+
+// StaticHeadersProvider returns a fixed header set.
+type StaticHeadersProvider struct {
+	headers map[string]string
+}
+
+// NewStaticHeadersProvider returns a provider that returns the same headers on
+// every call.
+func NewStaticHeadersProvider(headers map[string]string) *StaticHeadersProvider {
+	cloned := make(map[string]string, len(headers))
+	for k, v := range headers {
+		cloned[k] = strings.TrimSpace(v)
+	}
+	return &StaticHeadersProvider{headers: cloned}
+}
+
+// GetHeaders returns a copy of the configured headers.
+func (p *StaticHeadersProvider) GetHeaders(_ context.Context, _ string) (map[string]string, error) {
+	if len(p.headers) == 0 {
+		return nil, fmt.Errorf("auth: static headers are empty")
+	}
+	out := make(map[string]string, len(p.headers))
+	for k, v := range p.headers {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// Invalidate is a no-op for static headers.
+func (p *StaticHeadersProvider) Invalidate(_ context.Context, _ string) {}

--- a/purego/internal/auth/headers_provider_test.go
+++ b/purego/internal/auth/headers_provider_test.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStaticHeadersProviderTrimsValues(t *testing.T) {
+	p := NewStaticHeadersProvider(map[string]string{"authorization": "  Bearer tok  "})
+	got, err := p.GetHeaders(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("GetHeaders: %v", err)
+	}
+	if got["authorization"] != "Bearer tok" {
+		t.Fatalf("want trimmed %q, got %q", "Bearer tok", got["authorization"])
+	}
+}
+
+func TestStaticHeadersProviderReturnsIndependentCopy(t *testing.T) {
+	p := NewStaticHeadersProvider(map[string]string{"authorization": "Bearer tok"})
+
+	got, err := p.GetHeaders(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("GetHeaders: %v", err)
+	}
+	// Mutating the returned map must not corrupt the provider's own copy.
+	got["authorization"] = "mutated"
+
+	got2, err := p.GetHeaders(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("GetHeaders: %v", err)
+	}
+	if got2["authorization"] != "Bearer tok" {
+		t.Fatalf("caller mutation leaked into provider: got %q", got2["authorization"])
+	}
+}
+
+func TestStaticHeadersProviderEmptyIsError(t *testing.T) {
+	for name, headers := range map[string]map[string]string{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := NewStaticHeadersProvider(headers)
+			if _, err := p.GetHeaders(context.Background(), "c.s.t"); err == nil {
+				t.Fatal("want error for empty static headers, got nil")
+			}
+		})
+	}
+}
+
+func TestStaticHeadersProviderInvalidateIsNoOp(t *testing.T) {
+	p := NewStaticHeadersProvider(map[string]string{"authorization": "Bearer tok"})
+	p.Invalidate(context.Background(), "c.s.t") // must not panic
+
+	got, err := p.GetHeaders(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("GetHeaders after Invalidate: %v", err)
+	}
+	if got["authorization"] != "Bearer tok" {
+		t.Fatalf("Invalidate should not alter static headers, got %q", got["authorization"])
+	}
+}

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -222,9 +222,9 @@ func (c *tokenCache) getOrFetch(
 			// Proactive refresh failed transiently; serve the still-valid token.
 			token, resErr = entry.cached.value, nil
 		}
+		// Publish to waiters: writes before close(done) happen-before <-done. The
+		// mutex just brackets the entry-state transition, not the flight publish.
 		flight.token, flight.err = token, resErr
-		// Publish the outcome to waiters under entry.mu, then release them; the
-		// mutex (not the close/write ordering) is what prevents a stale read.
 		close(flight.done)
 		entry.mu.Unlock()
 		return token, resErr

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -26,7 +26,6 @@ const (
 	mintReasonColdMiss      mintReason = iota // no usable entry in cache
 	mintReasonRefresh                         // token is within the refresh buffer
 	mintReasonCacheDisabled                   // caching is off, so every call mints
-	mintReasonDirect                          // minted outside the cache via FetchToken
 )
 
 func (r mintReason) String() string {
@@ -37,8 +36,6 @@ func (r mintReason) String() string {
 		return "refresh"
 	case mintReasonCacheDisabled:
 		return "cache_disabled"
-	case mintReasonDirect:
-		return "direct"
 	default:
 		return "unknown"
 	}

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -126,9 +126,8 @@ type tokenCache struct {
 	disabled      bool // when true, every getOrFetch mints without caching
 }
 
-// CacheOption configures a [SharedTokenCache] passed to [NewSharedTokenCache].
-// The same settings are available per-provider via [WithTokenCacheEnabled] and
-// [WithRefreshBuffer].
+// CacheOption configures a token cache at construction. See [CacheEnabled] and
+// [CacheRefreshBuffer].
 type CacheOption func(*tokenCache)
 
 // CacheEnabled toggles token caching. When disabled, every token request mints

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"sync"
 	"time"
 )
@@ -18,8 +19,8 @@ type fetchedToken struct {
 	expiresIn *time.Duration
 }
 
-// mintReason is surfaced in log messages so operators can distinguish a cold
-// start from a proactive refresh from caching being off.
+// mintReason is passed to the mint callback so it can distinguish a cold start
+// from a proactive refresh from caching being off (e.g. for logging or metrics).
 type mintReason int
 
 const (
@@ -123,20 +124,21 @@ type tokenCache struct {
 	disabled      bool // when true, every getOrFetch mints without caching
 }
 
-// CacheOption configures a token cache at construction. See [CacheEnabled] and
-// [CacheRefreshBuffer].
-type CacheOption func(*tokenCache)
+// cacheOption configures a token cache at construction. See [cacheEnabled] and
+// [cacheRefreshBuffer]. Unexported until a public SDK builder needs to surface
+// these knobs.
+type cacheOption func(*tokenCache)
 
-// CacheEnabled toggles token caching. When disabled, every token request mints
+// cacheEnabled toggles token caching. When disabled, every token request mints
 // a fresh token instead of consulting the cache. Caching is enabled by default.
-func CacheEnabled(enabled bool) CacheOption {
+func cacheEnabled(enabled bool) cacheOption {
 	return func(c *tokenCache) { c.disabled = !enabled }
 }
 
-// CacheRefreshBuffer sets the lead time before a token's expiry at which it is
+// cacheRefreshBuffer sets the lead time before a token's expiry at which it is
 // proactively re-minted; it defaults to 5 minutes. A non-positive value is
 // ignored so the default holds.
-func CacheRefreshBuffer(d time.Duration) CacheOption {
+func cacheRefreshBuffer(d time.Duration) cacheOption {
 	return func(c *tokenCache) {
 		if d > 0 {
 			c.refreshBuffer = d
@@ -144,7 +146,7 @@ func CacheRefreshBuffer(d time.Duration) CacheOption {
 	}
 }
 
-func newTokenCache(opts ...CacheOption) *tokenCache {
+func newTokenCache(opts ...cacheOption) *tokenCache {
 	c := &tokenCache{
 		entries:       make(map[tokenKey]*tokenCacheEntry),
 		refreshBuffer: defaultRefreshBuffer,
@@ -161,7 +163,10 @@ func newTokenCache(opts ...CacheOption) *tokenCache {
 // a non-retryable error propagates.
 //
 // mint runs at most once per key at a time; other callers wait for it and share
-// the result, or return ctx.Err() if their own ctx expires while waiting.
+// the result, or return ctx.Err() if their own ctx expires while waiting. If the
+// leader's mint fails because the leader's own context was cancelled, a waiter
+// whose context is still live re-attempts (and usually mints for itself) rather
+// than inheriting a cancellation it never requested.
 func (c *tokenCache) getOrFetch(
 	ctx context.Context,
 	clientID, clientSecret, tableName string,
@@ -176,6 +181,28 @@ func (c *tokenCache) getOrFetch(
 	}
 
 	key := newTokenKey(clientID, clientSecret, tableName)
+
+	for {
+		token, err, retry := c.tryGetOrFetch(ctx, key, mint)
+		if retry {
+			// The leader we parked on failed because its own ctx was cancelled,
+			// but ours is still live. Re-attempt rather than inheriting a cancel
+			// we never asked for; typically we become the next leader and mint.
+			continue
+		}
+		return token, err
+	}
+}
+
+// tryGetOrFetch makes one attempt to serve or mint a token for key. It returns
+// retry == true only when the caller parked on another goroutine's in-flight
+// mint that failed due to that leader's context cancellation while the caller's
+// own context is still live; the caller then loops to re-attempt.
+func (c *tokenCache) tryGetOrFetch(
+	ctx context.Context,
+	key tokenKey,
+	mint func(ctx context.Context, reason mintReason) (fetchedToken, error),
+) (string, error, bool) {
 	entry := c.slot(key)
 
 	entry.mu.Lock()
@@ -183,7 +210,7 @@ func (c *tokenCache) getOrFetch(
 	if entry.cached != nil && !c.needsRefresh(entry.cached) {
 		token := entry.cached.value
 		entry.mu.Unlock()
-		return token, nil
+		return token, nil, false
 	}
 
 	// A mint is already in progress: wait for it (or our own ctx) and share the
@@ -194,9 +221,15 @@ func (c *tokenCache) getOrFetch(
 		entry.mu.Unlock()
 		select {
 		case <-flight.done:
-			return flight.token, flight.err
+			// If the leader failed solely because its own context was cancelled,
+			// don't propagate that cancel to a waiter whose context is still
+			// live; signal a re-attempt so this caller can mint for itself.
+			if flight.err != nil && isContextError(flight.err) && ctx.Err() == nil {
+				return "", nil, true
+			}
+			return flight.token, flight.err, false
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", ctx.Err(), false
 		}
 	}
 
@@ -224,10 +257,12 @@ func (c *tokenCache) getOrFetch(
 		}
 		// Publish to waiters: writes before close(done) happen-before <-done. The
 		// mutex just brackets the entry-state transition, not the flight publish.
+		// A context error published here is what lets a live-ctx waiter re-attempt
+		// instead of inheriting our cancellation.
 		flight.token, flight.err = token, resErr
 		close(flight.done)
 		entry.mu.Unlock()
-		return token, resErr
+		return token, resErr, false
 	}
 
 	token := fetched.token
@@ -247,7 +282,14 @@ func (c *tokenCache) getOrFetch(
 	close(flight.done)
 	entry.mu.Unlock()
 
-	return token, nil
+	return token, nil, false
+}
+
+// isContextError reports whether err is (or wraps) a context cancellation or
+// deadline, the signal that a mint failed because its leader's context ended
+// rather than because the token endpoint itself failed.
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // invalidate drops the cached token for the given credentials and table. The
@@ -312,25 +354,30 @@ func (c *tokenCache) needsRefresh(cached *cachedToken) bool {
 }
 
 // isRetryable reports whether the error tree holds a retryable [retryableError],
-// walking both single- and multi-error (errors.Join) unwrap chains.
+// walking both single- and multi-error (errors.Join) unwrap chains. A
+// retryableError that reports IsRetryable() == false does not short-circuit the
+// walk: a wrapper may deny retry while wrapping a retryable cause, so we keep
+// unwrapping until we either find a retryable node or exhaust the tree.
 func isRetryable(err error) bool {
-	switch x := err.(type) {
-	case nil:
-		return false
-	case retryableError:
-		return x.IsRetryable()
-	case interface{ Unwrap() error }:
-		return isRetryable(x.Unwrap())
-	case interface{ Unwrap() []error }:
-		for _, e := range x.Unwrap() {
-			if isRetryable(e) {
-				return true
-			}
+	for err != nil {
+		if re, ok := err.(retryableError); ok && re.IsRetryable() {
+			return true
 		}
-		return false
-	default:
-		return false
+		switch x := err.(type) {
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+		case interface{ Unwrap() []error }:
+			for _, e := range x.Unwrap() {
+				if isRetryable(e) {
+					return true
+				}
+			}
+			return false
+		default:
+			return false
+		}
 	}
+	return false
 }
 
 // retryableError is implemented by errors from the mint path that are safe to

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -1,0 +1,344 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+// defaultRefreshBuffer is the lead time before a token's expiry at which the
+// cache proactively re-mints; 5 minutes is the SDK-wide standard.
+const defaultRefreshBuffer = 5 * time.Minute
+
+// fetchedToken is the raw result of a mint: the token string plus its
+// server-reported lifetime (nil when the OAuth server omits expires_in).
+type fetchedToken struct {
+	token     string
+	expiresIn *time.Duration
+}
+
+// mintReason is surfaced in log messages so operators can distinguish a cold
+// start from a proactive refresh from caching being off.
+type mintReason int
+
+const (
+	mintReasonColdMiss      mintReason = iota // no usable entry in cache
+	mintReasonRefresh                         // token is within the refresh buffer
+	mintReasonCacheDisabled                   // caching is off, so every call mints
+	mintReasonDirect                          // minted outside the cache via FetchToken
+)
+
+func (r mintReason) String() string {
+	switch r {
+	case mintReasonColdMiss:
+		return "cold_miss"
+	case mintReasonRefresh:
+		return "refresh"
+	case mintReasonCacheDisabled:
+		return "cache_disabled"
+	case mintReasonDirect:
+		return "direct"
+	default:
+		return "unknown"
+	}
+}
+
+// tokenKey identifies a cache entry. The client secret is stored as its
+// SHA-256 digest so the raw credential is never kept in the map: distinct
+// secrets still yield distinct keys (collision resistance), and a rotated
+// secret gets a fresh entry.
+type tokenKey struct {
+	clientID     string
+	secretDigest [sha256.Size]byte
+	tableName    string
+}
+
+func newTokenKey(clientID, clientSecret, tableName string) tokenKey {
+	return tokenKey{
+		clientID:     clientID,
+		secretDigest: sha256.Sum256([]byte(clientSecret)),
+		tableName:    tableName,
+	}
+}
+
+// cachedToken is one live entry in the cache. refreshAt is precomputed from the
+// TTL and the cache's refresh buffer so needsRefresh is a plain timestamp
+// comparison; it never sits after expiresAt.
+type cachedToken struct {
+	value     string
+	expiresAt time.Time
+	refreshAt time.Time
+}
+
+func (c *cachedToken) isExpired() bool {
+	return time.Now().After(c.expiresAt)
+}
+
+// newCachedToken builds an entry for a token whose TTL started at mintedAt
+// (response-receipt time, matching the Rust SDK). ttl must be positive.
+//
+// The effective refresh lead time is clamped to at most half the TTL: with the
+// default 5-minute buffer a 10-minute token would otherwise be due for refresh
+// the instant it is cached, collapsing to a re-mint on every call. Clamping
+// guarantees at least ttl/2 of reuse before proactive refresh kicks in.
+func newCachedToken(value string, ttl, refreshBuffer time.Duration, mintedAt time.Time) *cachedToken {
+	if maxBuffer := ttl / 2; refreshBuffer > maxBuffer {
+		refreshBuffer = maxBuffer
+	}
+	expiresAt := mintedAt.Add(ttl)
+	return &cachedToken{
+		value:     value,
+		expiresAt: expiresAt,
+		refreshAt: expiresAt.Add(-refreshBuffer),
+	}
+}
+
+// tokenCacheEntry is the per-key slot. Its mutex is held only for short state
+// transitions, never across the mint call, so callers single-flight the mint
+// yet each waiter can still abandon on its own context. Different keys never
+// block each other.
+type tokenCacheEntry struct {
+	mu       sync.Mutex
+	cached   *cachedToken // nil when no valid entry has been stored yet
+	inflight *tokenFlight // non-nil while a mint is in progress
+}
+
+// tokenFlight is a single in-progress mint. The leader records its resolved
+// outcome (the same token or error it returns to its own caller) before closing
+// done, so every waiter parked on the flight shares that outcome instead of
+// re-minting — matching golang.org/x/sync/singleflight and bounding a failing
+// token endpoint to one mint per burst rather than N serial attempts.
+type tokenFlight struct {
+	done  chan struct{} // closed when the mint completes
+	token string        // resolved token (empty on error)
+	err   error         // resolved error (nil on success)
+}
+
+// tokenCache caches OAuth tokens per (clientID, secret, tableName).
+//
+// It is safe for concurrent use. Construct one with [newTokenCache]; the
+// methods do not guard against a nil receiver.
+type tokenCache struct {
+	mu            sync.Mutex
+	entries       map[tokenKey]*tokenCacheEntry
+	refreshBuffer time.Duration
+	disabled      bool // when true, every getOrFetch mints without caching
+}
+
+// CacheOption configures a [SharedTokenCache] passed to [NewSharedTokenCache].
+// The same settings are available per-provider via [WithTokenCacheEnabled] and
+// [WithRefreshBuffer].
+type CacheOption func(*tokenCache)
+
+// CacheEnabled toggles token caching. When disabled, every token request mints
+// a fresh token instead of consulting the cache. Caching is enabled by default.
+func CacheEnabled(enabled bool) CacheOption {
+	return func(c *tokenCache) { c.disabled = !enabled }
+}
+
+// CacheRefreshBuffer sets the lead time before a token's expiry at which it is
+// proactively re-minted; it defaults to 5 minutes. A non-positive value is
+// ignored so the default holds.
+func CacheRefreshBuffer(d time.Duration) CacheOption {
+	return func(c *tokenCache) {
+		if d > 0 {
+			c.refreshBuffer = d
+		}
+	}
+}
+
+func newTokenCache(opts ...CacheOption) *tokenCache {
+	c := &tokenCache{
+		entries:       make(map[tokenKey]*tokenCacheEntry),
+		refreshBuffer: defaultRefreshBuffer,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// getOrFetch returns a valid token for the given credentials and table, minting
+// (via mint, bounded by ctx) only when the cache is empty or within the refresh
+// window. A retryable refresh error falls back to the still-valid cached token;
+// a non-retryable error propagates.
+//
+// mint runs at most once per key at a time; other callers wait for it and share
+// the result, or return ctx.Err() if their own ctx expires while waiting.
+func (c *tokenCache) getOrFetch(
+	ctx context.Context,
+	clientID, clientSecret, tableName string,
+	mint func(ctx context.Context, reason mintReason) (fetchedToken, error),
+) (string, error) {
+	if c.disabled {
+		fetched, err := mint(ctx, mintReasonCacheDisabled)
+		if err != nil {
+			return "", err
+		}
+		return fetched.token, nil
+	}
+
+	key := newTokenKey(clientID, clientSecret, tableName)
+	entry := c.slot(key)
+
+	entry.mu.Lock()
+
+	if entry.cached != nil && !c.needsRefresh(entry.cached) {
+		token := entry.cached.value
+		entry.mu.Unlock()
+		return token, nil
+	}
+
+	// A mint is already in progress: wait for it (or our own ctx) and share the
+	// leader's resolved outcome rather than launching a second mint. This bounds
+	// a failing token endpoint to one mint per burst instead of N serial retries.
+	if entry.inflight != nil {
+		flight := entry.inflight
+		entry.mu.Unlock()
+		select {
+		case <-flight.done:
+			return flight.token, flight.err
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	// We are the leader: claim the mint. The reason is a refresh only when a
+	// still-valid token is being re-minted early; an expired entry is a cold
+	// miss operationally, not a refresh.
+	reason := mintReasonColdMiss
+	if entry.cached != nil && !entry.cached.isExpired() {
+		reason = mintReasonRefresh
+	}
+	flight := &tokenFlight{done: make(chan struct{})}
+	entry.inflight = flight
+	entry.mu.Unlock()
+
+	fetched, err := mint(ctx, reason)
+
+	entry.mu.Lock()
+	entry.inflight = nil
+
+	if err != nil {
+		token, resErr := "", err
+		if entry.cached != nil && !entry.cached.isExpired() && isRetryable(err) {
+			// Proactive refresh failed transiently; serve the still-valid token.
+			token, resErr = entry.cached.value, nil
+		}
+		flight.token, flight.err = token, resErr
+		// Publish the outcome to waiters under entry.mu, then release them; the
+		// mutex (not the close/write ordering) is what prevents a stale read.
+		close(flight.done)
+		entry.mu.Unlock()
+		return token, resErr
+	}
+
+	token := fetched.token
+
+	// Cache only tokens with a usable TTL. If refresh returned no expires_in,
+	// keep any existing still-valid token rather than discarding it.
+	if fetched.expiresIn != nil && *fetched.expiresIn > 0 {
+		mintedAt := time.Now()
+		entry.cached = newCachedToken(token, *fetched.expiresIn, c.refreshBuffer, mintedAt)
+	} else {
+		keepExisting := entry.cached != nil && !entry.cached.isExpired()
+		if !keepExisting {
+			entry.cached = nil
+		}
+	}
+	flight.token, flight.err = token, nil
+	close(flight.done)
+	entry.mu.Unlock()
+
+	return token, nil
+}
+
+// invalidate drops the cached token for the given credentials and table. The
+// next getOrFetch call will re-mint from scratch.
+func (c *tokenCache) invalidate(clientID, clientSecret, tableName string) {
+	key := newTokenKey(clientID, clientSecret, tableName)
+
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+	entry.mu.Lock()
+	entry.cached = nil
+	entry.mu.Unlock()
+}
+
+// slot returns the per-key entry, creating it on first access. The outer lock
+// is held only for the map lookup/insert, keeping contention off the hot path.
+func (c *tokenCache) slot(key tokenKey) *tokenCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if e, ok := c.entries[key]; ok {
+		return e
+	}
+	// Sweep expired entries on a miss to prevent unbounded map growth in
+	// clients that ingest into many tables over the lifetime of one process.
+	c.pruneExpiredLocked()
+	e := &tokenCacheEntry{}
+	c.entries[key] = e
+	return e
+}
+
+// pruneExpiredLocked drops cache entries whose token is fully expired and that
+// have no mint in progress. Must be called with c.mu held.
+//
+// A goroutine can still hold a *tokenCacheEntry pointer that this prunes if the
+// entry's cached token is expired and no mint is in flight — a fresh slot() for
+// the same key would then create a second entry and briefly duplicate a mint.
+// The inflight guard keeps this from touching an in-progress mint, and the
+// window only opens for entries with no usable cached token (i.e. no-TTL / fully
+// expired), so in normal TTL'd operation a valid entry is never pruned.
+func (c *tokenCache) pruneExpiredLocked() {
+	for k, e := range c.entries {
+		if e.mu.TryLock() {
+			// Never evict a mint in flight: its leader writes back to this entry.
+			expired := e.inflight == nil && (e.cached == nil || e.cached.isExpired())
+			e.mu.Unlock()
+			if expired {
+				delete(c.entries, k)
+			}
+		}
+		// A locked entry is mid-transition; leave it alone.
+	}
+}
+
+func (c *tokenCache) needsRefresh(cached *cachedToken) bool {
+	return time.Now().After(cached.refreshAt)
+}
+
+// isRetryable reports whether the error tree holds a retryable [retryableError],
+// walking both single- and multi-error (errors.Join) unwrap chains.
+func isRetryable(err error) bool {
+	switch x := err.(type) {
+	case nil:
+		return false
+	case retryableError:
+		return x.IsRetryable()
+	case interface{ Unwrap() error }:
+		return isRetryable(x.Unwrap())
+	case interface{ Unwrap() []error }:
+		for _, e := range x.Unwrap() {
+			if isRetryable(e) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// retryableError is implemented by errors from the mint path that are safe to
+// suppress when a cached token is still valid.
+type retryableError interface {
+	IsRetryable() bool
+}

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -100,6 +100,7 @@ type tokenCacheEntry struct {
 	mu       sync.Mutex
 	cached   *cachedToken // nil when no valid entry has been stored yet
 	inflight *tokenFlight // non-nil while a mint is in progress
+	minted   bool         // true after the first mint completes; guards pruning
 }
 
 // tokenFlight is a single in-progress mint. The leader records its resolved
@@ -248,6 +249,7 @@ func (c *tokenCache) tryGetOrFetch(
 
 	entry.mu.Lock()
 	entry.inflight = nil
+	entry.minted = true
 
 	if err != nil {
 		token, resErr := "", err
@@ -329,19 +331,19 @@ func (c *tokenCache) slot(key tokenKey) *tokenCacheEntry {
 // pruneExpiredLocked drops cache entries whose token is fully expired and that
 // have no mint in progress. Must be called with c.mu held.
 //
-// A goroutine can still hold a *tokenCacheEntry pointer that this prunes if the
-// entry's cached token is expired and no mint is in flight — a fresh slot() for
-// the same key would then create a second entry and briefly duplicate a mint.
-// The inflight guard keeps this from touching an in-progress mint, and the
-// window only opens for entries with no usable cached token (i.e. no-TTL / fully
-// expired), so in normal TTL'd operation a valid entry is never pruned.
+// Only entries that have completed at least one mint (minted == true) are
+// eligible for eviction: a freshly created entry (minted == false) could still
+// have a goroutine racing to acquire entry.mu and become its first leader.
+// Evicting it would cause a second entry to be created for the same key,
+// briefly duplicating a mint. The minted flag closes that window.
 func (c *tokenCache) pruneExpiredLocked() {
 	for k, e := range c.entries {
 		if e.mu.TryLock() {
-			// Never evict a mint in flight: its leader writes back to this entry.
-			expired := e.inflight == nil && (e.cached == nil || e.cached.isExpired())
+			// Never evict a mint in flight, and never evict an entry whose first
+			// mint has not yet completed — its leader writes back to this entry.
+			pruneable := e.minted && e.inflight == nil && (e.cached == nil || e.cached.isExpired())
 			e.mu.Unlock()
-			if expired {
+			if pruneable {
 				delete(c.entries, k)
 			}
 		}

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -384,6 +384,49 @@ func TestTokenCacheContextDeadlineRespectedDuringMint(t *testing.T) {
 	}
 }
 
+// TestTokenCacheInvalidateDuringInFlightMint runs invalidate concurrently with
+// an in-flight mint on the same key. The leader's fresh token is what should
+// win: invalidate clears cached mid-mint, and the leader then repopulates it.
+func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
+	c := newTokenCache()
+	// Seed so invalidate has an entry to clear.
+	seedRefreshable(c, "id", "secret", "c.s.t", "old")
+
+	mintStarted := make(chan struct{})
+	releaseMint := make(chan struct{})
+
+	var out string
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		out, err = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+			func(_ context.Context, _ mintReason) (fetchedToken, error) {
+				close(mintStarted)
+				<-releaseMint
+				return fetchedToken{token: "fresh", expiresIn: dur(3600)}, nil
+			},
+		)
+	}()
+
+	<-mintStarted
+	c.invalidate("id", "secret", "c.s.t") // clears cached mid-mint
+	close(releaseMint)
+	<-done
+
+	if err != nil || out != "fresh" {
+		t.Fatalf("want fresh/nil, got %q/%v", out, err)
+	}
+	// Leader's fresh token should be the one now cached.
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t"))
+	entry.mu.Lock()
+	cached := entry.cached
+	entry.mu.Unlock()
+	if cached == nil || cached.value != "fresh" {
+		t.Fatalf("want fresh cached after leader completes, got %+v", cached)
+	}
+}
+
 func TestTokenCacheJoinedRetryableErrorFallsBack(t *testing.T) {
 	c := newTokenCache()
 	seedRefreshable(c, "id", "secret", "c.s.t", "valid")

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -21,6 +21,15 @@ type fatalErr struct{ msg string }
 func (e *fatalErr) Error() string     { return e.msg }
 func (e *fatalErr) IsRetryable() bool { return false }
 
+// denyingWrapper reports IsRetryable() == false yet wraps another error: it
+// exercises that isRetryable keeps walking past a non-retryable node instead of
+// short-circuiting on it.
+type denyingWrapper struct{ cause error }
+
+func (e *denyingWrapper) Error() string     { return "denied: " + e.cause.Error() }
+func (e *denyingWrapper) IsRetryable() bool { return false }
+func (e *denyingWrapper) Unwrap() error     { return e.cause }
+
 func makeMint(token string, ttlSecs int) func(context.Context, mintReason) (fetchedToken, error) {
 	return func(_ context.Context, _ mintReason) (fetchedToken, error) {
 		ft := fetchedToken{token: token}
@@ -447,8 +456,86 @@ func TestTokenCacheJoinedRetryableErrorFallsBack(t *testing.T) {
 	}
 }
 
+func TestTokenCacheRetryableCauseUnderNonRetryableWrapperFallsBack(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+
+	// The outermost error reports IsRetryable() == false but unwraps a retryable
+	// cause. isRetryable must keep walking and detect the cause, so the cache
+	// falls back to the still-valid token rather than propagating the failure.
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &denyingWrapper{cause: &retryErr{"transient"}}
+		},
+	)
+	if err != nil {
+		t.Fatalf("want fallback to cached token, got error: %v", err)
+	}
+	if tok != "valid" {
+		t.Fatalf("want %q, got %q", "valid", tok)
+	}
+}
+
+// TestTokenCacheWaiterRemintsWhenLeaderContextCancelled verifies that a waiter
+// with a live context does not inherit the leader's context cancellation: it
+// re-attempts and mints for itself instead.
+func TestTokenCacheWaiterRemintsWhenLeaderContextCancelled(t *testing.T) {
+	c := newTokenCache()
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	mintStarted := make(chan struct{})
+	var mints atomic.Int64
+
+	// Leader: parks in mint until its own context is cancelled, then returns that
+	// cancellation as its error (as an OAuth mint bounded by ctx would).
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _ = c.getOrFetch(leaderCtx, "id", "secret", "c.s.t",
+			func(ctx context.Context, _ mintReason) (fetchedToken, error) {
+				mints.Add(1)
+				close(mintStarted)
+				<-ctx.Done()
+				return fetchedToken{}, ctx.Err()
+			},
+		)
+	}()
+
+	<-mintStarted // leader holds the in-flight slot
+
+	// Waiter with a healthy context parks on the leader's flight.
+	waiterResult := make(chan string, 1)
+	waiterErr := make(chan error, 1)
+	go func() {
+		tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+			func(_ context.Context, _ mintReason) (fetchedToken, error) {
+				mints.Add(1)
+				return fetchedToken{token: "waiter-tok", expiresIn: dur(3600)}, nil
+			},
+		)
+		waiterErr <- err
+		waiterResult <- tok
+	}()
+
+	// Give the waiter time to park before cancelling the leader.
+	time.Sleep(50 * time.Millisecond)
+	cancelLeader() // leader's mint fails with context.Canceled
+
+	<-leaderDone
+	if err := <-waiterErr; err != nil {
+		t.Fatalf("waiter with live ctx should not inherit leader cancel, got %v", err)
+	}
+	if tok := <-waiterResult; tok != "waiter-tok" {
+		t.Fatalf("waiter should have re-minted its own token, got %q", tok)
+	}
+	// Leader minted once (and was cancelled); waiter re-minted once.
+	if n := mints.Load(); n != 2 {
+		t.Fatalf("want 2 mints (leader cancelled + waiter re-mint), got %d", n)
+	}
+}
+
 func TestTokenCacheDisabledAlwaysMints(t *testing.T) {
-	c := newTokenCache(CacheEnabled(false))
+	c := newTokenCache(cacheEnabled(false))
 	var calls atomic.Int64
 	reasons := make(chan mintReason, 2)
 	mint := func(_ context.Context, r mintReason) (fetchedToken, error) {
@@ -477,7 +564,7 @@ func TestTokenCacheCustomRefreshBuffer(t *testing.T) {
 	// effect. Compare against the default 5-minute buffer, which would place it
 	// ~55 minutes out.
 	const buffer = 20 * time.Minute
-	c := newTokenCache(CacheRefreshBuffer(buffer))
+	c := newTokenCache(cacheRefreshBuffer(buffer))
 
 	before := time.Now()
 	getOrFetch(t, c, "id", "secret", "c.s.t", makeMint("tok", 3600))
@@ -523,7 +610,7 @@ func TestNewCachedToken(t *testing.T) {
 }
 
 func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
-	c := newTokenCache(CacheRefreshBuffer(-1))
+	c := newTokenCache(cacheRefreshBuffer(-1))
 	if c.refreshBuffer != defaultRefreshBuffer {
 		t.Fatalf("non-positive buffer should be ignored, got %v", c.refreshBuffer)
 	}

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -193,6 +193,32 @@ func TestTokenCacheNonRetryableRefreshErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestTokenCacheColdMissFailureLeavesNoEntry(t *testing.T) {
+	c := newTokenCache()
+
+	// A failed cold-miss mint must not cache anything: the error propagates and a
+	// retry re-mints rather than serving a phantom token.
+	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &fatalErr{"boom"}
+		},
+	)
+	if err == nil {
+		t.Fatal("want error from failed cold-miss mint, got nil")
+	}
+
+	var calls atomic.Int64
+	tok := getOrFetch(t, c, "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			calls.Add(1)
+			return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+		},
+	)
+	if tok != "tok" || calls.Load() != 1 {
+		t.Fatalf("want a fresh mint after cold-miss failure, got %q with %d calls", tok, calls.Load())
+	}
+}
+
 func TestTokenCacheNoTTLResponseKeepsExistingCachedToken(t *testing.T) {
 	c := newTokenCache()
 	// Seed a token that is due for refresh (refreshAt already in the past).

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -1,0 +1,484 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// retryErr is a test error that reports itself as retryable.
+type retryErr struct{ msg string }
+
+func (e *retryErr) Error() string     { return e.msg }
+func (e *retryErr) IsRetryable() bool { return true }
+
+// fatalErr is a test error that is non-retryable.
+type fatalErr struct{ msg string }
+
+func (e *fatalErr) Error() string     { return e.msg }
+func (e *fatalErr) IsRetryable() bool { return false }
+
+func makeMint(token string, ttlSecs int) func(context.Context, mintReason) (fetchedToken, error) {
+	return func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		ft := fetchedToken{token: token}
+		if ttlSecs > 0 {
+			d := time.Duration(ttlSecs) * time.Second
+			ft.expiresIn = &d
+		}
+		return ft, nil
+	}
+}
+
+func getOrFetch(t *testing.T, c *tokenCache, clientID, secret, table string,
+	mint func(context.Context, mintReason) (fetchedToken, error),
+) string {
+	t.Helper()
+	tok, err := c.getOrFetch(context.Background(), clientID, secret, table, mint)
+	if err != nil {
+		t.Fatalf("getOrFetch: %v", err)
+	}
+	return tok
+}
+
+func TestTokenCacheCachesAcrossCalls(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+	}
+
+	a := getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+	b := getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+
+	if a != "tok" || b != "tok" {
+		t.Fatalf("want tok/tok, got %q/%q", a, b)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("want 1 mint, got %d", n)
+	}
+}
+
+func TestTokenCacheSeparateTablesGetSeparateEntries(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		n := calls.Add(1)
+		return fetchedToken{token: "tok" + string(rune('0'+n)), expiresIn: dur(3600)}, nil
+	}
+
+	a := getOrFetch(t, c, "id", "secret", "c.s.t1", mint)
+	b := getOrFetch(t, c, "id", "secret", "c.s.t2", mint)
+
+	if a == b {
+		t.Fatal("different tables must get different tokens")
+	}
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("want 2 mints, got %d", n)
+	}
+}
+
+func TestTokenCacheRotatedSecretGetsFreshEntry(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+	}
+
+	getOrFetch(t, c, "id", "secret-v1", "c.s.t", mint)
+	getOrFetch(t, c, "id", "secret-v2", "c.s.t", mint)
+
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("want 2 mints for different secrets, got %d", n)
+	}
+}
+
+func TestTokenCacheNoTTLIsNotCached(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "tok"}, nil // no expiresIn
+	}
+
+	a := getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+	b := getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+
+	if a != "tok" || b != "tok" {
+		t.Fatalf("want tok/tok, got %q/%q", a, b)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("want 2 mints for no-TTL token (not cached), got %d", n)
+	}
+}
+
+func TestTokenCacheInvalidateForcesMintOnNextCall(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+	}
+
+	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+	c.invalidate("id", "secret", "c.s.t")
+	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("want 2 mints after invalidate, got %d", n)
+	}
+}
+
+func TestTokenCacheWithinRefreshBufferRemints(t *testing.T) {
+	c := newTokenCache()
+	// A cached token past its refresh point is re-minted on the next call, and
+	// the fresh long-TTL result is then cached and reused.
+	seedRefreshable(c, "id", "secret", "c.s.t", "stale")
+
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "fresh", expiresIn: dur(3600)}, nil
+	}
+
+	a := getOrFetch(t, c, "id", "secret", "c.s.t", mint) // refresh due -> re-mints
+	b := getOrFetch(t, c, "id", "secret", "c.s.t", mint) // fresh token cached -> hit
+
+	if a != "fresh" || b != "fresh" {
+		t.Fatalf("want fresh/fresh, got %q/%q", a, b)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("want 1 mint (refresh, then cache hit), got %d", n)
+	}
+}
+
+func TestTokenCacheRetryableRefreshFailureFallsBack(t *testing.T) {
+	c := newTokenCache()
+	// Seed a token that is valid but due for proactive refresh.
+	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+
+	// Retryable refresh error: should fall back to the still-valid cached token.
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &retryErr{"transient"}
+		},
+	)
+	if err != nil {
+		t.Fatalf("want fallback to cached token, got error: %v", err)
+	}
+	if tok != "valid" {
+		t.Fatalf("want %q, got %q", "valid", tok)
+	}
+}
+
+func TestTokenCacheNonRetryableRefreshErrorPropagates(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+
+	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &fatalErr{"revoked"}
+		},
+	)
+	if err == nil {
+		t.Fatal("want error for non-retryable refresh failure, got nil")
+	}
+	var fe *fatalErr
+	if !errors.As(err, &fe) {
+		t.Fatalf("want fatalErr, got %T: %v", err, err)
+	}
+}
+
+func TestTokenCacheNoTTLResponseKeepsExistingCachedToken(t *testing.T) {
+	c := newTokenCache()
+	// Seed a token that is due for refresh (refreshAt already in the past).
+	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+
+	// A refresh returns a token with no TTL; caller gets the fresh token but the
+	// existing valid cached token is retained (Rust parity).
+	fresh := getOrFetch(t, c, "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{token: "nottl"}, nil
+		},
+	)
+	if fresh != "nottl" {
+		t.Fatalf("want %q, got %q", "nottl", fresh)
+	}
+
+	// A subsequent retryable refresh failure should still fall back to the
+	// original valid cached token, proving it was retained.
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &retryErr{"blip"}
+		},
+	)
+	if err != nil {
+		t.Fatalf("want fallback to retained cached token, got error: %v", err)
+	}
+	if tok != "valid" {
+		t.Fatalf("want retained cached token %q, got %q", "valid", tok)
+	}
+}
+
+func TestTokenCacheSingleFlightMintOnce(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	results := make([]string, goroutines)
+
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+				func(_ context.Context, _ mintReason) (fetchedToken, error) {
+					calls.Add(1)
+					time.Sleep(20 * time.Millisecond) // hold lock so others queue up
+					return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+				},
+			)
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				return
+			}
+			results[i] = tok
+		}(i)
+	}
+	wg.Wait()
+
+	for i, tok := range results {
+		if tok != "tok" {
+			t.Errorf("goroutine %d: want %q, got %q", i, "tok", tok)
+		}
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("single-flight: want 1 mint, got %d", n)
+	}
+}
+
+func TestTokenCacheConcurrentMintFailureSharesError(t *testing.T) {
+	c := newTokenCache()
+	var calls atomic.Int64
+
+	// The leader deterministically claims the in-flight slot and blocks until
+	// released, so every waiter is guaranteed to arrive while the mint is in
+	// flight. While inflight is held no waiter can start a second mint, so this
+	// exercises single-flight without racing a wall-clock sleep.
+	leaderMinting := make(chan struct{})
+	release := make(chan struct{})
+
+	const waiters = 15
+	var wg sync.WaitGroup
+	errs := make([]error, waiters+1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+			func(_ context.Context, _ mintReason) (fetchedToken, error) {
+				calls.Add(1)
+				close(leaderMinting)
+				<-release
+				return fetchedToken{}, &fatalErr{"boom"}
+			},
+		)
+	}()
+
+	<-leaderMinting // leader holds the flight; inflight stays set until release
+
+	wg.Add(waiters)
+	for i := range waiters {
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i+1] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+				func(_ context.Context, _ mintReason) (fetchedToken, error) {
+					calls.Add(1) // a waiter reaching here means single-flight broke
+					return fetchedToken{}, &fatalErr{"boom"}
+				},
+			)
+		}(i)
+	}
+
+	// Let the waiters reach getOrFetch and park on the leader's in-flight mint.
+	// The leader has no deadline — it blocks on release — so this only needs to
+	// outlast goroutine scheduling, not race a wall clock as the old sleep did.
+	// Any waiter that parks before release shares the leader's failure and never
+	// mints; the calls==1 assertion below catches it if one slips through.
+	time.Sleep(100 * time.Millisecond)
+	close(release) // fail the leader's mint; parked waiters share its error
+	wg.Wait()
+
+	// One mint total — the leader's. Every waiter shared its failure.
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("concurrent failure should mint once, got %d mints", n)
+	}
+	for i, err := range errs {
+		var fe *fatalErr
+		if !errors.As(err, &fe) {
+			t.Errorf("goroutine %d: want shared fatalErr, got %T: %v", i, err, err)
+		}
+	}
+}
+
+func TestTokenCacheContextDeadlineRespectedDuringMint(t *testing.T) {
+	c := newTokenCache()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	// Leader holds the mint open until release is closed.
+	go func() {
+		_, _ = c.getOrFetch(context.Background(), "id", "s", "c.s.t",
+			func(_ context.Context, _ mintReason) (fetchedToken, error) {
+				close(started)
+				<-release
+				return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+			},
+		)
+	}()
+	<-started
+
+	// A second caller with a short deadline must not block on the leader's mint.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.getOrFetch(ctx, "id", "s", "c.s.t", makeMint("tok2", 3600))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("waiter blocked %v on in-progress mint, want ~100ms", elapsed)
+	}
+}
+
+func TestTokenCacheJoinedRetryableErrorFallsBack(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+
+	// A retryable error buried inside errors.Join must still be detected so the
+	// cache falls back to the still-valid token.
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			joined := errors.Join(errors.New("context note"), &retryErr{"transient"})
+			return fetchedToken{}, joined
+		},
+	)
+	if err != nil {
+		t.Fatalf("want fallback to cached token, got error: %v", err)
+	}
+	if tok != "valid" {
+		t.Fatalf("want %q, got %q", "valid", tok)
+	}
+}
+
+func TestTokenCacheDisabledAlwaysMints(t *testing.T) {
+	c := newTokenCache(CacheEnabled(false))
+	var calls atomic.Int64
+	reasons := make(chan mintReason, 2)
+	mint := func(_ context.Context, r mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		reasons <- r
+		return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+	}
+
+	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
+
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("want 2 mints with caching disabled, got %d", n)
+	}
+	close(reasons)
+	for r := range reasons {
+		if r != mintReasonCacheDisabled {
+			t.Fatalf("want mintReasonCacheDisabled, got %v", r)
+		}
+	}
+}
+
+func TestTokenCacheCustomRefreshBuffer(t *testing.T) {
+	// A custom 20-minute buffer against a 1-hour token places the refresh point
+	// ~40 minutes out (20m < ttl/2, so no clamping) — proving the option took
+	// effect. Compare against the default 5-minute buffer, which would place it
+	// ~55 minutes out.
+	const buffer = 20 * time.Minute
+	c := newTokenCache(CacheRefreshBuffer(buffer))
+
+	before := time.Now()
+	getOrFetch(t, c, "id", "secret", "c.s.t", makeMint("tok", 3600))
+	after := time.Now()
+
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t"))
+	entry.mu.Lock()
+	cached := entry.cached
+	entry.mu.Unlock()
+	if cached == nil {
+		t.Fatal("token should be cached")
+	}
+
+	// refreshAt should sit buffer before expiresAt, i.e. ttl-buffer after mint.
+	wantMin := before.Add(time.Hour - buffer)
+	wantMax := after.Add(time.Hour - buffer)
+	if cached.refreshAt.Before(wantMin) || cached.refreshAt.After(wantMax) {
+		t.Fatalf("refreshAt %v outside expected window [%v, %v] for 20m buffer",
+			cached.refreshAt, wantMin, wantMax)
+	}
+}
+
+func TestNewCachedToken(t *testing.T) {
+	now := time.Now()
+
+	// Normal case: buffer smaller than ttl/2 is applied verbatim.
+	ct := newCachedToken("v", time.Hour, 5*time.Minute, now)
+	if !ct.expiresAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("expiresAt = %v, want +1h", ct.expiresAt)
+	}
+	if !ct.refreshAt.Equal(now.Add(time.Hour - 5*time.Minute)) {
+		t.Fatalf("refreshAt = %v, want +55m", ct.refreshAt)
+	}
+
+	// Buffer larger than ttl/2 is clamped so at least half the TTL is reusable.
+	ct = newCachedToken("v", 10*time.Minute, time.Hour, now)
+	if !ct.refreshAt.Equal(now.Add(5 * time.Minute)) {
+		t.Fatalf("clamped refreshAt = %v, want +5m (ttl/2)", ct.refreshAt)
+	}
+	if !ct.refreshAt.After(now) {
+		t.Fatal("clamped refreshAt must stay in the future so the token is reusable")
+	}
+}
+
+func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
+	c := newTokenCache(CacheRefreshBuffer(-1))
+	if c.refreshBuffer != defaultRefreshBuffer {
+		t.Fatalf("non-positive buffer should be ignored, got %v", c.refreshBuffer)
+	}
+}
+
+// dur returns a pointer to a Duration of d seconds, for test readability.
+func dur(secs int) *time.Duration {
+	d := time.Duration(secs) * time.Second
+	return &d
+}
+
+// seedRefreshable directly installs a cached token that is still valid but past
+// its refresh point (refreshAt in the past, expiresAt in the future). This is
+// the "due for proactive refresh yet safe to fall back to" state; seeding it
+// explicitly avoids depending on TTL/buffer arithmetic that clamping changes.
+func seedRefreshable(c *tokenCache, clientID, secret, table, value string) {
+	key := newTokenKey(clientID, secret, table)
+	entry := c.slot(key)
+	now := time.Now()
+	entry.mu.Lock()
+	entry.cached = &cachedToken{
+		value:     value,
+		expiresAt: now.Add(time.Hour), // still valid
+		refreshAt: now.Add(-time.Second),
+	}
+	entry.mu.Unlock()
+}

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -42,8 +42,9 @@ type Stream struct {
 // the live stream once the server acknowledges it with a stream ID.
 //
 // ctx bounds opening the stream — GetHeaders (when a HeadersProvider is set),
-// the RPC start, and the handshake — and is defaulted to defaultHandshakeTimeout
-// when it carries no deadline.
+// the RPC start, and the handshake. When ctx has no deadline, Open applies
+// default bounds independently to GetHeaders and the handshake so a slow token
+// mint can't consume the entire open budget.
 // Cancelling ctx aborts an in-progress Open promptly, but once Open succeeds
 // the live stream is detached and cancelled only by Close, so a later ctx
 // timeout won't tear it down mid-ingest. ctx's values (including caller
@@ -64,19 +65,25 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	if p.RecordType == zerobuspb.RecordType_PROTO && len(p.DescriptorProto) == 0 {
 		return nil, fmt.Errorf("transport: open %q: descriptor proto required for PROTO records", p.TableName)
 	}
-	// openCtx bounds the whole open attempt — GetHeaders (which may block on a
-	// token mint), the RPC start, and the handshake — using the caller's ctx,
-	// defaulted to defaultHandshakeTimeout when it has no deadline.
-	openCtx := ctx
+	headersCtx := ctx
+	useDefaultBudgets := false
 	if _, ok := ctx.Deadline(); !ok {
-		var cancelOpen context.CancelFunc
-		openCtx, cancelOpen = context.WithTimeout(ctx, defaultHandshakeTimeout)
-		defer cancelOpen()
+		useDefaultBudgets = true
+		var cancelHeaders context.CancelFunc
+		headersCtx, cancelHeaders = context.WithTimeout(ctx, defaultHeadersTimeout)
+		defer cancelHeaders()
 	}
 
-	headers, err := p.resolveHeaders(openCtx)
+	headers, err := p.resolveHeaders(headersCtx)
 	if err != nil {
 		return nil, err
+	}
+
+	handshakeCtx := ctx
+	if useDefaultBudgets {
+		var cancelHandshake context.CancelFunc
+		handshakeCtx, cancelHandshake = context.WithTimeout(ctx, defaultHandshakeTimeout)
+		defer cancelHandshake()
 	}
 
 	// Detach the live stream from ctx's cancel/deadline (WithoutCancel keeps its
@@ -84,12 +91,12 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	streamCtx := withStreamMetadataHeaders(context.WithoutCancel(ctx), p.TableName, headers)
 	streamCtx, cancelStream := context.WithCancel(streamCtx)
 
-	// Until the handshake succeeds, bridge openCtx to cancelStream so a caller
+	// Until the handshake succeeds, bridge handshakeCtx to cancelStream so a caller
 	// cancel/timeout unblocks the in-progress RPC start, first Send, and readiness
 	// wait. stopBridge removes it on success so the live stream is fully detached.
-	stopBridge := context.AfterFunc(openCtx, cancelStream)
+	stopBridge := context.AfterFunc(handshakeCtx, cancelStream)
 
-	stream, err := c.open(openCtx, streamCtx, cancelStream, p)
+	stream, err := c.open(handshakeCtx, streamCtx, cancelStream, p)
 	if err != nil {
 		if p.HeadersProvider != nil && isAuthRejection(err) {
 			p.HeadersProvider.Invalidate(ctx, p.TableName)
@@ -101,7 +108,7 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	// return one racing cancellation.
 	if !stopBridge() {
 		cancelStream()
-		return nil, fmt.Errorf("transport: open %q: %w", p.TableName, openCtx.Err())
+		return nil, fmt.Errorf("transport: open %q: %w", p.TableName, handshakeCtx.Err())
 	}
 	stream.cancel = cancelStream
 	return stream, nil

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -101,6 +101,10 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 		if p.HeadersProvider != nil && isAuthRejection(err) {
 			p.HeadersProvider.Invalidate(ctx, p.TableName)
 		}
+		// Deregister the bridge before returning so its AfterFunc doesn't linger
+		// until handshakeCtx ends (which, on the default-budget path, is bounded,
+		// but on a caller-supplied long-lived ctx would otherwise stay pinned).
+		stopBridge()
 		cancelStream()
 		return nil, err
 	}

--- a/purego/internal/transport/export_test.go
+++ b/purego/internal/transport/export_test.go
@@ -21,3 +21,19 @@ func SetDefaultDrainTimeout(d time.Duration) (restore func()) {
 	defaultDrainTimeout = d
 	return func() { defaultDrainTimeout = prev }
 }
+
+// SetDefaultHeadersTimeout overrides the no-deadline header-resolution timeout
+// and returns a restore func for tests.
+func SetDefaultHeadersTimeout(d time.Duration) (restore func()) {
+	prev := defaultHeadersTimeout
+	defaultHeadersTimeout = d
+	return func() { defaultHeadersTimeout = prev }
+}
+
+// SetDefaultHandshakeTimeout overrides the no-deadline handshake timeout and
+// returns a restore func for tests.
+func SetDefaultHandshakeTimeout(d time.Duration) (restore func()) {
+	prev := defaultHandshakeTimeout
+	defaultHandshakeTimeout = d
+	return func() { defaultHandshakeTimeout = prev }
+}

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -19,6 +19,10 @@ const (
 )
 
 // HeadersProvider provides gRPC metadata headers for stream authentication.
+//
+// Structurally identical to auth.HeadersProvider; defined here so transport (the
+// lowest layer) does not import auth, which would invert the dependency. An
+// *auth.StaticHeadersProvider satisfies this interface directly.
 type HeadersProvider interface {
 	// GetHeaders returns the metadata headers to attach to the stream. Called
 	// during Open before the RPC handshake starts. Keys are case-folded to

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -26,7 +26,7 @@ type HeadersProvider interface {
 	// returned for it is ignored in favor of the stream-open TableName.
 	//
 	// ctx bounds GetHeaders: it is the caller's Open context, or, when that
-	// context has no deadline, one bounded by defaultHandshakeTimeout. A
+	// context has no deadline, one bounded by defaultHeadersTimeout. A
 	// GetHeaders that blocks on network I/O (e.g. a token mint) is therefore
 	// cancelled once the open budget is exhausted rather than hanging forever.
 	GetHeaders(ctx context.Context, tableName string) (map[string]string, error)

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -10,9 +10,14 @@ import (
 	"time"
 )
 
-// defaultHandshakeTimeout bounds the open attempt when the caller's context has
-// no deadline, so Open can't hang if the server half-opens the stream.
-const defaultHandshakeTimeout = 15 * time.Second
+// defaultHeadersTimeout bounds header resolution during Open when the caller's
+// context has no deadline. A var so tests can shrink it.
+var defaultHeadersTimeout = 15 * time.Second
+
+// defaultHandshakeTimeout bounds the create-stream handshake during Open when
+// the caller's context has no deadline, so Open can't hang if the server
+// half-opens the stream. A var so tests can shrink it.
+var defaultHandshakeTimeout = 15 * time.Second
 
 // defaultDrainTimeout bounds gracefulClose's drain-to-EOF when the caller's
 // context has no deadline, so it can't hang on an unresponsive server. This caps

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -11,19 +11,22 @@ import (
 )
 
 // defaultHeadersTimeout bounds header resolution during Open when the caller's
-// context has no deadline. A var so tests can shrink it.
+// context has no deadline. A var so tests can shrink it via export_test.go;
+// tests that override it therefore must not call t.Parallel().
 var defaultHeadersTimeout = 15 * time.Second
 
 // defaultHandshakeTimeout bounds the create-stream handshake during Open when
 // the caller's context has no deadline, so Open can't hang if the server
-// half-opens the stream. A var so tests can shrink it.
+// half-opens the stream. A var so tests can shrink it via export_test.go;
+// tests that override it therefore must not call t.Parallel().
 var defaultHandshakeTimeout = 15 * time.Second
 
 // defaultDrainTimeout bounds gracefulClose's drain-to-EOF when the caller's
 // context has no deadline, so it can't hang on an unresponsive server. This caps
 // only the clean-close wait (letting the server send END_STREAM rather than an
 // abrupt reset), not any ack wait — ack handling lands in a later layer. A var so
-// tests can shrink it.
+// tests can shrink it via export_test.go; tests that override it therefore must
+// not call t.Parallel().
 var defaultDrainTimeout = 500 * time.Millisecond
 
 // bidiRPC is the subset of a generated gRPC bidirectional streaming client that

--- a/purego/internal/transport/transport_test.go
+++ b/purego/internal/transport/transport_test.go
@@ -662,6 +662,52 @@ func TestOpenBoundsGetHeadersWithDeadline(t *testing.T) {
 	}
 }
 
+// delayedHeadersProvider sleeps before returning headers unless ctx is done.
+type delayedHeadersProvider struct {
+	delay time.Duration
+}
+
+func (p *delayedHeadersProvider) GetHeaders(ctx context.Context, _ string) (map[string]string, error) {
+	timer := time.NewTimer(p.delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return map[string]string{"authorization": "tok"}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *delayedHeadersProvider) Invalidate(context.Context, string) {}
+
+// TestOpenNoDeadlineUsesIndependentHeaderAndHandshakeBudgets verifies that with
+// no caller deadline, Open applies separate default budgets to GetHeaders and to
+// the handshake: a slow (but successful) GetHeaders call does not consume the
+// handshake budget.
+func TestOpenNoDeadlineUsesIndependentHeaderAndHandshakeBudgets(t *testing.T) {
+	defer transport.SetDefaultHeadersTimeout(60 * time.Millisecond)()
+	defer transport.SetDefaultHandshakeTimeout(60 * time.Millisecond)()
+
+	srv := &fakeServer{streamID: "s", seen: make(chan observed, 1), hangHandshake: true}
+	conn := dialFake(t, srv)
+
+	start := time.Now()
+	_, err := conn.Open(context.Background(), transport.StreamParams{
+		TableName:       "c.s.t",
+		RecordType:      zerobuspb.RecordType_JSON,
+		HeadersProvider: &delayedHeadersProvider{delay: 40 * time.Millisecond},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Open with hanging handshake and no caller deadline: err = %v, want DeadlineExceeded", err)
+	}
+	elapsed := time.Since(start)
+	// With split budgets this should be roughly headers delay + handshake timeout.
+	// A single shared budget would fail much earlier.
+	if elapsed < 80*time.Millisecond {
+		t.Fatalf("Open returned too quickly (%v); expected separate header and handshake budgets", elapsed)
+	}
+}
+
 func TestStreamCloseAbortsRecv(t *testing.T) {
 	srv := &fakeServer{streamID: "s", seen: make(chan observed, 1)}
 	conn := dialFake(t, srv)


### PR DESCRIPTION
## Summary

Second of a 3-PR stack. **Stacked on #494** (base branch `purego-transport-headers`).

Introduces the `auth` package foundations:
- `HeadersProvider` interface — the single auth extension point, matching the Rust SDK (and duck-type compatible with the transport's local `HeadersProvider` from #494).
- `StaticHeadersProvider` — returns a fixed headers map, for tests or externally managed credentials.
- A per-table token cache with proactive refresh and single-flight minting, which bounds a failing token endpoint to one mint per burst rather than N serial attempts.

OAuth-backed providers land in the follow-up PR.

## Stack
1. #494 — transport header hook
2. **this PR** — auth HeadersProvider + token cache
3. #496 — UC OAuth provider

## Test plan
- `go build ./internal/auth/` and `go test ./internal/auth/` pass.

## Note
Rebased on the updated #494, which dropped `StreamParams.Token` in favor of the `HeadersProvider` hook. Auth is expressed solely through `HeadersProvider`; a speculative `TokenProvider` interface (and `StaticTokenProvider`) was dropped as unused, mirroring the Rust SDK where `HeadersProvider` is the only extension point. The header-provider types live in `headers_provider.go`.
