### PR TITLE
[Java] Guard against publishing JARs without JNI libs

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -59,6 +59,41 @@ jobs:
         working-directory: java
         run: mvn -DskipTests=true --batch-mode package
 
+      - name: Verify JAR bundles JNI libraries
+        working-directory: java
+        run: |
+          required_entries=(
+            native/linux-x86_64/libzerobus_jni.so
+            native/linux-aarch64/libzerobus_jni.so
+            native/linux-musl-x86_64/libzerobus_jni.so
+            native/linux-musl-aarch64/libzerobus_jni.so
+            native/windows-x86_64/zerobus_jni.dll
+          )
+
+          shopt -s nullglob
+          jars=(target/zerobus-ingest-sdk-*.jar)
+          checked=0
+          for jar in "${jars[@]}"; do
+            case "$jar" in
+              *-sources.jar|*-javadoc.jar) continue ;;
+            esac
+            checked=$((checked + 1))
+            echo "Verifying native entries in $jar"
+            for entry in "${required_entries[@]}"; do
+              if ! jar tf "$jar" | grep -Fxq "$entry"; then
+                echo "ERROR: $jar is missing $entry"
+                echo "Native entries present:"
+                jar tf "$jar" | grep '^native/' | sort || true
+                exit 1
+              fi
+            done
+          done
+
+          if [[ "$checked" -eq 0 ]]; then
+            echo "ERROR: no deployable zerobus-ingest-sdk JARs found"
+            exit 1
+          fi
+
       - name: Upload JAR
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/java/CLAUDE.md
+++ b/java/CLAUDE.md
@@ -48,7 +48,7 @@ Run from `java/`:
 - `mvn compile` — Compile
 - `mvn test` — Run tests
 - `mvn test -Dtest=ClassName#method` — Run specific test
-- `mvn clean package` — Build JAR (includes fat JAR)
+- `mvn clean package -Dzerobus.skipNativeLibCheck=true` — Build local Java JARs without staged release JNI libraries
 - `mvn spotless:check` — Check formatting (Google Java Format)
 - `mvn spotless:apply` — Auto-format
 

--- a/java/CONTRIBUTING.md
+++ b/java/CONTRIBUTING.md
@@ -23,10 +23,10 @@ This document covers Java-specific development setup and workflow.
 
 2. **Build the project:**
    ```bash
-   mvn clean install
+   mvn clean install -Dzerobus.skipNativeLibCheck=true
    ```
 
-   This will generate protobuf Java classes, compile the source code, run tests, and install the artifact to your local Maven repository.
+   This will generate protobuf Java classes, compile the source code, run tests, and install the artifact to your local Maven repository. Omit `-Dzerobus.skipNativeLibCheck=true` only when you have staged release JNI libraries under `src/main/resources/native/` and want to build a redistributable SDK JAR.
 
 3. **Run tests:**
    ```bash
@@ -97,10 +97,10 @@ mvn spotless:apply
 mvn spotless:check
 
 # Create JARs (regular + fat JAR)
-mvn package
+mvn package -Dzerobus.skipNativeLibCheck=true
 
 # Install to local Maven repo
-mvn install
+mvn install -Dzerobus.skipNativeLibCheck=true
 
 # Generate protobuf classes
 mvn protobuf:compile

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -27,6 +27,14 @@
 ### Internal Changes
 
 - The Java SDK now generates its protobuf classes from the canonical `rust/sdk/zerobus_service.proto` instead of a local copy under `src/main/proto/`. This reconciles schema drift: the generated classes now include the batch-ingest messages (`JsonRecordBatch`, `ProtoEncodedRecordBatch`, `IngestRecordBatchRequest`) that the canonical schema already defined. Purely additive — no change to the hand-written `com.databricks.zerobus` public API, and batch ingestion (`ingestRecordsOffset`) already worked via the JNI boundary.
+- Added a `maven-enforcer-plugin` rule that fails `mvn package`/`install`/`deploy`
+  if the JNI native libraries (`linux-x86_64`, `linux-aarch64`,
+  `linux-musl-x86_64`, `linux-musl-aarch64`, `windows-x86_64`) aren't staged
+  under `src/main/resources/native/`. v1.2.0 was published with an empty JAR
+  because the release pipeline ran `mvn deploy` on a fresh checkout without
+  staging natives; this guard makes that failure mode impossible going forward.
+  Local Java-only builds that don't need packaged natives can skip this specific
+  rule with `-Dzerobus.skipNativeLibCheck=true`.
 
 ### Breaking Changes
 

--- a/java/README.md
+++ b/java/README.md
@@ -215,7 +215,7 @@ Clone and build the SDK:
 ```bash
 git clone https://github.com/databricks/zerobus-sdk.git
 cd zerobus-sdk/java
-mvn clean package
+mvn clean package -Dzerobus.skipNativeLibCheck=true
 ```
 
 This generates two JAR files in the `target/` directory:
@@ -227,6 +227,10 @@ This generates two JAR files in the `target/` directory:
 - **Fat JAR**: `zerobus-ingest-sdk-0.2.0-jar-with-dependencies.jar` (~19MB, includes native libraries + all dependencies)
   - Contains SDK classes plus all dependencies bundled
   - Self-contained, easier to deploy
+
+The skip flag is for local Java-only builds. Release builds must stage the JNI
+libraries under `src/main/resources/native/` and run Maven without that flag so
+the packaged JAR includes native libraries.
 
 **Which JAR to use?**
 - **Regular JAR**: When using Maven/Gradle (recommended)

--- a/java/examples/README.md
+++ b/java/examples/README.md
@@ -146,7 +146,7 @@ export DATABRICKS_CLIENT_SECRET="your-client-secret"
 
 ```bash
 cd ..  # Go to SDK root
-mvn package -DskipTests
+mvn package -DskipTests -Dzerobus.skipNativeLibCheck=true
 ```
 
 ## Running Examples

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -186,10 +186,10 @@
         <executions>
           <execution>
             <id>require-native-libs</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>enforce</goal>
             </goals>
+            <phase>prepare-package</phase>
             <configuration>
               <skip>${zerobus.skipNativeLibCheck}</skip>
               <rules>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,6 +32,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <zerobus.skipNativeLibCheck>false</zerobus.skipNativeLibCheck>
   </properties>
   <dependencies>
     <!-- Protocol Buffers -->
@@ -177,6 +178,35 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>require-native-libs</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <skip>${zerobus.skipNativeLibCheck}</skip>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                    <file>${project.basedir}/src/main/resources/native/linux-x86_64/libzerobus_jni.so</file>
+                    <file>${project.basedir}/src/main/resources/native/linux-aarch64/libzerobus_jni.so</file>
+                    <file>${project.basedir}/src/main/resources/native/linux-musl-x86_64/libzerobus_jni.so</file>
+                    <file>${project.basedir}/src/main/resources/native/linux-musl-aarch64/libzerobus_jni.so</file>
+                    <file>${project.basedir}/src/main/resources/native/windows-x86_64/zerobus_jni.dll</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <!-- Maven Shade Plugin for creating fat JAR -->
       <plugin>

--- a/java/tools/README.md
+++ b/java/tools/README.md
@@ -21,7 +21,7 @@ The tool is **packaged within the Zerobus SDK JAR**, so users can run it directl
 ## Requirements
 
 - Java 8 or higher
-- Zerobus SDK JAR (built with `mvn package`)
+- Zerobus SDK JAR (built with `mvn package -Dzerobus.skipNativeLibCheck=true`)
 - OAuth client ID and client secret with access to Unity Catalog
 - Access to a Unity Catalog endpoint
 

--- a/java/tools/README.md
+++ b/java/tools/README.md
@@ -33,7 +33,7 @@ If you have the SDK source repository:
 
 ```bash
 # First, build the SDK JAR
-mvn package
+mvn package -Dzerobus.skipNativeLibCheck=true
 
 # Then run the tool
 ./tools/generate_proto.sh \
@@ -241,7 +241,7 @@ The tool is distributed as part of the Zerobus SDK JAR. When you download or bui
 Users can run the tool directly from the JAR without needing access to the source code:
 
 ```bash
-# Download the SDK JAR (or build it with mvn package)
+# Download the SDK JAR (or build it with mvn package -Dzerobus.skipNativeLibCheck=true)
 # Then simply run:
 java -jar databricks-zerobus-ingest-sdk-0.1.0-jar-with-dependencies.jar \
   --uc-endpoint "..." \

--- a/java/tools/generate_proto.sh
+++ b/java/tools/generate_proto.sh
@@ -19,7 +19,7 @@ SHADED_JAR=$(find "${TARGET_DIR}" -name "databricks-zerobus-ingest-sdk-*-jar-wit
 
 if [ -z "${SHADED_JAR}" ] || [ ! -f "${SHADED_JAR}" ]; then
     echo "Error: Zerobus SDK JAR not found in ${TARGET_DIR}"
-    echo "Please run 'mvn package' first to build the SDK JAR"
+    echo "Please run 'mvn package -Dzerobus.skipNativeLibCheck=true' first to build the SDK JAR"
     exit 1
 fi
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes the Java SDK native-library packaging regression reported in #334.

The Java `1.2.0` artifact was published without any `native/.../libzerobus_jni` entries, so `NativeLoader` failed at runtime with errors like:

```text
Native library not found in classpath: /native/linux-x86_64/libzerobus_jni.so
```

This PR adds two release safeguards:

- Adds a Maven enforcer rule that fails `mvn package` / `install` / `deploy` unless the release JNI libraries are staged under `java/src/main/resources/native/`.
- Adds an explicit `release-java.yml` verification step that inspects the built deployable JARs and fails if required JNI entries are missing.

The required entries now match the JNI artifacts built by `release-jni.yml`:

- `native/linux-x86_64/libzerobus_jni.so`
- `native/linux-aarch64/libzerobus_jni.so`
- `native/linux-musl-x86_64/libzerobus_jni.so`
- `native/linux-musl-aarch64/libzerobus_jni.so`
- `native/windows-x86_64/zerobus_jni.dll`

This PR also documents `-Dzerobus.skipNativeLibCheck=true` for local Java-only builds, where developers usually do not have release JNI artifacts staged. Release builds should not use that skip flag.

## How is this tested?

- Parsed `java/pom.xml` with Python's XML parser.
- Parsed `.github/workflows/release-java.yml` with PyYAML.
- Manually verified the required native-library list matches the artifacts produced by `release-jni.yml`.