### PR TITLE
[C++] Instrument the Rust FFI under ASan/TSan sanitizer builds

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -73,13 +73,16 @@ jobs:
 
       # clang: the instrumented Rust archive emits LLVM sanitizer runtime calls,
       # so the C++ side must link with clang (GCC's runtime can't resolve them).
+      # Unpinned; a clang/rustc LLVM mismatch would surface as unresolved
+      # __tsan_*/__asan_* at link, not silent breakage.
       - name: Install clang
         run: sudo apt-get update && sudo apt-get install -y clang
 
       # Build the SDK, tests, and examples with AddressSanitizer and run the
       # existing suite under it. This catches the memory bugs a thin FFI wrapper
-      # is prone to (use-after-free, double-free, buffer overflow), now including
-      # inside the Rust core. Debug build for readable stack traces.
+      # is prone to (use-after-free, double-free, buffer overflow), in both the
+      # C++ wrapper and the instrumented Rust core. Debug build for readable
+      # stack traces.
       - name: Build + test with AddressSanitizer
         env:
           # The Rust core's global tokio runtime is intentionally never torn
@@ -114,6 +117,8 @@ jobs:
 
       # clang: the instrumented Rust archive emits LLVM sanitizer runtime calls,
       # so the C++ side must link with clang (GCC's runtime can't resolve them).
+      # Unpinned; a clang/rustc LLVM mismatch would surface as unresolved
+      # __tsan_*/__asan_* at link, not silent breakage.
       - name: Install clang
         run: sudo apt-get update && sudo apt-get install -y clang
 

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -64,19 +64,29 @@ jobs:
         shell: bash
         run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Nightly + rust-src: the sanitizer build instruments the Rust FFI too
+      # (BuildRustFfi.cmake), which needs -Zsanitizer + -Zbuild-std.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+        with:
+          toolchain: nightly
+          components: rust-src
+
+      # clang: the instrumented Rust archive emits LLVM sanitizer runtime calls,
+      # so the C++ side must link with clang (GCC's runtime can't resolve them).
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
 
       # Build the SDK, tests, and examples with AddressSanitizer and run the
       # existing suite under it. This catches the memory bugs a thin FFI wrapper
-      # is prone to (use-after-free, double-free, buffer overflow) without adding
-      # any dependency. Debug build for readable stack traces.
+      # is prone to (use-after-free, double-free, buffer overflow), now including
+      # inside the Rust core. Debug build for readable stack traces.
       - name: Build + test with AddressSanitizer
         env:
           # The Rust core's global tokio runtime is intentionally never torn
           # down, so the leak detector would flag it as a false positive.
           # Disable leak detection; keep the use-after-free/double-free checks.
           ASAN_OPTIONS: detect_leaks=0
-        run: make test SANITIZE=address BUILD_TYPE=Debug
+        run: make test SANITIZE=address BUILD_TYPE=Debug CLANG_CC=clang CLANG_CXX=clang++
 
   sanitize-thread:
     runs-on:
@@ -95,15 +105,24 @@ jobs:
         shell: bash
         run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Nightly + rust-src: the sanitizer build instruments the Rust FFI too
+      # (BuildRustFfi.cmake), which needs -Zsanitizer + -Zbuild-std.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+        with:
+          toolchain: nightly
+          components: rust-src
 
-      # Build + run the suite under ThreadSanitizer as a concurrent-liveness /
-      # consistency smoke test of the wrapper's concurrency contracts (e.g.
-      # concurrent readers on a shared ProtoSchema). Note: the FFI is a plain
-      # `cargo build --release`, so the Rust core is not TSan-instrumented; this
-      # job watches only the C++ side. Debug build for readable stack traces.
+      # clang: the instrumented Rust archive emits LLVM sanitizer runtime calls,
+      # so the C++ side must link with clang (GCC's runtime can't resolve them).
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+
+      # Build + run the suite under ThreadSanitizer over the wrapper's
+      # concurrency contracts (e.g. concurrent readers on a shared ProtoSchema).
+      # The Rust FFI is instrumented too, so races inside the core are visible,
+      # not just on the C++ side. Debug build for readable stack traces.
       - name: Build + test with ThreadSanitizer
         env:
           # Fail the job on the first race rather than merely printing it.
           TSAN_OPTIONS: halt_on_error=1
-        run: make test SANITIZE=thread BUILD_TYPE=Debug
+        run: make test SANITIZE=thread BUILD_TYPE=Debug CLANG_CC=clang CLANG_CXX=clang++

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -53,7 +53,9 @@ Run from `cpp/`:
   (`address`, `thread`, or `undefined`; CMake option `-DZEROBUS_SANITIZE=`). Off
   by default. Targets the memory/lifetime bugs this FFI wrapper is prone to
   (use-after-free, double-free). `address`/`thread` also instrument the Rust FFI
-  (nightly `-Zsanitizer` + `-Zbuild-std`), so they need a nightly toolchain with
+  (nightly `-Zsanitizer` + `-Zbuild-std`) — a sanitizer only observes code
+  compiled with it, so leaving the core uninstrumented would miss the races/UAF
+  that live inside the FFI. This needs a nightly toolchain with
   `rust-src` and build the C++ side with clang to match the LLVM sanitizer
   runtime (`CLANG_CC`/`CLANG_CXX`, default `clang`/`clang++`); GCC can't resolve
   the instrumented archive's runtime symbols. `undefined` uses the default
@@ -151,6 +153,10 @@ callback](#ack-callback)).
   be thread-safe with respect to their own state.
 - A single `ProtoSchema` may be used by concurrent readers
   (`descriptor_bytes`, `encode_json`); destruction must not race those calls.
+  `tests/concurrency_test.cpp` exercises this under ThreadSanitizer (which
+  instruments the Rust core too), so a race in the read path is caught in CI.
+  The destruction-vs-read contract, though, is not tested — it is the caller's
+  responsibility, not something the TSan job enforces.
 
 ## Breaking change rules
 

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -52,7 +52,12 @@ Run from `cpp/`:
 - `make test SANITIZE=address` — Build + run the suite under a sanitizer
   (`address`, `thread`, or `undefined`; CMake option `-DZEROBUS_SANITIZE=`). Off
   by default. Targets the memory/lifetime bugs this FFI wrapper is prone to
-  (use-after-free, double-free) with no added dependency.
+  (use-after-free, double-free). `address`/`thread` also instrument the Rust FFI
+  (nightly `-Zsanitizer` + `-Zbuild-std`), so they need a nightly toolchain with
+  `rust-src` and build the C++ side with clang to match the LLVM sanitizer
+  runtime (`CLANG_CC`/`CLANG_CXX`, default `clang`/`clang++`); GCC can't resolve
+  the instrumented archive's runtime symbols. `undefined` uses the default
+  compiler and a plain FFI build.
 
 CMake builds the FFI library from local Rust source by default
 (`cargo build --release` in `rust/ffi`). To link a prebuilt/vendored library

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -57,7 +57,9 @@ Run from `cpp/`:
   `rust-src` and build the C++ side with clang to match the LLVM sanitizer
   runtime (`CLANG_CC`/`CLANG_CXX`, default `clang`/`clang++`); GCC can't resolve
   the instrumented archive's runtime symbols. `undefined` uses the default
-  compiler and a plain FFI build.
+  compiler and a plain FFI build. Sanitizer builds use their own build dir
+  (`build-<sanitizer>`), so they don't clash with a normal `build/` (CMake
+  caches the compiler per build dir).
 
 CMake builds the FFI library from local Rust source by default
 (`cargo build --release` in `rust/ffi`). To link a prebuilt/vendored library

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -12,6 +12,16 @@ JOBS ?= 4
 SANITIZE ?=
 SANITIZE_FLAG := $(if $(SANITIZE),-DZEROBUS_SANITIZE=$(SANITIZE),)
 
+# address/thread also instrument the Rust FFI (see BuildRustFfi.cmake), which
+# emits LLVM sanitizer runtime calls. GCC's sanitizer runtime can't resolve
+# those, so build the C++ side with clang to match. Override CLANG_CC/CLANG_CXX
+# for a versioned binary (e.g. `make test SANITIZE=thread CLANG_CXX=clang++-18`).
+CLANG_CC ?= clang
+CLANG_CXX ?= clang++
+ifneq ($(filter $(SANITIZE),address thread),)
+SANITIZE_FLAG += -DCMAKE_C_COMPILER=$(CLANG_CC) -DCMAKE_CXX_COMPILER=$(CLANG_CXX)
+endif
+
 # All hand-written C++ sources (excludes the CMake build tree and fetched deps).
 SOURCES := $(shell find include src tests examples -name '*.cpp' -o -name '*.hpp' 2>/dev/null)
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,7 +3,6 @@
 # Thin convenience wrappers around CMake/CTest and clang-format, mirroring the
 # build/test/lint/fmt verbs used by the other SDKs in this monorepo.
 
-BUILD_DIR ?= build
 BUILD_TYPE ?= Release
 JOBS ?= 4
 
@@ -11,6 +10,11 @@ JOBS ?= 4
 # undefined). Empty by default, so normal builds are unaffected.
 SANITIZE ?=
 SANITIZE_FLAG := $(if $(SANITIZE),-DZEROBUS_SANITIZE=$(SANITIZE),)
+
+# Sanitizer builds use their own build dir so they don't clash with a normal
+# (GCC) build dir — CMake caches the compiler, so reusing one build dir across
+# compilers errors. Override BUILD_DIR to force a specific path.
+BUILD_DIR ?= $(if $(SANITIZE),build-$(SANITIZE),build)
 
 # address/thread also instrument the Rust FFI (see BuildRustFfi.cmake), which
 # emits LLVM sanitizer runtime calls. GCC's sanitizer runtime can't resolve

--- a/cpp/NEXT_CHANGELOG.md
+++ b/cpp/NEXT_CHANGELOG.md
@@ -47,6 +47,12 @@
   `concurrency_test` that exercises the documented "concurrent readers on a
   shared `ProtoSchema`" contract under many threads, catching data races the
   AddressSanitizer job cannot.
+- The `address`/`thread` sanitizer builds now instrument the Rust FFI too
+  (nightly `-Zsanitizer` + `-Zbuild-std`), so races/UAF inside the core are
+  visible rather than only in the C++ wrapper. These builds require a nightly
+  toolchain with `rust-src` and link the C++ side with clang (LLVM sanitizer
+  runtime); each sanitizer uses an isolated cargo target dir. The default build
+  is unchanged (GCC, plain FFI).
 
 ### Breaking Changes
 

--- a/cpp/cmake/BuildRustFfi.cmake
+++ b/cpp/cmake/BuildRustFfi.cmake
@@ -38,11 +38,32 @@ else()
   # need a --target (which relocates the archive under target/<triple>/). ASan
   # and TSan map to the sanitizer runtime; other values (e.g. undefined) fall
   # back to a plain release build.
+  # asan/tsan instrument the Rust core too; other values (e.g. undefined) use a
+  # plain release build.
+  if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
+    set(_zb_ffi_instrumented TRUE)
+  else()
+    set(_zb_ffi_instrumented FALSE)
+  endif()
+
   set(_zb_cargo "${CARGO_EXECUTABLE}")
   set(_zb_cargo_flags "")
   set(_zb_target_dir "${ZEROBUS_RUST_TARGET_DIR}")
   set(_zb_ffi_lib "${ZEROBUS_RUST_TARGET_DIR}/release/${_zb_ffi_lib_name}")
-  if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
+  if(_zb_ffi_instrumented)
+    # Instrument the Rust core — otherwise TSan/ASan only watch the thin C++
+    # wrapper and miss races/UAF inside the FFI, where the real work runs.
+    # -Zsanitizer + -Zbuild-std are nightly-only and need a --target (which
+    # relocates the archive under target/<triple>/). +nightly requires cargo to
+    # be the rustup proxy; fail clearly if nightly is unavailable.
+    execute_process(COMMAND "${CARGO_EXECUTABLE}" +nightly --version
+        RESULT_VARIABLE _zb_nightly_rc OUTPUT_QUIET ERROR_QUIET)
+    if(NOT _zb_nightly_rc EQUAL 0)
+      message(FATAL_ERROR
+          "ZEROBUS_SANITIZE=${ZEROBUS_SANITIZE} needs a nightly toolchain with "
+          "rust-src via rustup (cargo +nightly). Install: rustup toolchain "
+          "install nightly && rustup component add rust-src --toolchain nightly")
+    endif()
     execute_process(COMMAND "${CARGO_EXECUTABLE}" -vV
         OUTPUT_VARIABLE _zb_rustc_v OUTPUT_STRIP_TRAILING_WHITESPACE)
     string(REGEX MATCH "host: ([^\n]+)" _zb_host_match "${_zb_rustc_v}")
@@ -75,7 +96,7 @@ else()
 
   # Instrumented builds pass RUSTFLAGS via the environment so they don't leak
   # into unrelated cargo invocations.
-  if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
+  if(_zb_ffi_instrumented)
     set(_zb_build_cmd ${CMAKE_COMMAND} -E env
         "RUSTFLAGS=-Zsanitizer=${ZEROBUS_SANITIZE}"
         ${_zb_cargo} build ${_zb_cargo_flags} --release)
@@ -88,7 +109,7 @@ else()
       COMMAND ${_zb_build_cmd}
       DEPENDS ${_zb_ffi_rust_sources}
       WORKING_DIRECTORY "${ZEROBUS_FFI_CRATE_DIR}"
-      COMMENT "Building Zerobus C FFI (cargo build --release)"
+      COMMENT "Building Zerobus C FFI"
       VERBATIM)
   add_custom_target(zerobus_ffi_build DEPENDS "${_zb_ffi_lib}")
 

--- a/cpp/cmake/BuildRustFfi.cmake
+++ b/cpp/cmake/BuildRustFfi.cmake
@@ -32,14 +32,8 @@ else()
   find_program(CARGO_EXECUTABLE cargo REQUIRED
       DOC "Path to the cargo build tool")
 
-  # When a sanitizer is requested, instrument the Rust core too — otherwise TSan
-  # / ASan only watch the thin C++ wrapper and miss races/UAF inside the FFI,
-  # where the real work runs. -Zsanitizer + -Zbuild-std are nightly-only and
-  # need a --target (which relocates the archive under target/<triple>/). ASan
-  # and TSan map to the sanitizer runtime; other values (e.g. undefined) fall
-  # back to a plain release build.
-  # asan/tsan instrument the Rust core too; other values (e.g. undefined) use a
-  # plain release build.
+  # asan/tsan instrument the Rust core too (see below); other values (e.g.
+  # undefined) fall back to a plain release build.
   if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
     set(_zb_ffi_instrumented TRUE)
   else()

--- a/cpp/cmake/BuildRustFfi.cmake
+++ b/cpp/cmake/BuildRustFfi.cmake
@@ -32,7 +32,33 @@ else()
   find_program(CARGO_EXECUTABLE cargo REQUIRED
       DOC "Path to the cargo build tool")
 
+  # When a sanitizer is requested, instrument the Rust core too — otherwise TSan
+  # / ASan only watch the thin C++ wrapper and miss races/UAF inside the FFI,
+  # where the real work runs. -Zsanitizer + -Zbuild-std are nightly-only and
+  # need a --target (which relocates the archive under target/<triple>/). ASan
+  # and TSan map to the sanitizer runtime; other values (e.g. undefined) fall
+  # back to a plain release build.
+  set(_zb_cargo "${CARGO_EXECUTABLE}")
+  set(_zb_cargo_flags "")
+  set(_zb_target_dir "${ZEROBUS_RUST_TARGET_DIR}")
   set(_zb_ffi_lib "${ZEROBUS_RUST_TARGET_DIR}/release/${_zb_ffi_lib_name}")
+  if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
+    execute_process(COMMAND "${CARGO_EXECUTABLE}" -vV
+        OUTPUT_VARIABLE _zb_rustc_v OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "host: ([^\n]+)" _zb_host_match "${_zb_rustc_v}")
+    set(_zb_host "${CMAKE_MATCH_1}")
+    # Per-sanitizer target dir: the --target output path is the same for asan and
+    # tsan, and changing only RUSTFLAGS does not invalidate cargo's cache, so a
+    # shared dir would link a stale archive built for the other sanitizer.
+    set(_zb_target_dir "${ZEROBUS_RUST_TARGET_DIR}/sanitize-${ZEROBUS_SANITIZE}")
+    set(_zb_cargo "${CARGO_EXECUTABLE}" "+nightly")
+    set(_zb_cargo_flags -Z build-std --target "${_zb_host}"
+        --target-dir "${_zb_target_dir}")
+    set(_zb_ffi_lib
+        "${_zb_target_dir}/${_zb_host}/release/${_zb_ffi_lib_name}")
+    message(STATUS
+        "Zerobus: building FFI with -Zsanitizer=${ZEROBUS_SANITIZE} (nightly, build-std)")
+  endif()
 
   # Track the Rust sources the archive is built from so editing rust/ffi or
   # rust/sdk re-invokes cargo. Without DEPENDS, CMake treats the archive as
@@ -47,9 +73,19 @@ else()
       "${ZEROBUS_REPO_ROOT}/rust/sdk/Cargo.toml"
       "${ZEROBUS_REPO_ROOT}/rust/Cargo.toml")
 
+  # Instrumented builds pass RUSTFLAGS via the environment so they don't leak
+  # into unrelated cargo invocations.
+  if(ZEROBUS_SANITIZE STREQUAL "thread" OR ZEROBUS_SANITIZE STREQUAL "address")
+    set(_zb_build_cmd ${CMAKE_COMMAND} -E env
+        "RUSTFLAGS=-Zsanitizer=${ZEROBUS_SANITIZE}"
+        ${_zb_cargo} build ${_zb_cargo_flags} --release)
+  else()
+    set(_zb_build_cmd ${_zb_cargo} build --release)
+  endif()
+
   add_custom_command(
       OUTPUT "${_zb_ffi_lib}"
-      COMMAND "${CARGO_EXECUTABLE}" build --release
+      COMMAND ${_zb_build_cmd}
       DEPENDS ${_zb_ffi_rust_sources}
       WORKING_DIRECTORY "${ZEROBUS_FFI_CRATE_DIR}"
       COMMENT "Building Zerobus C FFI (cargo build --release)"

--- a/cpp/tests/concurrency_test.cpp
+++ b/cpp/tests/concurrency_test.cpp
@@ -1,11 +1,9 @@
-// Concurrent-liveness / consistency smoke test for the documented contract that
-// a single ProtoSchema supports concurrent readers (descriptor_bytes /
-// encode_json are const). Run under ThreadSanitizer (`make test
-// SANITIZE=thread`), but note TSan only instruments the C++ side: the work runs
-// in the Rust FFI, which is built without sanitizer RUSTFLAGS, so this asserts
-// consistent results across threads rather than detecting a Rust-side race.
-// Hermetic, so it runs in CI. No concurrent-Stream case: a Stream is not safe
-// for concurrent use, so that would test misuse.
+// Concurrency test for the documented contract that a single ProtoSchema
+// supports concurrent readers (descriptor_bytes / encode_json are const). Run
+// under ThreadSanitizer (`make test SANITIZE=thread`), which instruments the
+// Rust FFI too, so a race inside the core's read path would be detected, not
+// just C++-side races. Hermetic, so it runs in CI. No concurrent-Stream case: a
+// Stream is not safe for concurrent use, so that would test misuse.
 
 #include <cstddef>
 #include <cstdio>


### PR DESCRIPTION
## Summary

Follow-up to the TSan CI job added in the C++ test-coverage work (#499). That job ran ThreadSanitizer over only the C++ side — the FFI was a plain `cargo build --release`, so the Rust core (where `descriptor_bytes()` / `encode_json()` actually run) was uninstrumented and TSan could not see races inside it. This PR instruments the Rust FFI too, so `address`/`thread` sanitizer builds genuinely cover the core, not just the wrapper.

This is option (a) from @irinatomic-db's review comment on the TSan job.

## How

- **`cpp/cmake/BuildRustFfi.cmake`** — when `ZEROBUS_SANITIZE` is `address`/`thread`, build the FFI with nightly `-Zsanitizer=<san>` + `-Zbuild-std --target <host>`. Each sanitizer gets an **isolated cargo target dir** (`target/sanitize-<san>/`), because the `--target` output path is identical across sanitizers and changing only `RUSTFLAGS` doesn't invalidate cargo's cache — a shared dir would link a stale archive built for the other sanitizer.
- **`cpp/Makefile`** — for `address`/`thread`, build the C++ side with clang (`CLANG_CC`/`CLANG_CXX`, default `clang`/`clang++`). The instrumented Rust archive emits LLVM sanitizer runtime calls (`__tsan_*` / `__asan_*`); GCC's sanitizer runtime can't resolve them, so the C++ link must use clang to share LLVM's compiler-rt runtime. The default (non-sanitized) build is unchanged (GCC, plain FFI).
- **`.github/workflows/ci-cpp.yml`** — both sanitizer jobs switch to nightly + `rust-src` and install clang.
- Docs: `concurrency_test.cpp` header, `cpp/CLAUDE.md`, `cpp/NEXT_CHANGELOG.md` updated to reflect that the core is now instrumented.

## Validation

Verified locally with clang-18:

- **TSan:** FFI archive carries 8991 `__tsan` symbols; the test binary links the LLVM TSan runtime and runs under "ThreadSanitizer v3"; all 13 tests pass.
- **ASan:** FFI archive carries 27828 `__asan` symbols and 0 `__tsan` (isolation confirmed); all 13 tests pass.
- **Default GCC build (no sanitizer):** unchanged, plain `target/release` archive, 13/13 pass.

## Notes / trade-offs

- Sanitizer builds now require a nightly toolchain with `rust-src` and rebuild `std` (`-Zbuild-std`), so those CI jobs are slower (~1 min extra for the std rebuild). The normal build/test path is untouched.
- No `ProtoSchema` race is expected (it's immutable with read-only borrows); the value is that a future regression introducing one would now be caught inside the core.
