### PR TITLE
[Java] Support glibc 2.26 JNI builds

### DIFF
--- a/.github/workflows/release-jni.yml
+++ b/.github/workflows/release-jni.yml
@@ -13,15 +13,19 @@ jobs:
           - os: linux-ubuntu-latest
             runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: x86_64-unknown-linux-gnu
+            build_target: x86_64-unknown-linux-gnu.2.26
             artifact: libzerobus_jni.so
             native_dir: linux-x86_64
             cross: false
+            zigbuild: true
           - os: linux-ubuntu-latest
             runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: aarch64-unknown-linux-gnu
+            build_target: aarch64-unknown-linux-gnu.2.26
             artifact: libzerobus_jni.so
             native_dir: linux-aarch64
-            cross: true
+            cross: false
+            zigbuild: true
           - os: linux-ubuntu-latest
             runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: x86_64-unknown-linux-musl
@@ -83,13 +87,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install Zig (musl cross-builds)
+      - name: Install Zig (zigbuild targets)
         if: matrix.zigbuild
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.13.0
 
-      - name: Install cargo-zigbuild (musl cross-builds)
+      - name: Install cargo-zigbuild (zigbuild targets)
         if: matrix.zigbuild
         run: cargo install cargo-zigbuild --locked --version 0.19.8
 
@@ -101,7 +105,7 @@ jobs:
         if: matrix.zigbuild
         env:
           RUSTFLAGS: -C target-feature=-crt-static
-        run: cargo zigbuild --release -p zerobus-jni --target ${{ matrix.target }}
+        run: cargo zigbuild --release -p zerobus-jni --target ${{ matrix.build_target || matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Bug Fixes
 
+- Lowered the glibc baseline for bundled Java JNI Linux artifacts to glibc 2.26, enabling the
+  standard Java SDK JAR to run on Amazon Linux 2 environments such as Mule Runtime 4.11.6e without
+  requiring customers to rebuild the native library.
 - Fixed the `GenerateProto` tool rejecting `VARIANT` columns with `Unsupported column type` (and `Unsupported array/map element type` when nested). `VARIANT` now maps to `string` (unshredded JSON-encoded text) at the top level and inside `ARRAY`/`MAP`, matching the other SDKs.
 - Fixed the default `recoveryRetries`, which was `3` instead of the `4` used by the Rust core and every other SDK (Go, TypeScript, C++). A stream left with the default now makes 4 recovery attempts on transient failures instead of 3, matching the documented cross-SDK behavior. Callers that set `recoveryRetries` explicitly are unaffected. (#438)
 

--- a/java/README.md
+++ b/java/README.md
@@ -83,6 +83,7 @@ This SDK includes native libraries for the following platforms:
 | macOS    | x86_64       | Supported |
 | macOS    | aarch64 (Apple Silicon) | Supported |
 
+Linux glibc builds support glibc 2.26 and newer, including Amazon Linux 2.
 On Linux, the libc flavor (glibc vs musl) is detected at runtime. To override detection, set
 `-Dzerobus.libc=musl` or `-Dzerobus.libc=glibc` on the JVM command line.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR lowers the glibc baseline for the Java SDK's bundled Linux JNI libraries to glibc 2.26.

Specifically, the Java JNI release workflow now builds the GNU/Linux x86_64 and aarch64 artifacts with `cargo-zigbuild` targets:

- `x86_64-unknown-linux-gnu.2.26`
- `aarch64-unknown-linux-gnu.2.26`

The packaged native resource paths stay unchanged (`linux-x86_64`, `linux-aarch64`), so Java runtime loading and downstream packaging continue to work as before.

This is needed because the current published Java SDK JNI libraries require a newer glibc than Amazon Linux 2 provides. That blocks customers running environments such as Mule Runtime 4.11.6e on Amazon Linux 2. Building against a glibc 2.26 baseline lets the standard Java SDK JAR run there without requiring customers to compile their own native library.

The PR also documents the supported glibc floor in the Java README and adds a Java changelog entry.

## How is this tested?

- Built x86_64 JNI library locally:
  - `cargo zigbuild --release -p zerobus-jni --target x86_64-unknown-linux-gnu.2.26`
- Built aarch64 JNI library locally:
  - `cargo zigbuild --release -p zerobus-jni --target aarch64-unknown-linux-gnu.2.26`
- Verified the resulting Linux JNI shared libraries require at most `GLIBC_2.25`, which is compatible with glibc 2.26 environments.
- Parsed `.github/workflows/release-jni.yml` with Python YAML loading.