### PR TITLE
[RUST] Introduce InvalidSchema error and return more details more from the server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -788,6 +788,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tonic-types",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3166,6 +3167,17 @@ dependencies = [
  "syn",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2856,6 +2856,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tonic-types",
  "tracing",
  "tracing-subscriber",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ prost-reflect = "0.16"
 tonic = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
+tonic-types = "0.14"
 protoc-bin-vendored = "3.0.0"
 
 # Async runtime

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,13 +6,17 @@
 
 ### New Features and Improvements
 
-- Arrow Flight: schema-validation rejections during stream setup now surface as
-  the new `ZerobusError::InvalidSchema` variant (carrying the server-reported
-  `causes` as typed `SchemaValidationCause` values) instead of a generic
-  `CreateStreamError`. This lets callers detect a table/stream schema mismatch —
-  e.g. a column added to or dropped from the target table — and re-resolve their
-  schema rather than treating it as an opaque invalid-argument failure. The
-  variant is not SDK-retryable.
+- Arrow Flight: schema-validation rejections now surface as the new
+  `ZerobusError::InvalidSchema` variant (carrying the server-reported `causes` as
+  typed `SchemaValidationCause` values) instead of a generic `CreateStreamError`.
+  This lets callers detect a table/stream schema mismatch — e.g. a column added
+  to or dropped from the target table — and re-resolve their schema rather than
+  treating it as an opaque invalid-argument failure. The variant is not
+  SDK-retryable. This applies both to initial stream setup and to mid-stream
+  reconnects: previously a schema change detected during recovery was retried
+  until the recovery budget drained and then reported as a generic failure;
+  now the non-retriable `InvalidSchema` is surfaced to a blocked `wait_for_offset`
+  (or `flush`) immediately so callers can rebuild the stream without downtime.
 
 ### Bug Fixes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### New Features and Improvements
 
+- Arrow Flight: schema-validation rejections during stream setup now surface as
+  the new `ZerobusError::InvalidSchema` variant (carrying the server-reported
+  `causes` as typed `SchemaValidationCause` values) instead of a generic
+  `CreateStreamError`. This lets callers detect a table/stream schema mismatch —
+  e.g. a column added to or dropped from the target table — and re-resolve their
+  schema rather than treating it as an opaque invalid-argument failure. The
+  variant is not SDK-retryable.
+
 ### Bug Fixes
 
 - **Arrow Flight — `close()` now propagates flush errors** (Beta): `ZerobusArrowStream::close()` previously swallowed a failed final `flush()` and always returned `Ok(())`, contradicting its documentation and diverging from the proto stream's `close()`. It now returns the flush error after still tearing down the stream and moving pending batches to the failed set (retrievable via `get_unacked_batches()`).

--- a/rust/README.md
+++ b/rust/README.md
@@ -797,9 +797,47 @@ Require manual intervention:
 - `InvalidUCTokenError` - Invalid OAuth credentials
 - `InvalidTableName` - Table doesn't exist or invalid format
 - `InvalidArgument` - Invalid parameters, schema mismatch, or payload too large (see [Payload Size Limit](#payload-size-limit))
+- `InvalidSchema` *(Arrow Flight, Beta)* - The client's Arrow schema does not match the target Delta table (see [Schema Mismatch](#schema-mismatch-arrow-flight))
 - `Code::Unauthenticated` - Authentication failure
 - `Code::PermissionDenied` - Insufficient table permissions
 - `ChannelCreationError` - Failed to establish TLS connection
+
+### Schema Mismatch (Arrow Flight)
+
+*(Beta; requires `features = ["arrow-flight"]`.)*
+
+When the server rejects an Arrow Flight stream because the client's schema no longer matches the target Delta table — for example, a column was added to or dropped from the table — the SDK surfaces a structured `ZerobusError::InvalidSchema` rather than an opaque `CreateStreamError`. This applies both to initial stream setup (`build_arrow()`) and to mid-stream reconnects: a schema change detected during recovery is surfaced immediately (via `wait_for_offset` / `flush`) instead of being retried until the recovery budget drains.
+
+`InvalidSchema` carries the raw, machine-readable facts the server reported so you can branch programmatically instead of parsing the message string. The SDK deliberately does not decide whether a mismatch is recoverable — that policy is yours (for example, re-resolving the table schema from Unity Catalog and rebuilding the stream):
+
+```rust
+use databricks_zerobus_ingest_sdk::{SchemaValidationCause, ZerobusError};
+
+match stream.wait_for_offset(offset).await {
+    Ok(()) => { /* durable */ }
+    // `InvalidSchema` is #[non_exhaustive], so match with `..`.
+    Err(ZerobusError::InvalidSchema { causes, error_code, message, .. }) => {
+        // `causes` are typed tokens (e.g. FieldNotInTable, MissingRequiredColumn);
+        // `error_code` is the server's numeric code (e.g. "8001") for telemetry;
+        // `message` carries per-field detail for diagnostics.
+        let drift_only = !causes.is_empty()
+            && causes.iter().all(|c| matches!(
+                c,
+                SchemaValidationCause::FieldNotInTable
+                    | SchemaValidationCause::MissingRequiredColumn
+            ));
+        if drift_only {
+            // Re-resolve the table schema and rebuild the stream, then replay.
+        } else {
+            // e.g. TypeIncompatible — a re-resolve won't help; surface to the operator.
+        }
+        let _ = (error_code, message);
+    }
+    Err(e) => { /* handle other errors */ }
+}
+```
+
+`SchemaValidationCause` is `#[non_exhaustive]` and includes an `Unknown(String)` variant, so a newer server cause the SDK doesn't recognize is still surfaced rather than dropped.
 
 ### Payload Size Limit
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -32,6 +32,7 @@ tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true, features = ["tls-native-roots", "transport"] }
 tonic-prost.workspace = true
+tonic-types.workspace = true
 tracing.workspace = true
 hyper-http-proxy.workspace = true
 hyper-util.workspace = true

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -32,7 +32,7 @@ tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true, features = ["tls-native-roots", "transport"] }
 tonic-prost.workspace = true
-tonic-types.workspace = true
+tonic-types = { workspace = true, optional = true }
 tracing.workspace = true
 hyper-http-proxy.workspace = true
 hyper-util.workspace = true
@@ -64,7 +64,7 @@ prost-build = { version = "0.14", optional = true }
 [features]
 default = []
 # Arrow Flight is in Beta
-arrow-flight = ["dep:arrow-flight", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-ipc", "dep:futures"]
+arrow-flight = ["dep:arrow-flight", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-ipc", "dep:futures", "dep:tonic-types"]
 # Zero-copy protobuf parser.
 zeroparser = ["dep:self_cell", "dep:prost-build"]
 testing = ["dep:futures"]

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -731,10 +731,34 @@ impl ZerobusArrowStream {
                                 // Loop continues with new stream.
                             }
                             Ok(Err(e)) => {
-                                // Mirror the initial-connect path: drop the cached
-                                // token on auth rejection so recovery re-mints.
                                 if e.is_auth_rejection() {
+                                    // Mirror the initial-connect path: drop the cached
+                                    // token on auth rejection so recovery re-mints, then
+                                    // fall through to retry with the fresh token.
                                     headers_provider.invalidate().await;
+                                } else if matches!(e, ZerobusError::InvalidSchema { .. }) {
+                                    // The table schema changed, so the server now rejects
+                                    // our fixed schema. This can never succeed on retry:
+                                    // the SDK holds a fixed schema and would just re-send
+                                    // the same rejected one until the recovery budget
+                                    // drains, burying the real cause under a generic
+                                    // "Reconnection failed". Surface it to waiters
+                                    // immediately so callers (e.g. Vector) can re-resolve
+                                    // their schema and rebuild the stream.
+                                    error!(
+                                        "Supervisor: Schema mismatch on reconnect, closing stream: {}",
+                                        e
+                                    );
+                                    is_closed.store(true, Ordering::Relaxed);
+                                    // Publish the classified error so a blocked
+                                    // wait_for_offset returns it (the reconnect error is
+                                    // generated inside reconnect() and, unlike the
+                                    // initial-disconnect path, was never sent on this
+                                    // channel).
+                                    let _ = server_error_tx.send(Some(e.clone()));
+                                    Self::move_pending_to_failed(&pending_batches, &failed_batches)
+                                        .await;
+                                    return Err(e);
                                 }
                                 warn!("Supervisor: Reconnection failed: {}", e);
                                 // Loop continues, will retry if retries remain.

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -574,7 +574,9 @@ impl ZerobusArrowStream {
             Ok(Some(Err(flight_error))) => {
                 // Server sent an error during setup (auth failed, schema mismatch, blocked table, etc.)
                 error!("Stream setup failed: {:?}", flight_error);
-                return Err(ZerobusError::CreateStreamError(flight_error.into()));
+                // Classify so a schema mismatch surfaces as ZerobusError::InvalidSchema
+                // rather than a generic CreateStreamError.
+                return Err(ZerobusError::from_setup_status(flight_error.into()));
             }
             Ok(None) => {
                 // Server closed the stream without sending anything.
@@ -873,7 +875,9 @@ impl ZerobusArrowStream {
             }
             Ok(Some(Err(flight_error))) => {
                 error!("Reconnection setup failed: {:?}", flight_error);
-                return Err(ZerobusError::CreateStreamError(flight_error.into()));
+                // Classify so a schema mismatch surfaces as ZerobusError::InvalidSchema
+                // rather than a generic CreateStreamError.
+                return Err(ZerobusError::from_setup_status(flight_error.into()));
             }
             Ok(None) => {
                 error!("Server closed stream during reconnect without response");

--- a/rust/sdk/src/errors.rs
+++ b/rust/sdk/src/errors.rs
@@ -1,4 +1,55 @@
 use thiserror::Error;
+use tonic_types::StatusExt;
+
+/// The `google.rpc.ErrorInfo.reason` the Zerobus server sets on a schema
+/// validation failure. Presence of this reason (in the gRPC status details) is
+/// what distinguishes a schema mismatch from any other `InvalidArgument`.
+const SCHEMA_VALIDATION_REASON: &str = "SCHEMA_VALIDATION_FAILED";
+
+/// A machine-readable cause of a schema-validation rejection, reported by the
+/// server in the gRPC `ErrorInfo` metadata (as stable string tokens) and
+/// decoded here into typed variants.
+///
+/// A single rejection can carry several distinct causes at once (see
+/// [`ZerobusError::InvalidSchema`]). The SDK reports the raw causes and does
+/// not interpret them: whether a given mismatch is recoverable — e.g. by
+/// re-resolving the table schema and rebuilding the stream — is a caller-side
+/// policy decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaValidationCause {
+    /// The client sent a field that does not exist in the Delta table schema
+    /// (e.g. a column was dropped from the table).
+    FieldNotInTable,
+    /// The client omitted a non-nullable Delta column (e.g. a required column
+    /// was added to the table).
+    MissingRequiredColumn,
+    /// The client's fields do not follow the Delta schema column order.
+    FieldOutOfOrder,
+    /// A client field's type is incompatible with the Delta column type.
+    TypeIncompatible,
+    /// The client field count does not match the Delta schema.
+    FieldCountMismatch,
+    /// A cause token the server sent that this SDK version does not recognize.
+    /// Carries the raw wire token so newer server causes are surfaced rather
+    /// than silently dropped.
+    Unknown(String),
+}
+
+impl SchemaValidationCause {
+    /// Decode a wire token (as sent in the server's `ErrorInfo` metadata) into
+    /// a typed cause. Unrecognized tokens map to [`SchemaValidationCause::Unknown`].
+    fn from_wire(token: &str) -> Self {
+        match token {
+            "FIELD_NOT_IN_TABLE" => SchemaValidationCause::FieldNotInTable,
+            "MISSING_REQUIRED_COLUMN" => SchemaValidationCause::MissingRequiredColumn,
+            "FIELD_OUT_OF_ORDER" => SchemaValidationCause::FieldOutOfOrder,
+            "TYPE_INCOMPATIBLE" => SchemaValidationCause::TypeIncompatible,
+            "FIELD_COUNT_MISMATCH" => SchemaValidationCause::FieldCountMismatch,
+            other => SchemaValidationCause::Unknown(other.to_string()),
+        }
+    }
+}
 
 /// Represents all possible errors that can occur when using Zerobus.
 #[derive(Error, Debug, Clone)]
@@ -31,6 +82,25 @@ pub enum ZerobusError {
     /// Returned when the client provided an invalid argument.
     #[error("Invalid argument: {0}.")]
     InvalidArgument(String),
+    /// Returned when the server rejected the stream because the client's Arrow
+    /// schema does not match the target Delta table (e.g. a column was added to
+    /// or dropped from the table). Distinguished from the generic
+    /// [`ZerobusError::CreateStreamError`] via the structured `ErrorInfo` the
+    /// server attaches to the gRPC status.
+    ///
+    /// `causes` carries the raw, machine-readable causes the server reported
+    /// (e.g. [`SchemaValidationCause::FieldNotInTable`]); a single rejection can
+    /// list several. The SDK deliberately does not interpret them: whether a
+    /// mismatch is recoverable — e.g. by re-resolving the table schema and
+    /// rebuilding the stream — is a caller-side policy decision. Per-field
+    /// detail (offending column names) is carried in `message` for diagnostics,
+    /// not structurally. This error is not SDK-retryable, since the SDK holds a
+    /// fixed schema and its recovery loop would re-send the same rejected schema.
+    #[error("Arrow schema does not match the target table: {message}.")]
+    InvalidSchema {
+        message: String,
+        causes: Vec<SchemaValidationCause>,
+    },
     /// Returned when the server returned an unexpected response.
     #[error("Unexpected response from server. Response: {0}")]
     UnexpectedStreamResponseError(String),
@@ -56,6 +126,36 @@ const UNRETRIABLE_STATUS_CODES: &[tonic::Code] = &[
 ];
 
 impl ZerobusError {
+    /// Classify a `tonic::Status` returned by the server during stream setup.
+    ///
+    /// If the server attached a schema-validation `ErrorInfo` detail (reason
+    /// `SCHEMA_VALIDATION_FAILED`), returns [`ZerobusError::InvalidSchema`]
+    /// carrying the structured `causes` the server reported.
+    /// Otherwise falls back to [`ZerobusError::CreateStreamError`], preserving
+    /// the original status (and its gRPC code) for retry/auth classification.
+    pub(crate) fn from_setup_status(status: tonic::Status) -> Self {
+        if let Some(info) = status.get_details_error_info() {
+            if info.reason == SCHEMA_VALIDATION_REASON {
+                // Comma-separated tokens; an absent key means no causes.
+                let causes = info
+                    .metadata
+                    .get("causes")
+                    .map(|v| {
+                        v.split(',')
+                            .filter(|s| !s.is_empty())
+                            .map(SchemaValidationCause::from_wire)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                return ZerobusError::InvalidSchema {
+                    message: status.message().to_string(),
+                    causes,
+                };
+            }
+        }
+        ZerobusError::CreateStreamError(status)
+    }
+
     /// Determines whether this error can be automatically recovered through stream recovery.
     ///
     /// Retryable errors typically indicate transient issues like network failures or
@@ -68,6 +168,7 @@ impl ZerobusError {
     pub fn is_retryable(&self) -> bool {
         match self {
             ZerobusError::InvalidArgument(_) => false,
+            ZerobusError::InvalidSchema { .. } => false,
             ZerobusError::StreamClosedError(status) => {
                 !UNRETRIABLE_STATUS_CODES.contains(&status.code())
             }
@@ -147,5 +248,106 @@ mod tests {
         let non_auth: tonic::Status =
             FlightError::Tonic(Box::new(tonic::Status::unavailable("blip"))).into();
         assert!(!ZerobusError::CreateStreamError(non_auth).is_auth_rejection());
+    }
+
+    /// Build an InvalidArgument status carrying the server's schema-validation
+    /// ErrorInfo, mirroring what Shinkansen sends on a schema mismatch.
+    fn schema_validation_status(causes: &str) -> tonic::Status {
+        use std::collections::HashMap;
+        use tonic_types::ErrorDetails;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("error_code".to_string(), "8001".to_string());
+        metadata.insert("causes".to_string(), causes.to_string());
+        tonic::Status::with_error_details(
+            tonic::Code::InvalidArgument,
+            "Arrow Flight schema validation failed: ...",
+            ErrorDetails::with_error_info(
+                "SCHEMA_VALIDATION_FAILED",
+                "zerobus.databricks.com",
+                metadata,
+            ),
+        )
+    }
+
+    #[test]
+    fn setup_status_with_schema_error_info_classifies_as_invalid_schema() {
+        let status = schema_validation_status("FIELD_NOT_IN_TABLE,TYPE_INCOMPATIBLE");
+        let err = ZerobusError::from_setup_status(status);
+        match err {
+            ZerobusError::InvalidSchema { causes, .. } => {
+                assert_eq!(
+                    causes,
+                    vec![
+                        SchemaValidationCause::FieldNotInTable,
+                        SchemaValidationCause::TypeIncompatible,
+                    ]
+                );
+            }
+            other => panic!("expected InvalidSchema, got {other:?}"),
+        }
+    }
+
+    /// A cause token this SDK version does not recognize is surfaced as
+    /// `Unknown` rather than dropped, so newer server causes still reach callers.
+    #[test]
+    fn setup_status_maps_unknown_cause_token() {
+        let status = schema_validation_status("FIELD_NOT_IN_TABLE,BRAND_NEW_CAUSE");
+        match ZerobusError::from_setup_status(status) {
+            ZerobusError::InvalidSchema { causes, .. } => {
+                assert_eq!(
+                    causes,
+                    vec![
+                        SchemaValidationCause::FieldNotInTable,
+                        SchemaValidationCause::Unknown("BRAND_NEW_CAUSE".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected InvalidSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_schema_is_not_retryable() {
+        let err = ZerobusError::from_setup_status(schema_validation_status("FIELD_NOT_IN_TABLE"));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn setup_status_without_error_info_falls_back_to_create_stream_error() {
+        // A plain InvalidArgument with no schema ErrorInfo stays a CreateStreamError.
+        let status = tonic::Status::invalid_argument("some other bad argument");
+        let err = ZerobusError::from_setup_status(status);
+        assert!(matches!(err, ZerobusError::CreateStreamError(_)));
+    }
+
+    #[test]
+    fn setup_status_preserves_grpc_code_on_fallback() {
+        // Non-schema setup failures keep their original code for retry/auth
+        // classification (e.g. Unauthenticated remains an auth rejection).
+        let err = ZerobusError::from_setup_status(tonic::Status::unauthenticated("denied"));
+        assert!(err.is_auth_rejection());
+    }
+
+    /// Absent metadata keys yield empty lists rather than panicking.
+    #[test]
+    fn invalid_schema_tolerates_missing_metadata() {
+        use tonic_types::ErrorDetails;
+
+        let status = tonic::Status::with_error_details(
+            tonic::Code::InvalidArgument,
+            "schema mismatch",
+            ErrorDetails::with_error_info(
+                "SCHEMA_VALIDATION_FAILED",
+                "zerobus.databricks.com",
+                std::collections::HashMap::new(),
+            ),
+        );
+        match ZerobusError::from_setup_status(status) {
+            ZerobusError::InvalidSchema { causes, .. } => {
+                assert!(causes.is_empty());
+            }
+            other => panic!("expected InvalidSchema, got {other:?}"),
+        }
     }
 }

--- a/rust/sdk/src/errors.rs
+++ b/rust/sdk/src/errors.rs
@@ -1,10 +1,20 @@
 use thiserror::Error;
+#[cfg(feature = "arrow-flight")]
 use tonic_types::StatusExt;
 
 /// The `google.rpc.ErrorInfo.reason` the Zerobus server sets on a schema
 /// validation failure. Presence of this reason (in the gRPC status details) is
 /// what distinguishes a schema mismatch from any other `InvalidArgument`.
+#[cfg(feature = "arrow-flight")]
 const SCHEMA_VALIDATION_REASON: &str = "SCHEMA_VALIDATION_FAILED";
+
+/// The `google.rpc.ErrorInfo.domain` the Zerobus server scopes its schema
+/// validation detail under. Requiring the domain (in addition to the reason)
+/// before specializing keeps an unrelated status that happens to reuse the same
+/// reason token from being misclassified as a schema mismatch. An empty domain
+/// is accepted for forward-compatibility with servers that omit it.
+#[cfg(feature = "arrow-flight")]
+const SCHEMA_VALIDATION_DOMAIN: &str = "zerobus.databricks.com";
 
 /// A machine-readable cause of a schema-validation rejection, reported by the
 /// server in the gRPC `ErrorInfo` metadata (as stable string tokens) and
@@ -39,6 +49,7 @@ pub enum SchemaValidationCause {
 impl SchemaValidationCause {
     /// Decode a wire token (as sent in the server's `ErrorInfo` metadata) into
     /// a typed cause. Unrecognized tokens map to [`SchemaValidationCause::Unknown`].
+    #[cfg(feature = "arrow-flight")]
     fn from_wire(token: &str) -> Self {
         match token {
             "FIELD_NOT_IN_TABLE" => SchemaValidationCause::FieldNotInTable,
@@ -94,12 +105,19 @@ pub enum ZerobusError {
     /// mismatch is recoverable — e.g. by re-resolving the table schema and
     /// rebuilding the stream — is a caller-side policy decision. Per-field
     /// detail (offending column names) is carried in `message` for diagnostics,
-    /// not structurally. This error is not SDK-retryable, since the SDK holds a
-    /// fixed schema and its recovery loop would re-send the same rejected schema.
+    /// not structurally. `error_code` is the server's numeric Shinkansen code
+    /// (e.g. `"8001"`) when present, useful for telemetry correlation. This
+    /// error is not SDK-retryable, since the SDK holds a fixed schema and its
+    /// recovery loop would re-send the same rejected schema.
+    ///
+    /// `#[non_exhaustive]` so additional server-reported detail (e.g. the gRPC
+    /// code or domain) can be added later without a breaking change.
     #[error("Arrow schema does not match the target table: {message}.")]
+    #[non_exhaustive]
     InvalidSchema {
         message: String,
         causes: Vec<SchemaValidationCause>,
+        error_code: Option<String>,
     },
     /// Returned when the server returned an unexpected response.
     #[error("Unexpected response from server. Response: {0}")]
@@ -129,13 +147,19 @@ impl ZerobusError {
     /// Classify a `tonic::Status` returned by the server during stream setup.
     ///
     /// If the server attached a schema-validation `ErrorInfo` detail (reason
-    /// `SCHEMA_VALIDATION_FAILED`), returns [`ZerobusError::InvalidSchema`]
-    /// carrying the structured `causes` the server reported.
+    /// `SCHEMA_VALIDATION_FAILED` scoped to the `zerobus.databricks.com`
+    /// domain), returns [`ZerobusError::InvalidSchema`] carrying the structured
+    /// `causes` the server reported.
     /// Otherwise falls back to [`ZerobusError::CreateStreamError`], preserving
     /// the original status (and its gRPC code) for retry/auth classification.
+    #[cfg(feature = "arrow-flight")]
     pub(crate) fn from_setup_status(status: tonic::Status) -> Self {
         if let Some(info) = status.get_details_error_info() {
-            if info.reason == SCHEMA_VALIDATION_REASON {
+            // Require both the reason and the server's domain (empty domain
+            // accepted for forward-compat) so an unrelated status reusing the
+            // reason token is not misread as a schema mismatch.
+            let domain_ok = info.domain == SCHEMA_VALIDATION_DOMAIN || info.domain.is_empty();
+            if info.reason == SCHEMA_VALIDATION_REASON && domain_ok {
                 // Comma-separated tokens; an absent key means no causes.
                 let causes = info
                     .metadata
@@ -150,6 +174,7 @@ impl ZerobusError {
                 return ZerobusError::InvalidSchema {
                     message: status.message().to_string(),
                     causes,
+                    error_code: info.metadata.get("error_code").cloned(),
                 };
             }
         }
@@ -250,8 +275,39 @@ mod tests {
         assert!(!ZerobusError::CreateStreamError(non_auth).is_auth_rejection());
     }
 
+    /// Pins the invariant the whole `InvalidSchema` feature rests on: the
+    /// server's `ErrorInfo` detail survives the `FlightError::Tonic -> tonic::Status`
+    /// conversion. Production never sees the raw `Status` — the Arrow setup and
+    /// reconnect paths (`arrow_stream.rs`) call `from_setup_status(flight_error.into())`,
+    /// so the details must round-trip through this `From` for schema-mismatch
+    /// classification to work at all. Building a `Status` directly (as the other
+    /// tests do) would skip this conversion and mask a regression here.
+    #[cfg(feature = "arrow-flight")]
+    #[test]
+    fn schema_error_info_survives_flight_error_conversion() {
+        use arrow_flight::error::FlightError;
+
+        let status = schema_validation_status("FIELD_NOT_IN_TABLE,TYPE_INCOMPATIBLE");
+        // Mirror the production path: server error arrives as a FlightError and
+        // is converted to a Status before from_setup_status classifies it.
+        let converted: tonic::Status = FlightError::Tonic(Box::new(status)).into();
+        match ZerobusError::from_setup_status(converted) {
+            ZerobusError::InvalidSchema { causes, .. } => {
+                assert_eq!(
+                    causes,
+                    vec![
+                        SchemaValidationCause::FieldNotInTable,
+                        SchemaValidationCause::TypeIncompatible,
+                    ]
+                );
+            }
+            other => panic!("expected InvalidSchema after FlightError conversion, got {other:?}"),
+        }
+    }
+
     /// Build an InvalidArgument status carrying the server's schema-validation
     /// ErrorInfo, mirroring what Shinkansen sends on a schema mismatch.
+    #[cfg(feature = "arrow-flight")]
     fn schema_validation_status(causes: &str) -> tonic::Status {
         use std::collections::HashMap;
         use tonic_types::ErrorDetails;
@@ -270,12 +326,15 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn setup_status_with_schema_error_info_classifies_as_invalid_schema() {
         let status = schema_validation_status("FIELD_NOT_IN_TABLE,TYPE_INCOMPATIBLE");
         let err = ZerobusError::from_setup_status(status);
         match err {
-            ZerobusError::InvalidSchema { causes, .. } => {
+            ZerobusError::InvalidSchema {
+                causes, error_code, ..
+            } => {
                 assert_eq!(
                     causes,
                     vec![
@@ -283,6 +342,8 @@ mod tests {
                         SchemaValidationCause::TypeIncompatible,
                     ]
                 );
+                // The server's numeric code is carried for telemetry.
+                assert_eq!(error_code.as_deref(), Some("8001"));
             }
             other => panic!("expected InvalidSchema, got {other:?}"),
         }
@@ -290,6 +351,7 @@ mod tests {
 
     /// A cause token this SDK version does not recognize is surfaced as
     /// `Unknown` rather than dropped, so newer server causes still reach callers.
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn setup_status_maps_unknown_cause_token() {
         let status = schema_validation_status("FIELD_NOT_IN_TABLE,BRAND_NEW_CAUSE");
@@ -307,12 +369,14 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn invalid_schema_is_not_retryable() {
         let err = ZerobusError::from_setup_status(schema_validation_status("FIELD_NOT_IN_TABLE"));
         assert!(!err.is_retryable());
     }
 
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn setup_status_without_error_info_falls_back_to_create_stream_error() {
         // A plain InvalidArgument with no schema ErrorInfo stays a CreateStreamError.
@@ -321,6 +385,31 @@ mod tests {
         assert!(matches!(err, ZerobusError::CreateStreamError(_)));
     }
 
+    /// A status carrying the schema reason but a *different* domain is not a
+    /// Zerobus schema mismatch and must stay a `CreateStreamError`, so an
+    /// unrelated service reusing the reason token can't be misclassified.
+    #[cfg(feature = "arrow-flight")]
+    #[test]
+    fn setup_status_with_wrong_domain_falls_back_to_create_stream_error() {
+        use std::collections::HashMap;
+        use tonic_types::ErrorDetails;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("causes".to_string(), "FIELD_NOT_IN_TABLE".to_string());
+        let status = tonic::Status::with_error_details(
+            tonic::Code::InvalidArgument,
+            "schema mismatch from some other service",
+            ErrorDetails::with_error_info(
+                "SCHEMA_VALIDATION_FAILED",
+                "someone.else.example.com",
+                metadata,
+            ),
+        );
+        let err = ZerobusError::from_setup_status(status);
+        assert!(matches!(err, ZerobusError::CreateStreamError(_)));
+    }
+
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn setup_status_preserves_grpc_code_on_fallback() {
         // Non-schema setup failures keep their original code for retry/auth
@@ -330,6 +419,7 @@ mod tests {
     }
 
     /// Absent metadata keys yield empty lists rather than panicking.
+    #[cfg(feature = "arrow-flight")]
     #[test]
     fn invalid_schema_tolerates_missing_metadata() {
         use tonic_types::ErrorDetails;
@@ -344,8 +434,11 @@ mod tests {
             ),
         );
         match ZerobusError::from_setup_status(status) {
-            ZerobusError::InvalidSchema { causes, .. } => {
+            ZerobusError::InvalidSchema {
+                causes, error_code, ..
+            } => {
                 assert!(causes.is_empty());
+                assert!(error_code.is_none());
             }
             other => panic!("expected InvalidSchema, got {other:?}"),
         }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -70,7 +70,7 @@ pub use arrow_stream::{ArrowSchema, DataType, Field, RecordBatch, TimeUnit, Zero
 pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
-pub use errors::ZerobusError;
+pub use errors::{SchemaValidationCause, ZerobusError};
 #[cfg(feature = "testing")]
 pub use headers_provider::NoAuthHeadersProvider;
 pub use headers_provider::{HeadersProvider, OAuthHeadersProvider};

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "ti
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["tls-native-roots", "transport"] }
 tonic-prost.workspace = true
+tonic-types.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "arrow-flight", "zeroparser"] }

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -368,6 +368,78 @@ mod arrow_flight_tests {
             Ok(())
         }
 
+        /// End-to-end: when the server rejects the stream *during setup* with the
+        /// structured schema-validation `ErrorInfo`, `build_arrow()` surfaces it
+        /// as `ZerobusError::InvalidSchema` carrying the decoded causes — not a
+        /// generic `CreateStreamError`. This exercises the full production path
+        /// (poll → `FlightError` → `from_setup_status`) that the errors.rs unit
+        /// tests can't reach, since they build a `tonic::Status` directly.
+        #[tokio::test]
+        async fn test_setup_schema_validation_error_surfaces_invalid_schema(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            use std::collections::HashMap;
+
+            use databricks_zerobus_ingest_sdk::{SchemaValidationCause, ZerobusError};
+            use tonic_types::{ErrorDetails, StatusExt};
+
+            setup_tracing();
+            info!("Starting test_setup_schema_validation_error_surfaces_invalid_schema");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Mirror what Shinkansen attaches on a schema mismatch.
+            let mut metadata = HashMap::new();
+            metadata.insert("error_code".to_string(), "8001".to_string());
+            metadata.insert(
+                "causes".to_string(),
+                "FIELD_NOT_IN_TABLE,MISSING_REQUIRED_COLUMN".to_string(),
+            );
+            let status = Status::with_error_details(
+                tonic::Code::InvalidArgument,
+                "Arrow Flight schema validation failed: ...",
+                ErrorDetails::with_error_info(
+                    "SCHEMA_VALIDATION_FAILED",
+                    "zerobus.databricks.com",
+                    metadata,
+                ),
+            );
+
+            mock_server
+                .inject_responses(TABLE_NAME, vec![MockFlightResponse::SetupError { status }])
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let result = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema)
+                .build_arrow()
+                .await;
+
+            match result {
+                Err(ZerobusError::InvalidSchema { causes, .. }) => {
+                    assert_eq!(
+                        causes,
+                        vec![
+                            SchemaValidationCause::FieldNotInTable,
+                            SchemaValidationCause::MissingRequiredColumn,
+                        ]
+                    );
+                }
+                Err(other) => panic!("expected InvalidSchema, got {other:?}"),
+                Ok(_) => panic!("expected InvalidSchema, but stream setup succeeded"),
+            }
+
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_ingest_after_close_rejected() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
@@ -962,6 +1034,102 @@ mod arrow_flight_tests {
 
             let result = stream.wait_for_offset(offset2).await;
             assert!(result.is_ok(), "Expected recovery to succeed: {:?}", result);
+
+            Ok(())
+        }
+
+        /// End-to-end: when the table schema changes mid-stream, the *reconnect*
+        /// is rejected with the structured schema-validation `ErrorInfo`. Because
+        /// `InvalidSchema` is non-retriable (the SDK holds a fixed schema and
+        /// would just re-send the rejected one), the supervisor must surface it to
+        /// a blocked `wait_for_offset` immediately rather than burning the recovery
+        /// budget and reporting a generic failure. This lets callers (e.g. Vector)
+        /// re-resolve their schema and rebuild the stream for zero-downtime.
+        ///
+        /// Sequence on the one table: ack batch 0 → drop the connection (retriable,
+        /// triggers recovery) → reject the reconnect with the schema `ErrorInfo`.
+        #[tokio::test]
+        async fn test_reconnect_schema_validation_error_surfaces_invalid_schema(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            use std::collections::HashMap;
+
+            use databricks_zerobus_ingest_sdk::{SchemaValidationCause, ZerobusError};
+            use tonic_types::{ErrorDetails, StatusExt};
+
+            setup_tracing();
+            info!("Starting test_reconnect_schema_validation_error_surfaces_invalid_schema");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            let mut metadata = HashMap::new();
+            metadata.insert("error_code".to_string(), "8001".to_string());
+            metadata.insert("causes".to_string(), "MISSING_REQUIRED_COLUMN".to_string());
+            let schema_status = tonic::Status::with_error_details(
+                tonic::Code::InvalidArgument,
+                "Arrow Flight schema validation failed: ...",
+                ErrorDetails::with_error_info(
+                    "SCHEMA_VALIDATION_FAILED",
+                    "zerobus.databricks.com",
+                    metadata,
+                ),
+            );
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // First connection: ack batch 0, then drop the connection
+                        // (retriable) to trigger recovery.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 1,
+                        },
+                        MockFlightResponse::CloseStream { delay_ms: 0 },
+                        // Second connection (the reconnect): reject during setup
+                        // with the schema-validation ErrorInfo.
+                        MockFlightResponse::SetupError {
+                            status: schema_status,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_timeout_ms(5000)
+                .recovery_backoff_ms(50)
+                .recovery_retries(3)
+                .build_arrow()
+                .await?;
+
+            // Batch 0 is acked on the first connection.
+            let batch1 = create_test_record_batch(schema.clone(), vec![1], vec![Some("first")]);
+            let offset1 = stream.ingest_batch(batch1).await?;
+            stream.wait_for_offset(offset1).await?;
+
+            // Batch 1 is in flight when the connection drops; recovery reconnects
+            // and is rejected with the schema error.
+            let batch2 = create_test_record_batch(schema.clone(), vec![2], vec![Some("second")]);
+            let offset2 = stream.ingest_batch(batch2).await?;
+
+            match stream.wait_for_offset(offset2).await {
+                Err(ZerobusError::InvalidSchema { causes, .. }) => {
+                    assert_eq!(causes, vec![SchemaValidationCause::MissingRequiredColumn]);
+                }
+                other => panic!("expected Err(InvalidSchema) after reconnect, got {other:?}"),
+            }
 
             Ok(())
         }

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -59,6 +59,13 @@ pub enum MockFlightResponse {
     },
     /// Error response - sent immediately when a batch arrives.
     Error { status: Status, delay_ms: u64 },
+    /// Error response sent *during stream setup*, before the ready signal — in
+    /// place of confirming the stream. Models the real server rejecting setup
+    /// (auth failure, schema mismatch, blocked table), which the SDK classifies
+    /// via `from_setup_status`. Unlike [`MockFlightResponse::Error`], this fires
+    /// on the schema message rather than on the first data batch, so it
+    /// exercises the setup error path.
+    SetupError { status: Status },
     /// Close stream (drop the connection) - useful for testing recovery.
     CloseStream { delay_ms: u64 },
     /// Graceful close signal - sends a close signal with grace period duration.
@@ -258,6 +265,25 @@ impl FlightService for MockFlightServer {
                 if is_first_message {
                     is_first_message = false;
                     if flight_data.app_metadata.is_empty() {
+                        // If the next configured response is a setup-time error,
+                        // fail the stream now instead of confirming it — mirrors
+                        // the real server rejecting during setup (auth, schema
+                        // mismatch, blocked table). Consumes the response so the
+                        // next connection (e.g. a reconnect) advances past it.
+                        if let Some(MockFlightResponse::SetupError { status }) =
+                            stream_responses.get(response_index)
+                        {
+                            info!("Sending setup error response: {:?}", status);
+                            let status = status.clone();
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
+                            let _ = tx.send(Err(status)).await;
+                            return;
+                        }
+
                         debug!("Received schema message, sending ready signal");
                         // Send ready signal to confirm setup succeeded.
                         // This mirrors real server behavior where the server sends this after
@@ -445,6 +471,17 @@ impl FlightService for MockFlightServer {
                             // Continue processing - the main loop waits for more batches.
                             // During grace period the client won't send new batches,
                             // so this effectively waits until the client disconnects.
+                        }
+                        MockFlightResponse::SetupError { .. } => {
+                            // Only meaningful at setup (handled on the schema
+                            // message above). If it reaches the batch loop it was
+                            // misconfigured after a successful setup; skip it.
+                            warn!("SetupError encountered in batch loop; skipping");
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Zerobus server can return extra error details when creating a schema and the table schema is incompatible. Parse it and return it to the SDK caller with the different reasons for why the schema failed.

Users of the SDK can then decide what to do when the schema differs slightly.

## How is this tested?

Added unit tests.