### PR TITLE
[PureGo] Add UC OAuth token provider with per-table caching

### DIFF
--- a/purego/README.md
+++ b/purego/README.md
@@ -21,9 +21,11 @@ Implemented packages:
   the `StreamParams.HeadersProvider`. The authorization value is sent verbatim as
   the provider formats it (e.g. `"Bearer <token>"`); the transport does not add a
   scheme prefix.
-- `internal/auth` — the `HeadersProvider` interface and `StaticHeadersProvider`
-  for fixed-header cases, plus a per-`(clientID, secret, table)` token cache
-  with single-flight minting, proactive refresh, and retryable-error fallback.
+- `internal/auth` — the `HeadersProvider` seam that feeds transport open, with
+  two implementations. `OAuthHeadersProvider` mints Unity Catalog OAuth 2.0
+  tokens (client-credentials flow) via `OAuthTokenProvider`, with per-table
+  token caching and proactive refresh; `StaticHeadersProvider` returns a fixed
+  header set for tests or externally managed credentials.
 
 Planned layers: ingest/ack state management, recovery, and the public API.
 

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -26,6 +26,40 @@ type HeadersProvider interface {
 	Invalidate(ctx context.Context, tableName string)
 }
 
+// OAuthHeadersProvider bridges OAuth token minting into headers-provider shape.
+type OAuthHeadersProvider struct {
+	tokenProvider *OAuthTokenProvider
+}
+
+// NewOAuthHeadersProvider creates an OAuth-backed headers provider.
+func NewOAuthHeadersProvider(
+	clientID, clientSecret, zerobusEndpoint, ucEndpoint string,
+	opts ...OAuthOption,
+) (*OAuthHeadersProvider, error) {
+	p, err := NewOAuthTokenProvider(clientID, clientSecret, zerobusEndpoint, ucEndpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &OAuthHeadersProvider{tokenProvider: p}, nil
+}
+
+// GetHeaders returns Zerobus auth headers for tableName.
+func (p *OAuthHeadersProvider) GetHeaders(ctx context.Context, tableName string) (map[string]string, error) {
+	token, err := p.tokenProvider.Token(ctx, tableName)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"authorization":                   "Bearer " + token,
+		"x-databricks-zerobus-table-name": tableName,
+	}, nil
+}
+
+// Invalidate drops the cached token for tableName.
+func (p *OAuthHeadersProvider) Invalidate(ctx context.Context, tableName string) {
+	p.tokenProvider.Invalidate(ctx, tableName)
+}
+
 // StaticHeadersProvider returns a fixed header set.
 type StaticHeadersProvider struct {
 	headers map[string]string

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -50,8 +50,8 @@ func NewOAuthHeadersProvider(
 
 // GetHeaders mints (or serves a cached) token for tableName and returns it as a
 // "Bearer" authorization header. It may block on the token mint, bounded by ctx.
-// The table-name header is included for cross-SDK parity; transport open treats
-// its own stream-open TableName as authoritative.
+// The table-name header is included as a convenience; transport open treats its
+// own stream-open TableName as authoritative and overwrites it.
 func (p *OAuthHeadersProvider) GetHeaders(ctx context.Context, tableName string) (map[string]string, error) {
 	token, err := p.tokenProvider.Token(ctx, tableName)
 	if err != nil {
@@ -59,7 +59,7 @@ func (p *OAuthHeadersProvider) GetHeaders(ctx context.Context, tableName string)
 	}
 	return map[string]string{
 		"authorization":                   "Bearer " + token,
-		"x-databricks-zerobus-table-name": tableName,
+		"x-databricks-zerobus-table-name": strings.TrimSpace(tableName),
 	}, nil
 }
 

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -29,6 +29,11 @@ type HeadersProvider interface {
 	Invalidate(ctx context.Context, tableName string)
 }
 
+var (
+	_ HeadersProvider = (*OAuthHeadersProvider)(nil)
+	_ HeadersProvider = (*StaticHeadersProvider)(nil)
+)
+
 // OAuthHeadersProvider adapts an [OAuthTokenProvider] to the [HeadersProvider]
 // seam: it mints per-table Unity Catalog OAuth tokens on demand and formats them
 // as gRPC auth metadata. The token cache and OAuth options are configured at

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -21,7 +21,9 @@ import (
 // Implementations may include it as well.
 //
 // Invalidate is called on server auth rejection so any cached credentials can
-// be dropped before the next open attempt.
+// be dropped before the next open attempt. It must not block on network I/O:
+// transport Open calls it synchronously on the failure path, and the ctx it
+// receives may already be cancelled.
 type HeadersProvider interface {
 	GetHeaders(ctx context.Context, tableName string) (map[string]string, error)
 	Invalidate(ctx context.Context, tableName string)

--- a/purego/internal/auth/headers_provider.go
+++ b/purego/internal/auth/headers_provider.go
@@ -18,7 +18,7 @@ import (
 //
 // GetHeaders returns headers for the given tableName. The transport layer will
 // always enforce the authoritative table-name header from stream-open params.
-// Implementations may include it for parity with other SDKs.
+// Implementations may include it as well.
 //
 // Invalidate is called on server auth rejection so any cached credentials can
 // be dropped before the next open attempt.

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -66,9 +67,10 @@ func WithHTTPClient(c *http.Client) OAuthOption {
 // [NewSharedTokenCache]. It exposes no methods and is safe for concurrent use.
 type SharedTokenCache = tokenCache
 
-// WithSharedTokenCache installs a shared token cache. Use this when multiple
-// OAuthTokenProviders are created for the same credentials but different tables
-// so they share one cache map rather than each allocating their own.
+// WithSharedTokenCache installs a shared token cache. A single provider already
+// caches all of its tables; use this only when multiple OAuthTokenProvider
+// instances should pool their tokens in one cache rather than each allocating
+// its own (a single provider serves many tables on its own).
 //
 // Obtain a cache with [NewSharedTokenCache]. A nil cache is ignored so the
 // provider's own default cache is preserved.
@@ -246,9 +248,9 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 	return fetched, err
 }
 
-// Invalidate drops the cached token for this provider's table so the next
-// Token call re-mints from Unity Catalog. Call this when the server rejects
-// the token with an authentication error.
+// Invalidate drops the cached token for the given table so the next Token call
+// re-mints from Unity Catalog. Call this when the server rejects the token with
+// an authentication error.
 //
 // The table name is not re-validated here: it was validated at stream open, and
 // invalidate is a no-op for a key with no cached entry, so an unrecognized name
@@ -303,8 +305,10 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 
 	var body struct {
 		AccessToken string `json:"access_token"`
-		// RFC 6749 §4.2.2 defines expires_in as an integer number of seconds.
-		ExpiresIn int64 `json:"expires_in"`
+		// RFC 6749 §4.2.2 defines expires_in as an integer number of seconds. It
+		// is captured raw and parsed tolerantly (see parseExpiresIn) so a server
+		// that sends it as a string or float doesn't fail the whole mint.
+		ExpiresIn json.RawMessage `json:"expires_in"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return fetchedToken{}, &TokenError{
@@ -321,10 +325,37 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 	}
 
 	ft := fetchedToken{token: body.AccessToken}
-	if d, ok := secondsToDuration(body.ExpiresIn); ok {
+	if d, ok := secondsToDuration(parseExpiresIn(body.ExpiresIn)); ok {
 		ft.expiresIn = &d
 	}
 	return ft, nil
+}
+
+// parseExpiresIn tolerantly reads an OAuth expires_in value. RFC 6749 specifies
+// an integer number of seconds, but some servers send a JSON string or float;
+// all are accepted. A missing, null, or unparseable value yields 0, which
+// secondsToDuration treats as "no usable TTL" so the token is still returned
+// (just not cached) rather than failing the mint on a cosmetic type mismatch.
+func parseExpiresIn(raw json.RawMessage) int64 {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return 0
+	}
+	// Unwrap a quoted JSON string ("3600") to its inner value before parsing.
+	if unquoted, err := strconv.Unquote(s); err == nil {
+		s = unquoted
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f >= 0 {
+		// Truncate toward zero; sub-second precision is irrelevant for a TTL.
+		if f > float64(math.MaxInt64) {
+			return math.MaxInt64
+		}
+		return int64(f)
+	}
+	return 0
 }
 
 // maxExpiresInSeconds bounds a server-reported expires_in so the seconds→

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -200,9 +200,9 @@ func (p *OAuthTokenProvider) tokenAudience() string {
 }
 
 // FetchToken mints a token directly from Unity Catalog, bypassing the cache. It
-// neither reads nor writes the cache, so callers get a guaranteed-fresh token;
-// most callers should use [OAuthTokenProvider.Token] instead so tokens are
-// reused across streams.
+// neither reads nor writes the cache and does not invalidate any existing cached
+// entry, so callers get a guaranteed-fresh token; most callers should use
+// [OAuthTokenProvider.Token] instead so tokens are reused across streams.
 func (p *OAuthTokenProvider) FetchToken(ctx context.Context, tableName string) (string, error) {
 	tableName = strings.TrimSpace(tableName)
 	if err := validateTableName(tableName); err != nil {
@@ -291,11 +291,14 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 	if err != nil {
 		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("token request: %v", err), retryable: isRetryableTransportError(ctx, err), cause: err}
 	}
-	// Drain any unread bytes before closing so the keep-alive connection can be
+	// Drain unread bytes before closing so the keep-alive connection can be
 	// reused: json.Decode stops at the end of the JSON value and classifyHTTPError
-	// caps its read, either of which can leave a trailing tail on the body.
+	// caps its read, either of which can leave a trailing tail on the body. The
+	// drain is itself capped so a server appending an unbounded tail after a valid
+	// response can't force an arbitrarily long read; past the cap the connection
+	// is simply closed instead of reused.
 	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 		resp.Body.Close()
 	}()
 
@@ -501,7 +504,7 @@ func isRetryableTransportError(ctx context.Context, err error) bool {
 // authorization header value. gRPC metadata rejects values with ASCII control
 // characters (bytes 0–31 and DEL).
 //
-// Note: transport.isUsableAsHeader applies the same character check but
+// Note: transport.isUsableAsHeaderValue applies the same character check but
 // intentionally treats the empty string as usable ("no header"); this copy
 // returns false for empty because a minted token must be non-empty. Keep the
 // character logic in sync if either is changed.
@@ -570,6 +573,14 @@ func deriveWorkspaceIDFromEndpoint(endpoint string) (workspaceID string, err err
 	host := u.Hostname()
 	if host == "" {
 		return "", fmt.Errorf("zerobusEndpoint has no host: %q", endpoint)
+	}
+	// A real Zerobus endpoint always carries the workspace as the first DNS label
+	// (e.g. "ws.zerobus.databricks.com"). A single-label host has no workspace
+	// subdomain — almost always the workspace URL passed by mistake — and would
+	// otherwise yield a syntactically valid but wrong audience whose every mint
+	// 401s with an opaque error. Reject it here so the misconfig fails fast.
+	if !strings.Contains(host, ".") && !isLoopbackHost(host) {
+		return "", fmt.Errorf("zerobusEndpoint host %q has no workspace subdomain", host)
 	}
 	workspaceID, _, _ = strings.Cut(host, ".")
 	if workspaceID == "" {

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -65,19 +65,25 @@ func WithHTTPClient(c *http.Client) OAuthOption {
 // SharedTokenCache is an OAuth token cache shared across multiple
 // [OAuthTokenProvider] instances via [WithSharedTokenCache]. Obtain one with
 // [NewSharedTokenCache]. It exposes no methods and is safe for concurrent use.
-type SharedTokenCache = tokenCache
+//
+// It is an opaque wrapper rather than an alias to the internal cache: a
+// zero-value SharedTokenCache holds no usable cache and is ignored by
+// [WithSharedTokenCache], so it cannot be mis-constructed into a nil-map panic.
+type SharedTokenCache struct {
+	c *tokenCache
+}
 
 // WithSharedTokenCache installs a shared token cache. A single provider already
 // caches all of its tables; use this only when multiple OAuthTokenProvider
 // instances should pool their tokens in one cache rather than each allocating
 // its own (a single provider serves many tables on its own).
 //
-// Obtain a cache with [NewSharedTokenCache]. A nil cache is ignored so the
-// provider's own default cache is preserved.
+// Obtain a cache with [NewSharedTokenCache]. A nil or zero-value (uninitialized)
+// cache is ignored so the provider's own default cache is preserved.
 func WithSharedTokenCache(cache *SharedTokenCache) OAuthOption {
 	return func(p *OAuthTokenProvider) {
-		if cache != nil {
-			p.cache = cache
+		if cache != nil && cache.c != nil {
+			p.cache = cache.c
 		}
 	}
 }
@@ -167,7 +173,7 @@ func NewOAuthTokenProvider(
 //
 // Configure it with [CacheEnabled] and [CacheRefreshBuffer].
 func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {
-	return newTokenCache(opts...)
+	return &SharedTokenCache{c: newTokenCache(opts...)}
 }
 
 // Token returns a valid bearer token for tableName, minting a new one via
@@ -232,7 +238,16 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 			slog.String("error", err.Error()),
 		)
 	case fetched.expiresIn == nil:
-		p.logger.LogAttrs(ctx, slog.LevelWarn, "minted UC OAuth token but UC returned no expires_in; token will not be cached",
+		// A direct mint (FetchToken) intentionally bypasses the cache, so a
+		// missing expires_in is expected there — log it at info, not as a warning
+		// about an unusable cache response.
+		level := slog.LevelWarn
+		msg := "minted UC OAuth token but UC returned no expires_in; token will not be cached"
+		if reason == mintReasonDirect {
+			level = slog.LevelInfo
+			msg = "minted UC OAuth token (direct, uncached)"
+		}
+		p.logger.LogAttrs(ctx, level, msg,
 			slog.String("table", tableName),
 			slog.String("reason", reason.String()),
 			slog.Duration("elapsed", elapsed),
@@ -258,6 +273,12 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 func (p *OAuthTokenProvider) Invalidate(_ context.Context, tableName string) {
 	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName), p.tokenAudience())
 }
+
+// maxTokenResponseBytes bounds how much of an OAuth token response body is read,
+// both for the success JSON and for a best-effort error payload, so a
+// misbehaving server can't force an unbounded read or allocation. A legitimate
+// token response is far smaller.
+const maxTokenResponseBytes = 4096
 
 // fetchToken performs the OAuth 2.0 client credentials request against Unity
 // Catalog's OIDC token endpoint.
@@ -298,7 +319,7 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 	// response can't force an arbitrarily long read; past the cap the connection
 	// is simply closed instead of reused.
 	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxTokenResponseBytes))
 		resp.Body.Close()
 	}()
 
@@ -313,7 +334,9 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 		// that sends it as a string or float doesn't fail the whole mint.
 		ExpiresIn json.RawMessage `json:"expires_in"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	// Bound the decode so a misbehaving server can't stream an unbounded body and
+	// force arbitrary allocation. A well-formed token response is well under this.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxTokenResponseBytes)).Decode(&body); err != nil {
 		return fetchedToken{}, &TokenError{
 			msg:       fmt.Sprintf("parse token response: %v", err),
 			retryable: false,
@@ -450,7 +473,7 @@ func isRetryableStatus(code int) bool {
 func classifyHTTPError(resp *http.Response) error {
 	// Best-effort read of the error payload, bounded so a misbehaving server
 	// can't stream an unbounded body into the error message.
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBytes))
 	raw := strings.TrimSpace(string(body))
 
 	// Prefer the structured OAuth error fields (RFC 6749 §5.2) for the message so
@@ -529,6 +552,16 @@ func validateEndpoint(endpoint string) error {
 	// here so misconfiguration fails fast in the constructor.
 	if u.Hostname() == "" {
 		return fmt.Errorf("ucEndpoint has no host: %q", endpoint)
+	}
+	// The token URL is formed by appending "/oidc/v1/token" to the endpoint
+	// string. A query or fragment would make that suffix part of the query data
+	// (or drop it entirely), silently posting client credentials to the wrong
+	// path. Reject them so the endpoint is a plain scheme://host[:port][/path].
+	if u.RawQuery != "" || u.ForceQuery {
+		return fmt.Errorf("ucEndpoint must not contain a query string: %q", endpoint)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("ucEndpoint must not contain a fragment: %q", endpoint)
 	}
 	switch u.Scheme {
 	case "https":

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -115,7 +115,7 @@ func WithLogger(l *slog.Logger) OAuthOption {
 // client credentials flow.
 //
 // zerobusEndpoint is the Zerobus service URL. The workspace ID used in OAuth
-// resource audience is derived from its host prefix (matching the Rust SDK).
+// resource audience is derived from its host prefix.
 // ucEndpoint is the workspace URL (e.g. "https://my-workspace.databricks.com").
 func NewOAuthTokenProvider(
 	clientID, clientSecret, zerobusEndpoint, ucEndpoint string,
@@ -177,7 +177,7 @@ func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {
 //
 // A successful mint is cached only when UC reports a usable expires_in. If UC
 // omits expires_in (or reports a non-positive value), the token is returned but
-// not cached to match Rust SDK behavior.
+// not cached.
 func (p *OAuthTokenProvider) Token(ctx context.Context, tableName string) (string, error) {
 	tableName = strings.TrimSpace(tableName)
 	if err := validateTableName(tableName); err != nil {
@@ -395,7 +395,7 @@ func (e *TokenError) Unwrap() error { return e.cause }
 
 // isRetryableStatus reports whether an HTTP status is a transient failure worth
 // suppressing when a cached token can be served. Only 5xx responses qualify;
-// all 4xx (including 429 and 408) are non-retryable, matching the Rust SDK.
+// all 4xx (including 429 and 408) are non-retryable.
 func isRetryableStatus(code int) bool {
 	return code >= 500
 }
@@ -493,7 +493,7 @@ func isLoopbackHost(host string) bool {
 }
 
 // deriveWorkspaceIDFromEndpoint extracts workspace ID from Zerobus endpoint
-// host by taking the first DNS label, matching Rust SDK behavior.
+// host by taking the first DNS label.
 func deriveWorkspaceIDFromEndpoint(endpoint string) (workspaceID string, err error) {
 	endpoint = strings.TrimSpace(endpoint)
 	if endpoint == "" {

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -192,7 +192,7 @@ func (p *OAuthTokenProvider) Token(ctx context.Context, tableName string) (strin
 	if err := validateTableName(tableName); err != nil {
 		return "", fmt.Errorf("auth: oauth: %w", err)
 	}
-	return p.cache.getOrFetch(ctx, p.clientID, p.clientSecret, tableName, p.tokenAudience(),
+	return p.cache.getOrFetch(ctx, p.clientID, p.clientSecret, tableName, p.cacheScope(),
 		func(ctx context.Context, reason mintReason) (fetchedToken, error) {
 			return p.mint(ctx, tableName, reason)
 		},
@@ -200,10 +200,18 @@ func (p *OAuthTokenProvider) Token(ctx context.Context, tableName string) (strin
 }
 
 // tokenAudience is the resource audience a minted token is bound to. It depends
-// on the workspace, so it is part of the cache key: tokens for the same
-// credentials and table but different workspaces are not interchangeable.
+// on the workspace and is sent as the OAuth request's resource field.
 func (p *OAuthTokenProvider) tokenAudience() string {
 	return fmt.Sprintf("api://databricks/workspaces/%s/zerobusDirectWriteApi", p.workspaceID)
+}
+
+// cacheScope discriminates cache entries that share credentials and table but
+// are not interchangeable. It combines the token audience (workspace binding)
+// with the issuing UC endpoint: a token minted for one workspace is rejected by
+// another, and two providers pointed at different UC endpoints mint through
+// different issuers, so a shared cache must not serve one's token to the other.
+func (p *OAuthTokenProvider) cacheScope() string {
+	return p.tokenAudience() + "\x00" + p.ucEndpoint
 }
 
 // FetchToken mints a token directly from Unity Catalog, bypassing the cache. It
@@ -272,7 +280,7 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 // invalidate is a no-op for a key with no cached entry, so an unrecognized name
 // simply does nothing.
 func (p *OAuthTokenProvider) Invalidate(_ context.Context, tableName string) {
-	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName), p.tokenAudience())
+	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName), p.cacheScope())
 }
 
 // maxTokenResponseBytes bounds how much of an OAuth token response body is read,
@@ -505,12 +513,12 @@ func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
 // non-retryable so a genuine failure isn't masked by a stale cached token.
 //
 // ctx is the caller's context. A mint request that times out on its own (a slow
-// UC endpoint tripping http.Client.Timeout, or an internal transport deadline)
-// is transient and retryable, so a proactive refresh can fall back to the
+// UC endpoint tripping http.Client.Timeout, or an SDK-internal open budget) is
+// transient and retryable, so a proactive refresh can fall back to the
 // still-valid cached token. Only a cancel/deadline that came from the caller's
 // own context is non-retryable — that is the caller's signal to stop, not a
-// server fault. Both surface as a wrapped context error, so they are told apart
-// by whether ctx itself is done.
+// server fault. All surface as a wrapped context error; isCallerCancellation
+// tells the caller's own cancel apart from a request or budget timeout.
 func isRetryableTransportError(ctx context.Context, err error) bool {
 	if isContextError(err) {
 		// A context error is retryable only when it came from the request itself

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -160,8 +160,8 @@ func NewOAuthTokenProvider(
 
 // NewSharedTokenCache allocates a token cache that can be passed to multiple
 // [OAuthTokenProvider] instances via [WithSharedTokenCache]. Sharing a cache
-// ensures tokens for the same (clientID, secret, table) are reused across
-// providers rather than each minting independently.
+// ensures tokens for the same (clientID, secret, table, workspace audience) are
+// reused across providers rather than each minting independently.
 //
 // Configure it with [CacheEnabled] and [CacheRefreshBuffer].
 func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -1,0 +1,550 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// OAuthTokenProvider obtains Unity Catalog OAuth 2.0 tokens using the client
+// credentials flow and caches them until they approach expiry.
+//
+// UC issues downscoped tokens — each token is minted with authorization_details
+// that limit it to a specific table — so the table name is part of the cache
+// key. A single OAuthTokenProvider can serve many tables; tokens are cached
+// independently per table.
+//
+// Refresh is on-access, not background: a token is re-minted on the next Token
+// call once it is within the 5-minute window before expiry. If that refresh
+// fails transiently the still-valid cached token is served; a non-retryable
+// failure (revoked credentials, 4xx) propagates. A token left untouched past
+// expiry is not refreshed until the next call, which pays a full cold mint.
+//
+// OAuthTokenProvider is safe for concurrent use.
+type OAuthTokenProvider struct {
+	clientID     string
+	clientSecret string
+	workspaceID  string
+	zerobusHost  string
+	ucEndpoint   string // e.g. "https://workspace.databricks.com"
+
+	cache  *tokenCache
+	client *http.Client
+	logger *slog.Logger
+
+	// cacheOpts are applied to the provider's own default cache. They are
+	// discarded when a shared cache is installed via WithSharedTokenCache, since
+	// that cache owns its own configuration.
+	cacheOpts []CacheOption
+}
+
+// OAuthOption configures an [OAuthTokenProvider].
+type OAuthOption func(*OAuthTokenProvider)
+
+// WithHTTPClient overrides the HTTP client used for token requests. The default
+// is a client with a 30-second timeout. A nil client is ignored so the default
+// is preserved.
+func WithHTTPClient(c *http.Client) OAuthOption {
+	return func(p *OAuthTokenProvider) {
+		if c != nil {
+			p.client = c
+		}
+	}
+}
+
+// SharedTokenCache is an OAuth token cache shared across multiple
+// [OAuthTokenProvider] instances via [WithSharedTokenCache]. Obtain one with
+// [NewSharedTokenCache]. It exposes no methods and is safe for concurrent use.
+type SharedTokenCache = tokenCache
+
+// WithSharedTokenCache installs a shared token cache. Use this when multiple
+// OAuthTokenProviders are created for the same credentials but different tables
+// so they share one cache map rather than each allocating their own.
+//
+// Obtain a cache with [NewSharedTokenCache]. A nil cache is ignored so the
+// provider's own default cache is preserved.
+func WithSharedTokenCache(cache *SharedTokenCache) OAuthOption {
+	return func(p *OAuthTokenProvider) {
+		if cache != nil {
+			p.cache = cache
+		}
+	}
+}
+
+// WithTokenCacheEnabled toggles token caching for the provider's own cache. When
+// disabled, every [OAuthTokenProvider.Token] call mints a fresh token. Caching
+// is enabled by default. Ignored when a shared cache is installed via
+// [WithSharedTokenCache] — that cache carries its own configuration.
+func WithTokenCacheEnabled(enabled bool) OAuthOption {
+	return func(p *OAuthTokenProvider) {
+		p.cacheOpts = append(p.cacheOpts, CacheEnabled(enabled))
+	}
+}
+
+// WithRefreshBuffer sets the lead time before expiry at which the provider's own
+// cache proactively re-mints a token. Defaults to 5 minutes; a non-positive
+// value is ignored. Ignored when a shared cache is installed via
+// [WithSharedTokenCache].
+func WithRefreshBuffer(d time.Duration) OAuthOption {
+	return func(p *OAuthTokenProvider) {
+		p.cacheOpts = append(p.cacheOpts, CacheRefreshBuffer(d))
+	}
+}
+
+// WithLogger sets the [slog.Logger] used for token-mint observability (mint
+// reason, latency, retryability). A nil logger is ignored so the default
+// (a no-op logger) is preserved.
+func WithLogger(l *slog.Logger) OAuthOption {
+	return func(p *OAuthTokenProvider) {
+		if l != nil {
+			p.logger = l
+		}
+	}
+}
+
+// NewOAuthTokenProvider creates a provider that mints UC OAuth tokens using the
+// client credentials flow.
+//
+// zerobusEndpoint is the Zerobus service URL. The workspace ID used in OAuth
+// resource audience is derived from its host prefix (matching the Rust SDK).
+// ucEndpoint is the workspace URL (e.g. "https://my-workspace.databricks.com").
+func NewOAuthTokenProvider(
+	clientID, clientSecret, zerobusEndpoint, ucEndpoint string,
+	opts ...OAuthOption,
+) (*OAuthTokenProvider, error) {
+	ucEndpoint = strings.TrimRight(strings.TrimSpace(ucEndpoint), "/")
+	if ucEndpoint == "" {
+		return nil, fmt.Errorf("auth: oauth: ucEndpoint is required")
+	}
+	if err := validateEndpoint(ucEndpoint); err != nil {
+		return nil, fmt.Errorf("auth: oauth: %w", err)
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("auth: oauth: clientID is required")
+	}
+	if clientSecret == "" {
+		return nil, fmt.Errorf("auth: oauth: clientSecret is required")
+	}
+	workspaceID, zerobusHost, err := deriveWorkspaceIDFromEndpoint(zerobusEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("auth: oauth: %w", err)
+	}
+
+	p := &OAuthTokenProvider{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		workspaceID:  workspaceID,
+		zerobusHost:  zerobusHost,
+		ucEndpoint:   ucEndpoint,
+		client:       &http.Client{Timeout: 30 * time.Second},
+		logger:       slog.New(slog.DiscardHandler),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	// A shared cache (set via WithSharedTokenCache) owns its own configuration;
+	// otherwise build the provider's own cache from any cache options collected.
+	if p.cache == nil {
+		p.cache = newTokenCache(p.cacheOpts...)
+	}
+	return p, nil
+}
+
+// NewSharedTokenCache allocates a token cache that can be passed to multiple
+// [OAuthTokenProvider] instances via [WithSharedTokenCache]. Sharing a cache
+// ensures tokens for the same (clientID, secret, table) are reused across
+// providers rather than each minting independently.
+//
+// Configure it with [CacheEnabled] and [CacheRefreshBuffer].
+func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {
+	return newTokenCache(opts...)
+}
+
+// Token returns a valid bearer token for tableName, minting a new one via
+// Unity Catalog's OIDC token endpoint when the cache is empty or nearing
+// expiry.
+//
+// ctx bounds the token request when a mint is required. Cancelling ctx during a
+// cached hit is a no-op.
+//
+// A successful mint is cached only when UC reports a usable expires_in. If UC
+// omits expires_in (or reports a non-positive value), the token is returned but
+// not cached to match Rust SDK behavior.
+func (p *OAuthTokenProvider) Token(ctx context.Context, tableName string) (string, error) {
+	tableName = strings.TrimSpace(tableName)
+	if err := validateTableName(tableName); err != nil {
+		return "", fmt.Errorf("auth: oauth: %w", err)
+	}
+	return p.cache.getOrFetch(ctx, p.clientID, p.clientSecret, tableName,
+		func(ctx context.Context, reason mintReason) (fetchedToken, error) {
+			return p.mint(ctx, tableName, reason)
+		},
+	)
+}
+
+// FetchToken mints a token directly from Unity Catalog, bypassing the cache. It
+// neither reads nor writes the cache, so callers get a guaranteed-fresh token;
+// most callers should use [OAuthTokenProvider.Token] instead so tokens are
+// reused across streams.
+func (p *OAuthTokenProvider) FetchToken(ctx context.Context, tableName string) (string, error) {
+	tableName = strings.TrimSpace(tableName)
+	if err := validateTableName(tableName); err != nil {
+		return "", fmt.Errorf("auth: oauth: %w", err)
+	}
+	fetched, err := p.mint(ctx, tableName, mintReasonDirect)
+	if err != nil {
+		return "", err
+	}
+	return fetched.token, nil
+}
+
+// mint fetches a token and emits structured observability for the outcome. It
+// is the single mint entry point shared by the cached and direct paths.
+func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason mintReason) (fetchedToken, error) {
+	started := time.Now()
+	fetched, err := p.fetchToken(ctx, tableName)
+	elapsed := time.Since(started)
+
+	switch {
+	case err != nil:
+		p.logger.LogAttrs(ctx, slog.LevelWarn, "failed to mint UC OAuth token",
+			slog.String("table", tableName),
+			slog.String("reason", reason.String()),
+			slog.Bool("retryable", isRetryable(err)),
+			slog.Duration("elapsed", elapsed),
+			slog.String("error", err.Error()),
+		)
+	case fetched.expiresIn == nil:
+		p.logger.LogAttrs(ctx, slog.LevelWarn, "minted UC OAuth token but UC returned no expires_in; token will not be cached",
+			slog.String("table", tableName),
+			slog.String("reason", reason.String()),
+			slog.Duration("elapsed", elapsed),
+		)
+	default:
+		p.logger.LogAttrs(ctx, slog.LevelInfo, "minted UC OAuth token",
+			slog.String("table", tableName),
+			slog.String("reason", reason.String()),
+			slog.Duration("expires_in", *fetched.expiresIn),
+			slog.Duration("elapsed", elapsed),
+		)
+	}
+	return fetched, err
+}
+
+// Invalidate drops the cached token for this provider's table so the next
+// Token call re-mints from Unity Catalog. Call this when the server rejects
+// the token with an authentication error.
+func (p *OAuthTokenProvider) Invalidate(_ context.Context, tableName string) {
+	tableName = strings.TrimSpace(tableName)
+	if err := validateTableName(tableName); err != nil {
+		return
+	}
+	p.cache.invalidate(p.clientID, p.clientSecret, tableName)
+}
+
+// fetchToken performs the OAuth 2.0 client credentials request against Unity
+// Catalog's OIDC token endpoint.
+func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (fetchedToken, error) {
+	catalog, schema, _, err := parseTableName(tableName)
+	if err != nil {
+		return fetchedToken{}, err
+	}
+
+	authDetails, err := buildAuthorizationDetails(catalog, schema, tableName)
+	if err != nil {
+		return fetchedToken{}, fmt.Errorf("auth: oauth: marshal authorization_details: %w", err)
+	}
+
+	form := url.Values{
+		"grant_type":            {"client_credentials"},
+		"scope":                 {"all-apis"},
+		"resource":              {fmt.Sprintf("api://databricks/workspaces/%s/zerobusDirectWriteApi", p.workspaceID)},
+		"authorization_details": {authDetails},
+	}
+
+	tokenURL := p.ucEndpoint + "/oidc/v1/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("build token request: %v", err), retryable: false, cause: err}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(p.clientID, p.clientSecret)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("token request: %v", err), retryable: isRetryableTransportError(err), cause: err}
+	}
+	// Drain any unread bytes before closing so the keep-alive connection can be
+	// reused: json.Decode stops at the end of the JSON value and classifyHTTPError
+	// caps its read, either of which can leave a trailing tail on the body.
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if !isHTTPSuccess(resp.StatusCode) {
+		return fetchedToken{}, classifyHTTPError(resp)
+	}
+
+	var body struct {
+		AccessToken string `json:"access_token"`
+		// RFC 6749 §4.2.2 defines expires_in as an integer number of seconds.
+		ExpiresIn int64 `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return fetchedToken{}, &TokenError{
+			msg:       fmt.Sprintf("parse token response: %v", err),
+			retryable: false,
+			cause:     err,
+		}
+	}
+	if body.AccessToken == "" {
+		return fetchedToken{}, &TokenError{msg: "token response missing access_token", retryable: false}
+	}
+	if !isUsableAsHeader(body.AccessToken) {
+		return fetchedToken{}, &TokenError{msg: "access token contains invalid header characters", retryable: false}
+	}
+
+	ft := fetchedToken{token: body.AccessToken}
+	if d, ok := secondsToDuration(body.ExpiresIn); ok {
+		ft.expiresIn = &d
+	}
+	return ft, nil
+}
+
+// maxExpiresInSeconds bounds a server-reported expires_in so the seconds→
+// nanoseconds conversion can't overflow time.Duration (an int64 nanosecond
+// count, ~292 years). A larger value is clamped to this ceiling rather than
+// wrapping to a negative (past) TTL.
+const maxExpiresInSeconds = int64(math.MaxInt64 / int64(time.Second))
+
+// secondsToDuration converts a positive expires_in (seconds) to a Duration,
+// clamped to maxExpiresInSeconds. It returns ok=false for a non-positive value,
+// which signals "no usable TTL, don't cache".
+func secondsToDuration(secs int64) (time.Duration, bool) {
+	if secs <= 0 {
+		return 0, false
+	}
+	if secs > maxExpiresInSeconds {
+		secs = maxExpiresInSeconds
+	}
+	return time.Duration(secs) * time.Second, true
+}
+
+// authorizationDetailsEntry mirrors the JSON structure sent in the OAuth request.
+type authorizationDetailsEntry struct {
+	Type           string   `json:"type"`
+	Privileges     []string `json:"privileges"`
+	ObjectType     string   `json:"object_type"`
+	ObjectFullPath string   `json:"object_full_path"`
+	Operations     []string `json:"operations,omitempty"`
+}
+
+func buildAuthorizationDetails(catalog, schema, fullTable string) (string, error) {
+	details := []authorizationDetailsEntry{
+		{
+			Type:           "unity_catalog_privileges",
+			Privileges:     []string{"USE CATALOG"},
+			ObjectType:     "CATALOG",
+			ObjectFullPath: catalog,
+		},
+		{
+			Type:           "unity_catalog_privileges",
+			Privileges:     []string{"USE SCHEMA"},
+			ObjectType:     "SCHEMA",
+			ObjectFullPath: catalog + "." + schema,
+		},
+		{
+			Type:           "unity_catalog_privileges",
+			Privileges:     []string{"SELECT", "MODIFY"},
+			ObjectType:     "TABLE",
+			ObjectFullPath: fullTable,
+			Operations:     []string{"zerobuswrite"},
+		},
+	}
+	b, err := json.Marshal(details)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// TokenError is returned by [OAuthTokenProvider.Token] when a mint fails.
+// It carries a retryability flag so the cache can decide whether to suppress
+// the error and serve a still-valid cached token, and wraps the underlying
+// cause (if any) so callers can inspect it with [errors.Is]/[errors.As].
+type TokenError struct {
+	msg       string
+	retryable bool
+	cause     error
+}
+
+func (e *TokenError) Error() string     { return "auth: oauth: " + e.msg }
+func (e *TokenError) IsRetryable() bool { return e.retryable }
+
+// Unwrap exposes the cause so [errors.Is]/[errors.As] can inspect it.
+func (e *TokenError) Unwrap() error { return e.cause }
+
+// isRetryableStatus reports whether an HTTP status is a transient failure worth
+// suppressing when a cached token can be served. Only 5xx responses qualify;
+// all 4xx (including 429 and 408) are non-retryable, matching the Rust SDK.
+func isRetryableStatus(code int) bool {
+	return code >= 500
+}
+
+func classifyHTTPError(resp *http.Response) error {
+	// Best-effort read of the error payload, bounded so a misbehaving server
+	// can't stream an unbounded body into the error message.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	detail := strings.TrimSpace(string(body))
+	msg := fmt.Sprintf("HTTP %d", resp.StatusCode)
+	if detail != "" {
+		msg += ": " + detail
+	}
+	return &TokenError{msg: msg, retryable: isRetryableStatus(resp.StatusCode)}
+}
+
+func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
+
+// isRetryableTransportError reports whether a transport-level error from the
+// token request is transient and safe to retry. Only timeouts and connection
+// failures qualify; a cancelled context is the caller's own signal, and any
+// other transport error is treated as non-retryable so a genuine failure isn't
+// masked by a stale cached token.
+func isRetryableTransportError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// Timeouts (client Timeout, dial/read deadlines) are transient.
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	// A failed dial/connection (refused, reset, unreachable) is transient too.
+	var oe *net.OpError
+	return errors.As(err, &oe)
+}
+
+// isUsableAsHeader reports whether token can be sent as a gRPC/HTTP
+// authorization header value. gRPC metadata rejects values with ASCII control
+// characters (bytes 0–31 and DEL).
+//
+// Note: transport.isUsableAsHeader applies the same character check but
+// intentionally treats the empty string as usable ("no header"); this copy
+// returns false for empty because a minted token must be non-empty. Keep the
+// character logic in sync if either is changed.
+func isUsableAsHeader(token string) bool {
+	for _, r := range token {
+		if r > unicode.MaxASCII || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return token != ""
+}
+
+// validateEndpoint requires an https UC endpoint so client credentials never
+// go over plaintext; plain http is allowed only for loopback hosts (local dev).
+func validateEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("ucEndpoint is not a valid URL: %w", err)
+	}
+	// A missing host (e.g. "https://") would otherwise pass scheme validation and
+	// only fail later at request time with an opaque transport error; reject it
+	// here so misconfiguration fails fast in the constructor.
+	if u.Hostname() == "" {
+		return fmt.Errorf("ucEndpoint has no host: %q", endpoint)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("ucEndpoint must use https (got plaintext http for non-loopback host %q); "+
+			"client credentials would be sent over an unencrypted connection", u.Host)
+	default:
+		return fmt.Errorf("ucEndpoint must be an https URL, got scheme %q", u.Scheme)
+	}
+}
+
+// isLoopbackHost reports whether host is "localhost" or a loopback IP.
+// The "localhost" match is case-insensitive since DNS hostnames are.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// deriveWorkspaceIDFromEndpoint extracts workspace ID from Zerobus endpoint
+// host by taking the first DNS label, matching Rust SDK behavior.
+func deriveWorkspaceIDFromEndpoint(endpoint string) (workspaceID, host string, err error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", "", fmt.Errorf("zerobusEndpoint is required")
+	}
+	if !strings.HasPrefix(endpoint, "https://") && !strings.HasPrefix(endpoint, "http://") {
+		endpoint = "https://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", fmt.Errorf("zerobusEndpoint is not a valid URL: %w", err)
+	}
+	host = u.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("zerobusEndpoint has no host: %q", endpoint)
+	}
+	workspaceID, _, _ = strings.Cut(host, ".")
+	if workspaceID == "" {
+		return "", "", fmt.Errorf("failed to extract workspaceID from zerobusEndpoint host %q", host)
+	}
+	return workspaceID, host, nil
+}
+
+// validateTableName checks that s is a non-empty three-part dotted name.
+func validateTableName(s string) error {
+	_, _, _, err := parseTableName(s)
+	return err
+}
+
+// parseTableName splits "catalog.schema.table" into its three components,
+// returning an error if any part is empty or the format is wrong.
+//
+// Only unquoted three-part names are supported: the split is purely on ".", so
+// a backtick-quoted identifier containing a dot (e.g. cat.sch.`weird.name`) is
+// rejected. This matches the naming used for downscoped-token tables.
+func parseTableName(s string) (catalog, schema, table string, err error) {
+	// SplitN with n=4 caps the slice at 4 parts: a valid name yields exactly 3,
+	// and anything with an extra dot yields 4 (rejected below) instead of
+	// splitting the whole string. The table part itself must not contain a dot.
+	parts := strings.SplitN(s, ".", 4)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("table name must be catalog.schema.table, got %q", s)
+	}
+	catalog, schema, table = parts[0], parts[1], parts[2]
+	if catalog == "" {
+		return "", "", "", fmt.Errorf("catalog part of table name is empty in %q", s)
+	}
+	if schema == "" {
+		return "", "", "", fmt.Errorf("schema part of table name is empty in %q", s)
+	}
+	if table == "" {
+		return "", "", "", fmt.Errorf("table part of table name is empty in %q", s)
+	}
+	return catalog, schema, table, nil
+}

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -169,8 +169,10 @@ func NewOAuthTokenProvider(
 
 // NewSharedTokenCache allocates a token cache that can be passed to multiple
 // [OAuthTokenProvider] instances via [WithSharedTokenCache]. Sharing a cache
-// ensures tokens for the same (clientID, secret, table, workspace audience) are
-// reused across providers rather than each minting independently.
+// ensures tokens for the same (clientID, secret, table, workspace audience, and
+// UC endpoint) are reused across providers rather than each minting
+// independently; providers differing in workspace or UC endpoint keep separate
+// entries.
 //
 // Configure it with [CacheEnabled] and [CacheRefreshBuffer].
 func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -163,6 +163,7 @@ func NewOAuthTokenProvider(
 	if p.cache == nil {
 		p.cache = newTokenCache(p.cacheOpts...)
 	}
+	p.cacheOpts = nil // closures are consumed; don't pin them on the provider.
 	return p, nil
 }
 
@@ -269,7 +270,7 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 //
 // The table name is not re-validated here: it was validated at stream open, and
 // invalidate is a no-op for a key with no cached entry, so an unrecognized name
-// simply clears nothing rather than failing silently.
+// simply does nothing.
 func (p *OAuthTokenProvider) Invalidate(_ context.Context, tableName string) {
 	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName), p.tokenAudience())
 }
@@ -312,6 +313,9 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 	if err != nil {
 		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("token request: %v", err), retryable: isRetryableTransportError(ctx, err), cause: err}
 	}
+	// Anchor the token's TTL to response receipt so post-receipt work (JSON
+	// decode, the synchronous mint logger) can't inflate its cached lifetime.
+	receivedAt := time.Now()
 	// Drain unread bytes before closing so the keep-alive connection can be
 	// reused: json.Decode stops at the end of the JSON value and classifyHTTPError
 	// caps its read, either of which can leave a trailing tail on the body. The
@@ -343,14 +347,14 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 			cause:     err,
 		}
 	}
-	if body.AccessToken == "" {
+	if strings.TrimSpace(body.AccessToken) == "" {
 		return fetchedToken{}, &TokenError{msg: "token response missing access_token", retryable: false}
 	}
 	if !isUsableAsHeader(body.AccessToken) {
 		return fetchedToken{}, &TokenError{msg: "access token contains invalid header characters", retryable: false}
 	}
 
-	ft := fetchedToken{token: body.AccessToken}
+	ft := fetchedToken{token: body.AccessToken, receivedAt: receivedAt}
 	if d, ok := secondsToDuration(parseExpiresIn(body.ExpiresIn)); ok {
 		ft.expiresIn = &d
 	}
@@ -553,6 +557,12 @@ func validateEndpoint(endpoint string) error {
 	if u.Hostname() == "" {
 		return fmt.Errorf("ucEndpoint has no host: %q", endpoint)
 	}
+	// Userinfo (user:pass@host) would be carried into the token URL and collide
+	// with the SetBasicAuth client credentials, silently overriding them or
+	// leaking creds in the URL. Reject it so the endpoint stays scheme://host.
+	if u.User != nil {
+		return fmt.Errorf("ucEndpoint must not contain userinfo: %q", endpoint)
+	}
 	// The token URL is formed by appending "/oidc/v1/token" to the endpoint
 	// string. A query or fragment would make that suffix part of the query data
 	// (or drop it entirely), silently posting client credentials to the wrong
@@ -596,7 +606,11 @@ func deriveWorkspaceIDFromEndpoint(endpoint string) (workspaceID string, err err
 	if endpoint == "" {
 		return "", fmt.Errorf("zerobusEndpoint is required")
 	}
-	if !strings.HasPrefix(endpoint, "https://") && !strings.HasPrefix(endpoint, "http://") {
+	// URL schemes are case-insensitive (RFC 3986), so match them that way before
+	// deciding whether to supply a default scheme; otherwise a valid uppercase
+	// "HTTPS://host" would get a second scheme prepended and be misparsed.
+	lower := strings.ToLower(endpoint)
+	if !strings.HasPrefix(lower, "https://") && !strings.HasPrefix(lower, "http://") {
 		endpoint = "https://" + endpoint
 	}
 	u, err := url.Parse(endpoint)

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -451,11 +451,10 @@ func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
 // server fault. Both surface as a wrapped context error, so they are told apart
 // by whether ctx itself is done.
 func isRetryableTransportError(ctx context.Context, err error) bool {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		// The caller's own context ended: honor it and don't retry. Otherwise the
-		// deadline came from the request itself (client Timeout / transport
-		// deadline), which is a transient fault we can retry.
-		return ctx.Err() == nil
+	if isContextError(err) {
+		// A context error is retryable only when it came from the request itself
+		// (client Timeout / transport deadline), not from the caller's own context.
+		return !isCallerCancellation(ctx, err)
 	}
 	// Network-level timeouts (dial/read deadlines, i/o timeout) are transient.
 	var ne net.Error

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -183,11 +183,18 @@ func (p *OAuthTokenProvider) Token(ctx context.Context, tableName string) (strin
 	if err := validateTableName(tableName); err != nil {
 		return "", fmt.Errorf("auth: oauth: %w", err)
 	}
-	return p.cache.getOrFetch(ctx, p.clientID, p.clientSecret, tableName,
+	return p.cache.getOrFetch(ctx, p.clientID, p.clientSecret, tableName, p.tokenAudience(),
 		func(ctx context.Context, reason mintReason) (fetchedToken, error) {
 			return p.mint(ctx, tableName, reason)
 		},
 	)
+}
+
+// tokenAudience is the resource audience a minted token is bound to. It depends
+// on the workspace, so it is part of the cache key: tokens for the same
+// credentials and table but different workspaces are not interchangeable.
+func (p *OAuthTokenProvider) tokenAudience() string {
+	return fmt.Sprintf("api://databricks/workspaces/%s/zerobusDirectWriteApi", p.workspaceID)
 }
 
 // FetchToken mints a token directly from Unity Catalog, bypassing the cache. It
@@ -247,7 +254,7 @@ func (p *OAuthTokenProvider) mint(ctx context.Context, tableName string, reason 
 // invalidate is a no-op for a key with no cached entry, so an unrecognized name
 // simply clears nothing rather than failing silently.
 func (p *OAuthTokenProvider) Invalidate(_ context.Context, tableName string) {
-	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName))
+	p.cache.invalidate(p.clientID, p.clientSecret, strings.TrimSpace(tableName), p.tokenAudience())
 }
 
 // fetchToken performs the OAuth 2.0 client credentials request against Unity
@@ -266,7 +273,7 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 	form := url.Values{
 		"grant_type":            {"client_credentials"},
 		"scope":                 {"all-apis"},
-		"resource":              {fmt.Sprintf("api://databricks/workspaces/%s/zerobusDirectWriteApi", p.workspaceID)},
+		"resource":              {p.tokenAudience()},
 		"authorization_details": {authDetails},
 	}
 
@@ -280,7 +287,7 @@ func (p *OAuthTokenProvider) fetchToken(ctx context.Context, tableName string) (
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("token request: %v", err), retryable: isRetryableTransportError(err), cause: err}
+		return fetchedToken{}, &TokenError{msg: fmt.Sprintf("token request: %v", err), retryable: isRetryableTransportError(ctx, err), cause: err}
 	}
 	// Drain any unread bytes before closing so the keep-alive connection can be
 	// reused: json.Decode stops at the end of the JSON value and classifyHTTPError
@@ -381,10 +388,16 @@ func buildAuthorizationDetails(catalog, schema, fullTable string) (string, error
 // It carries a retryability flag so the cache can decide whether to suppress
 // the error and serve a still-valid cached token, and wraps the underlying
 // cause (if any) so callers can inspect it with [errors.Is]/[errors.As].
+//
+// For an HTTP error response, Error() reports the status and the structured
+// OAuth error / error_description fields (RFC 6749 §5.2) rather than the raw
+// body. The raw body is retained on ResponseBody for diagnostics without
+// widening the logged message.
 type TokenError struct {
-	msg       string
-	retryable bool
-	cause     error
+	msg          string
+	retryable    bool
+	cause        error
+	ResponseBody string // raw (bounded) HTTP error body, empty for non-HTTP failures
 }
 
 func (e *TokenError) Error() string     { return "auth: oauth: " + e.msg }
@@ -404,12 +417,23 @@ func classifyHTTPError(resp *http.Response) error {
 	// Best-effort read of the error payload, bounded so a misbehaving server
 	// can't stream an unbounded body into the error message.
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	detail := strings.TrimSpace(string(body))
+	raw := strings.TrimSpace(string(body))
+
+	// Prefer the structured OAuth error fields (RFC 6749 §5.2) for the message so
+	// the log carries a clean, parseable summary rather than the raw body; the
+	// raw body is retained on the error type for diagnostics.
 	msg := fmt.Sprintf("HTTP %d", resp.StatusCode)
-	if detail != "" {
-		msg += ": " + detail
+	var oauthErr struct {
+		Error       string `json:"error"`
+		Description string `json:"error_description"`
 	}
-	return &TokenError{msg: msg, retryable: isRetryableStatus(resp.StatusCode)}
+	if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Error != "" {
+		msg += ": " + oauthErr.Error
+		if oauthErr.Description != "" {
+			msg += ": " + oauthErr.Description
+		}
+	}
+	return &TokenError{msg: msg, retryable: isRetryableStatus(resp.StatusCode), ResponseBody: raw}
 }
 
 func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
@@ -418,13 +442,20 @@ func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
 // token request is transient and safe to retry. Network-level timeouts and
 // connection failures qualify; any other transport error is treated as
 // non-retryable so a genuine failure isn't masked by a stale cached token.
-func isRetryableTransportError(err error) bool {
-	// A context cancel/deadline is the caller's own signal, not a transient
-	// server fault. http.Client.Timeout also surfaces as a wrapped
-	// DeadlineExceeded, so it is caught here (non-retryable) before the
-	// net.Error check below.
+//
+// ctx is the caller's context. A mint request that times out on its own (a slow
+// UC endpoint tripping http.Client.Timeout, or an internal transport deadline)
+// is transient and retryable, so a proactive refresh can fall back to the
+// still-valid cached token. Only a cancel/deadline that came from the caller's
+// own context is non-retryable — that is the caller's signal to stop, not a
+// server fault. Both surface as a wrapped context error, so they are told apart
+// by whether ctx itself is done.
+func isRetryableTransportError(ctx context.Context, err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
+		// The caller's own context ended: honor it and don't retry. Otherwise the
+		// deadline came from the request itself (client Timeout / transport
+		// deadline), which is a transient fault we can retry.
+		return ctx.Err() == nil
 	}
 	// Network-level timeouts (dial/read deadlines, i/o timeout) are transient.
 	var ne net.Error

--- a/purego/internal/auth/oauth.go
+++ b/purego/internal/auth/oauth.go
@@ -168,11 +168,9 @@ func NewOAuthTokenProvider(
 }
 
 // NewSharedTokenCache allocates a token cache that can be passed to multiple
-// [OAuthTokenProvider] instances via [WithSharedTokenCache]. Sharing a cache
-// ensures tokens for the same (clientID, secret, table, workspace audience, and
-// UC endpoint) are reused across providers rather than each minting
-// independently; providers differing in workspace or UC endpoint keep separate
-// entries.
+// [OAuthTokenProvider] instances via [WithSharedTokenCache]. Providers pool
+// tokens across matching (clientID, secret, table, workspace audience, UC
+// endpoint); any difference in workspace or endpoint keeps a separate entry.
 //
 // Configure it with [CacheEnabled] and [CacheRefreshBuffer].
 func NewSharedTokenCache(opts ...CacheOption) *SharedTokenCache {
@@ -208,10 +206,8 @@ func (p *OAuthTokenProvider) tokenAudience() string {
 }
 
 // cacheScope discriminates cache entries that share credentials and table but
-// are not interchangeable. It combines the token audience (workspace binding)
-// with the issuing UC endpoint: a token minted for one workspace is rejected by
-// another, and two providers pointed at different UC endpoints mint through
-// different issuers, so a shared cache must not serve one's token to the other.
+// are not interchangeable: tokens minted for different workspace audiences or
+// through different UC endpoints must not be reused across a shared cache.
 func (p *OAuthTokenProvider) cacheScope() string {
 	return p.tokenAudience() + "\x00" + p.ucEndpoint
 }
@@ -510,17 +506,10 @@ func classifyHTTPError(resp *http.Response) error {
 func isHTTPSuccess(code int) bool { return code >= 200 && code < 300 }
 
 // isRetryableTransportError reports whether a transport-level error from the
-// token request is transient and safe to retry. Network-level timeouts and
-// connection failures qualify; any other transport error is treated as
-// non-retryable so a genuine failure isn't masked by a stale cached token.
-//
-// ctx is the caller's context. A mint request that times out on its own (a slow
-// UC endpoint tripping http.Client.Timeout, or an SDK-internal open budget) is
-// transient and retryable, so a proactive refresh can fall back to the
-// still-valid cached token. Only a cancel/deadline that came from the caller's
-// own context is non-retryable — that is the caller's signal to stop, not a
-// server fault. All surface as a wrapped context error; isCallerCancellation
-// tells the caller's own cancel apart from a request or budget timeout.
+// token request is transient and safe to retry. Network timeouts, dial
+// failures, and request/budget timeouts qualify; a caller-owned cancel or
+// deadline does not — that is the caller's signal to stop, not a server fault.
+// isCallerCancellation tells the two apart when the error is a context error.
 func isRetryableTransportError(ctx context.Context, err error) bool {
 	if isContextError(err) {
 		// A context error is retryable only when it came from the request itself

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -450,6 +450,7 @@ func TestNewOAuthTokenProviderValidation(t *testing.T) {
 		{"bad table (2 parts)", "id", "s", "https://ws.zerobus.databricks.com", "https://host", "c.s"},
 		{"bad table (empty schema)", "id", "s", "https://ws.zerobus.databricks.com", "https://host", "c..t"},
 		{"bad zerobus endpoint host", "id", "s", "https://", "https://host", "c.s.t"},
+		{"dotless zerobus host (no workspace subdomain)", "id", "s", "https://ws1", "https://host", "c.s.t"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -41,7 +41,7 @@ func (s *tokenServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func newTestProvider(t *testing.T, srv *tokenServer, table string) (*OAuthTokenProvider, *httptest.Server) {
+func newTestProvider(t *testing.T, srv *tokenServer) (*OAuthTokenProvider, *httptest.Server) {
 	t.Helper()
 	ts := httptest.NewServer(srv)
 	p, err := NewOAuthTokenProvider("clientID", "clientSecret", "https://ws123.zerobus.databricks.com", ts.URL,
@@ -55,7 +55,7 @@ func newTestProvider(t *testing.T, srv *tokenServer, table string) (*OAuthTokenP
 
 func TestOAuthTokenProviderHappyPath(t *testing.T) {
 	srv := &tokenServer{accessToken: "eyJtb2NrfQ", expiresIn: 3600}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	tok, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -69,7 +69,7 @@ func TestOAuthTokenProviderHappyPath(t *testing.T) {
 
 func TestOAuthTokenProviderCachesToken(t *testing.T) {
 	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
@@ -85,7 +85,7 @@ func TestOAuthTokenProviderCachesToken(t *testing.T) {
 
 func TestOAuthTokenProviderInvalidateForcesRemint(t *testing.T) {
 	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
@@ -102,7 +102,7 @@ func TestOAuthTokenProviderInvalidateForcesRemint(t *testing.T) {
 
 func TestOAuthTokenProvider5xxIsRetryable(t *testing.T) {
 	srv := &tokenServer{statusCode: http.StatusInternalServerError}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	_, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -117,7 +117,7 @@ func TestOAuthTokenProvider5xxIsRetryable(t *testing.T) {
 
 func TestOAuthTokenProvider4xxIsNonRetryable(t *testing.T) {
 	srv := &tokenServer{statusCode: http.StatusUnauthorized}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	_, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -318,7 +318,7 @@ func TestOAuthTokenProviderSharedCacheKeyedByWorkspace(t *testing.T) {
 
 func TestOAuthTokenProvider429IsNonRetryable(t *testing.T) {
 	srv := &tokenServer{statusCode: http.StatusTooManyRequests}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	_, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -334,7 +334,7 @@ func TestOAuthTokenProvider429IsNonRetryable(t *testing.T) {
 
 func TestOAuthTokenProvider408IsNonRetryable(t *testing.T) {
 	srv := &tokenServer{statusCode: http.StatusRequestTimeout}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	_, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -414,7 +414,7 @@ func TestOAuthTokenProviderNilOptionsKeepDefaults(t *testing.T) {
 
 func TestClassifyHTTPErrorPreservesBody(t *testing.T) {
 	srv := &tokenServer{statusCode: http.StatusUnauthorized}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	_, err := p.Token(context.Background(), "cat.sch.tbl")
@@ -592,7 +592,7 @@ func TestSharedTokenCacheDisabled(t *testing.T) {
 
 func TestOAuthTokenProviderFetchTokenBypassesCache(t *testing.T) {
 	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
-	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	p, ts := newTestProvider(t, srv)
 	defer ts.Close()
 
 	// Warm the cache.

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -515,8 +515,8 @@ func TestParseExpiresIn(t *testing.T) {
 	}
 }
 
-// A non-integer expires_in must not fail the mint: the token is returned, and
-// (being unparseable/absent) not cached, so a second call mints again.
+// A non-integer but parseable expires_in (quoted string, float) must not fail
+// the mint, and must be cached like a regular integer TTL.
 func TestOAuthTokenProviderToleratesNonIntExpiresIn(t *testing.T) {
 	for _, raw := range []string{`"3600"`, `3600.0`} {
 		t.Run(raw, func(t *testing.T) {
@@ -557,6 +557,18 @@ func TestOAuthTokenProviderUnparseableExpiresInIsNotCached(t *testing.T) {
 	}
 	if got := srv.calls.Load(); got != 2 {
 		t.Fatalf("want 2 server calls (uncached), got %d", got)
+	}
+}
+
+// A whitespace-only access_token is unusable: it must be rejected rather than
+// shipped as "Bearer    ".
+func TestOAuthTokenProviderRejectsBlankAccessToken(t *testing.T) {
+	srv := &tokenServer{accessToken: "   ", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv)
+	defer ts.Close()
+
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err == nil {
+		t.Fatal("want error for whitespace-only access_token, got nil")
 	}
 }
 
@@ -602,12 +614,45 @@ func TestValidateEndpoint(t *testing.T) {
 		"://nonsense",
 		"https://",  // scheme but no host
 		"https:///", // no host, only a path
-		"https://workspace.databricks.com?tenant=x", // query would swallow the /oidc/v1/token suffix
-		"https://workspace.databricks.com#frag",     // fragment would drop the suffix
+		"https://workspace.databricks.com?tenant=x",  // query would swallow the /oidc/v1/token suffix
+		"https://workspace.databricks.com#frag",      // fragment would drop the suffix
+		"https://user:pass@workspace.databricks.com", // userinfo would collide with basic-auth creds
 	}
 	for _, e := range bad {
 		if err := validateEndpoint(e); err == nil {
 			t.Errorf("validateEndpoint(%q): want error, got nil", e)
+		}
+	}
+}
+
+func TestDeriveWorkspaceIDFromEndpoint(t *testing.T) {
+	ok := []struct {
+		in, want string
+	}{
+		{"https://ws.zerobus.databricks.com", "ws"},
+		{"ws.zerobus.databricks.com", "ws"},         // scheme supplied by default
+		{"HTTPS://ws.zerobus.databricks.com", "ws"}, // scheme is case-insensitive
+		{"HTTP://ws.zerobus.databricks.com", "ws"},
+	}
+	for _, tc := range ok {
+		got, err := deriveWorkspaceIDFromEndpoint(tc.in)
+		if err != nil {
+			t.Errorf("deriveWorkspaceIDFromEndpoint(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("deriveWorkspaceIDFromEndpoint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+
+	bad := []string{
+		"",            // required
+		"https://",    // no host
+		"https://ws1", // dotless host, no workspace subdomain
+	}
+	for _, in := range bad {
+		if _, err := deriveWorkspaceIDFromEndpoint(in); err == nil {
+			t.Errorf("deriveWorkspaceIDFromEndpoint(%q): want error, got nil", in)
 		}
 	}
 }

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -188,12 +189,13 @@ func TestOAuthTokenProviderConnectionRefusedIsRetryable(t *testing.T) {
 	}
 }
 
-func TestOAuthTokenProviderClientTimeoutIsNonRetryable(t *testing.T) {
+func TestOAuthTokenProviderClientTimeoutIsRetryable(t *testing.T) {
 	// A handler slower than the client's Timeout drives Do() into a client-level
 	// timeout. http.Client.Timeout surfaces as an error wrapping
-	// context.DeadlineExceeded, so it is classified non-retryable (like the
-	// caller's own ctx deadline) rather than as a transient network timeout —
-	// the cache must not mask it with a stale token.
+	// context.DeadlineExceeded, but the caller's own context is still live, so it
+	// is the request that timed out, not the caller cancelling. That is a
+	// transient fault and must be classified retryable so a proactive refresh can
+	// fall back to a still-valid cached token instead of failing the open.
 	// release is closed before ts.Close() so the parked handler returns and Close
 	// does not block waiting on the outstanding request.
 	release := make(chan struct{})
@@ -216,14 +218,101 @@ func TestOAuthTokenProviderClientTimeoutIsNonRetryable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOAuthTokenProvider: %v", err)
 	}
+	// Pass a context with no deadline so the timeout can only come from the
+	// client, not the caller — the case the classification must get right.
 	_, err = p.Token(context.Background(), "c.s.t")
 	if err == nil {
 		t.Fatal("want error for client timeout, got nil")
 	}
 	var te *TokenError
-	if !asTokenError(err, &te) || te.IsRetryable() {
-		t.Fatalf("want non-retryable TokenError for client timeout, got %T (retryable=%v): %v",
+	if !asTokenError(err, &te) || !te.IsRetryable() {
+		t.Fatalf("want retryable TokenError for client timeout, got %T (retryable=%v): %v",
 			err, te != nil && te.IsRetryable(), err)
+	}
+}
+
+func TestOAuthTokenProviderClientTimeoutRefreshServesCachedToken(t *testing.T) {
+	// End-to-end: a token that is still valid but due for proactive refresh, whose
+	// refresh mint trips the client timeout, must fall back to the cached token
+	// rather than failing. This is the payoff of classifying a client timeout as
+	// retryable: transport.Open (which adds its own header budget) still succeeds.
+	release := make(chan struct{})
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	defer close(release)
+
+	client := ts.Client()
+	client.Timeout = 50 * time.Millisecond
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	// Seed a still-valid-but-refresh-due token under the provider's real audience.
+	seedRefreshable(p.cache, "id", "secret", "c.s.t", p.tokenAudience(), "cached-valid")
+
+	tok, err := p.Token(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("want fallback to cached token on client-timeout refresh, got error: %v", err)
+	}
+	if tok != "cached-valid" {
+		t.Fatalf("want cached token served, got %q", tok)
+	}
+}
+
+func TestOAuthTokenProviderSharedCacheKeyedByWorkspace(t *testing.T) {
+	// Two providers with the same credentials and table but different workspaces
+	// share a cache. Because a minted token is bound to its workspace audience,
+	// they must NOT collide on one entry — the second must mint its own token
+	// rather than being served the first's workspace-scoped one.
+	var mu sync.Mutex
+	seen := map[string]string{} // resource audience -> token minted for it
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		res := r.FormValue("resource")
+		mu.Lock()
+		tok, ok := seen[res]
+		if !ok {
+			tok = "tok-for-" + res
+			seen[res] = tok
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": tok, "expires_in": 3600})
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	shared := NewSharedTokenCache()
+	p1, err := NewOAuthTokenProvider("id", "secret", "https://ws1.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()), WithSharedTokenCache(shared))
+	if err != nil {
+		t.Fatalf("provider 1: %v", err)
+	}
+	p2, err := NewOAuthTokenProvider("id", "secret", "https://ws2.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()), WithSharedTokenCache(shared))
+	if err != nil {
+		t.Fatalf("provider 2: %v", err)
+	}
+
+	t1, err := p1.Token(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("p1.Token: %v", err)
+	}
+	t2, err := p2.Token(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("p2.Token: %v", err)
+	}
+	if t1 == t2 {
+		t.Fatalf("providers for different workspaces shared a cached token %q; audience must be part of the key", t1)
 	}
 }
 

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -17,8 +17,9 @@ import (
 // tokenServer is a minimal OAuth 2.0 token endpoint stub.
 type tokenServer struct {
 	accessToken string
-	expiresIn   int // 0 means omit expires_in
-	statusCode  int // 0 defaults to 200
+	expiresIn   int    // 0 means omit expires_in
+	rawExpires  string // when non-empty, emitted verbatim as expires_in (overrides expiresIn)
+	statusCode  int    // 0 defaults to 200
 	calls       atomic.Int32
 }
 
@@ -32,6 +33,11 @@ func (s *tokenServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(code)
 	if code != http.StatusOK {
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "test_error"})
+		return
+	}
+	if s.rawExpires != "" {
+		// Emit a hand-built body so expires_in can be a non-integer JSON type.
+		_, _ = w.Write([]byte(`{"access_token":"` + s.accessToken + `","expires_in":` + s.rawExpires + `}`))
 		return
 	}
 	resp := map[string]any{"access_token": s.accessToken}
@@ -421,10 +427,11 @@ func TestClassifyHTTPErrorPreservesBody(t *testing.T) {
 	if err == nil {
 		t.Fatal("want error for 401, got nil")
 	}
-	// The server error payload (`{"error":"test_error"}`) must survive into the
-	// error message so on-call has something to debug with.
+	// The structured OAuth error field (`{"error":"test_error"}`) must survive
+	// into the message so on-call has something to debug with; the raw body is
+	// retained separately on TokenError.ResponseBody.
 	if !strings.Contains(err.Error(), "test_error") {
-		t.Fatalf("error message dropped server body: %q", err.Error())
+		t.Fatalf("error message dropped OAuth error field: %q", err.Error())
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Fatalf("error message dropped status code: %q", err.Error())
@@ -470,6 +477,98 @@ func TestSecondsToDuration(t *testing.T) {
 	d, ok := secondsToDuration(1 << 60)
 	if !ok || d <= 0 {
 		t.Fatalf("secondsToDuration(1<<60) = (%v, %v), want a positive clamped duration", d, ok)
+	}
+}
+
+func TestParseExpiresIn(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{`3600`, 3600},   // RFC 6749 integer
+		{`"3600"`, 3600}, // quoted string
+		{`3600.0`, 3600}, // float
+		{`3600.9`, 3600}, // float truncates toward zero
+		{`0`, 0},         // zero → no TTL
+		{`-5`, -5},       // negative int passes through; secondsToDuration rejects it
+		{`null`, 0},      // JSON null
+		{``, 0},          // absent
+		{`"nope"`, 0},    // unparseable string
+		{`{}`, 0},        // wrong type
+		{` "42" `, 42},   // surrounding whitespace
+		{`"-5"`, -5},     // quoted negative
+	}
+	for _, tc := range cases {
+		if got := parseExpiresIn(json.RawMessage(tc.in)); got != tc.want {
+			t.Errorf("parseExpiresIn(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// A non-integer expires_in must not fail the mint: the token is returned, and
+// (being unparseable/absent) not cached, so a second call mints again.
+func TestOAuthTokenProviderToleratesNonIntExpiresIn(t *testing.T) {
+	for _, raw := range []string{`"3600"`, `3600.0`} {
+		t.Run(raw, func(t *testing.T) {
+			srv := &tokenServer{accessToken: "tok", rawExpires: raw}
+			p, ts := newTestProvider(t, srv)
+			defer ts.Close()
+
+			tok, err := p.Token(context.Background(), "cat.sch.tbl")
+			if err != nil {
+				t.Fatalf("Token: %v", err)
+			}
+			if tok != "tok" {
+				t.Fatalf("want %q, got %q", "tok", tok)
+			}
+			// A parseable TTL caches; a second call is served from cache.
+			if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+				t.Fatalf("second Token: %v", err)
+			}
+			if got := srv.calls.Load(); got != 1 {
+				t.Fatalf("want 1 server call (cached), got %d", got)
+			}
+		})
+	}
+}
+
+// An unparseable expires_in keeps the token but skips caching, so every call
+// mints afresh instead of failing.
+func TestOAuthTokenProviderUnparseableExpiresInIsNotCached(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", rawExpires: `"not-a-number"`}
+	p, ts := newTestProvider(t, srv)
+	defer ts.Close()
+
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("want 2 server calls (uncached), got %d", got)
+	}
+}
+
+// Omitting expires_in entirely returns the token but leaves the cache empty, so
+// a second call mints again.
+func TestOAuthTokenProviderOmittedExpiresInIsNotCached(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok"} // expiresIn 0 → omitted
+	p, ts := newTestProvider(t, srv)
+	defer ts.Close()
+
+	tok, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if tok != "tok" {
+		t.Fatalf("want %q, got %q", "tok", tok)
+	}
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("want 2 server calls (uncached), got %d", got)
 	}
 }
 

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -436,6 +436,15 @@ func TestClassifyHTTPErrorPreservesBody(t *testing.T) {
 	if !strings.Contains(err.Error(), "401") {
 		t.Fatalf("error message dropped status code: %q", err.Error())
 	}
+	// The raw body must be retained on ResponseBody for diagnostics — and kept
+	// out of Error() so a %+v log of the wrapped error can't re-expose it.
+	var te *TokenError
+	if !errors.As(err, &te) {
+		t.Fatalf("want *TokenError, got %T", err)
+	}
+	if !strings.Contains(te.ResponseBody, "test_error") {
+		t.Fatalf("raw body not retained on ResponseBody: %q", te.ResponseBody)
+	}
 }
 
 func TestNewOAuthTokenProviderValidation(t *testing.T) {
@@ -593,6 +602,8 @@ func TestValidateEndpoint(t *testing.T) {
 		"://nonsense",
 		"https://",  // scheme but no host
 		"https:///", // no host, only a path
+		"https://workspace.databricks.com?tenant=x", // query would swallow the /oidc/v1/token suffix
+		"https://workspace.databricks.com#frag",     // fragment would drop the suffix
 	}
 	for _, e := range bad {
 		if err := validateEndpoint(e); err == nil {
@@ -687,6 +698,44 @@ func TestSharedTokenCacheDisabled(t *testing.T) {
 	}
 	if got := srv.calls.Load(); got != 2 {
 		t.Fatalf("want 2 calls with disabled shared cache, got %d", got)
+	}
+}
+
+func TestWithSharedTokenCacheZeroValueIsIgnored(t *testing.T) {
+	// A zero-value SharedTokenCache holds no usable cache. It must be ignored
+	// (falling back to the provider's own cache) rather than installed, which
+	// would previously panic on a nil map at the first Token call.
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+		WithSharedTokenCache(&SharedTokenCache{}),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if p.cache == nil {
+		t.Fatal("zero-value shared cache left provider without a cache")
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("Token with zero-value shared cache: %v", err)
+	}
+}
+
+func TestFetchTokenValidatesTableName(t *testing.T) {
+	// FetchToken must reject a malformed table name before contacting UC, just
+	// like Token does.
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv)
+	defer ts.Close()
+
+	if _, err := p.FetchToken(context.Background(), "c..t"); err == nil {
+		t.Fatal("FetchToken with invalid table name: want error, got nil")
+	}
+	if got := srv.calls.Load(); got != 0 {
+		t.Fatalf("FetchToken must not contact UC for an invalid table (0 calls), got %d", got)
 	}
 }
 

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -1,0 +1,609 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// tokenServer is a minimal OAuth 2.0 token endpoint stub.
+type tokenServer struct {
+	accessToken string
+	expiresIn   int // 0 means omit expires_in
+	statusCode  int // 0 defaults to 200
+	calls       atomic.Int32
+}
+
+func (s *tokenServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.calls.Add(1)
+	code := s.statusCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if code != http.StatusOK {
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "test_error"})
+		return
+	}
+	resp := map[string]any{"access_token": s.accessToken}
+	if s.expiresIn > 0 {
+		resp["expires_in"] = s.expiresIn
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func newTestProvider(t *testing.T, srv *tokenServer, table string) (*OAuthTokenProvider, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(srv)
+	p, err := NewOAuthTokenProvider("clientID", "clientSecret", "https://ws123.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	return p, ts
+}
+
+func TestOAuthTokenProviderHappyPath(t *testing.T) {
+	srv := &tokenServer{accessToken: "eyJtb2NrfQ", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	tok, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "eyJtb2NrfQ" {
+		t.Fatalf("want %q, got %q", "eyJtb2NrfQ", tok)
+	}
+}
+
+func TestOAuthTokenProviderCachesToken(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 1 {
+		t.Fatalf("want 1 server call (cached), got %d", got)
+	}
+}
+
+func TestOAuthTokenProviderInvalidateForcesRemint(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	p.Invalidate(context.Background(), "cat.sch.tbl")
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("Token after Invalidate: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("want 2 server calls after invalidate, got %d", got)
+	}
+}
+
+func TestOAuthTokenProvider5xxIsRetryable(t *testing.T) {
+	srv := &tokenServer{statusCode: http.StatusInternalServerError}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	_, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err == nil {
+		t.Fatal("want error for 500, got nil")
+	}
+	var te *TokenError
+	if !asTokenError(err, &te) || !te.IsRetryable() {
+		t.Fatalf("want retryable TokenError, got %T: %v", err, err)
+	}
+}
+
+func TestOAuthTokenProvider4xxIsNonRetryable(t *testing.T) {
+	srv := &tokenServer{statusCode: http.StatusUnauthorized}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	_, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err == nil {
+		t.Fatal("want error for 401, got nil")
+	}
+	var te *TokenError
+	if !asTokenError(err, &te) || te.IsRetryable() {
+		t.Fatalf("want non-retryable TokenError, got %T (retryable=%v): %v", err, te != nil && te.IsRetryable(), err)
+	}
+}
+
+func TestOAuthTokenProviderContextCancellation(t *testing.T) {
+	// unblock is closed when the test ends so the hanging handler exits before
+	// httptest.Server.Close() tries to drain in-flight requests.
+	unblock := make(chan struct{})
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+		http.Error(w, "cancelled", http.StatusServiceUnavailable)
+	}))
+	defer hang.Close()   // executed second: server is now idle
+	defer close(unblock) // executed first: unblocks the handler
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", hang.URL,
+		WithHTTPClient(hang.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = p.Token(ctx, "c.s.t")
+	if err == nil {
+		t.Fatal("want error on ctx cancellation, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("Token took %v, expected it to return near 100ms deadline", elapsed)
+	}
+}
+
+func TestOAuthTokenProviderConnectionRefusedIsRetryable(t *testing.T) {
+	// Point the provider at a closed port so Do() fails with a dial error, which
+	// must be classified as a retryable transport failure.
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client := ts.Client()
+	url := ts.URL
+	ts.Close() // close immediately so connections are refused
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", url,
+		WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	_, err = p.Token(context.Background(), "c.s.t")
+	if err == nil {
+		t.Fatal("want error for refused connection, got nil")
+	}
+	var te *TokenError
+	if !asTokenError(err, &te) || !te.IsRetryable() {
+		t.Fatalf("want retryable TokenError for dial failure, got %T (retryable=%v): %v",
+			err, te != nil && te.IsRetryable(), err)
+	}
+}
+
+func TestOAuthTokenProvider429IsNonRetryable(t *testing.T) {
+	srv := &tokenServer{statusCode: http.StatusTooManyRequests}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	_, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err == nil {
+		t.Fatal("want error for 429, got nil")
+	}
+	var te *TokenError
+	if !asTokenError(err, &te) || te.IsRetryable() {
+		t.Fatalf("want non-retryable TokenError for 429, got %T (retryable=%v): %v",
+			err, te != nil && te.IsRetryable(), err)
+	}
+}
+
+func TestOAuthTokenProvider408IsNonRetryable(t *testing.T) {
+	srv := &tokenServer{statusCode: http.StatusRequestTimeout}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	_, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err == nil {
+		t.Fatal("want error for 408, got nil")
+	}
+	var te *TokenError
+	if !asTokenError(err, &te) || te.IsRetryable() {
+		t.Fatalf("want non-retryable TokenError for 408, got %T (retryable=%v): %v",
+			err, te != nil && te.IsRetryable(), err)
+	}
+}
+
+func TestTokenErrorUnwrapsContextCancellation(t *testing.T) {
+	// A cancelled context must be visible via errors.Is on the returned error,
+	// and must NOT be classified as retryable (else a cancelled proactive
+	// refresh would silently serve a stale token).
+	unblock := make(chan struct{})
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+	}))
+	defer hang.Close()
+	defer close(unblock)
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", hang.URL,
+		WithHTTPClient(hang.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err = p.Token(ctx, "c.s.t")
+	if err == nil {
+		t.Fatal("want error on ctx cancellation, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want errors.Is(err, DeadlineExceeded), got %v", err)
+	}
+	var te *TokenError
+	if asTokenError(err, &te) && te.IsRetryable() {
+		t.Fatal("context deadline must not be classified as retryable")
+	}
+}
+
+func TestOAuthTokenProviderNilOptionsKeepDefaults(t *testing.T) {
+	// A nil client / cache passed via options must be ignored so the provider's
+	// defaults survive rather than being overwritten with nil (which would panic
+	// on the first Token call).
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(nil),
+		WithSharedTokenCache(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if p.client == nil {
+		t.Fatal("WithHTTPClient(nil) overwrote the default client")
+	}
+	if p.cache == nil {
+		t.Fatal("WithSharedTokenCache(nil) overwrote the default cache")
+	}
+	// It must not panic and must actually work end to end.
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("Token with nil options: %v", err)
+	}
+}
+
+func TestClassifyHTTPErrorPreservesBody(t *testing.T) {
+	srv := &tokenServer{statusCode: http.StatusUnauthorized}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	_, err := p.Token(context.Background(), "cat.sch.tbl")
+	if err == nil {
+		t.Fatal("want error for 401, got nil")
+	}
+	// The server error payload (`{"error":"test_error"}`) must survive into the
+	// error message so on-call has something to debug with.
+	if !strings.Contains(err.Error(), "test_error") {
+		t.Fatalf("error message dropped server body: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("error message dropped status code: %q", err.Error())
+	}
+}
+
+func TestNewOAuthTokenProviderValidation(t *testing.T) {
+	cases := []struct {
+		name                                                 string
+		clientID, secret, zerobusEndpoint, ucEndpoint, table string
+	}{
+		{"empty clientID", "", "s", "https://ws.zerobus.databricks.com", "https://host", "c.s.t"},
+		{"empty secret", "id", "", "https://ws.zerobus.databricks.com", "https://host", "c.s.t"},
+		{"empty zerobus endpoint", "id", "s", "", "https://host", "c.s.t"},
+		{"empty ucEndpoint", "id", "s", "https://ws.zerobus.databricks.com", "", "c.s.t"},
+		{"bad table (2 parts)", "id", "s", "https://ws.zerobus.databricks.com", "https://host", "c.s"},
+		{"bad table (empty schema)", "id", "s", "https://ws.zerobus.databricks.com", "https://host", "c..t"},
+		{"bad zerobus endpoint host", "id", "s", "https://", "https://host", "c.s.t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewOAuthTokenProvider(tc.clientID, tc.secret, tc.zerobusEndpoint, tc.ucEndpoint)
+			if err == nil {
+				if _, tokErr := p.Token(context.Background(), tc.table); tokErr == nil {
+					t.Fatal("want constructor or token validation error, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestSecondsToDuration(t *testing.T) {
+	if d, ok := secondsToDuration(3600); !ok || d != time.Hour {
+		t.Fatalf("secondsToDuration(3600) = (%v, %v), want (1h, true)", d, ok)
+	}
+	if _, ok := secondsToDuration(0); ok {
+		t.Fatal("secondsToDuration(0) should report no usable TTL")
+	}
+	if _, ok := secondsToDuration(-5); ok {
+		t.Fatal("secondsToDuration(negative) should report no usable TTL")
+	}
+	// An absurd value must clamp to a positive duration, never wrap negative.
+	d, ok := secondsToDuration(1 << 60)
+	if !ok || d <= 0 {
+		t.Fatalf("secondsToDuration(1<<60) = (%v, %v), want a positive clamped duration", d, ok)
+	}
+}
+
+func TestValidateEndpoint(t *testing.T) {
+	ok := []string{
+		"https://workspace.databricks.com",
+		"http://localhost:8080",
+		"http://LOCALHOST:8080", // hostnames are case-insensitive
+		"http://127.0.0.1:1234",
+		"http://[::1]:9000",
+	}
+	for _, e := range ok {
+		if err := validateEndpoint(e); err != nil {
+			t.Errorf("validateEndpoint(%q): unexpected error: %v", e, err)
+		}
+	}
+
+	bad := []string{
+		"http://workspace.databricks.com", // plaintext to a remote host
+		"ftp://host",
+		"://nonsense",
+		"https://",  // scheme but no host
+		"https:///", // no host, only a path
+	}
+	for _, e := range bad {
+		if err := validateEndpoint(e); err == nil {
+			t.Errorf("validateEndpoint(%q): want error, got nil", e)
+		}
+	}
+}
+
+func TestOAuthTokenProviderCacheDisabledAlwaysMints(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+		WithTokenCacheEnabled(false),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("want 2 server calls with caching disabled, got %d", got)
+	}
+}
+
+func TestOAuthTokenProviderCustomRefreshBuffer(t *testing.T) {
+	// WithRefreshBuffer must reach the provider's own cache. (The refresh-timing
+	// behavior itself is covered by the tokenCache unit tests; a large buffer no
+	// longer forces a re-mint on every call because it is clamped to ttl/2.)
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", "https://host",
+		WithRefreshBuffer(90*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if p.cache.refreshBuffer != 90*time.Second {
+		t.Fatalf("WithRefreshBuffer not applied: got %v", p.cache.refreshBuffer)
+	}
+}
+
+func TestOAuthTokenProviderSharedCacheIgnoresProviderCacheOpts(t *testing.T) {
+	// A shared cache owns its own config; per-provider cache options are ignored
+	// so the shared cache still caches even though the provider asked to disable.
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	shared := NewSharedTokenCache()
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+		WithSharedTokenCache(shared),
+		WithTokenCacheEnabled(false),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 1 {
+		t.Fatalf("shared cache should cache (1 call), got %d", got)
+	}
+}
+
+func TestSharedTokenCacheDisabled(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	shared := NewSharedTokenCache(CacheEnabled(false))
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+		WithSharedTokenCache(shared),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("first Token: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("second Token: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("want 2 calls with disabled shared cache, got %d", got)
+	}
+}
+
+func TestOAuthTokenProviderFetchTokenBypassesCache(t *testing.T) {
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	p, ts := newTestProvider(t, srv, "cat.sch.tbl")
+	defer ts.Close()
+
+	// Warm the cache.
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	// FetchToken must mint fresh regardless of the warm cache…
+	if _, err := p.FetchToken(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("FetchToken should bypass cache (2 calls), got %d", got)
+	}
+	// …and must not populate/replace the cached entry the next Token call uses.
+	if _, err := p.Token(context.Background(), "cat.sch.tbl"); err != nil {
+		t.Fatalf("Token after FetchToken: %v", err)
+	}
+	if got := srv.calls.Load(); got != 2 {
+		t.Fatalf("Token after FetchToken should hit cache (still 2 calls), got %d", got)
+	}
+}
+
+func TestOAuthTokenProviderLoggerReceivesMint(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	srv := &tokenServer{accessToken: "tok", expiresIn: 3600}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+		WithLogger(logger),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "c.s.t"); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "minted UC OAuth token") || !strings.Contains(out, "reason=cold_miss") {
+		t.Fatalf("logger did not receive expected mint line: %q", out)
+	}
+}
+
+func TestAuthorizationDetailsContent(t *testing.T) {
+	var captured []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			captured = []byte(r.FormValue("authorization_details"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "expires_in": 3600})
+	}))
+	defer ts.Close()
+
+	p, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts.URL,
+		WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenProvider: %v", err)
+	}
+	if _, err := p.Token(context.Background(), "mycat.mysch.mytbl"); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	var details []authorizationDetailsEntry
+	if err := json.Unmarshal(captured, &details); err != nil {
+		t.Fatalf("parse authorization_details: %v", err)
+	}
+	if len(details) != 3 {
+		t.Fatalf("want 3 authorization_details entries, got %d", len(details))
+	}
+
+	catalog := details[0]
+	if catalog.ObjectFullPath != "mycat" {
+		t.Errorf("catalog entry: want ObjectFullPath %q, got %q", "mycat", catalog.ObjectFullPath)
+	}
+
+	schema := details[1]
+	if schema.ObjectFullPath != "mycat.mysch" {
+		t.Errorf("schema entry: want ObjectFullPath %q, got %q", "mycat.mysch", schema.ObjectFullPath)
+	}
+
+	table := details[2]
+	if table.ObjectFullPath != "mycat.mysch.mytbl" {
+		t.Errorf("table entry: want ObjectFullPath %q, got %q", "mycat.mysch.mytbl", table.ObjectFullPath)
+	}
+	if len(table.Operations) != 1 || table.Operations[0] != "zerobuswrite" {
+		t.Errorf("table entry: want Operations [zerobuswrite], got %v", table.Operations)
+	}
+}
+
+func TestIsUsableAsHeader(t *testing.T) {
+	cases := []struct {
+		token string
+		want  bool
+	}{
+		{"eyJhbGciOiJSUzI1NiJ9.payload.sig", true},
+		{"", false},
+		{"bad\ntoken", false},
+		{"bad\x00token", false},
+		{strings.Repeat("a", 1000), true},
+	}
+	for _, tc := range cases {
+		if got := isUsableAsHeader(tc.token); got != tc.want {
+			t.Errorf("isUsableAsHeader(%q) = %v, want %v", tc.token, got, tc.want)
+		}
+	}
+}
+
+func TestParseTableName(t *testing.T) {
+	good := []struct{ in, c, s, tbl string }{
+		{"a.b.c", "a", "b", "c"},
+		{"cat.schema.table", "cat", "schema", "table"},
+	}
+	for _, tc := range good {
+		c, s, tbl, err := parseTableName(tc.in)
+		if err != nil {
+			t.Errorf("parseTableName(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if c != tc.c || s != tc.s || tbl != tc.tbl {
+			t.Errorf("parseTableName(%q) = (%q,%q,%q), want (%q,%q,%q)", tc.in, c, s, tbl, tc.c, tc.s, tc.tbl)
+		}
+	}
+
+	bad := []string{"", "a", "a.b", "a.b.c.d", ".b.c", "a..c", "a.b."}
+	for _, tc := range bad {
+		if _, _, _, err := parseTableName(tc); err == nil {
+			t.Errorf("parseTableName(%q): want error, got nil", tc)
+		}
+	}
+}
+
+// asTokenError is a test helper to check if err is or wraps a *TokenError.
+// TokenError implements Unwrap, so errors.As handles both single- and
+// multi-error chains.
+func asTokenError(err error, target **TokenError) bool {
+	return errors.As(err, target)
+}

--- a/purego/internal/auth/oauth_test.go
+++ b/purego/internal/auth/oauth_test.go
@@ -263,7 +263,7 @@ func TestOAuthTokenProviderClientTimeoutRefreshServesCachedToken(t *testing.T) {
 		t.Fatalf("NewOAuthTokenProvider: %v", err)
 	}
 	// Seed a still-valid-but-refresh-due token under the provider's real audience.
-	seedRefreshable(p.cache, "id", "secret", "c.s.t", p.tokenAudience(), "cached-valid")
+	seedRefreshable(p.cache, "id", "secret", "c.s.t", p.cacheScope(), "cached-valid")
 
 	tok, err := p.Token(context.Background(), "c.s.t")
 	if err != nil {
@@ -319,6 +319,48 @@ func TestOAuthTokenProviderSharedCacheKeyedByWorkspace(t *testing.T) {
 	}
 	if t1 == t2 {
 		t.Fatalf("providers for different workspaces shared a cached token %q; audience must be part of the key", t1)
+	}
+}
+
+func TestOAuthTokenProviderSharedCacheKeyedByEndpoint(t *testing.T) {
+	// Two providers with the same credentials, table, and workspace audience but
+	// DIFFERENT UC endpoints (issuers) share a cache. They must NOT collide: each
+	// endpoint issues its own token, so the second provider must mint against its
+	// own endpoint rather than be served the first issuer's token.
+	newIssuer := func(label string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok-from-" + label, "expires_in": 3600})
+		}))
+	}
+	ts1 := newIssuer("issuer1")
+	defer ts1.Close()
+	ts2 := newIssuer("issuer2")
+	defer ts2.Close()
+
+	shared := NewSharedTokenCache()
+	// Same zerobusEndpoint (same workspace audience) for both, different ucEndpoint.
+	p1, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts1.URL,
+		WithHTTPClient(ts1.Client()), WithSharedTokenCache(shared))
+	if err != nil {
+		t.Fatalf("provider 1: %v", err)
+	}
+	p2, err := NewOAuthTokenProvider("id", "secret", "https://ws.zerobus.databricks.com", ts2.URL,
+		WithHTTPClient(ts2.Client()), WithSharedTokenCache(shared))
+	if err != nil {
+		t.Fatalf("provider 2: %v", err)
+	}
+
+	t1, err := p1.Token(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("p1.Token: %v", err)
+	}
+	t2, err := p2.Token(context.Background(), "c.s.t")
+	if err != nil {
+		t.Fatalf("p2.Token: %v", err)
+	}
+	if t1 == t2 {
+		t.Fatalf("providers with different UC endpoints shared a token %q; issuer must be part of the key", t1)
 	}
 }
 
@@ -388,6 +430,39 @@ func TestTokenErrorUnwrapsContextCancellation(t *testing.T) {
 	var te *TokenError
 	if asTokenError(err, &te) && te.IsRetryable() {
 		t.Fatal("context deadline must not be classified as retryable")
+	}
+}
+
+// isCallerCancellation must classify only the caller's own cancel/deadline as
+// caller cancellation. An SDK-internal budget wrapping a live caller context via
+// WithTimeoutCause carries a custom cause, so it is a request/budget timeout —
+// retryable — not the caller giving up.
+func TestIsCallerCancellationDistinguishesBudgetFromCaller(t *testing.T) {
+	// Caller cancelled their own context.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !isCallerCancellation(cancelledCtx, context.Canceled) {
+		t.Error("caller cancel must be classified as caller cancellation")
+	}
+
+	// SDK-internal budget with a custom cause over a still-live caller context.
+	budgetCause := errors.New("open budget exceeded")
+	budgetCtx, cancelBudget := context.WithTimeoutCause(context.Background(), time.Nanosecond, budgetCause)
+	defer cancelBudget()
+	<-budgetCtx.Done() // budget fires; underlying caller context never cancelled
+	if isCallerCancellation(budgetCtx, context.DeadlineExceeded) {
+		t.Error("internal budget timeout must NOT be classified as caller cancellation")
+	}
+	if !isRetryableTransportError(budgetCtx, context.DeadlineExceeded) {
+		t.Error("internal budget timeout must be retryable so a cached token can be served")
+	}
+
+	// A caller's own plain deadline (no custom cause) is caller cancellation.
+	deadlineCtx, cancelDeadline := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelDeadline()
+	<-deadlineCtx.Done()
+	if !isCallerCancellation(deadlineCtx, context.DeadlineExceeded) {
+		t.Error("caller's own deadline must be classified as caller cancellation")
 	}
 }
 

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -27,6 +27,7 @@ const (
 	mintReasonColdMiss      mintReason = iota // no usable entry in cache
 	mintReasonRefresh                         // token is within the refresh buffer
 	mintReasonCacheDisabled                   // caching is off, so every call mints
+	mintReasonDirect                          // minted outside the cache via FetchToken
 )
 
 func (r mintReason) String() string {
@@ -37,6 +38,8 @@ func (r mintReason) String() string {
 		return "refresh"
 	case mintReasonCacheDisabled:
 		return "cache_disabled"
+	case mintReasonDirect:
+		return "direct"
 	default:
 		return "unknown"
 	}
@@ -125,21 +128,20 @@ type tokenCache struct {
 	disabled      bool // when true, every getOrFetch mints without caching
 }
 
-// cacheOption configures a token cache at construction. See [cacheEnabled] and
-// [cacheRefreshBuffer]. Unexported until a public SDK builder needs to surface
-// these knobs.
-type cacheOption func(*tokenCache)
+// CacheOption configures a token cache at construction. See [CacheEnabled] and
+// [CacheRefreshBuffer].
+type CacheOption func(*tokenCache)
 
-// cacheEnabled toggles token caching. When disabled, every token request mints
+// CacheEnabled toggles token caching. When disabled, every token request mints
 // a fresh token instead of consulting the cache. Caching is enabled by default.
-func cacheEnabled(enabled bool) cacheOption {
+func CacheEnabled(enabled bool) CacheOption {
 	return func(c *tokenCache) { c.disabled = !enabled }
 }
 
-// cacheRefreshBuffer sets the lead time before a token's expiry at which it is
+// CacheRefreshBuffer sets the lead time before a token's expiry at which it is
 // proactively re-minted; it defaults to 5 minutes. A non-positive value is
 // ignored so the default holds.
-func cacheRefreshBuffer(d time.Duration) cacheOption {
+func CacheRefreshBuffer(d time.Duration) CacheOption {
 	return func(c *tokenCache) {
 		if d > 0 {
 			c.refreshBuffer = d
@@ -147,7 +149,7 @@ func cacheRefreshBuffer(d time.Duration) cacheOption {
 	}
 }
 
-func newTokenCache(opts ...cacheOption) *tokenCache {
+func newTokenCache(opts ...CacheOption) *tokenCache {
 	c := &tokenCache{
 		entries:       make(map[tokenKey]*tokenCacheEntry),
 		refreshBuffer: defaultRefreshBuffer,

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -315,23 +315,32 @@ func (c *tokenCache) tryGetOrFetch(
 	// Anchor the TTL to when the response was received, not now: a slow custom
 	// logger between receipt and here must not extend the lifetime. That same
 	// delay can also consume the whole TTL, so a short-lived token may already be
-	// expired by the time we publish; treat that like a no-TTL response (return
-	// the token to this caller but don't cache a dead entry) rather than storing
-	// something isExpired would immediately reject.
+	// expired by the time we publish; treat that like a no-TTL response (don't
+	// cache a dead entry) rather than storing something isExpired would reject.
 	mintedAt := fetched.receivedAt
 	if mintedAt.IsZero() {
 		mintedAt = time.Now()
 	}
 	usableTTL := fetched.expiresIn != nil && *fetched.expiresIn > 0
 	alreadyExpired := usableTTL && !time.Now().Before(mintedAt.Add(*fetched.expiresIn))
-	if usableTTL && !alreadyExpired {
+	keepExisting := entry.cached != nil && !entry.cached.isExpired()
+	switch {
+	case usableTTL && !alreadyExpired:
+		// Live TTL: cache it and serve it.
 		entry.cached = newCachedToken(token, *fetched.expiresIn, c.refreshBuffer, mintedAt)
-	} else {
-		keepExisting := entry.cached != nil && !entry.cached.isExpired()
-		if !keepExisting {
-			entry.cached = nil
-		}
+	case alreadyExpired && keepExisting:
+		// The mint is dead on arrival but a still-valid token is cached (a
+		// proactive refresh whose TTL elapsed before publication). Serve the
+		// cached token, not the dead mint — returning the mint would hand the
+		// caller a token we already know is expired while discarding a good one.
+		token = entry.cached.value
+	case !keepExisting:
+		// No usable TTL and no live cache to keep: a no-expires_in token is still
+		// returned to this caller (uncached), and a dead mint leaves nothing.
+		entry.cached = nil
 	}
+	// Remaining case (no usable TTL but keepExisting): a valid no-expires_in token
+	// is returned as-is while the existing cache entry is retained untouched.
 	flight.token, flight.err = token, nil
 	close(flight.done)
 	entry.mu.Unlock()
@@ -361,6 +370,11 @@ func isContextError(err error) bool {
 // other cause means an intermediate context (e.g. transport's own bounded open
 // budget) fired via WithTimeoutCause — that is not the caller giving up, so it
 // stays retryable and a still-valid cached token can be served.
+//
+// A caller that cancels via context.WithCancelCause with its own custom cause is
+// therefore not seen as a caller stop here. In practice that is moot: such a
+// cancellation makes the HTTP client wrap the custom cause (not context.Canceled),
+// so err is not a context error and this function is never reached for it.
 func isCallerCancellation(ctx context.Context, err error) bool {
 	if !isContextError(err) || ctx.Err() == nil {
 		return false

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -77,7 +77,7 @@ func (c *cachedToken) isExpired() bool {
 }
 
 // newCachedToken builds an entry for a token whose TTL started at mintedAt
-// (response-receipt time, matching the Rust SDK). ttl must be positive.
+// (response-receipt time). ttl must be positive.
 //
 // The effective refresh lead time is clamped to at most half the TTL: with the
 // default 5-minute buffer a 10-minute token would otherwise be due for refresh

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -303,10 +303,22 @@ func (c *tokenCache) tryGetOrFetch(
 }
 
 // isContextError reports whether err is (or wraps) a context cancellation or
-// deadline, the signal that a mint failed because its leader's context ended
-// rather than because the token endpoint itself failed.
+// deadline. This alone does not say where the cancellation came from: an
+// http.Client.Timeout or transport deadline surfaces as a wrapped context error
+// just as a caller's own cancellation does. Use [isCallerCancellation] to tell
+// the two apart when the request context is in hand.
 func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// isCallerCancellation reports whether err is a context error that originated
+// from ctx — the caller cancelled or its deadline fired — rather than from the
+// request itself. It is the caller's signal to stop: such a failure must not be
+// retried or masked by serving a cached token. A context error seen while ctx is
+// still live came from the request (a client/transport timeout) and is a
+// transient, retryable fault instead.
+func isCallerCancellation(ctx context.Context, err error) bool {
+	return isContextError(err) && ctx.Err() != nil
 }
 
 // invalidate drops the cached token for the given credentials, table, and

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -287,8 +287,12 @@ func (c *tokenCache) tryGetOrFetch(
 
 	if err != nil {
 		token, resErr := "", err
-		if entry.cached != nil && !entry.cached.isExpired() && isRetryable(err) {
-			// Proactive refresh failed transiently; serve the still-valid token.
+		if entry.cached != nil && !entry.cached.isExpired() && (isRetryable(err) || isContextError(err)) {
+			// Proactive refresh failed but the old token is still valid; serve it.
+			// Any context error counts, not just retryable ones: transport bounds a
+			// deadline-less open with its own budget, so a budget timeout looks like
+			// caller cancellation here. Serving the valid token is safe — a genuine
+			// caller cancel is re-checked by the downstream handshake, which aborts.
 			token, resErr = entry.cached.value, nil
 		}
 		// Publish to waiters: writes before close(done) happen-before <-done. The

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -49,17 +49,25 @@ func (r mintReason) String() string {
 // SHA-256 digest so the raw credential is never kept in the map: distinct
 // secrets still yield distinct keys (collision resistance), and a rotated
 // secret gets a fresh entry.
+//
+// audience scopes the entry to the token's target audience (the workspace the
+// minted token is bound to). Two providers with the same credentials and table
+// but different workspaces mint tokens that are not interchangeable, so they
+// must not share an entry; without audience in the key the second provider would
+// be served the first's workspace-scoped token and rejected on audience mismatch.
 type tokenKey struct {
 	clientID     string
 	secretDigest [sha256.Size]byte
 	tableName    string
+	audience     string
 }
 
-func newTokenKey(clientID, clientSecret, tableName string) tokenKey {
+func newTokenKey(clientID, clientSecret, tableName, audience string) tokenKey {
 	return tokenKey{
 		clientID:     clientID,
 		secretDigest: sha256.Sum256([]byte(clientSecret)),
 		tableName:    tableName,
+		audience:     audience,
 	}
 }
 
@@ -172,7 +180,7 @@ func newTokenCache(opts ...CacheOption) *tokenCache {
 // than inheriting a cancellation it never requested.
 func (c *tokenCache) getOrFetch(
 	ctx context.Context,
-	clientID, clientSecret, tableName string,
+	clientID, clientSecret, tableName, audience string,
 	mint func(ctx context.Context, reason mintReason) (fetchedToken, error),
 ) (string, error) {
 	if c.disabled {
@@ -183,7 +191,7 @@ func (c *tokenCache) getOrFetch(
 		return fetched.token, nil
 	}
 
-	key := newTokenKey(clientID, clientSecret, tableName)
+	key := newTokenKey(clientID, clientSecret, tableName, audience)
 
 	for {
 		token, err, retry := c.tryGetOrFetch(ctx, key, mint)
@@ -224,10 +232,15 @@ func (c *tokenCache) tryGetOrFetch(
 		entry.mu.Unlock()
 		select {
 		case <-flight.done:
-			// If the leader failed solely because its own context was cancelled,
-			// don't propagate that cancel to a waiter whose context is still
-			// live; signal a re-attempt so this caller can mint for itself.
-			if flight.err != nil && isContextError(flight.err) && ctx.Err() == nil {
+			// If the leader failed solely because its own caller cancelled its
+			// context, don't propagate that cancel to a waiter whose context is
+			// still live; signal a re-attempt so this caller can mint for itself.
+			//
+			// A leader mint that timed out on its own (a slow endpoint tripping a
+			// client/transport deadline) is reported retryable, not a cancellation,
+			// so it is excluded here: the waiter shares that one outcome instead of
+			// each re-minting, which is what single-flight is for.
+			if flight.err != nil && isContextError(flight.err) && !isRetryable(flight.err) && ctx.Err() == nil {
 				return "", nil, true
 			}
 			return flight.token, flight.err, false
@@ -296,10 +309,10 @@ func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
-// invalidate drops the cached token for the given credentials and table. The
-// next getOrFetch call will re-mint from scratch.
-func (c *tokenCache) invalidate(clientID, clientSecret, tableName string) {
-	key := newTokenKey(clientID, clientSecret, tableName)
+// invalidate drops the cached token for the given credentials, table, and
+// audience. The next getOrFetch call will re-mint from scratch.
+func (c *tokenCache) invalidate(clientID, clientSecret, tableName, audience string) {
+	key := newTokenKey(clientID, clientSecret, tableName, audience)
 
 	c.mu.Lock()
 	entry, ok := c.entries[key]

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -114,6 +114,7 @@ type tokenCacheEntry struct {
 	cached   *cachedToken // nil when no valid entry has been stored yet
 	inflight *tokenFlight // non-nil while a mint is in progress
 	minted   bool         // true after the first mint completes; guards pruning
+	pruned   bool         // true once evicted from the map; caller must re-slot
 }
 
 // tokenFlight is a single in-progress mint. The leader records its resolved
@@ -198,9 +199,10 @@ func (c *tokenCache) getOrFetch(
 	for {
 		token, err, retry := c.tryGetOrFetch(ctx, key, mint)
 		if retry {
-			// The leader we parked on failed because its own ctx was cancelled,
-			// but ours is still live. Re-attempt rather than inheriting a cancel
-			// we never asked for; typically we become the next leader and mint.
+			// Re-attempt. Either the leader we parked on failed because its own
+			// ctx was cancelled while ours is still live (don't inherit a cancel we
+			// never asked for), or our entry was pruned out from under us before we
+			// could use it. Loop to re-slot and typically mint as the next leader.
 			continue
 		}
 		return token, err
@@ -208,9 +210,10 @@ func (c *tokenCache) getOrFetch(
 }
 
 // tryGetOrFetch makes one attempt to serve or mint a token for key. It returns
-// retry == true only when the caller parked on another goroutine's in-flight
-// mint that failed due to that leader's context cancellation while the caller's
-// own context is still live; the caller then loops to re-attempt.
+// retry == true when the caller should loop and re-attempt: either the entry it
+// slotted was pruned before it could be used, or it parked on another
+// goroutine's in-flight mint that failed due to that leader's context
+// cancellation while the caller's own context is still live.
 func (c *tokenCache) tryGetOrFetch(
 	ctx context.Context,
 	key tokenKey,
@@ -219,6 +222,15 @@ func (c *tokenCache) tryGetOrFetch(
 	entry := c.slot(key)
 
 	entry.mu.Lock()
+
+	// The entry was evicted by a concurrent prune between slot() releasing the
+	// map lock and us acquiring entry.mu. It is no longer in the map, so a new
+	// leader would attach to a stale slot while others attach to the replacement,
+	// splitting the single-flight into two mints. Re-slot instead.
+	if entry.pruned {
+		entry.mu.Unlock()
+		return "", nil, true
+	}
 
 	if entry.cached != nil && !c.needsRefresh(entry.cached) {
 		token := entry.cached.value
@@ -371,6 +383,12 @@ func (c *tokenCache) pruneExpiredLocked() {
 			// Never evict a mint in flight, and never evict an entry whose first
 			// mint has not yet completed — its leader writes back to this entry.
 			pruneable := e.minted && e.inflight == nil && (e.cached == nil || e.cached.isExpired())
+			if pruneable {
+				// Mark before deleting: a caller that already holds a pointer to
+				// this entry (returned by slot() before it locked entry.mu) sees
+				// pruned and re-slots instead of minting against a detached entry.
+				e.pruned = true
+			}
 			e.mu.Unlock()
 			if pruneable {
 				delete(c.entries, k)

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -55,24 +55,26 @@ func (r mintReason) String() string {
 // secrets still yield distinct keys (collision resistance), and a rotated
 // secret gets a fresh entry.
 //
-// audience scopes the entry to the token's target audience (the workspace the
-// minted token is bound to). Two providers with the same credentials and table
-// but different workspaces mint tokens that are not interchangeable, so they
-// must not share an entry; without audience in the key the second provider would
-// be served the first's workspace-scoped token and rejected on audience mismatch.
+// scope discriminates entries that share credentials and table but are not
+// interchangeable. The provider derives it from both the token's target
+// audience (the workspace the minted token is bound to) and the issuing UC
+// endpoint. Two providers with the same credentials and table but a different
+// workspace mint audience-scoped tokens that would be rejected on mismatch; two
+// providers with a different UC endpoint mint through different issuers. Either
+// difference must yield a distinct entry, so both feed the shared cache key.
 type tokenKey struct {
 	clientID     string
 	secretDigest [sha256.Size]byte
 	tableName    string
-	audience     string
+	scope        string
 }
 
-func newTokenKey(clientID, clientSecret, tableName, audience string) tokenKey {
+func newTokenKey(clientID, clientSecret, tableName, scope string) tokenKey {
 	return tokenKey{
 		clientID:     clientID,
 		secretDigest: sha256.Sum256([]byte(clientSecret)),
 		tableName:    tableName,
-		audience:     audience,
+		scope:        scope,
 	}
 }
 
@@ -133,7 +135,7 @@ type tokenFlight struct {
 	err   error         // resolved error (nil on success)
 }
 
-// tokenCache caches OAuth tokens per (clientID, secret, tableName, audience).
+// tokenCache caches OAuth tokens per (clientID, secret, tableName, scope).
 //
 // It is safe for concurrent use. Construct one with [newTokenCache]; the
 // methods do not guard against a nil receiver.
@@ -188,7 +190,7 @@ func newTokenCache(opts ...CacheOption) *tokenCache {
 // than inheriting a cancellation it never requested.
 func (c *tokenCache) getOrFetch(
 	ctx context.Context,
-	clientID, clientSecret, tableName, audience string,
+	clientID, clientSecret, tableName, scope string,
 	mint func(ctx context.Context, reason mintReason) (fetchedToken, error),
 ) (string, error) {
 	if c.disabled {
@@ -199,7 +201,7 @@ func (c *tokenCache) getOrFetch(
 		return fetched.token, nil
 	}
 
-	key := newTokenKey(clientID, clientSecret, tableName, audience)
+	key := newTokenKey(clientID, clientSecret, tableName, scope)
 
 	for {
 		token, err, retry := c.tryGetOrFetch(ctx, key, mint)
@@ -287,18 +289,18 @@ func (c *tokenCache) tryGetOrFetch(
 
 	if err != nil {
 		token, resErr := "", err
-		if entry.cached != nil && !entry.cached.isExpired() && (isRetryable(err) || isContextError(err)) {
-			// Proactive refresh failed but the old token is still valid; serve it.
-			// Any context error counts, not just retryable ones: transport bounds a
-			// deadline-less open with its own budget, so a budget timeout looks like
-			// caller cancellation here. Serving the valid token is safe — a genuine
-			// caller cancel is re-checked by the downstream handshake, which aborts.
+		if entry.cached != nil && !entry.cached.isExpired() && isRetryable(err) {
+			// Proactive refresh failed transiently; serve the still-valid token. A
+			// genuine caller cancellation is not retryable (see isRetryableTransport
+			// Error / isCallerCancellation), so it is not masked here and propagates,
+			// honoring the Token(ctx) contract. The transport's own bounded open
+			// budget is classified retryable, so it falls back to the cached token.
 			token, resErr = entry.cached.value, nil
 		}
 		// Publish to waiters: writes before close(done) happen-before <-done. The
 		// mutex just brackets the entry-state transition, not the flight publish.
-		// A context error published here is what lets a live-ctx waiter re-attempt
-		// instead of inheriting our cancellation.
+		// A caller-cancellation error published here is what lets a live-ctx waiter
+		// re-attempt instead of inheriting a cancellation it never requested.
 		flight.token, flight.err = token, resErr
 		close(flight.done)
 		entry.mu.Unlock()
@@ -309,13 +311,20 @@ func (c *tokenCache) tryGetOrFetch(
 
 	// Cache only tokens with a usable TTL. If refresh returned no expires_in,
 	// keep any existing still-valid token rather than discarding it.
-	if fetched.expiresIn != nil && *fetched.expiresIn > 0 {
-		// Anchor the TTL to when the response was received, not now: a slow
-		// custom logger between receipt and here must not extend the lifetime.
-		mintedAt := fetched.receivedAt
-		if mintedAt.IsZero() {
-			mintedAt = time.Now()
-		}
+	//
+	// Anchor the TTL to when the response was received, not now: a slow custom
+	// logger between receipt and here must not extend the lifetime. That same
+	// delay can also consume the whole TTL, so a short-lived token may already be
+	// expired by the time we publish; treat that like a no-TTL response (return
+	// the token to this caller but don't cache a dead entry) rather than storing
+	// something isExpired would immediately reject.
+	mintedAt := fetched.receivedAt
+	if mintedAt.IsZero() {
+		mintedAt = time.Now()
+	}
+	usableTTL := fetched.expiresIn != nil && *fetched.expiresIn > 0
+	alreadyExpired := usableTTL && !time.Now().Before(mintedAt.Add(*fetched.expiresIn))
+	if usableTTL && !alreadyExpired {
 		entry.cached = newCachedToken(token, *fetched.expiresIn, c.refreshBuffer, mintedAt)
 	} else {
 		keepExisting := entry.cached != nil && !entry.cached.isExpired()
@@ -340,19 +349,30 @@ func isContextError(err error) bool {
 }
 
 // isCallerCancellation reports whether err is a context error that originated
-// from ctx — the caller cancelled or its deadline fired — rather than from the
-// request itself. It is the caller's signal to stop: such a failure must not be
-// retried or masked by serving a cached token. A context error seen while ctx is
-// still live came from the request (a client/transport timeout) and is a
-// transient, retryable fault instead.
+// from the caller stopping — the caller cancelled or its own deadline fired —
+// rather than from the request or an SDK-internal budget. It is the caller's
+// signal to stop: such a failure must not be retried or masked by serving a
+// cached token.
+//
+// A context error seen while ctx is still live came from the request (a
+// client/transport timeout) and is a transient, retryable fault. When ctx is
+// done, context.Cause distinguishes the two remaining cases: a plain
+// context.Canceled/DeadlineExceeded cause is the caller stopping, whereas any
+// other cause means an intermediate context (e.g. transport's own bounded open
+// budget) fired via WithTimeoutCause — that is not the caller giving up, so it
+// stays retryable and a still-valid cached token can be served.
 func isCallerCancellation(ctx context.Context, err error) bool {
-	return isContextError(err) && ctx.Err() != nil
+	if !isContextError(err) || ctx.Err() == nil {
+		return false
+	}
+	cause := context.Cause(ctx)
+	return cause == context.Canceled || cause == context.DeadlineExceeded
 }
 
 // invalidate drops the cached token for the given credentials, table, and
-// audience. The next getOrFetch call will re-mint from scratch.
-func (c *tokenCache) invalidate(clientID, clientSecret, tableName, audience string) {
-	key := newTokenKey(clientID, clientSecret, tableName, audience)
+// scope. The next getOrFetch call will re-mint from scratch.
+func (c *tokenCache) invalidate(clientID, clientSecret, tableName, scope string) {
+	key := newTokenKey(clientID, clientSecret, tableName, scope)
 
 	c.mu.Lock()
 	entry, ok := c.entries[key]

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -348,7 +348,13 @@ func (c *tokenCache) invalidate(clientID, clientSecret, tableName, audience stri
 		return
 	}
 	entry.mu.Lock()
-	entry.cached = nil
+	// If the entry was pruned between the map read and this lock, it is detached:
+	// a fresh entry (with no cached token) already replaced it in the map, so
+	// clearing this stale one would be a silent no-op on the live entry. The
+	// replacement starts empty, so no re-invalidation is needed.
+	if !entry.pruned {
+		entry.cached = nil
+	}
 	entry.mu.Unlock()
 }
 

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -81,7 +81,9 @@ type cachedToken struct {
 }
 
 func (c *cachedToken) isExpired() bool {
-	return time.Now().After(c.expiresAt)
+	// Expired at or after expiresAt: at the exact instant the token is already
+	// unusable, so treat it as expired rather than serving it.
+	return !time.Now().Before(c.expiresAt)
 }
 
 // newCachedToken builds an entry for a token whose TTL started at mintedAt
@@ -125,7 +127,7 @@ type tokenFlight struct {
 	err   error         // resolved error (nil on success)
 }
 
-// tokenCache caches OAuth tokens per (clientID, secret, tableName).
+// tokenCache caches OAuth tokens per (clientID, secret, tableName, audience).
 //
 // It is safe for concurrent use. Construct one with [newTokenCache]; the
 // methods do not guard against a nil receiver.

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -14,9 +14,14 @@ const defaultRefreshBuffer = 5 * time.Minute
 
 // fetchedToken is the raw result of a mint: the token string plus its
 // server-reported lifetime (nil when the OAuth server omits expires_in).
+//
+// receivedAt anchors the TTL to when the response was received, so slow
+// post-mint work (e.g. a custom slog handler) can't inflate the cached
+// lifetime. It is zero when the mint failed; the cache falls back to time.Now.
 type fetchedToken struct {
-	token     string
-	expiresIn *time.Duration
+	token      string
+	expiresIn  *time.Duration
+	receivedAt time.Time
 }
 
 // mintReason is passed to the mint callback so it can distinguish a cold start
@@ -301,7 +306,12 @@ func (c *tokenCache) tryGetOrFetch(
 	// Cache only tokens with a usable TTL. If refresh returned no expires_in,
 	// keep any existing still-valid token rather than discarding it.
 	if fetched.expiresIn != nil && *fetched.expiresIn > 0 {
-		mintedAt := time.Now()
+		// Anchor the TTL to when the response was received, not now: a slow
+		// custom logger between receipt and here must not extend the lifetime.
+		mintedAt := fetched.receivedAt
+		if mintedAt.IsZero() {
+			mintedAt = time.Now()
+		}
 		entry.cached = newCachedToken(token, *fetched.expiresIn, c.refreshBuffer, mintedAt)
 	} else {
 		keepExisting := entry.cached != nil && !entry.cached.isExpired()

--- a/purego/internal/auth/token_cache.go
+++ b/purego/internal/auth/token_cache.go
@@ -52,16 +52,11 @@ func (r mintReason) String() string {
 
 // tokenKey identifies a cache entry. The client secret is stored as its
 // SHA-256 digest so the raw credential is never kept in the map: distinct
-// secrets still yield distinct keys (collision resistance), and a rotated
-// secret gets a fresh entry.
+// secrets still yield distinct keys, and a rotated secret gets a fresh entry.
 //
 // scope discriminates entries that share credentials and table but are not
-// interchangeable. The provider derives it from both the token's target
-// audience (the workspace the minted token is bound to) and the issuing UC
-// endpoint. Two providers with the same credentials and table but a different
-// workspace mint audience-scoped tokens that would be rejected on mismatch; two
-// providers with a different UC endpoint mint through different issuers. Either
-// difference must yield a distinct entry, so both feed the shared cache key.
+// interchangeable — different workspace audience or different issuing UC
+// endpoint. Composed by the provider; opaque to the cache.
 type tokenKey struct {
 	clientID     string
 	secretDigest [sha256.Size]byte
@@ -290,16 +285,12 @@ func (c *tokenCache) tryGetOrFetch(
 	if err != nil {
 		token, resErr := "", err
 		if entry.cached != nil && !entry.cached.isExpired() && isRetryable(err) {
-			// Proactive refresh failed transiently; serve the still-valid token. A
-			// genuine caller cancellation is not retryable (see isRetryableTransport
-			// Error / isCallerCancellation), so it is not masked here and propagates,
-			// honoring the Token(ctx) contract. The transport's own bounded open
-			// budget is classified retryable, so it falls back to the cached token.
+			// Proactive refresh failed transiently; serve the still-valid token.
+			// Caller cancellation is non-retryable, so it propagates instead.
 			token, resErr = entry.cached.value, nil
 		}
-		// Publish to waiters: writes before close(done) happen-before <-done. The
-		// mutex just brackets the entry-state transition, not the flight publish.
-		// A caller-cancellation error published here is what lets a live-ctx waiter
+		// Publish to waiters: writes before close(done) happen-before <-done.
+		// A caller-cancellation error published here lets a live-ctx waiter
 		// re-attempt instead of inheriting a cancellation it never requested.
 		flight.token, flight.err = token, resErr
 		close(flight.done)
@@ -309,14 +300,9 @@ func (c *tokenCache) tryGetOrFetch(
 
 	token := fetched.token
 
-	// Cache only tokens with a usable TTL. If refresh returned no expires_in,
-	// keep any existing still-valid token rather than discarding it.
-	//
-	// Anchor the TTL to when the response was received, not now: a slow custom
-	// logger between receipt and here must not extend the lifetime. That same
-	// delay can also consume the whole TTL, so a short-lived token may already be
-	// expired by the time we publish; treat that like a no-TTL response (don't
-	// cache a dead entry) rather than storing something isExpired would reject.
+	// Anchor the TTL to response receipt so post-receipt work (e.g. a custom
+	// logger) can't extend the cached lifetime. That same delay can consume a
+	// short TTL entirely, so a token can arrive already expired.
 	mintedAt := fetched.receivedAt
 	if mintedAt.IsZero() {
 		mintedAt = time.Now()
@@ -326,21 +312,15 @@ func (c *tokenCache) tryGetOrFetch(
 	keepExisting := entry.cached != nil && !entry.cached.isExpired()
 	switch {
 	case usableTTL && !alreadyExpired:
-		// Live TTL: cache it and serve it.
 		entry.cached = newCachedToken(token, *fetched.expiresIn, c.refreshBuffer, mintedAt)
 	case alreadyExpired && keepExisting:
-		// The mint is dead on arrival but a still-valid token is cached (a
-		// proactive refresh whose TTL elapsed before publication). Serve the
-		// cached token, not the dead mint — returning the mint would hand the
-		// caller a token we already know is expired while discarding a good one.
+		// Dead mint but a still-valid token is cached: serve the cached one so
+		// the caller doesn't get a token we already know is expired.
 		token = entry.cached.value
 	case !keepExisting:
-		// No usable TTL and no live cache to keep: a no-expires_in token is still
-		// returned to this caller (uncached), and a dead mint leaves nothing.
 		entry.cached = nil
 	}
-	// Remaining case (no usable TTL but keepExisting): a valid no-expires_in token
-	// is returned as-is while the existing cache entry is retained untouched.
+	// !usableTTL with a live cache: return the fresh token as-is, keep the cache.
 	flight.token, flight.err = token, nil
 	close(flight.done)
 	entry.mu.Unlock()
@@ -358,23 +338,11 @@ func isContextError(err error) bool {
 }
 
 // isCallerCancellation reports whether err is a context error that originated
-// from the caller stopping — the caller cancelled or its own deadline fired —
-// rather than from the request or an SDK-internal budget. It is the caller's
-// signal to stop: such a failure must not be retried or masked by serving a
-// cached token.
-//
-// A context error seen while ctx is still live came from the request (a
-// client/transport timeout) and is a transient, retryable fault. When ctx is
-// done, context.Cause distinguishes the two remaining cases: a plain
-// context.Canceled/DeadlineExceeded cause is the caller stopping, whereas any
-// other cause means an intermediate context (e.g. transport's own bounded open
-// budget) fired via WithTimeoutCause — that is not the caller giving up, so it
-// stays retryable and a still-valid cached token can be served.
-//
-// A caller that cancels via context.WithCancelCause with its own custom cause is
-// therefore not seen as a caller stop here. In practice that is moot: such a
-// cancellation makes the HTTP client wrap the custom cause (not context.Canceled),
-// so err is not a context error and this function is never reached for it.
+// from the caller stopping, not from the request or an SDK-internal budget.
+// Only such failures are non-retryable; a client/transport timeout or a
+// WithTimeoutCause budget stays retryable so a cached token can be served.
+// When ctx is done, context.Cause tells the caller's own cancel/deadline (plain
+// context.Canceled/DeadlineExceeded) apart from an intermediate budget cause.
 func isCallerCancellation(ctx context.Context, err error) bool {
 	if !isContextError(err) || ctx.Err() == nil {
 		return false

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -790,6 +790,33 @@ func TestTokenCacheDoesNotCacheAlreadyExpiredToken(t *testing.T) {
 	}
 }
 
+// When a proactive refresh mints a token that is already expired on arrival but
+// a still-valid token is cached, the caller must receive the cached token, not
+// the dead mint — and the live cache entry must be retained.
+func TestTokenCacheRefreshExpiredMintServesExistingCachedToken(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
+
+	// Refresh returns a token whose receipt-anchored TTL already elapsed.
+	receivedAt := time.Now().Add(-time.Hour)
+	ttl := time.Second
+	tok := getOrFetch(t, c, "id", "secret", "c.s.t",
+		func(context.Context, mintReason) (fetchedToken, error) {
+			return fetchedToken{token: "dead", expiresIn: &ttl, receivedAt: receivedAt}, nil
+		})
+	if tok != "valid" {
+		t.Fatalf("want still-valid cached token served, got %q", tok)
+	}
+	// The valid entry must still be cached (not overwritten by the dead mint).
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t", ""))
+	entry.mu.Lock()
+	cached := entry.cached
+	entry.mu.Unlock()
+	if cached == nil || cached.value != "valid" {
+		t.Fatalf("valid cached token must be retained, got %+v", cached)
+	}
+}
+
 func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
 	c := newTokenCache(CacheRefreshBuffer(-1))
 	if c.refreshBuffer != defaultRefreshBuffer {

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -685,6 +685,31 @@ func TestNewCachedToken(t *testing.T) {
 	}
 }
 
+// getOrFetch must anchor a cached token's expiry to the mint's receivedAt, not
+// to when getOrFetch finishes storing it. A mint that reports receipt in the
+// past (standing in for slow post-receipt work such as a blocking logger) must
+// yield a correspondingly earlier expiresAt.
+func TestTokenCacheAnchorsExpiryToReceivedAt(t *testing.T) {
+	c := newTokenCache()
+	receivedAt := time.Now().Add(-30 * time.Minute)
+	d := time.Hour
+	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
+		func(context.Context, mintReason) (fetchedToken, error) {
+			return fetchedToken{token: "tok", expiresIn: &d, receivedAt: receivedAt}, nil
+		})
+	if err != nil {
+		t.Fatalf("getOrFetch: %v", err)
+	}
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t", ""))
+	entry.mu.Lock()
+	got := entry.cached.expiresAt
+	entry.mu.Unlock()
+	want := receivedAt.Add(d)
+	if diff := got.Sub(want); diff < -time.Second || diff > time.Second {
+		t.Fatalf("expiresAt = %v, want ~%v (anchored to receivedAt+ttl)", got, want)
+	}
+}
+
 func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
 	c := newTokenCache(CacheRefreshBuffer(-1))
 	if c.refreshBuffer != defaultRefreshBuffer {

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -243,7 +243,7 @@ func TestTokenCacheNoTTLResponseKeepsExistingCachedToken(t *testing.T) {
 	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
 	// A refresh returns a token with no TTL; caller gets the fresh token but the
-	// existing valid cached token is retained (Rust parity).
+	// existing valid cached token is retained.
 	fresh := getOrFetch(t, c, "id", "secret", "c.s.t",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{token: "nottl"}, nil

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -535,7 +535,7 @@ func TestTokenCacheWaiterRemintsWhenLeaderContextCancelled(t *testing.T) {
 }
 
 func TestTokenCacheDisabledAlwaysMints(t *testing.T) {
-	c := newTokenCache(cacheEnabled(false))
+	c := newTokenCache(CacheEnabled(false))
 	var calls atomic.Int64
 	reasons := make(chan mintReason, 2)
 	mint := func(_ context.Context, r mintReason) (fetchedToken, error) {
@@ -564,7 +564,7 @@ func TestTokenCacheCustomRefreshBuffer(t *testing.T) {
 	// effect. Compare against the default 5-minute buffer, which would place it
 	// ~55 minutes out.
 	const buffer = 20 * time.Minute
-	c := newTokenCache(cacheRefreshBuffer(buffer))
+	c := newTokenCache(CacheRefreshBuffer(buffer))
 
 	before := time.Now()
 	getOrFetch(t, c, "id", "secret", "c.s.t", makeMint("tok", 3600))
@@ -610,7 +610,7 @@ func TestNewCachedToken(t *testing.T) {
 }
 
 func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
-	c := newTokenCache(cacheRefreshBuffer(-1))
+	c := newTokenCache(CacheRefreshBuffer(-1))
 	if c.refreshBuffer != defaultRefreshBuffer {
 		t.Fatalf("non-positive buffer should be ignored, got %v", c.refreshBuffer)
 	}

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -193,30 +193,52 @@ func TestTokenCacheRetryableRefreshFailureFallsBack(t *testing.T) {
 	}
 }
 
-// A proactive refresh that fails with a context deadline/cancel must still fall
-// back to the still-valid cached token. Transport bounds a deadline-less open
-// with its own internal budget, so a mint that trips that budget surfaces as a
-// context error even though the caller never gave up; failing the open here
-// (when a usable token is in hand) would be a spurious outage. Regression for
-// the transport-budget case that the isCallerCancellation heuristic can't tell
-// apart from a genuine caller cancel.
-func TestTokenCacheContextErrorRefreshFailureFallsBack(t *testing.T) {
+// A genuine caller cancellation during a proactive refresh must propagate, not
+// be masked by serving the cached token: Token(ctx) is contractually bound by
+// ctx. The mint reports it non-retryable (as isRetryableTransportError does for
+// a caller-owned cancel), so the still-valid cached token is NOT served.
+func TestTokenCacheCallerCancelRefreshFailurePropagates(t *testing.T) {
 	c := newTokenCache()
 	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
-	// A mint failure carrying a context deadline, classified non-retryable (as a
-	// mint bounded by the transport open budget produces when that budget fires).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // caller has given up
+
+	tok, err := c.getOrFetch(ctx, "id", "secret", "c.s.t", "",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			// A caller cancel surfaces as a non-retryable context error.
+			return fetchedToken{}, &TokenError{
+				msg:       "token request: context canceled",
+				retryable: false,
+				cause:     context.Canceled,
+			}
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("caller cancellation must propagate, got tok=%q err=%v", tok, err)
+	}
+}
+
+// A proactive refresh that fails because the SDK's own bounded open budget
+// fired (a retryable request timeout, not a caller cancel) must fall back to the
+// still-valid cached token rather than failing the open spuriously.
+func TestTokenCacheBudgetTimeoutRefreshFailureFallsBack(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
+
+	// The transport open budget surfaces as a retryable timeout (see
+	// isRetryableTransportError classifying a non-caller context error retryable).
 	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &TokenError{
 				msg:       "token request: context deadline exceeded",
-				retryable: false,
+				retryable: true,
 				cause:     context.DeadlineExceeded,
 			}
 		},
 	)
 	if err != nil {
-		t.Fatalf("want fallback to cached token on context-error refresh failure, got: %v", err)
+		t.Fatalf("want fallback to cached token on budget-timeout refresh, got: %v", err)
 	}
 	if tok != "valid" {
 		t.Fatalf("want %q, got %q", "valid", tok)
@@ -737,6 +759,34 @@ func TestTokenCacheAnchorsExpiryToReceivedAt(t *testing.T) {
 	want := receivedAt.Add(d)
 	if diff := got.Sub(want); diff < -time.Second || diff > time.Second {
 		t.Fatalf("expiresAt = %v, want ~%v (anchored to receivedAt+ttl)", got, want)
+	}
+}
+
+// A token whose receipt-anchored TTL has already elapsed by the time the cache
+// publishes it (e.g. a slow custom logger consumed the whole short TTL) must not
+// be cached: the caller still gets the token, but a dead entry is not stored.
+func TestTokenCacheDoesNotCacheAlreadyExpiredToken(t *testing.T) {
+	c := newTokenCache()
+	// Received well in the past with a tiny TTL: expired before publication.
+	receivedAt := time.Now().Add(-time.Hour)
+	ttl := time.Second
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
+		func(context.Context, mintReason) (fetchedToken, error) {
+			return fetchedToken{token: "stale", expiresIn: &ttl, receivedAt: receivedAt}, nil
+		})
+	if err != nil {
+		t.Fatalf("getOrFetch: %v", err)
+	}
+	if tok != "stale" {
+		t.Fatalf("caller must still receive the minted token, got %q", tok)
+	}
+	// Nothing usable should be cached.
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t", ""))
+	entry.mu.Lock()
+	cached := entry.cached
+	entry.mu.Unlock()
+	if cached != nil {
+		t.Fatalf("expired-on-arrival token must not be cached, got %+v", cached)
 	}
 }
 

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -30,6 +30,15 @@ func (e *denyingWrapper) Error() string     { return "denied: " + e.cause.Error(
 func (e *denyingWrapper) IsRetryable() bool { return false }
 func (e *denyingWrapper) Unwrap() error     { return e.cause }
 
+// timeoutRetryErr is retryable and unwraps to context.DeadlineExceeded, mirroring
+// the TokenError a client-Timeout mint produces: the request timed out (transient,
+// retryable) even though a context deadline is in the cause chain.
+type timeoutRetryErr struct{}
+
+func (e *timeoutRetryErr) Error() string     { return "request timeout" }
+func (e *timeoutRetryErr) IsRetryable() bool { return true }
+func (e *timeoutRetryErr) Unwrap() error     { return context.DeadlineExceeded }
+
 func makeMint(token string, ttlSecs int) func(context.Context, mintReason) (fetchedToken, error) {
 	return func(_ context.Context, _ mintReason) (fetchedToken, error) {
 		ft := fetchedToken{token: token}
@@ -45,7 +54,7 @@ func getOrFetch(t *testing.T, c *tokenCache, clientID, secret, table string,
 	mint func(context.Context, mintReason) (fetchedToken, error),
 ) string {
 	t.Helper()
-	tok, err := c.getOrFetch(context.Background(), clientID, secret, table, mint)
+	tok, err := c.getOrFetch(context.Background(), clientID, secret, table, "", mint)
 	if err != nil {
 		t.Fatalf("getOrFetch: %v", err)
 	}
@@ -134,7 +143,7 @@ func TestTokenCacheInvalidateForcesMintOnNextCall(t *testing.T) {
 	}
 
 	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
-	c.invalidate("id", "secret", "c.s.t")
+	c.invalidate("id", "secret", "c.s.t", "")
 	getOrFetch(t, c, "id", "secret", "c.s.t", mint)
 
 	if n := calls.Load(); n != 2 {
@@ -146,7 +155,7 @@ func TestTokenCacheWithinRefreshBufferRemints(t *testing.T) {
 	c := newTokenCache()
 	// A cached token past its refresh point is re-minted on the next call, and
 	// the fresh long-TTL result is then cached and reused.
-	seedRefreshable(c, "id", "secret", "c.s.t", "stale")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "stale")
 
 	var calls atomic.Int64
 	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
@@ -168,10 +177,10 @@ func TestTokenCacheWithinRefreshBufferRemints(t *testing.T) {
 func TestTokenCacheRetryableRefreshFailureFallsBack(t *testing.T) {
 	c := newTokenCache()
 	// Seed a token that is valid but due for proactive refresh.
-	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
 	// Retryable refresh error: should fall back to the still-valid cached token.
-	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &retryErr{"transient"}
 		},
@@ -186,9 +195,9 @@ func TestTokenCacheRetryableRefreshFailureFallsBack(t *testing.T) {
 
 func TestTokenCacheNonRetryableRefreshErrorPropagates(t *testing.T) {
 	c := newTokenCache()
-	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
-	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &fatalErr{"revoked"}
 		},
@@ -207,7 +216,7 @@ func TestTokenCacheColdMissFailureLeavesNoEntry(t *testing.T) {
 
 	// A failed cold-miss mint must not cache anything: the error propagates and a
 	// retry re-mints rather than serving a phantom token.
-	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	_, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &fatalErr{"boom"}
 		},
@@ -231,7 +240,7 @@ func TestTokenCacheColdMissFailureLeavesNoEntry(t *testing.T) {
 func TestTokenCacheNoTTLResponseKeepsExistingCachedToken(t *testing.T) {
 	c := newTokenCache()
 	// Seed a token that is due for refresh (refreshAt already in the past).
-	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
 	// A refresh returns a token with no TTL; caller gets the fresh token but the
 	// existing valid cached token is retained (Rust parity).
@@ -246,7 +255,7 @@ func TestTokenCacheNoTTLResponseKeepsExistingCachedToken(t *testing.T) {
 
 	// A subsequent retryable refresh failure should still fall back to the
 	// original valid cached token, proving it was retained.
-	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &retryErr{"blip"}
 		},
@@ -271,7 +280,7 @@ func TestTokenCacheSingleFlightMintOnce(t *testing.T) {
 	for i := range goroutines {
 		go func(i int) {
 			defer wg.Done()
-			tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+			tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 				func(_ context.Context, _ mintReason) (fetchedToken, error) {
 					calls.Add(1)
 					time.Sleep(20 * time.Millisecond) // hold lock so others queue up
@@ -315,7 +324,7 @@ func TestTokenCacheConcurrentMintFailureSharesError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, errs[0] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		_, errs[0] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 			func(_ context.Context, _ mintReason) (fetchedToken, error) {
 				calls.Add(1)
 				close(leaderMinting)
@@ -331,7 +340,7 @@ func TestTokenCacheConcurrentMintFailureSharesError(t *testing.T) {
 	for i := range waiters {
 		go func(i int) {
 			defer wg.Done()
-			_, errs[i+1] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+			_, errs[i+1] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 				func(_ context.Context, _ mintReason) (fetchedToken, error) {
 					calls.Add(1) // a waiter reaching here means single-flight broke
 					return fetchedToken{}, &fatalErr{"boom"}
@@ -369,7 +378,7 @@ func TestTokenCacheContextDeadlineRespectedDuringMint(t *testing.T) {
 
 	// Leader holds the mint open until release is closed.
 	go func() {
-		_, _ = c.getOrFetch(context.Background(), "id", "s", "c.s.t",
+		_, _ = c.getOrFetch(context.Background(), "id", "s", "c.s.t", "",
 			func(_ context.Context, _ mintReason) (fetchedToken, error) {
 				close(started)
 				<-release
@@ -384,7 +393,7 @@ func TestTokenCacheContextDeadlineRespectedDuringMint(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	_, err := c.getOrFetch(ctx, "id", "s", "c.s.t", makeMint("tok2", 3600))
+	_, err := c.getOrFetch(ctx, "id", "s", "c.s.t", "", makeMint("tok2", 3600))
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("want DeadlineExceeded, got %v", err)
 	}
@@ -399,7 +408,7 @@ func TestTokenCacheContextDeadlineRespectedDuringMint(t *testing.T) {
 func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
 	c := newTokenCache()
 	// Seed so invalidate has an entry to clear.
-	seedRefreshable(c, "id", "secret", "c.s.t", "old")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "old")
 
 	mintStarted := make(chan struct{})
 	releaseMint := make(chan struct{})
@@ -409,7 +418,7 @@ func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		out, err = c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		out, err = c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 			func(_ context.Context, _ mintReason) (fetchedToken, error) {
 				close(mintStarted)
 				<-releaseMint
@@ -419,7 +428,7 @@ func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
 	}()
 
 	<-mintStarted
-	c.invalidate("id", "secret", "c.s.t") // clears cached mid-mint
+	c.invalidate("id", "secret", "c.s.t", "") // clears cached mid-mint
 	close(releaseMint)
 	<-done
 
@@ -427,7 +436,7 @@ func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
 		t.Fatalf("want fresh/nil, got %q/%v", out, err)
 	}
 	// Leader's fresh token should be the one now cached.
-	entry := c.slot(newTokenKey("id", "secret", "c.s.t"))
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t", ""))
 	entry.mu.Lock()
 	cached := entry.cached
 	entry.mu.Unlock()
@@ -438,11 +447,11 @@ func TestTokenCacheInvalidateDuringInFlightMint(t *testing.T) {
 
 func TestTokenCacheJoinedRetryableErrorFallsBack(t *testing.T) {
 	c := newTokenCache()
-	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
 	// A retryable error buried inside errors.Join must still be detected so the
 	// cache falls back to the still-valid token.
-	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			joined := errors.Join(errors.New("context note"), &retryErr{"transient"})
 			return fetchedToken{}, joined
@@ -458,12 +467,12 @@ func TestTokenCacheJoinedRetryableErrorFallsBack(t *testing.T) {
 
 func TestTokenCacheRetryableCauseUnderNonRetryableWrapperFallsBack(t *testing.T) {
 	c := newTokenCache()
-	seedRefreshable(c, "id", "secret", "c.s.t", "valid")
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
 
 	// The outermost error reports IsRetryable() == false but unwraps a retryable
 	// cause. isRetryable must keep walking and detect the cause, so the cache
 	// falls back to the still-valid token rather than propagating the failure.
-	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 		func(_ context.Context, _ mintReason) (fetchedToken, error) {
 			return fetchedToken{}, &denyingWrapper{cause: &retryErr{"transient"}}
 		},
@@ -491,7 +500,7 @@ func TestTokenCacheWaiterRemintsWhenLeaderContextCancelled(t *testing.T) {
 	leaderDone := make(chan struct{})
 	go func() {
 		defer close(leaderDone)
-		_, _ = c.getOrFetch(leaderCtx, "id", "secret", "c.s.t",
+		_, _ = c.getOrFetch(leaderCtx, "id", "secret", "c.s.t", "",
 			func(ctx context.Context, _ mintReason) (fetchedToken, error) {
 				mints.Add(1)
 				close(mintStarted)
@@ -507,7 +516,7 @@ func TestTokenCacheWaiterRemintsWhenLeaderContextCancelled(t *testing.T) {
 	waiterResult := make(chan string, 1)
 	waiterErr := make(chan error, 1)
 	go func() {
-		tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t",
+		tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
 			func(_ context.Context, _ mintReason) (fetchedToken, error) {
 				mints.Add(1)
 				return fetchedToken{token: "waiter-tok", expiresIn: dur(3600)}, nil
@@ -531,6 +540,73 @@ func TestTokenCacheWaiterRemintsWhenLeaderContextCancelled(t *testing.T) {
 	// Leader minted once (and was cancelled); waiter re-minted once.
 	if n := mints.Load(); n != 2 {
 		t.Fatalf("want 2 mints (leader cancelled + waiter re-mint), got %d", n)
+	}
+}
+
+// TestTokenCacheWaiterSharesLeaderRetryableTimeout verifies that when the
+// leader's mint times out on its own (a retryable error that also wraps a
+// context deadline, as a client-Timeout does), waiters share that one outcome
+// instead of each re-minting. This is the single-flight guarantee: a slow
+// endpoint must not turn one mint into N. It is the counterpart to
+// TestTokenCacheWaiterRemintsWhenLeaderContextCancelled, which covers genuine
+// caller cancellation (non-retryable) where re-attempt IS wanted.
+func TestTokenCacheWaiterSharesLeaderRetryableTimeout(t *testing.T) {
+	c := newTokenCache()
+	var mints atomic.Int64
+
+	leaderMinting := make(chan struct{})
+	release := make(chan struct{})
+
+	// timeoutErr is retryable AND unwraps to a context deadline, mirroring the
+	// TokenError a client-Timeout mint produces after the isRetryableTransportError
+	// fix (retryable=true, cause wraps context.DeadlineExceeded).
+	leaderErr := &timeoutRetryErr{}
+
+	const waiters = 10
+	var wg sync.WaitGroup
+	errs := make([]error, waiters+1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
+			func(_ context.Context, _ mintReason) (fetchedToken, error) {
+				mints.Add(1)
+				close(leaderMinting)
+				<-release
+				return fetchedToken{}, leaderErr
+			},
+		)
+	}()
+
+	<-leaderMinting
+
+	wg.Add(waiters)
+	for i := range waiters {
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i+1] = c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
+				func(_ context.Context, _ mintReason) (fetchedToken, error) {
+					mints.Add(1) // a waiter minting here means single-flight broke
+					return fetchedToken{}, leaderErr
+				},
+			)
+		}(i)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	// One mint total — the leader's. Waiters shared its retryable failure rather
+	// than each re-attempting on the wrapped deadline.
+	if n := mints.Load(); n != 1 {
+		t.Fatalf("retryable leader timeout should mint once, got %d mints", n)
+	}
+	for i, err := range errs {
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("goroutine %d: want shared timeout error, got %v", i, err)
+		}
 	}
 }
 
@@ -570,7 +646,7 @@ func TestTokenCacheCustomRefreshBuffer(t *testing.T) {
 	getOrFetch(t, c, "id", "secret", "c.s.t", makeMint("tok", 3600))
 	after := time.Now()
 
-	entry := c.slot(newTokenKey("id", "secret", "c.s.t"))
+	entry := c.slot(newTokenKey("id", "secret", "c.s.t", ""))
 	entry.mu.Lock()
 	cached := entry.cached
 	entry.mu.Unlock()
@@ -626,8 +702,8 @@ func dur(secs int) *time.Duration {
 // its refresh point (refreshAt in the past, expiresAt in the future). This is
 // the "due for proactive refresh yet safe to fall back to" state; seeding it
 // explicitly avoids depending on TTL/buffer arithmetic that clamping changes.
-func seedRefreshable(c *tokenCache, clientID, secret, table, value string) {
-	key := newTokenKey(clientID, secret, table)
+func seedRefreshable(c *tokenCache, clientID, secret, table, audience, value string) {
+	key := newTokenKey(clientID, secret, table, audience)
 	entry := c.slot(key)
 	now := time.Now()
 	entry.mu.Lock()

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -193,6 +193,36 @@ func TestTokenCacheRetryableRefreshFailureFallsBack(t *testing.T) {
 	}
 }
 
+// A proactive refresh that fails with a context deadline/cancel must still fall
+// back to the still-valid cached token. Transport bounds a deadline-less open
+// with its own internal budget, so a mint that trips that budget surfaces as a
+// context error even though the caller never gave up; failing the open here
+// (when a usable token is in hand) would be a spurious outage. Regression for
+// the transport-budget case that the isCallerCancellation heuristic can't tell
+// apart from a genuine caller cancel.
+func TestTokenCacheContextErrorRefreshFailureFallsBack(t *testing.T) {
+	c := newTokenCache()
+	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")
+
+	// A mint failure carrying a context deadline, classified non-retryable (as a
+	// mint bounded by the transport open budget produces when that budget fires).
+	tok, err := c.getOrFetch(context.Background(), "id", "secret", "c.s.t", "",
+		func(_ context.Context, _ mintReason) (fetchedToken, error) {
+			return fetchedToken{}, &TokenError{
+				msg:       "token request: context deadline exceeded",
+				retryable: false,
+				cause:     context.DeadlineExceeded,
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("want fallback to cached token on context-error refresh failure, got: %v", err)
+	}
+	if tok != "valid" {
+		t.Fatalf("want %q, got %q", "valid", tok)
+	}
+}
+
 func TestTokenCacheNonRetryableRefreshErrorPropagates(t *testing.T) {
 	c := newTokenCache()
 	seedRefreshable(c, "id", "secret", "c.s.t", "", "valid")

--- a/purego/internal/auth/token_cache_test.go
+++ b/purego/internal/auth/token_cache_test.go
@@ -692,6 +692,91 @@ func TestTokenCacheNonPositiveRefreshBufferKeepsDefault(t *testing.T) {
 	}
 }
 
+// pruneExpiredLocked must mark an evicted entry pruned before removing it from
+// the map, so a caller still holding that entry's pointer (returned by slot()
+// before it locked entry.mu) can detect the eviction and re-slot instead of
+// minting against a detached entry — which would split single-flight into two
+// mints for one key.
+func TestTokenCachePruneMarksEntryPruned(t *testing.T) {
+	c := newTokenCache()
+	key := newTokenKey("id", "secret", "c.s.t", "")
+	entry := c.slot(key)
+
+	// A completed-mint entry whose token has expired: exactly what prune evicts.
+	entry.mu.Lock()
+	entry.minted = true
+	entry.cached = &cachedToken{value: "stale", expiresAt: time.Now().Add(-time.Second)}
+	entry.mu.Unlock()
+
+	c.mu.Lock()
+	c.pruneExpiredLocked()
+	_, stillInMap := c.entries[key]
+	c.mu.Unlock()
+
+	if stillInMap {
+		t.Fatal("expired entry should have been pruned from the map")
+	}
+	entry.mu.Lock()
+	pruned := entry.pruned
+	entry.mu.Unlock()
+	if !pruned {
+		t.Fatal("pruned entry must be marked so a stale holder re-slots instead of minting")
+	}
+
+	// A caller re-slotting after the prune gets a fresh, unpruned entry and mints.
+	var calls atomic.Int64
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		calls.Add(1)
+		return fetchedToken{token: "fresh", expiresIn: dur(3600)}, nil
+	}
+	if tok := getOrFetch(t, c, "id", "secret", "c.s.t", mint); tok != "fresh" {
+		t.Fatalf("want fresh after re-slot, got %q", tok)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("want 1 mint after re-slot, got %d", n)
+	}
+}
+
+// Stress the prune-vs-mint interaction under -race: many short-lived keys churn
+// the map (driving pruneExpiredLocked) while a hot key is minted concurrently.
+// The hot key must always resolve to a valid token with no data race.
+func TestTokenCacheConcurrentPruneAndMint(t *testing.T) {
+	c := newTokenCache()
+	mint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		return fetchedToken{token: "tok", expiresIn: dur(3600)}, nil
+	}
+	// A mint that yields an already-expired token, so its entry becomes prunable
+	// the moment it is stored — maximizing prune activity on the next miss.
+	expiredMint := func(_ context.Context, _ mintReason) (fetchedToken, error) {
+		d := time.Nanosecond
+		return fetchedToken{token: "tok", expiresIn: &d}, nil
+	}
+
+	const workers = 24
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := range workers {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if i%2 == 0 {
+					// Churn distinct, immediately-expired keys to trigger pruning.
+					tbl := "c.s.t" + string(rune('a'+(j%16)))
+					_, _ = c.getOrFetch(context.Background(), "id", "secret", tbl, "", expiredMint)
+				} else {
+					// Hammer one hot key that a prune could race to evict.
+					tok, err := c.getOrFetch(context.Background(), "id", "secret", "hot.k.t", "", mint)
+					if err != nil || tok != "tok" {
+						t.Errorf("hot key: got (%q, %v), want (tok, nil)", tok, err)
+						return
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
 // dur returns a pointer to a Duration of d seconds, for test readability.
 func dur(secs int) *time.Duration {
 	d := time.Duration(secs) * time.Second

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -70,9 +70,8 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		useDefaultBudgets = true
 		var cancelHeaders context.CancelFunc
-		// Tag the budget with an explicit cause so a HeadersProvider (e.g. an OAuth
-		// token mint) can distinguish this internal timeout from a caller-driven
-		// cancel and still serve a valid cached token rather than failing the open.
+		// Tag the budget so a HeadersProvider can tell this internal timeout
+		// apart from a caller cancel via context.Cause.
 		headersCtx, cancelHeaders = context.WithTimeoutCause(ctx, defaultHeadersTimeout, errHeadersBudgetExceeded)
 		defer cancelHeaders()
 	}

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -70,7 +70,10 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		useDefaultBudgets = true
 		var cancelHeaders context.CancelFunc
-		headersCtx, cancelHeaders = context.WithTimeout(ctx, defaultHeadersTimeout)
+		// Tag the budget with an explicit cause so a HeadersProvider (e.g. an OAuth
+		// token mint) can distinguish this internal timeout from a caller-driven
+		// cancel and still serve a valid cached token rather than failing the open.
+		headersCtx, cancelHeaders = context.WithTimeoutCause(ctx, defaultHeadersTimeout, errHeadersBudgetExceeded)
 		defer cancelHeaders()
 	}
 

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -66,20 +66,20 @@ func (p StreamParams) resolveHeaders(ctx context.Context) (map[string]string, er
 	}
 	seenNormalizedKeys := make(map[string]struct{}, len(snapshot))
 	for k, v := range snapshot {
-		normalized := normalizeHeaderKey(k)
-		if normalized != "" {
-			if _, exists := seenNormalizedKeys[normalized]; exists {
-				return nil, fmt.Errorf("transport: open %q: duplicate header key %q after normalization", p.TableName, normalized)
-			}
-			seenNormalizedKeys[normalized] = struct{}{}
-		}
-		// Reject at the wire boundary; gRPC would otherwise fail opaquely.
+		// Reject at the wire boundary before deduping; gRPC would otherwise fail
+		// opaquely, and validating first means a doubled invalid key reports as
+		// invalid rather than misleadingly as a duplicate.
 		if !isUsableAsHeaderKey(k) {
 			return nil, fmt.Errorf("transport: open %q: header key %q is not a valid gRPC metadata key", p.TableName, strings.TrimSpace(k))
 		}
 		if !isUsableAsHeaderValue(v) {
 			return nil, fmt.Errorf("transport: open %q: header %q contains invalid value characters", p.TableName, strings.TrimSpace(k))
 		}
+		normalized := normalizeHeaderKey(k)
+		if _, exists := seenNormalizedKeys[normalized]; exists {
+			return nil, fmt.Errorf("transport: open %q: duplicate header key %q after normalization", p.TableName, normalized)
+		}
+		seenNormalizedKeys[normalized] = struct{}{}
 	}
 	return snapshot, nil
 }

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -10,11 +10,9 @@ import (
 	"time"
 )
 
-// errHeadersBudgetExceeded is the cause set on the internal header-resolution
-// budget (see defaultHeadersTimeout). It lets a HeadersProvider tell the SDK's
-// own open budget firing apart from the caller cancelling their context:
-// context.Cause reports this sentinel for the former and the plain
-// context.Canceled/DeadlineExceeded for the latter.
+// errHeadersBudgetExceeded tags the internal header-resolution budget (see
+// defaultHeadersTimeout) so a HeadersProvider can distinguish the SDK's own
+// budget firing from a caller-owned cancel via context.Cause.
 var errHeadersBudgetExceeded = errors.New("transport: open header budget exceeded")
 
 // defaultHeadersTimeout bounds header resolution during Open when the caller's

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// errHeadersBudgetExceeded is the cause set on the internal header-resolution
+// budget (see defaultHeadersTimeout). It lets a HeadersProvider tell the SDK's
+// own open budget firing apart from the caller cancelling their context:
+// context.Cause reports this sentinel for the former and the plain
+// context.Canceled/DeadlineExceeded for the latter.
+var errHeadersBudgetExceeded = errors.New("transport: open header budget exceeded")
+
 // defaultHeadersTimeout bounds header resolution during Open when the caller's
 // context has no deadline. A var so tests can shrink it via export_test.go;
 // tests that override it therefore must not call t.Parallel().


### PR DESCRIPTION
## Summary

Third of a 3-PR stack. **Stacked on #495** (base branch \`purego-auth-cache\`).

Adds the Unity Catalog OAuth 2.0 provider:
- \`OAuthTokenProvider\` — client-credentials flow minting downscoped per-table tokens, with proactive refresh, endpoint/table validation, structured \`slog\` observability, and an injectable \`*http.Client\`. A concrete type, not an interface — the \`HeadersProvider\` interface is the extension point.
- \`OAuthHeadersProvider\` — wraps \`OAuthTokenProvider\` and emits the Zerobus metadata headers (\`authorization: Bearer <token>\` and \`x-databricks-zerobus-table-name\`), satisfying the transport headers-provider hook from #494.
- \`SharedTokenCache\` / \`NewSharedTokenCache\` — allows multiple providers to share one token cache so tokens are reused across streams for the same credentials.
- \`FetchToken\` — bypasses the cache for a guaranteed-fresh mint; useful for diagnostics and forced refreshes.
- Treats all 4xx token responses (including 429/408) as non-retryable and anchors cached token TTL at response receipt, matching the Rust SDK.
- Requires \`https\` for non-loopback \`ucEndpoint\` so client credentials are never sent over plaintext.

## Stack
1. #494 — transport header hook
2. #495 — auth \`HeadersProvider\` + token cache
3. **this PR** — UC OAuth provider

## Test plan
- \`go build ./...\` and \`go test ./internal/...\` pass.

## Note
\`OAuthHeadersProvider\` lives in \`headers_provider.go\` alongside \`HeadersProvider\`/\`StaticHeadersProvider\` (added in #495), since it depends on \`oauth.go\` in this PR. The \`deriveWorkspaceIDFromEndpoint\` helper extracts the workspace ID from the Zerobus endpoint host prefix; the \`zerobusHost\` return value was dropped in a later revision as it was unused.