### PR TITLE
[Rust SDK] Bump Rust SDK to version 2.3.1

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Version changelog
 
+## Release v2.3.1
+
+### Major Changes
+
+### New Features and Improvements
+
+### Bug Fixes
+
+- Fixed `VARIANT` columns nested inside a `STRUCT`, `ARRAY`, or `MAP` failing with `unknown primitive type 'variant'` when building a descriptor from a Unity Catalog schema. Nested `VARIANT` now maps to `string` (unshredded JSON-encoded text) at any depth, matching the top-level behavior. Applies to both the protobuf and Arrow Flight schema paths (`descriptor_from_uc_columns` / `arrow_schema_from_uc_columns`).
+
+### Documentation
+
+- Reworked ingestion docs to lead with the high-throughput pattern (ingest in a loop, then `flush()` once) and explicitly warn against calling `wait_for_offset()` after every record. Updated the README, crate- and method-level doc comments (`ingest_record_offset`, `ingest_records_offset`, `wait_for_offset`, `flush`), and the `json`/`proto` single-record examples accordingly.
+
+### Internal Changes
+
+- Established `rust/sdk/zerobus_service.proto` as the single canonical gRPC schema, now referenced directly by the cgo Go SDK tests and the Java SDK build instead of their own duplicated (and drifted) copies. No schema or behavior change for the Rust core — the file stays where it was.
+
+### Breaking Changes
+
+### Deprecations
+
+### API Changes
+
 ## Release v2.3.0
 
 ### Major Changes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,15 +8,9 @@
 
 ### Bug Fixes
 
-- Fixed `VARIANT` columns nested inside a `STRUCT`, `ARRAY`, or `MAP` failing with `unknown primitive type 'variant'` when building a descriptor from a Unity Catalog schema. Nested `VARIANT` now maps to `string` (unshredded JSON-encoded text) at any depth, matching the top-level behavior. Applies to both the protobuf and Arrow Flight schema paths (`descriptor_from_uc_columns` / `arrow_schema_from_uc_columns`).
-
 ### Documentation
 
-- Reworked ingestion docs to lead with the high-throughput pattern (ingest in a loop, then `flush()` once) and explicitly warn against calling `wait_for_offset()` after every record. Updated the README, crate- and method-level doc comments (`ingest_record_offset`, `ingest_records_offset`, `wait_for_offset`, `flush`), and the `json`/`proto` single-record examples accordingly.
-
 ### Internal Changes
-
-- Established `rust/sdk/zerobus_service.proto` as the single canonical gRPC schema, now referenced directly by the cgo Go SDK tests and the Java SDK build instead of their own duplicated (and drifted) copies. No schema or behavior change for the Rust core — the file stays where it was.
 
 ### Breaking Changes
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Databricks"]
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bump Rust SDK version to 2.3.1.

## How is this tested?

