### PR TITLE
[TypeScript] Bump SDK version to 1.2.0

### DIFF
--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-sdk-ts"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-sdk-ts"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Databricks"]
 edition = "2021"
 license = "Apache-2.0"

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -26,9 +26,11 @@
 
 ### Internal Changes
 
+- Bumped the NAPI crate/package metadata to v1.2.0 for the next TypeScript SDK
+  release.
+
 ### Breaking Changes
 
 ### Deprecations
 
 ### API Changes
-

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/zerobus-ingest-sdk",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -22,11 +22,11 @@
         "node": ">= 16"
       },
       "optionalDependencies": {
-        "@databricks/zerobus-ingest-sdk-darwin-arm64": "1.1.0",
-        "@databricks/zerobus-ingest-sdk-darwin-x64": "1.1.0",
-        "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.1.0",
-        "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.1.0",
-        "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.1.0"
+        "@databricks/zerobus-ingest-sdk-darwin-arm64": "1.2.0",
+        "@databricks/zerobus-ingest-sdk-darwin-x64": "1.2.0",
+        "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.2.0",
+        "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.2.0",
+        "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.2.0"
       },
       "peerDependencies": {
         "apache-arrow": "^18.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/zerobus-ingest-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "TypeScript/Node.js SDK for streaming data ingestion into Databricks Delta tables using Zerobus",
   "main": "index.js",
   "types": "index.d.ts",
@@ -66,11 +66,11 @@
     "example:arrow": "tsx examples/arrow/batch.ts"
   },
   "optionalDependencies": {
-    "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.1.0",
-    "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.1.0",
-    "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.1.0",
-    "@databricks/zerobus-ingest-sdk-darwin-x64": "1.1.0",
-    "@databricks/zerobus-ingest-sdk-darwin-arm64": "1.1.0"
+    "@databricks/zerobus-ingest-sdk-linux-x64-gnu": "1.2.0",
+    "@databricks/zerobus-ingest-sdk-linux-arm64-gnu": "1.2.0",
+    "@databricks/zerobus-ingest-sdk-win32-x64-msvc": "1.2.0",
+    "@databricks/zerobus-ingest-sdk-darwin-x64": "1.2.0",
+    "@databricks/zerobus-ingest-sdk-darwin-arm64": "1.2.0"
   },
   "peerDependencies": {
     "protobufjs": "^7.0.0",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps the TypeScript SDK version from 1.1.0 to 1.2.0 across the package/crate metadata: `package.json` (including the five per-platform `optionalDependencies`), `package-lock.json`, and `Cargo.toml`, plus the matching `Cargo.lock` entry, and adds a changelog note under Internal Changes.

This prepares the version bump for the next TypeScript SDK release. It only touches version metadata; there are no source changes. Note it does not finalize the changelog (moving `NEXT_CHANGELOG.md` into `CHANGELOG.md`) — that is left for the release step.

## How is this tested?

N/A — version metadata only, no source or behavior changes. The existing TypeScript CI (ci-typescript.yml) still builds the package and runs the suite to confirm the bumped metadata is consistent.