### PR TITLE
[TypeScript] Bump wrapped Rust SDK to 2.6.0

### DIFF
--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow-array"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
 dependencies = [
  "bytes",
  "half",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
+checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -106,13 +106,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c379738a9e41eda5873bb3256c89164f87c65b16b0b153cccc74d8a462b7e8"
+checksum = "42115e09dbb694b5955da998912121451c6910b338228cb80a5701370dba43ff"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
+ "arrow-data",
  "arrow-ipc",
  "arrow-schema",
  "base64 0.22.1",
@@ -126,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -142,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
+checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -155,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
 
 [[package]]
 name = "arrow-select"
-version = "58.2.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -353,16 +354,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -414,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.0.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f87c99484cd20e2c9c361e2fe8884f614f35d8cde7d630cfaacbc09c4c21e9"
+checksum = "e5c2574a4e2fbcf3ee98afced16bcdf1673f8918c993790914c1801a46e242cc"
 dependencies = [
  "arrow-array",
  "arrow-flight",
@@ -426,13 +417,16 @@ dependencies = [
  "bytes",
  "futures",
  "hyper-http-proxy",
+ "hyper-rustls",
  "hyper-util",
  "prost",
+ "prost-reflect",
  "prost-types",
  "protoc-bin-vendored",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
@@ -442,6 +436,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tonic-types",
  "tracing",
 ]
 
@@ -836,12 +831,9 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls",
  "tower-service",
 ]
 
@@ -855,7 +847,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1353,12 +1345,6 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -1497,6 +1483,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
+dependencies = [
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -1777,7 +1773,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1854,36 +1850,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -1930,25 +1904,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2030,6 +1991,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2285,7 +2257,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "socket2",
  "sync_wrapper",
  "tokio",
@@ -2334,6 +2306,17 @@ dependencies = [
  "syn",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -16,12 +16,8 @@ crate-type = ["cdylib"]
 napi = { version = "2", features = ["async", "tokio_rt", "serde-json", "napi6"] }
 napi-derive = "2"
 
-# Rust SDK 2.6.0 brings token caching, payload size limits, and Arrow Flight
-# fixes used by the TypeScript binding. CI overlays `[patch.crates-io]` to swap
-# in the in-tree Rust SDK when `use_local_sdk` is set (see ci-typescript.yml).
 databricks-zerobus-ingest-sdk = "2.6.0"
 
-# Match the Rust SDK 2.6 workspace versions.
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 
 prost = "0.14"
@@ -36,8 +32,6 @@ async-trait = "0.1"
 # `Bytes` is the input type for the Rust SDK's `ingest_ipc_batch` entry.
 bytes = "1"
 
-# Arrow dependencies (only used when arrow-flight feature is enabled).
-# 59.1 matches the Rust SDK 2.6 workspace.
 arrow-array = { version = "59.1", optional = true }
 arrow-schema = { version = "59.1", optional = true }
 arrow-ipc = { version = "59.1", features = ["lz4", "zstd"], optional = true }

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -16,13 +16,12 @@ crate-type = ["cdylib"]
 napi = { version = "2", features = ["async", "tokio_rt", "serde-json", "napi6"] }
 napi-derive = "2"
 
-# Rust SDK 2.0.1 brings Arrow Flight Beta and the `ingest_ipc_batch` IPC
-# entry point used by `ingestBatch`. CI overlays `[patch.crates-io]` to
-# swap in the in-tree Rust SDK when `use_local_sdk` is set (see
-# ci-typescript.yml).
-databricks-zerobus-ingest-sdk = "2.0.1"
+# Rust SDK 2.6.0 brings token caching, payload size limits, and Arrow Flight
+# fixes used by the TypeScript binding. CI overlays `[patch.crates-io]` to swap
+# in the in-tree Rust SDK when `use_local_sdk` is set (see ci-typescript.yml).
+databricks-zerobus-ingest-sdk = "2.6.0"
 
-# Match the Rust SDK 2.0 workspace versions.
+# Match the Rust SDK 2.6 workspace versions.
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 
 prost = "0.14"
@@ -38,10 +37,10 @@ async-trait = "0.1"
 bytes = "1"
 
 # Arrow dependencies (only used when arrow-flight feature is enabled).
-# 58.2 matches the Rust SDK 2.0 workspace.
-arrow-array = { version = "58.2", optional = true }
-arrow-schema = { version = "58.2", optional = true }
-arrow-ipc = { version = "58.2", features = ["lz4", "zstd"], optional = true }
+# 59.1 matches the Rust SDK 2.6 workspace.
+arrow-array = { version = "59.1", optional = true }
+arrow-schema = { version = "59.1", optional = true }
+arrow-ipc = { version = "59.1", features = ["lz4", "zstd"], optional = true }
 
 [build-dependencies]
 napi-build = "2"

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - Updated TypeScript SDK development dependencies and the NAPI Cargo lockfile to
   resolve Dependabot security alerts without changing the public SDK API.
+- Updated the wrapped Rust SDK dependency from v2.0.1 to v2.6.0 and aligned
+  Arrow dependencies with the Rust SDK 2.6 workspace.
 
 ### Breaking Changes
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps the Rust SDK dependency wrapped by the TypeScript binding from 2.0.1 to 2.6.0. It also aligns the Rust Arrow dependencies (`arrow-array`, `arrow-schema`, and `arrow-ipc`) from 58.2 to 59.1 to match the Rust SDK 2.6 workspace.

The Arrow crates are internal to the optional native Arrow Flight build. The npm-facing API and the `apache-arrow ^18.0.0` peer dependency are unchanged. The `[patch.crates-io]` CI overlay used for `use_local_sdk` is also unchanged.

## How is this tested?

- `cargo check --locked`
- `cargo check --locked --features arrow-flight`
- `npm run build`
- `npm run build:arrow`
- `npm test` — 31 unit tests passed; integration tests skipped because the required Zerobus environment variables were not configured.

No new tests are needed because this is an internal dependency compatibility update with no TypeScript API changes.
