### PR TITLE
[Go] Cross-build Darwin release libraries

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -18,6 +18,16 @@ jobs:
             target: aarch64-unknown-linux-gnu
             lib_dir: linux_arm64
             cross: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-apple-darwin
+            lib_dir: darwin_amd64
+            cross: false
+            zigbuild: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-apple-darwin
+            lib_dir: darwin_arm64
+            cross: false
+            zigbuild: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-gnu
             lib_dir: windows_amd64
@@ -63,8 +73,23 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (macOS cross-builds)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (macOS cross-builds)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build FFI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI static library (macOS cross-builds)
+        if: matrix.zigbuild
+        run: cargo-zigbuild rustc --release -p zerobus-ffi --target ${{ matrix.target }} --crate-type staticlib
 
       - name: Prepare artifact
         shell: bash

--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Internal Changes
 
+- Added Darwin AMD64 and ARM64 static-library artifacts to the Go release build by cross-compiling the FFI with Zig, so release PRs can include the full supported platform matrix without a macOS runner.
 - Added the new ack-callback fields (`ack_on_ack`, `ack_on_error`, `ack_user_data`) to the cgo `CStreamConfigurationOptions` mirror to keep it byte-identical with the C FFI struct. The Go SDK has no ack-callback API yet and leaves these null, so behavior is unchanged.
 - The integration-test protobuf bindings (`go/tests/pb`) and the pure-Go SDK bindings (`purego/internal/zerobuspb`) are now generated from the single canonical `rust/sdk/zerobus_service.proto`, instead of local per-module copies. Regenerate with `go/tests/generate_proto.sh` or `go generate ./...` in the purego package. No behavior change — the committed generated code is unchanged.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds Darwin AMD64 and ARM64 to the Go FFI release matrix. Both static libraries are cross-compiled on Linux with Zig and cargo-zigbuild, then uploaded using the existing go/lib platform directory names.

Go releases require prebuilt libraries for all five supported platforms, but the repository has no macOS runners. Cross-compiling the Darwin libraries removes the manual macOS build step and makes the complete Go release artifact set reproducible in CI.

## How is this tested?

- [Build Go SDK FFI libs](https://github.com/databricks/zerobus-sdk/actions/runs/30007259143) passed for all five targets: Linux AMD64, Linux ARM64, Darwin AMD64, Darwin ARM64, and Windows AMD64. Each job uploaded its expected artifact.