### PR TITLE
[ArrowFlight] Bound in-flight batches by ack lifetime; make recovery replay failure-safe

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bug Fixes
 
 - **Arrow Flight — `close()` now propagates flush errors** (Beta): `ZerobusArrowStream::close()` previously swallowed a failed final `flush()` and always returned `Ok(())`, contradicting its documentation and diverging from the proto stream's `close()`. It now returns the flush error after still tearing down the stream and moving pending batches to the failed set (retrievable via `get_unacked_batches()`).
+- **Arrow Flight — `max_inflight_batches` now bounds batches awaiting acknowledgment** (Beta): it previously limited only the pre-encode channel, so pending batches could grow unbounded under a slow-acking server. `ingest_batch` now holds a permit until the batch is acked, applying backpressure (it blocks) at the configured limit. `max_inflight_batches = 0` is now rejected with `InvalidArgument` instead of panicking.
+- **Arrow Flight — recovery replay is now failure-safe** (Beta): if a batch send failed while replaying after a reconnect, the pending set was drained and lost (unrecoverable via automatic replay or `get_unacked_batches()`). Pending batches (and their in-flight accounting) are now retained so the next recovery attempt replays them.
 
 ### Documentation
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1309,6 +1309,10 @@ impl ZerobusArrowStream {
 
         // Acquire the backpressure permit BEFORE ingest_mutex: reconnect() holds that
         // mutex, so blocking on a permit while holding it could stall recovery.
+        // `inflight` is never closed, so the map_err is unreachable defensive code; a
+        // close during the wait is handled by the is_closed re-check below (not by
+        // semaphore closure), and permit-blocked ingests wake when acks or
+        // move_pending_to_failed free permits.
         let permit = Arc::clone(&self.inflight)
             .acquire_owned()
             .await
@@ -1359,6 +1363,11 @@ impl ZerobusArrowStream {
         let sender = match sender {
             Some(s) => s,
             None => {
+                // Narrow recovery-handoff window (sender nulled before reconnect). The
+                // batch intentionally stays in pending_batches (holding its permit) so
+                // it remains recoverable/replayable, even though this attempt returns
+                // an error. Permit is freed when the batch is later acked, moved to the
+                // failed set, or the stream closes.
                 if let Some(server_error) = self.server_error_rx.borrow().clone() {
                     return Err(server_error);
                 }

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -19,7 +19,7 @@ use arrow_flight::{FlightClient, PutResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{sleep, Duration};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
@@ -56,7 +56,9 @@ pub(crate) struct ArrowTableProperties {
 }
 
 /// A pending batch waiting for acknowledgment.
-#[derive(Clone)]
+///
+/// Not `Clone`: owns an `inflight` permit released (RAII) when the batch leaves
+/// `pending_batches`.
 struct PendingBatch {
     batch: RecordBatch,
     /// Offset ID assigned by the client for this batch.
@@ -66,6 +68,8 @@ struct PendingBatch {
     /// Cumulative record count after this batch.
     /// Batch is fully acked when `acked_records >= end_record`.
     end_record: u64,
+    /// Backpressure permit; dropping it frees one `max_inflight_batches` slot.
+    _permit: OwnedSemaphorePermit,
 }
 
 /// Returns the portion of a batch that needs to be replayed after recovery.
@@ -238,6 +242,9 @@ pub struct ZerobusArrowStream {
     headers_provider: Arc<dyn HeadersProvider>,
     /// Synchronization mutex for serializing ingest operations.
     ingest_mutex: Arc<Mutex<()>>,
+    /// Bounds batches awaiting ack (`max_inflight_batches`). Capacity mirrors the
+    /// `batch_tx` channel so the inline send never blocks while holding `ingest_mutex`.
+    inflight: Arc<Semaphore>,
     /// Last error received from the server (watch channel for race-free access).
     /// When process_acks receives a server error, it sends to this channel.
     /// When ingest_batch has a send failure, it can immediately check the current value.
@@ -273,6 +280,13 @@ impl ZerobusArrowStream {
         options: ArrowStreamConfigurationOptions,
         sdk_identifier: Arc<str>,
     ) -> ZerobusResult<Self> {
+        // A zero bound would deadlock every ingest and panic the zero-capacity channel.
+        if options.max_inflight_batches == 0 {
+            return Err(ZerobusError::InvalidArgument(
+                "max_inflight_batches must be greater than 0".to_string(),
+            ));
+        }
+
         let (last_ack_tx, _last_ack_rx) = tokio::sync::watch::channel(None);
         let is_closed = Arc::new(AtomicBool::new(false));
         let pending_batches = Arc::new(Mutex::new(Vec::new()));
@@ -283,6 +297,8 @@ impl ZerobusArrowStream {
         let cumulative_records_sent = Arc::new(AtomicU64::new(0));
         let last_acked_records = Arc::new(AtomicU64::new(0));
         let is_paused = Arc::new(AtomicBool::new(false));
+        // Capacity mirrors the batch_tx channel so a permit holder always has a slot.
+        let inflight = Arc::new(Semaphore::new(options.max_inflight_batches));
 
         let (server_error_tx, server_error_rx) = watch::channel(None);
 
@@ -302,6 +318,7 @@ impl ZerobusArrowStream {
             tls_config,
             headers_provider,
             ingest_mutex: Arc::new(Mutex::new(())),
+            inflight,
             server_error_tx,
             server_error_rx,
             cumulative_records_sent,
@@ -909,13 +926,42 @@ impl ZerobusArrowStream {
         // It will be recalculated as we replay batches.
         cumulative_records_sent.store(0, Ordering::Relaxed);
 
-        // Replay pending batches, slicing partially-acked ones if present.
-        // We rebuild the pending list to drop fully-acked batches.
-        // Lock order matches ingest_batch: ingest_mutex -> pending_batches.
+        // Hold ingest_mutex across the replay so no concurrent ingest interleaves.
         let _ingest_guard = ingest_mutex.lock().await;
-        {
+        Self::replay_pending_batches(
+            &tx,
+            pending_batches,
+            cumulative_records_sent,
+            acked_before_disconnect,
+        )
+        .await?;
+
+        // Clear the pause gate while still holding ingest_mutex.
+        is_paused.store(false, Ordering::Relaxed);
+
+        Ok(response_stream)
+    }
+
+    /// Rebuilds `pending_batches` for replay after a reconnect and replays them over
+    /// `tx`: partially-acked batches (vs `acked_before_disconnect`) are sliced to their
+    /// un-acked suffix, fully-acked ones dropped.
+    ///
+    /// The rebuilt set and `cumulative_records_sent` are installed together under the
+    /// `pending_batches` lock before any send, and sends happen after that lock is
+    /// released. So a replay-send failure leaves pending (with permits) and the counter
+    /// intact for the next attempt, and no send is awaited while holding
+    /// `pending_batches`. Caller holds `ingest_mutex` throughout.
+    async fn replay_pending_batches(
+        tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
+        pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
+        cumulative_records_sent: &Arc<AtomicU64>,
+        acked_before_disconnect: u64,
+    ) -> ZerobusResult<()> {
+        let replay_batches: Vec<RecordBatch> = {
             let mut pending = pending_batches.lock().await;
-            if !pending.is_empty() {
+            if pending.is_empty() {
+                Vec::new()
+            } else {
                 info!(
                     batch_count = pending.len(),
                     acked_records = acked_before_disconnect,
@@ -923,6 +969,7 @@ impl ZerobusArrowStream {
                 );
 
                 let mut new_pending = Vec::with_capacity(pending.len());
+                let mut replay = Vec::with_capacity(pending.len());
                 let mut new_cumulative: u64 = 0;
 
                 for pb in pending.drain(..) {
@@ -931,50 +978,59 @@ impl ZerobusArrowStream {
                         continue;
                     };
 
-                    if tx.send(Ok(batch.clone())).await.is_err() {
-                        return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                            "Failed to replay batch during recovery",
-                        )));
-                    }
-
                     let num_records = batch.num_rows() as u64;
                     let start_record = new_cumulative;
                     let end_record = new_cumulative + num_records;
                     new_cumulative = end_record;
 
+                    replay.push(batch.clone());
                     new_pending.push(PendingBatch {
                         batch,
                         offset_id: pb.offset_id,
                         start_record,
                         end_record,
+                        // Carry the permit across recovery; skipped batches drop theirs.
+                        _permit: pb._permit,
                     });
                 }
 
+                // Install pending + counter together (before any send) so a send
+                // failure can't pair installed ranges with a stale counter.
                 *pending = new_pending;
                 cumulative_records_sent.store(new_cumulative, Ordering::Relaxed);
+
+                // Debug-only: rebuilt ranges must be contiguous from 0. Guards a
+                // rebuild regression or an orphaned batch from the pause-gate handoff.
+                #[cfg(debug_assertions)]
+                {
+                    let mut expected_start: u64 = 0;
+                    for pb in pending.iter() {
+                        debug_assert_eq!(
+                            pb.start_record, expected_start,
+                            "pending_batches has non-contiguous record ranges after recovery \
+                             (expected start_record = {}, found {} for offset_id {}); \
+                             possible orphaned buffered batch from pause-gate handoff race",
+                            expected_start, pb.start_record, pb.offset_id,
+                        );
+                        expected_start = pb.end_record;
+                    }
+                }
+
+                replay
+            }
+        };
+
+        // Send only after the pending_batches lock is released (ingest_mutex is still
+        // held by the caller); pending stays intact on failure.
+        for batch in replay_batches {
+            if tx.send(Ok(batch)).await.is_err() {
+                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                    "Failed to replay batch during recovery",
+                )));
             }
         }
 
-        #[cfg(debug_assertions)]
-        {
-            let pending = pending_batches.lock().await;
-            let mut expected_start: u64 = 0;
-            for pb in pending.iter() {
-                debug_assert_eq!(
-                    pb.start_record, expected_start,
-                    "pending_batches has non-contiguous record ranges after recovery \
-                     (expected start_record = {}, found {} for offset_id {}); \
-                     possible orphaned buffered batch from pause-gate handoff race",
-                    expected_start, pb.start_record, pb.offset_id,
-                );
-                expected_start = pb.end_record;
-            }
-        }
-
-        // Clear the pause gate while still holding ingest_mutex.
-        is_paused.store(false, Ordering::Relaxed);
-
-        Ok(response_stream)
+        Ok(())
     }
 
     /// Moves all pending batches to the failed batches list.
@@ -1251,8 +1307,24 @@ impl ZerobusArrowStream {
             )));
         }
 
+        // Acquire the backpressure permit BEFORE ingest_mutex: reconnect() holds that
+        // mutex, so blocking on a permit while holding it could stall recovery.
+        let permit = Arc::clone(&self.inflight)
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                ZerobusError::StreamClosedError(tonic::Status::internal("Stream is closed"))
+            })?;
+
         // Serialize ingestion operations.
         let _guard = self.ingest_mutex.lock().await;
+
+        // May have closed while we blocked on the permit; returning drops it.
+        if self.is_closed.load(Ordering::Relaxed) {
+            return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                "Stream is closed",
+            )));
+        }
 
         let offset_id = self.offset_generator.next();
         let record_count = batch.num_rows() as u64;
@@ -1269,6 +1341,7 @@ impl ZerobusArrowStream {
                 offset_id,
                 start_record,
                 end_record,
+                _permit: permit,
             });
         }
 
@@ -1704,6 +1777,7 @@ impl Drop for ZerobusArrowStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_array::Int32Array;
     use arrow_schema::{DataType, Field};
 
     #[test]
@@ -1720,5 +1794,133 @@ mod tests {
 
         assert_eq!(props.table_name, "catalog.schema.table");
         assert_eq!(props.schema.fields().len(), 2);
+    }
+
+    fn one_col_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![Field::new("id", DataType::Int32, false)]))
+    }
+
+    fn batch_with_rows(schema: &Arc<ArrowSchema>, n: i32) -> RecordBatch {
+        let ids: Vec<i32> = (0..n).collect();
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(ids))]).unwrap()
+    }
+
+    fn pending_batch(
+        sem: &Arc<Semaphore>,
+        batch: RecordBatch,
+        offset_id: OffsetId,
+        start_record: u64,
+        end_record: u64,
+    ) -> PendingBatch {
+        PendingBatch {
+            batch,
+            offset_id,
+            start_record,
+            end_record,
+            _permit: Arc::clone(sem).try_acquire_owned().unwrap(),
+        }
+    }
+
+    /// A replay-send failure must not drop pending batches, their permits, or desync
+    /// the counter. A dropped receiver gives a deterministic send failure.
+    #[tokio::test]
+    async fn replay_send_failure_retains_pending_permits_and_cumulative() {
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(4));
+        let pending = Arc::new(Mutex::new(vec![
+            pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
+            pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
+        ]));
+        assert_eq!(sem.available_permits(), 2, "two permits held by pending batches");
+
+        // Stale value that must be overwritten with the reinstalled ranges' total.
+        let cumulative = Arc::new(AtomicU64::new(999));
+
+        // Receiver dropped -> every send fails.
+        let (tx, rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
+        drop(rx);
+
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        assert!(res.is_err(), "replay must surface the send failure");
+
+        let guard = pending.lock().await;
+        assert_eq!(guard.len(), 2, "pending must retain all batches on replay failure");
+        assert_eq!((guard[0].start_record, guard[0].end_record), (0, 3));
+        assert_eq!((guard[1].start_record, guard[1].end_record), (3, 5));
+        drop(guard);
+
+        assert_eq!(
+            cumulative.load(Ordering::Relaxed),
+            5,
+            "cumulative_records_sent must match the reinstalled ranges, not the stale value"
+        );
+        assert_eq!(
+            sem.available_permits(),
+            2,
+            "permits must not be released on replay failure"
+        );
+    }
+
+    /// Happy path: with an open receiver, all batches are replayed and the pending set
+    /// is rebuilt with contiguous, connection-relative ranges.
+    #[tokio::test]
+    async fn replay_success_reinstalls_and_sends_all() {
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(4));
+        let pending = Arc::new(Mutex::new(vec![
+            pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
+            pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
+        ]));
+        let cumulative = Arc::new(AtomicU64::new(0));
+
+        let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
+
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        assert!(res.is_ok());
+
+        assert_eq!(pending.lock().await.len(), 2);
+        assert_eq!(cumulative.load(Ordering::Relaxed), 5);
+
+        // Both batches were sent, in order.
+        let first = rx.try_recv().expect("first replay batch");
+        assert_eq!(first.unwrap().num_rows(), 3);
+        let second = rx.try_recv().expect("second replay batch");
+        assert_eq!(second.unwrap().num_rows(), 2);
+    }
+
+    /// A fully-acked batch is dropped during replay (permit released), and a partially
+    /// acked batch is sliced to its un-acked suffix.
+    #[tokio::test]
+    async fn replay_slices_partial_and_drops_fully_acked() {
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(4));
+        // Batch 0: rows [0,3) fully acked (acked_before_disconnect = 4 covers it).
+        // Batch 1: rows [3,6), 1 record acked -> 2-row suffix replayed.
+        let pending = Arc::new(Mutex::new(vec![
+            pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
+            pending_batch(&sem, batch_with_rows(&schema, 3), 1, 3, 6),
+        ]));
+        assert_eq!(sem.available_permits(), 2);
+        let cumulative = Arc::new(AtomicU64::new(0));
+        let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
+
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 4).await;
+        assert!(res.is_ok());
+
+        // Only the partially-acked batch remains, rebuilt from cumulative 0.
+        let guard = pending.lock().await;
+        assert_eq!(guard.len(), 1);
+        assert_eq!((guard[0].start_record, guard[0].end_record), (0, 2));
+        drop(guard);
+        assert_eq!(cumulative.load(Ordering::Relaxed), 2);
+        // Fully-acked batch's permit was released; one remains.
+        assert_eq!(sem.available_permits(), 3);
+
+        let replayed = rx.try_recv().expect("suffix replay batch");
+        assert_eq!(replayed.unwrap().num_rows(), 2);
+        assert!(rx.try_recv().is_err(), "only one batch should be replayed");
     }
 }

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -56,9 +56,6 @@ pub(crate) struct ArrowTableProperties {
 }
 
 /// A pending batch waiting for acknowledgment.
-///
-/// Not `Clone`: owns an `inflight` permit released (RAII) when the batch leaves
-/// `pending_batches`.
 struct PendingBatch {
     batch: RecordBatch,
     /// Offset ID assigned by the client for this batch.
@@ -1259,9 +1256,10 @@ impl ZerobusArrowStream {
 
     /// Ingests a single Arrow RecordBatch into the stream.
     ///
-    /// This method queues the batch for transmission and returns the assigned offset
-    /// immediately. Use `wait_for_offset()` to explicitly wait for server acknowledgment
-    /// of this batch when needed.
+    /// Queues the batch for transmission and returns its assigned offset. This applies
+    /// backpressure: it blocks once `max_inflight_batches` batches are awaiting
+    /// acknowledgment, resuming when an ack frees a slot. Use `wait_for_offset()` to
+    /// explicitly wait for server acknowledgment of this batch when needed.
     ///
     /// # Arguments
     ///
@@ -1806,7 +1804,11 @@ mod tests {
     }
 
     fn one_col_schema() -> Arc<ArrowSchema> {
-        Arc::new(ArrowSchema::new(vec![Field::new("id", DataType::Int32, false)]))
+        Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]))
     }
 
     fn batch_with_rows(schema: &Arc<ArrowSchema>, n: i32) -> RecordBatch {
@@ -1840,7 +1842,11 @@ mod tests {
             pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
             pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
         ]));
-        assert_eq!(sem.available_permits(), 2, "two permits held by pending batches");
+        assert_eq!(
+            sem.available_permits(),
+            2,
+            "two permits held by pending batches"
+        );
 
         // Stale value that must be overwritten with the reinstalled ranges' total.
         let cumulative = Arc::new(AtomicU64::new(999));
@@ -1849,12 +1855,15 @@ mod tests {
         let (tx, rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
         drop(rx);
 
-        let res =
-            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
         assert!(res.is_err(), "replay must surface the send failure");
 
         let guard = pending.lock().await;
-        assert_eq!(guard.len(), 2, "pending must retain all batches on replay failure");
+        assert_eq!(
+            guard.len(),
+            2,
+            "pending must retain all batches on replay failure"
+        );
         assert_eq!((guard[0].start_record, guard[0].end_record), (0, 3));
         assert_eq!((guard[1].start_record, guard[1].end_record), (3, 5));
         drop(guard);
@@ -1885,8 +1894,7 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
 
-        let res =
-            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
         assert!(res.is_ok());
 
         assert_eq!(pending.lock().await.len(), 2);
@@ -1915,8 +1923,7 @@ mod tests {
         let cumulative = Arc::new(AtomicU64::new(0));
         let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
 
-        let res =
-            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 4).await;
+        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 4).await;
         assert!(res.is_ok());
 
         // Only the partially-acked batch remains, rebuilt from cumulative 0.

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -436,6 +436,14 @@ impl<'a> StreamBuilder<'a> {
     pub async fn build_arrow(self) -> ZerobusResult<ZerobusArrowStream> {
         self.validate()?;
 
+        // Arrow-only: a zero bound deadlocks ingest / panics the channel. Not in the
+        // shared validate() since it's irrelevant to JSON/proto build().
+        if self.arrow_config.max_inflight_batches == 0 {
+            return Err(ZerobusError::InvalidArgument(
+                "max_inflight_batches must be greater than 0".into(),
+            ));
+        }
+
         // `max_ingest_payload_bytes` only applies to gRPC streams; warn if the
         // user changed it from the default before building an Arrow stream.
         if self.grpc_config.max_ingest_payload_bytes

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -775,7 +775,11 @@ mod arrow_flight_tests {
             let joined = tokio::time::timeout(std::time::Duration::from_secs(3), handle)
                 .await
                 .expect("2nd ingest_batch should unblock after the ack frees a permit")?;
-            assert!(joined.is_ok(), "2nd ingest_batch failed: {:?}", joined.err());
+            assert!(
+                joined.is_ok(),
+                "2nd ingest_batch failed: {:?}",
+                joined.err()
+            );
 
             Ok(())
         }

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -698,6 +698,127 @@ mod arrow_flight_tests {
         }
     }
 
+    mod backpressure_tests {
+        use super::*;
+
+        /// #6: `max_inflight_batches` bounds batches awaiting ACK, not just batches
+        /// buffered before the encoder drains. With capacity 1 the second ingest must
+        /// block until the first is acked.
+        #[tokio::test]
+        async fn test_max_inflight_batches_blocks_until_ack(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_max_inflight_batches_blocks_until_ack");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Ack for offset 0 is delayed; until it arrives the single permit stays held.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: 500,
+                        ack_up_to_records: 1,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = Arc::new(
+                sdk.stream_builder()
+                    .table(TABLE_NAME)
+                    .headers_provider(Arc::new(TestHeadersProvider::default()))
+                    .arrow(schema.clone())
+                    .max_inflight_batches(1)
+                    .recovery(false)
+                    .build_arrow()
+                    .await?,
+            );
+
+            // First batch takes the only permit; held until the delayed ack.
+            let batch1 = create_test_record_batch(schema.clone(), vec![1], vec![Some("a")]);
+            stream.ingest_batch(batch1).await?;
+
+            // Wait until the mock received batch 1 (encoder freed the channel slot), so
+            // a later block is attributable to the permit, not channel capacity.
+            let mut waited_ms = 0;
+            while mock_server.get_batch_count().await < 1 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                waited_ms += 5;
+                assert!(waited_ms < 2000, "mock never received the first batch");
+            }
+
+            // Second ingest must block on the permit (not just the encoder drain).
+            let stream2 = Arc::clone(&stream);
+            let schema2 = schema.clone();
+            let mut handle = tokio::spawn(async move {
+                let batch2 = create_test_record_batch(schema2, vec![2], vec![Some("b")]);
+                stream2.ingest_batch(batch2).await
+            });
+
+            // Well under the 500ms ack delay it should still be blocked.
+            tokio::select! {
+                res = &mut handle => {
+                    panic!("2nd ingest_batch should block until the 1st is acked, returned: {:?}", res)
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_millis(150)) => {}
+            }
+
+            // Once the ack frees the permit, the second ingest completes.
+            let joined = tokio::time::timeout(std::time::Duration::from_secs(3), handle)
+                .await
+                .expect("2nd ingest_batch should unblock after the ack frees a permit")?;
+            assert!(joined.is_ok(), "2nd ingest_batch failed: {:?}", joined.err());
+
+            Ok(())
+        }
+
+        /// `max_inflight_batches == 0` must be rejected by `build_arrow` (a zero bound
+        /// would deadlock every ingest / panic the zero-capacity channel). This is
+        /// Arrow-only validation; JSON/proto `build()` is unaffected.
+        #[tokio::test]
+        async fn test_max_inflight_batches_zero_rejected() -> Result<(), Box<dyn std::error::Error>>
+        {
+            setup_tracing();
+            info!("Starting test_max_inflight_batches_zero_rejected");
+
+            let schema = create_test_arrow_schema();
+            let sdk = ZerobusSdk::builder()
+                .endpoint("http://127.0.0.1:1")
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            // Rejected before any connection attempt.
+            let result = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema)
+                .max_inflight_batches(0)
+                .build_arrow()
+                .await;
+
+            assert!(
+                matches!(
+                    result,
+                    Err(databricks_zerobus_ingest_sdk::ZerobusError::InvalidArgument(_))
+                ),
+                "expected InvalidArgument for max_inflight_batches(0), got {:?}",
+                result.err()
+            );
+
+            Ok(())
+        }
+    }
+
     mod unacked_tests {
         use super::*;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add an inflight semaphore (capacity = max_inflight_batches) so ingest_batch bounds batches awaiting ack, not just pre-encode buffering — fixes unbounded pending_batches growth and applies real backpressure. Permit held on PendingBatch until ack/terminal/recovery-drop.
- Reject max_inflight_batches == 0 in build_arrow (+ guard in new()); previously panicked the zero-capacity channel.
- Recovery replay now rebuilds/installs pending_batches + counter under the lock before sending; a replay-send failure retains pending (with permits) for the next attempt instead of dropping it.

## How is this tested?

New backpressure_tests (blocks-until-ack, zero rejected) + replay_* unit tests (send-failure retention, in-order replay, partial-slice/drop).
