### PR TITLE
[C++] Add release workflow and finalize v0.1.0 changelog

### DIFF
--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -1,0 +1,196 @@
+name: Build C++
+run-name: "Build C++ SDK ${{ github.ref_name }}"
+
+# Builds one self-contained artifact per target platform for the C++ SDK. Each
+# artifact bundles:
+#   - the C++ SDK source tree (headers, sources, CMake build) — platform-neutral
+#   - the matching prebuilt Rust C FFI archive (libzerobus_ffi.a / zerobus_ffi.lib)
+#     plus zerobus.h, cross-built for that platform
+#
+# Rationale: the FFI archive is a C ABI (stable across C++ compilers) and is the
+# one piece a consumer can't build without a Rust toolchain, so we ship it
+# prebuilt per platform. The thin C++ wrapper is ABI-fragile across
+# compiler/stdlib, so we ship it as source and let the consumer's own compiler
+# build it, pointing CMake at the bundled FFI archive:
+#
+#   cmake -S <artifact>/cpp -B build \
+#     -DZEROBUS_FFI_LIBRARY=<artifact>/lib/libzerobus_ffi.a \
+#     -DZEROBUS_FFI_HEADER_DIR=<artifact>/lib
+#
+# The FFI build steps mirror release-ffi.yml (cargo-zigbuild for the cross
+# targets); no C++ cross-compilation is performed here.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-cpp:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-unknown-linux-gnu
+            static_lib: libzerobus_ffi.a
+            artifact_dir: linux-x86_64
+            cross: false
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-unknown-linux-gnu
+            static_lib: libzerobus_ffi.a
+            artifact_dir: linux-aarch64
+            cross: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            artifact_dir: linux-musl-x86_64
+            cross: false
+            zigbuild: true
+            rustflags: "-C target-feature=-crt-static"
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            artifact_dir: linux-musl-aarch64
+            cross: false
+            zigbuild: true
+            rustflags: "-C target-feature=-crt-static"
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-apple-darwin
+            static_lib: libzerobus_ffi.a
+            artifact_dir: darwin-x86_64
+            cross: false
+            zigbuild: true
+            static_only: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-apple-darwin
+            static_lib: libzerobus_ffi.a
+            artifact_dir: darwin-aarch64
+            cross: false
+            zigbuild: true
+            static_only: true
+          - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
+            target: x86_64-pc-windows-msvc
+            static_lib: zerobus_ffi.lib
+            artifact_dir: windows-x86_64
+            cross: false
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-pc-windows-gnu
+            static_lib: libzerobus_ffi.a
+            artifact_dir: windows-gnu-x86_64
+            cross: false
+            zigbuild: true
+
+    name: Build C++ - ${{ matrix.artifact_dir }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+
+    defaults:
+      run:
+        working-directory: rust
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Get JFrog OIDC token
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"
+
+      - name: Configure cargo for JFrog
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cross-compilation toolchain (Linux ARM64)
+        if: matrix.cross
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcc-aarch64-linux-gnu
+          mkdir -p .cargo
+          echo '[target.aarch64-unknown-linux-gnu]' > .cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Zig (zigbuild targets)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (zigbuild targets)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
+      - name: Build FFI library
+        if: '!matrix.zigbuild'
+        run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI library (zigbuild)
+        if: matrix.zigbuild && !matrix.static_only
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      - name: Build FFI static library (zigbuild, static only)
+        if: matrix.zigbuild && matrix.static_only
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo zigbuild rustc --release -p zerobus-ffi --target ${{ matrix.target }} --crate-type staticlib
+
+      - name: Assemble C++ SDK bundle
+        shell: bash
+        run: |
+          root="$GITHUB_WORKSPACE"
+          out="$root/artifacts/${{ matrix.artifact_dir }}"
+          mkdir -p "$out/cpp" "$out/lib"
+
+          # Platform-neutral C++ SDK source (everything CMake needs to build the
+          # wrapper: headers, sources, the CMake build, and top-level docs).
+          cp -R "$root/cpp/include"        "$out/cpp/"
+          cp -R "$root/cpp/src"            "$out/cpp/"
+          cp -R "$root/cpp/cmake"          "$out/cpp/"
+          cp -R "$root/cpp/examples"       "$out/cpp/"
+          cp "$root/cpp/CMakeLists.txt"    "$out/cpp/"
+          cp "$root/cpp/README.md"         "$out/cpp/"
+          cp "$root/cpp/CHANGELOG.md"      "$out/cpp/"
+          cp "$root/cpp/LICENSE"           "$out/cpp/"
+          cp "$root/cpp/NOTICE"            "$out/cpp/"
+
+          # Prebuilt FFI archive + header for this platform (keep the native
+          # filename: libzerobus_ffi.a on Unix, zerobus_ffi.lib on MSVC).
+          cp "target/${{ matrix.target }}/release/${{ matrix.static_lib }}" "$out/lib/"
+          cp "ffi/zerobus.h" "$out/lib/"
+
+          # A short pointer so the bundle is self-explanatory.
+          cat > "$out/README.md" <<EOF
+          # Zerobus C++ SDK — prebuilt bundle
+
+          This bundle contains the C++ SDK source under \`cpp/\` and the matching
+          prebuilt Rust C FFI archive under \`lib/\` for this platform. Building the
+          C++ wrapper needs a C++17 compiler and CMake, but NOT a Rust toolchain:
+
+              cmake -S cpp -B build \\
+                -DZEROBUS_FFI_LIBRARY="\$PWD/lib/${{ matrix.static_lib }}" \\
+                -DZEROBUS_FFI_HEADER_DIR="\$PWD/lib"
+              cmake --build build -j
+
+          See \`cpp/README.md\` for usage.
+          EOF
+
+          echo "Bundle contents:"
+          find "$out" -type f | sort
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cpp-${{ matrix.artifact_dir }}
+          path: artifacts/${{ matrix.artifact_dir }}
+          if-no-files-found: error

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -59,25 +59,17 @@ jobs:
             artifact_dir: darwin-x86_64
             cross: false
             zigbuild: true
-            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: aarch64-apple-darwin
             static_lib: libzerobus_ffi.a
             artifact_dir: darwin-aarch64
             cross: false
             zigbuild: true
-            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
             static_lib: zerobus_ffi.lib
             artifact_dir: windows-x86_64
             cross: false
-          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
-            target: x86_64-pc-windows-gnu
-            static_lib: libzerobus_ffi.a
-            artifact_dir: windows-gnu-x86_64
-            cross: false
-            zigbuild: true
 
     name: Build C++ - ${{ matrix.artifact_dir }}
     runs-on: ${{ matrix.runner }}
@@ -134,16 +126,10 @@ jobs:
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Build FFI library (zigbuild)
-        if: matrix.zigbuild && !matrix.static_only
+        if: matrix.zigbuild
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
         run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
-
-      - name: Build FFI static library (zigbuild, static only)
-        if: matrix.zigbuild && matrix.static_only
-        env:
-          RUSTFLAGS: ${{ matrix.rustflags }}
-        run: cargo zigbuild rustc --release -p zerobus-ffi --target ${{ matrix.target }} --crate-type staticlib
 
       - name: Assemble C++ SDK bundle
         shell: bash

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -149,8 +149,6 @@ jobs:
         shell: bash
         run: |
           root="$GITHUB_WORKSPACE"
-          # Bundle is written under the rust/ working-directory (rust/artifacts/...)
-          # to match release-ffi.yml; the upload step's path is relative to it.
           out="artifacts/${{ matrix.artifact_dir }}"
           mkdir -p "$out/cpp" "$out/lib"
 

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -59,12 +59,14 @@ jobs:
             artifact_dir: darwin-x86_64
             cross: false
             zigbuild: true
+            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: aarch64-apple-darwin
             static_lib: libzerobus_ffi.a
             artifact_dir: darwin-aarch64
             cross: false
             zigbuild: true
+            static_only: true
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
             static_lib: zerobus_ffi.lib
@@ -126,10 +128,21 @@ jobs:
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Build FFI library (zigbuild)
-        if: matrix.zigbuild
+        if: matrix.zigbuild && !matrix.static_only
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
         run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      # Darwin: a plain zigbuild also links the manifest's cdylib, whose link
+      # needs the macOS Security/CoreFoundation frameworks (absent when
+      # cross-compiling from Linux). Emit only the staticlib, which the C++ SDK
+      # consumes. Use the `cargo-zigbuild` binary directly: `cargo zigbuild
+      # rustc` mis-parses `rustc` as a zigbuild arg.
+      - name: Build FFI static library (zigbuild, static only)
+        if: matrix.zigbuild && matrix.static_only
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo-zigbuild rustc --release -p zerobus-ffi --target ${{ matrix.target }} --crate-type staticlib
 
       - name: Assemble C++ SDK bundle
         shell: bash

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -149,7 +149,9 @@ jobs:
         shell: bash
         run: |
           root="$GITHUB_WORKSPACE"
-          out="$root/artifacts/${{ matrix.artifact_dir }}"
+          # Bundle is written under the rust/ working-directory (rust/artifacts/...)
+          # to match release-ffi.yml; the upload step's path is relative to it.
+          out="artifacts/${{ matrix.artifact_dir }}"
           mkdir -p "$out/cpp" "$out/lib"
 
           # Platform-neutral C++ SDK source (everything CMake needs to build the
@@ -192,5 +194,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cpp-${{ matrix.artifact_dir }}
-          path: artifacts/${{ matrix.artifact_dir }}
+          path: rust/artifacts/${{ matrix.artifact_dir }}
           if-no-files-found: error

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -4,3 +4,76 @@ All notable changes to the Zerobus C++ SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
+
+## Release v0.1.0
+
+Initial release of the Zerobus C++ SDK — a RAII C++17 wrapper over the Zerobus C
+FFI for ingesting data into Databricks Delta tables.
+
+### New Features and Improvements
+
+- Ingest into Databricks Delta tables over a `Stream` (proto and JSON record
+  formats) or an `ArrowStream` (Arrow Flight, Beta), with single-record and
+  batch APIs. Streams are RAII, move-only handles over the Rust core; errors
+  surface as `zerobus::ZerobusException`. Proto schemas are built at runtime from
+  Unity Catalog table metadata via `ProtoSchema::from_uc_json()` (no `protoc`
+  required).
+- Added an async ack callback: implement `AckCallback` (or use the
+  `AckCallback::from(on_ack, on_error)` lambda adapter) and register it via
+  `StreamOptions::ack_callback` to track durability without blocking in
+  `wait_for_offset()` / `flush()`. The callback methods are `noexcept`.
+  `StreamOptions::callback_wait_policy` (a `CallbackWaitPolicy` of
+  `use_default()` / `duration(ms)` / `forever()`) controls how long `close()`
+  drains the callback task.
+- Recover unacknowledged records after a failure via
+  `Stream::get_unacked_records()` / `ArrowStream::get_unacked_batches()`, and
+  supply per-stream request headers with a custom `HeadersProvider`.
+
+### Documentation
+
+- Added the C++ SDK `README.md` (build, install, quickstart for JSON / proto /
+  Arrow Flight ingestion, ingestion-format guidance, credential model, API
+  overview, `StreamOptions` / `ArrowStreamOptions` configuration tables, and an
+  HTTP-proxy note) and `CLAUDE.md` (contributor guide covering the FFI boundary,
+  RAII/memory ownership, thread-safety, and release process). Added
+  `CONTRIBUTING.md` with C++-specific development setup and workflow. Added C++
+  rows to the root `README.md` and `CLAUDE.md`, and reconciled the root
+  Arrow-Flight and `examples/arrow/` notes with the C++ SDK's `0.1.0` state.
+- Documented running the tests in `README.md`: the sanitizer runs
+  (`make test SANITIZE=address` / `thread`) and the env-var-gated
+  `integration_test` (which variables it needs and that it skips without them).
+- Added runnable examples under `examples/` covering all three record formats —
+  JSON and protobuf (dynamic schema built at runtime from Unity Catalog metadata
+  via `ProtoSchema::from_uc_json`, no `protoc` required), each with a
+  single-record and a batch variant, plus Arrow Flight (Beta). Every example
+  reads its connection settings from the environment (`ZEROBUS_SERVER_ENDPOINT`,
+  `DATABRICKS_WORKSPACE_URL`, `ZEROBUS_TABLE_NAME`, `DATABRICKS_CLIENT_ID`,
+  `DATABRICKS_CLIENT_SECRET`). They build with
+  the SDK via `ZEROBUS_BUILD_EXAMPLES` (the Arrow example is skipped when Apache
+  Arrow C++ is not installed). Includes a top-level `examples/README.md` and
+  per-format guides.
+- The examples also demonstrate advanced features inline: an async ack callback
+  (`StreamOptions::ack_callback`) and a custom `HeadersProvider` in
+  `examples/json/batch.cpp`, recovery of unacknowledged records
+  (`Stream::get_unacked_records()`) in `examples/json/single.cpp`, and Arrow IPC
+  compression in `examples/arrow/arrow_ingest.cpp`.
+
+### Internal Changes
+
+- Hermetic unit-test suite covering the API surface: `ZerobusException` (message
+  + retryable flag), `UnackedRecord`, `version()`, `ProtoSchema` (UC-JSON round
+  trip, error paths, move semantics), the `HeadersProvider` FFI trampoline
+  (marshalling, empty/embedded-NUL/throwing guards, null `user_data`), and
+  `Sdk` / `SdkBuilder` (offline build, move, and `create_stream` /
+  `create_arrow_stream` argument validation). Dependency-free and network-free;
+  the suite also passes under AddressSanitizer.
+- Added an env-var-gated live integration test (`integration_test`) covering the
+  create-stream -> ingest -> flush -> close path against a real endpoint,
+  mirroring the Java/TypeScript integration suites. It skips (passes) unless
+  `ZEROBUS_SERVER_ENDPOINT`, `DATABRICKS_WORKSPACE_URL`, `ZEROBUS_TABLE_NAME`,
+  `DATABRICKS_CLIENT_ID`, and `DATABRICKS_CLIENT_SECRET` are set, so `make test`
+  and CI stay hermetic.
+- Added a ThreadSanitizer CI job (`make test SANITIZE=thread`) and a
+  `concurrency_test` that exercises the documented "concurrent readers on a
+  shared `ProtoSchema`" contract under many threads, catching data races the
+  AddressSanitizer job cannot.

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -188,25 +188,41 @@ Public API is everything under `include/zerobus/`:
 
 ## Release
 
-The intended distribution model is CMake + GitHub Releases only — no package
-manager (no Conan, vcpkg, etc.), mirroring the C FFI. Consumers build from
-source via CMake (`add_subdirectory` / `FetchContent` / `find_package` against a
-`cmake --install` tree). The install tree already produces headers, the
-`libzerobus_cpp` static library, the bundled `libzerobus_ffi` archive, and the
-`find_package(zerobus)` package config; the tag-triggered release workflow that
-publishes prebuilt per-platform archives is not yet implemented (no
-`release-cpp.yml` exists — the other SDKs each have a `release-<sdk>.yml`).
+The distribution model is CMake + GitHub Releases only — no package manager (no
+Conan, vcpkg, etc.), mirroring the C FFI. The C++ wrapper is always built from
+the consumer's own compiler (its C++ ABI is not stable across compiler/stdlib),
+so we do **not** ship a prebuilt `libzerobus_cpp`. What we ship prebuilt is the
+Rust C FFI archive (`libzerobus_ffi.a`) — a stable C ABI, and the one piece a
+consumer can't build without a Rust toolchain. A consumer then either builds
+everything from source (needs Rust) via `add_subdirectory` / `FetchContent` /
+`find_package`, or points `-DZEROBUS_FFI_LIBRARY=` at the matching prebuilt FFI
+archive from a release and builds only the C++ (no Rust needed).
+
+Releases follow the same two-repo split as the other SDKs:
+
+- **Builder** — `.github/workflows/release-cpp.yml` (this repo). Manually
+  dispatched; for each target platform it cross-builds the Rust C FFI archive
+  (`cargo-zigbuild`, mirroring `release-ffi.yml`) and bundles it with the
+  platform-neutral C++ source tree into one artifact. No C++ cross-compilation.
+  Produces artifacts only — no GitHub Release.
+- **Orchestrator** — `release-zerobus-sdk-cpp.yml` in
+  `databricks/secure-public-registry-releases-eng`. Validates the `cpp/v*` tag
+  against `ZEROBUS_CPP_VERSION`, triggers the builder, downloads the artifacts,
+  runs the mandatory security scan, and creates the GitHub Release on
+  `databricks/zerobus-sdk` with a per-platform `tar.gz` attached and notes from
+  `cpp/CHANGELOG.md`.
 
 - Version source: `cpp/include/zerobus/version.hpp` (`ZEROBUS_CPP_VERSION`) and
   the `project(... VERSION ...)` line in `cpp/CMakeLists.txt` — keep them in
   sync (CMake fails configuration if they disagree).
-- Tag pattern (planned): `cpp/v<semver>`, to trigger the C++ release workflow
-  once it is added.
+- Tag pattern: `cpp/v<semver>`. The orchestrator is dispatched with that tag as
+  its `ref` input (a `dry-run` input defaults to true).
 - The C++ SDK links the FFI static library. If Rust FFI code changed, an FFI
   release (`ffi/v*`) must happen first; for source builds the workspace must be
   present.
-- On version bump PR: move `NEXT_CHANGELOG.md` contents to `CHANGELOG.md`, reset
-  `NEXT_CHANGELOG.md`.
+- On version bump PR: move `NEXT_CHANGELOG.md` contents to `CHANGELOG.md` under a
+  `## Release v<semver>` heading (the orchestrator's changelog extractor matches
+  that heading), reset `NEXT_CHANGELOG.md`.
 
 ## Config / requirements
 

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -198,30 +198,19 @@ everything from source (needs Rust) via `add_subdirectory` / `FetchContent` /
 `find_package`, or points `-DZEROBUS_FFI_LIBRARY=` at the matching prebuilt FFI
 archive from a release and builds only the C++ (no Rust needed).
 
-Releases follow the same two-repo split as the other SDKs:
-
-- **Builder** — `.github/workflows/release-cpp.yml` (this repo). Manually
-  dispatched; for each target platform it cross-builds the Rust C FFI archive
-  (`cargo-zigbuild`, mirroring `release-ffi.yml`) and bundles it with the
-  platform-neutral C++ source tree into one artifact. No C++ cross-compilation.
-  Produces artifacts only — no GitHub Release.
-- **Orchestrator** — `release-zerobus-sdk-cpp.yml` in
-  `databricks/secure-public-registry-releases-eng`. Validates the `cpp/v*` tag
-  against `ZEROBUS_CPP_VERSION`, triggers the builder, downloads the artifacts,
-  runs the mandatory security scan, and creates the GitHub Release on
-  `databricks/zerobus-sdk` with a per-platform `tar.gz` attached and notes from
-  `cpp/CHANGELOG.md`.
-
+- Tag: `cpp/v<semver>` → `release-cpp.yml` builds the per-platform bundles (the
+  Rust C FFI archive cross-built with `cargo-zigbuild`, plus the platform-neutral
+  C++ source tree) → creates a GitHub Release with a per-platform `tar.gz`
+  attached and notes from `cpp/CHANGELOG.md`.
 - Version source: `cpp/include/zerobus/version.hpp` (`ZEROBUS_CPP_VERSION`) and
   the `project(... VERSION ...)` line in `cpp/CMakeLists.txt` — keep them in
-  sync (CMake fails configuration if they disagree).
-- Tag pattern: `cpp/v<semver>`. The orchestrator is dispatched with that tag as
-  its `ref` input (a `dry-run` input defaults to true).
+  sync (CMake fails configuration if they disagree). The release validates the
+  tag version against `ZEROBUS_CPP_VERSION`.
 - The C++ SDK links the FFI static library. If Rust FFI code changed, an FFI
   release (`ffi/v*`) must happen first; for source builds the workspace must be
   present.
 - On version bump PR: move `NEXT_CHANGELOG.md` contents to `CHANGELOG.md` under a
-  `## Release v<semver>` heading (the orchestrator's changelog extractor matches
+  `## Release v<semver>` heading (the release notes are extracted by matching
   that heading), reset `NEXT_CHANGELOG.md`.
 
 ## Config / requirements

--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -198,10 +198,13 @@ everything from source (needs Rust) via `add_subdirectory` / `FetchContent` /
 `find_package`, or points `-DZEROBUS_FFI_LIBRARY=` at the matching prebuilt FFI
 archive from a release and builds only the C++ (no Rust needed).
 
-- Tag: `cpp/v<semver>` → `release-cpp.yml` builds the per-platform bundles (the
-  Rust C FFI archive cross-built with `cargo-zigbuild`, plus the platform-neutral
-  C++ source tree) → creates a GitHub Release with a per-platform `tar.gz`
-  attached and notes from `cpp/CHANGELOG.md`.
+- Create the `cpp/v<semver>` tag.
+- Manually dispatch the `release-zerobus-sdk-cpp.yml` orchestrator (in
+  `secure-public-registry-releases-eng`) with the tag as `ref`. It invokes
+  `release-cpp.yml` in this repo to build the per-platform bundles (the Rust C
+  FFI archive cross-built with `cargo-zigbuild`, plus the platform-neutral C++
+  source tree), scans the artifacts, and cuts the GitHub Release with a
+  per-platform `tar.gz` attached and notes from `cpp/CHANGELOG.md`.
 - Version source: `cpp/include/zerobus/version.hpp` (`ZEROBUS_CPP_VERSION`) and
   the `project(... VERSION ...)` line in `cpp/CMakeLists.txt` — keep them in
   sync (CMake fails configuration if they disagree). The release validates the

--- a/cpp/NEXT_CHANGELOG.md
+++ b/cpp/NEXT_CHANGELOG.md
@@ -1,73 +1,14 @@
 # NEXT CHANGELOG
 
-## Release v0.1.0
+## Release v0.2.0
 
 ### New Features and Improvements
-
-- Added an async ack callback: implement `AckCallback` (or use the
-  `AckCallback::from(on_ack, on_error)` lambda adapter) and register it via
-  `StreamOptions::ack_callback` to track durability without blocking in
-  `wait_for_offset()` / `flush()`. The callback methods are `noexcept`.
-  `StreamOptions::callback_wait_policy` (a `CallbackWaitPolicy` of
-  `use_default()` / `duration(ms)` / `forever()`) controls how long `close()`
-  drains the callback task.
 
 ### Bug Fixes
 
 ### Documentation
 
-- Added the C++ SDK `README.md` (build, install, quickstart for JSON / proto /
-  Arrow Flight ingestion, ingestion-format guidance, credential model, API
-  overview, `StreamOptions` / `ArrowStreamOptions` configuration tables, and an
-  HTTP-proxy note) and `CLAUDE.md` (contributor guide covering the FFI boundary,
-  RAII/memory ownership, thread-safety, and release process). Added
-  `CONTRIBUTING.md` with C++-specific development setup and workflow. Added C++
-  rows to the root `README.md` and `CLAUDE.md`, and reconciled the root
-  Arrow-Flight and `examples/arrow/` notes with the C++ SDK's `0.1.0` state.
-- Documented running the tests in `README.md`: the sanitizer runs
-  (`make test SANITIZE=address` / `thread`) and the env-var-gated
-  `integration_test` (which variables it needs and that it skips without them).
-- Added runnable examples under `examples/` covering all three record formats —
-  JSON and protobuf (dynamic schema built at runtime from Unity Catalog metadata
-  via `ProtoSchema::from_uc_json`, no `protoc` required), each with a
-  single-record and a batch variant, plus Arrow Flight (Beta). Every example
-  reads its connection settings from the environment (`ZEROBUS_SERVER_ENDPOINT`,
-  `DATABRICKS_WORKSPACE_URL`, `ZEROBUS_TABLE_NAME`, `DATABRICKS_CLIENT_ID`,
-  `DATABRICKS_CLIENT_SECRET`). They build with
-  the SDK via `ZEROBUS_BUILD_EXAMPLES` (the Arrow example is skipped when Apache
-  Arrow C++ is not installed). Includes a top-level `examples/README.md` and
-  per-format guides.
-- The examples also demonstrate advanced features inline: an async ack callback
-  (`StreamOptions::ack_callback`) and a custom `HeadersProvider` in
-  `examples/json/batch.cpp`, recovery of unacknowledged records
-  (`Stream::get_unacked_records()`) in `examples/json/single.cpp`, and Arrow IPC
-  compression in `examples/arrow/arrow_ingest.cpp`.
-
 ### Internal Changes
-
-- Expanded the hermetic unit-test suite to cover the previously untested API
-  surface: `ZerobusException` (message + retryable flag), `UnackedRecord`,
-  `version()`, `ProtoSchema` (UC-JSON round trip, error paths, move semantics),
-  the `HeadersProvider` FFI trampoline (marshalling, empty/embedded-NUL/throwing
-  guards, null `user_data`), and `Sdk` / `SdkBuilder` (offline build, move, and
-  `create_stream` / `create_arrow_stream` argument validation). Still
-  dependency-free and network-free; the suite also passes under AddressSanitizer.
-- Added an env-var-gated live integration test (`integration_test`) covering the
-  create-stream -> ingest -> flush -> close path against a real endpoint,
-  mirroring the Java/TypeScript integration suites. It skips (passes) unless
-  `ZEROBUS_SERVER_ENDPOINT`, `DATABRICKS_WORKSPACE_URL`, `ZEROBUS_TABLE_NAME`,
-  `DATABRICKS_CLIENT_ID`, and `DATABRICKS_CLIENT_SECRET` are set, so `make test`
-  and CI stay hermetic.
-- Added a ThreadSanitizer CI job (`make test SANITIZE=thread`) and a
-  `concurrency_test` that exercises the documented "concurrent readers on a
-  shared `ProtoSchema`" contract under many threads, catching data races the
-  AddressSanitizer job cannot.
-- The `address`/`thread` sanitizer builds now instrument the Rust FFI too
-  (nightly `-Zsanitizer` + `-Zbuild-std`), so races/UAF inside the core are
-  visible rather than only in the C++ wrapper. These builds require a nightly
-  toolchain with `rust-src` and link the C++ side with clang (LLVM sanitizer
-  runtime); each sanitizer uses an isolated cargo target dir. The default build
-  is unchanged (GCC, plain FFI).
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary

Adds the C++ SDK release pipeline (builder half) and finalizes the `v0.1.0` changelog, so the C++ SDK can cut its first release.

## What this does

- **`.github/workflows/release-cpp.yml`** — the builder workflow. Manually dispatched; for each of the 7 target platforms it cross-builds the Rust C FFI archive (`cargo-zigbuild`, mirroring `release-ffi.yml`) and bundles it with the platform-neutral C++ source tree into one artifact. Produces artifacts only — no GitHub Release.
- **`cpp/CHANGELOG.md`** — promoted the accumulated `v0.1.0` entry from `NEXT_CHANGELOG.md`.
- **`cpp/NEXT_CHANGELOG.md`** — reset to an empty `v0.2.0` template.
- **`cpp/CLAUDE.md`** — rewrote the Release section to describe the two-repo split and the FFI-prebuilt + C++-from-source distribution model.

## Distribution model

The C++ wrapper is shipped as **source** (its C++ ABI is not stable across compiler/stdlib), while the Rust C FFI archive (`libzerobus_ffi.a`, a stable C ABI, and the one piece a consumer can't build without a Rust toolchain) is shipped **prebuilt per platform**. A consumer builds only the thin C++ wrapper with their own compiler, pointing CMake at the bundled FFI archive via `-DZEROBUS_FFI_LIBRARY`. This matches the source-build model already documented in `cpp/CLAUDE.md` and mirrors how `release-go.yml` / `release-jni.yml` build from source.

## Release flow (two repos)

This is the **builder** half, in `zerobus-sdk`. The **orchestrator** half (`release-zerobus-sdk-cpp.yml`) lands separately in `databricks/secure-public-registry-releases-eng`: it validates the `cpp/v*` tag against `ZEROBUS_CPP_VERSION`, triggers this builder, downloads the artifacts, runs the mandatory security scan, and creates the GitHub Release on `zerobus-sdk`.

## Target platforms (7)

`linux-x86_64` (gnu), `linux-aarch64` (gnu, cross), `linux-musl-x86_64`, `linux-musl-aarch64`, `darwin-x86_64`, `darwin-aarch64`, and `windows-x86_64` (MSVC). The `windows-gnu-x86_64` (MinGW) leg was dropped during review — its cross-build fails on the missing mingw `dlltool`, and the MSVC leg already covers Windows.

## Testing

- Native install/build path verified locally: built `libzerobus_ffi.a`, then built `libzerobus_cpp.a` against it via `-DZEROBUS_FFI_LIBRARY=` — CMake logged "using prebuilt FFI library" (no cargo invoked; no Rust toolchain needed for the C++ half).
- Every FFI build leg exercised locally with each platform's exact workflow command (Zig 0.13.0, cross-compiling from Linux x86_64): all 4 Linux legs and both darwin legs produce a valid `libzerobus_ffi.a`. The darwin legs build only the staticlib (`cargo-zigbuild rustc … --crate-type staticlib`) because a plain `zigbuild` also links the manifest's `cdylib`, whose macOS `Security`/`CoreFoundation` framework link can't be satisfied when cross-compiling from Linux.
- `windows-x86_64` (MSVC) builds natively on a Windows runner, so it is validated by the workflow dispatch rather than locally.
- Both workflow YAML files parse.
- Changelog note extraction verified against the orchestrator's `awk` logic.

## Before the first real release

Dispatch this workflow once (or run the `dry-run: true` orchestrator) to green the full matrix on the real runners — in particular the `windows-x86_64` (MSVC) leg, which can't be exercised locally — before pushing the first `cpp/v0.1.0` tag.
