### PR TITLE
[ArrowFlight] Make recovery handoff atomic with ingest

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -11,10 +11,14 @@
 - **Arrow Flight — `close()` now propagates flush errors** (Beta): `ZerobusArrowStream::close()` previously swallowed a failed final `flush()` and always returned `Ok(())`, contradicting its documentation and diverging from the proto stream's `close()`. It now returns the flush error after still tearing down the stream and moving pending batches to the failed set (retrievable via `get_unacked_batches()`).
 - **Arrow Flight — `max_inflight_batches` now bounds batches awaiting acknowledgment** (Beta): it previously limited only the pre-encode channel, so pending batches could grow unbounded under a slow-acking server. `ingest_batch` now holds a permit until the batch is acked, applying backpressure (it blocks) at the configured limit. `max_inflight_batches = 0` is now rejected with `InvalidArgument` instead of panicking.
 - **Arrow Flight — recovery replay is now failure-safe** (Beta): if a batch send failed while replaying after a reconnect, the pending set was drained and lost (unrecoverable via automatic replay or `get_unacked_batches()`). Pending batches (and their in-flight accounting) are now retained so the next recovery attempt replays them.
+- **Arrow Flight — no spurious ingest error during recovery handoff** (Beta): a race between starting recovery and an in-flight `ingest_batch` could make ingest return a "stream sender is closed" error for a batch that was actually retained and replayed. The pause and sender-detach is now atomic with respect to ingest, so ingest either sends or buffers (returns `Ok`).
+- **Arrow Flight — records ingested during recovery are always replayed** (Beta): `reconnect` reset the recovery counters before rebuilding the pending record ranges, so a record ingested in that window could be assigned a stale range and skipped by replay as already acknowledged. The counter reset and range rebuild are now applied atomically, so a record ingested during a recovery handoff is always replayed.
 
 ### Documentation
 
 ### Internal Changes
+
+- Added a test-only `test-hooks` Cargo feature that exposes deterministic synchronization seams in the Arrow stream for recovery-race tests. It has zero footprint in default and FFI builds.
 
 ### Breaking Changes
 

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -67,6 +67,9 @@ arrow-flight = ["dep:arrow-flight", "dep:arrow-array", "dep:arrow-schema", "dep:
 # Zero-copy protobuf parser.
 zeroparser = ["dep:self_cell", "dep:prost-build"]
 testing = ["dep:futures"]
+# Test-only deterministic seams (barriers/notifies) for the Arrow stream. Zero footprint
+# unless enabled; never enabled by FFI/production builds.
+test-hooks = ["arrow-flight"]
 
 [[test]]
 name = "zeroparser_e2e"

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -20,6 +20,8 @@ use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
+#[cfg(feature = "test-hooks")]
+use tokio::sync::Notify;
 use tokio::time::{sleep, Duration};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
@@ -40,6 +42,27 @@ use crate::ZerobusResult;
 
 /// Type alias for the batch sender channel, wrapped for thread-safe sharing.
 type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
+
+/// Test-only barrier used to pause `reconnect` at a precise point — the new connection
+/// is established but pending ranges are not yet rebuilt — so a test can schedule a
+/// concurrent ingest or `close()`.
+#[cfg(feature = "test-hooks")]
+type ReconnectRebuildGate = Arc<Mutex<Option<ReconnectRebuildBarrier>>>;
+
+/// Paired notifications for [`ReconnectRebuildGate`]: `reached` fires when reconnect
+/// hits the barrier; `proceed` releases it (or a test aborts via `close()` instead).
+#[cfg(feature = "test-hooks")]
+#[derive(Clone)]
+struct ReconnectRebuildBarrier {
+    reached: Arc<Notify>,
+    proceed: Arc<Notify>,
+}
+
+/// Test-only gate: when armed, `process_acks` fires the notify right after applying a
+/// non-empty ack (i.e. after storing `last_acked_records`), letting a test confirm a
+/// partial ack has landed before it proceeds.
+#[cfg(feature = "test-hooks")]
+type AckAppliedGate = Arc<Mutex<Option<Arc<Notify>>>>;
 
 /// Properties for an Arrow Flight ingestion table.
 ///
@@ -259,6 +282,12 @@ pub struct ZerobusArrowStream {
     /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
     /// Re-applied to each fresh Channel built during recovery.
     sdk_identifier: Arc<str>,
+    /// Test seam (see [`ReconnectRebuildGate`]); compiled only under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    reconnect_rebuild_gate: ReconnectRebuildGate,
+    /// Test seam (see [`AckAppliedGate`]); compiled only under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    ack_applied_gate: AckAppliedGate,
 }
 
 impl ZerobusArrowStream {
@@ -322,6 +351,10 @@ impl ZerobusArrowStream {
             last_acked_records,
             is_paused,
             sdk_identifier,
+            #[cfg(feature = "test-hooks")]
+            reconnect_rebuild_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            ack_applied_gate: Arc::new(Mutex::new(None)),
         };
 
         // Initialize the connection with retry logic.
@@ -398,6 +431,10 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.ingest_mutex),
             response_stream,
             Arc::clone(&stream.sdk_identifier),
+            #[cfg(feature = "test-hooks")]
+            Arc::clone(&stream.reconnect_rebuild_gate),
+            #[cfg(feature = "test-hooks")]
+            Arc::clone(&stream.ack_applied_gate),
         );
 
         {
@@ -639,6 +676,8 @@ impl ZerobusArrowStream {
         ingest_mutex: Arc<Mutex<()>>,
         initial_response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
         sdk_identifier: Arc<str>,
+        #[cfg(feature = "test-hooks")] reconnect_rebuild_gate: ReconnectRebuildGate,
+        #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
         tokio::spawn(async move {
             let ack_timeout = Duration::from_millis(options.server_lack_of_ack_timeout_ms);
@@ -661,6 +700,8 @@ impl ZerobusArrowStream {
                     Arc::clone(&last_acked_records),
                     Arc::clone(&is_paused),
                     &options,
+                    #[cfg(feature = "test-hooks")]
+                    Arc::clone(&ack_applied_gate),
                 )
                 .await;
 
@@ -699,20 +740,18 @@ impl ZerobusArrowStream {
                             "Supervisor: Attempting recovery after retriable error"
                         );
 
-                        // Pause ingest before reconnect; gate is lifted inside reconnect().
-                        is_paused.store(true, Ordering::Relaxed);
+                        // Atomically pause ingest and detach the sender under
+                        // ingest_mutex, so an in-flight ingest_batch either completes
+                        // before the pause or observes is_paused and buffers — it never
+                        // sees is_paused=false with a detached sender. Gate is lifted
+                        // inside reconnect().
+                        Self::pause_and_detach_sender(&ingest_mutex, &is_paused, &batch_tx).await;
 
                         // Backoff before retry.
                         sleep(Duration::from_millis(options.recovery_backoff_ms)).await;
 
                         // Clear the server error.
                         let _ = server_error_tx.send(None);
-
-                        // Close old sender.
-                        {
-                            let mut tx_guard = batch_tx.lock().await;
-                            *tx_guard = None;
-                        }
 
                         // Create new connection.
                         let reconnect_result = tokio::time::timeout(
@@ -730,6 +769,8 @@ impl ZerobusArrowStream {
                                 &sdk_identifier,
                                 &ingest_mutex,
                                 &is_paused,
+                                #[cfg(feature = "test-hooks")]
+                                &reconnect_rebuild_gate,
                             ),
                         )
                         .await;
@@ -807,6 +848,7 @@ impl ZerobusArrowStream {
         sdk_identifier: &str,
         ingest_mutex: &Arc<Mutex<()>>,
         is_paused: &Arc<AtomicBool>,
+        #[cfg(feature = "test-hooks")] reconnect_rebuild_gate: &ReconnectRebuildGate,
     ) -> ZerobusResult<Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>> {
         // Create new client.
         let client = Self::create_flight_client(
@@ -907,21 +949,30 @@ impl ZerobusArrowStream {
             }
         }
 
-        // Store the new sender.
+        // Store the new sender before taking ingest_mutex for the rebuild. Safe only
+        // because is_paused stays true until after replay: a concurrent ingest that
+        // observes this new sender still buffers rather than sending out of order.
         {
             let mut tx_guard = batch_tx.lock().await;
             *tx_guard = Some(tx.clone());
         }
 
-        // Get the last acked record count before the disconnect.
-        // This tells us how many records were durably stored.
-        let acked_before_disconnect = last_acked_records.load(Ordering::Relaxed);
-        // Reset for the new connection to avoid reusing stale values.
-        last_acked_records.store(0, Ordering::Relaxed);
+        // Counters are reset atomically with the range rebuild inside
+        // replay_pending_batches, so a concurrent ingest can't fetch_add a reset counter,
+        // fabricate a low range, and have replay drop it as fully-acked.
+        let acked_before_disconnect = last_acked_records.load(Ordering::Acquire);
 
-        // Reset cumulative_records_sent for the new connection.
-        // It will be recalculated as we replay batches.
-        cumulative_records_sent.store(0, Ordering::Relaxed);
+        // Test seam: pause after the connection is established but before ingest_mutex is
+        // held and ranges/watermark are rebuilt, so a test can schedule a paused ingest
+        // that wins ingest_mutex first (reset/rebase race) or drive a concurrent close().
+        #[cfg(feature = "test-hooks")]
+        {
+            let barrier = reconnect_rebuild_gate.lock().await.take();
+            if let Some(barrier) = barrier {
+                barrier.reached.notify_one();
+                barrier.proceed.notified().await;
+            }
+        }
 
         // Hold ingest_mutex across the replay so no concurrent ingest interleaves.
         let _ingest_guard = ingest_mutex.lock().await;
@@ -929,6 +980,7 @@ impl ZerobusArrowStream {
             &tx,
             pending_batches,
             cumulative_records_sent,
+            last_acked_records,
             acked_before_disconnect,
         )
         .await?;
@@ -943,31 +995,30 @@ impl ZerobusArrowStream {
     /// `tx`: partially-acked batches (vs `acked_before_disconnect`) are sliced to their
     /// un-acked suffix, fully-acked ones dropped.
     ///
-    /// The rebuilt set and `cumulative_records_sent` are installed together under the
-    /// `pending_batches` lock before any send, and sends happen after that lock is
-    /// released. So a replay-send failure leaves pending (with permits) and the counter
-    /// intact for the next attempt, and no send is awaited while holding
-    /// `pending_batches`. Caller holds `ingest_mutex` throughout.
+    /// The rebuilt pending set and the counter reset are installed together under the
+    /// `pending_batches` lock, before any send: a replay-send failure keeps pending (and
+    /// permits) intact, and no concurrent ingest can observe reset counters against stale
+    /// ranges. Caller holds `ingest_mutex`.
     async fn replay_pending_batches(
         tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
         cumulative_records_sent: &Arc<AtomicU64>,
+        last_acked_records: &Arc<AtomicU64>,
         acked_before_disconnect: u64,
     ) -> ZerobusResult<()> {
         let replay_batches: Vec<RecordBatch> = {
             let mut pending = pending_batches.lock().await;
-            if pending.is_empty() {
-                Vec::new()
-            } else {
+
+            let mut new_pending = Vec::with_capacity(pending.len());
+            let mut replay = Vec::with_capacity(pending.len());
+            let mut new_cumulative: u64 = 0;
+
+            if !pending.is_empty() {
                 info!(
                     batch_count = pending.len(),
                     acked_records = acked_before_disconnect,
                     "Replaying pending batches after recovery"
                 );
-
-                let mut new_pending = Vec::with_capacity(pending.len());
-                let mut replay = Vec::with_capacity(pending.len());
-                let mut new_cumulative: u64 = 0;
 
                 for pb in pending.drain(..) {
                     let Some(batch) = slice_batch_for_recovery(&pb, acked_before_disconnect) else {
@@ -991,30 +1042,31 @@ impl ZerobusArrowStream {
                     });
                 }
 
-                // Install pending + counter together (before any send) so a send
-                // failure can't pair installed ranges with a stale counter.
                 *pending = new_pending;
-                cumulative_records_sent.store(new_cumulative, Ordering::Relaxed);
-
-                // Debug-only: rebuilt ranges must be contiguous from 0. Guards a
-                // rebuild regression or an orphaned batch from the pause-gate handoff.
-                #[cfg(debug_assertions)]
-                {
-                    let mut expected_start: u64 = 0;
-                    for pb in pending.iter() {
-                        debug_assert_eq!(
-                            pb.start_record, expected_start,
-                            "pending_batches has non-contiguous record ranges after recovery \
-                             (expected start_record = {}, found {} for offset_id {}); \
-                             possible orphaned buffered batch from pause-gate handoff race",
-                            expected_start, pb.start_record, pb.offset_id,
-                        );
-                        expected_start = pb.end_record;
-                    }
-                }
-
-                replay
             }
+
+            // Reset counters together with the range install, before any send.
+            cumulative_records_sent.store(new_cumulative, Ordering::Relaxed);
+            last_acked_records.store(0, Ordering::Release);
+
+            // Debug-only: rebuilt ranges must be contiguous from 0. Guards a rebuild
+            // regression or an orphaned batch from the pause-gate handoff.
+            #[cfg(debug_assertions)]
+            {
+                let mut expected_start: u64 = 0;
+                for pb in pending.iter() {
+                    debug_assert_eq!(
+                        pb.start_record, expected_start,
+                        "pending_batches has non-contiguous record ranges after recovery \
+                         (expected start_record = {}, found {} for offset_id {}); \
+                         possible orphaned buffered batch from pause-gate handoff race",
+                        expected_start, pb.start_record, pb.offset_id,
+                    );
+                    expected_start = pb.end_record;
+                }
+            }
+
+            replay
         };
 
         // Send only after the pending_batches lock is released (ingest_mutex is still
@@ -1028,6 +1080,23 @@ impl ZerobusArrowStream {
         }
 
         Ok(())
+    }
+
+    /// Atomically pauses ingest and detaches the sender, under `ingest_mutex`.
+    ///
+    /// Holding `ingest_mutex` across both stores makes the pause + sender-detach a
+    /// single step relative to `ingest_batch`'s critical section: a concurrent ingest
+    /// either finishes first, or observes `is_paused == true` and buffers — it never
+    /// reads a detached (`None`) sender while `is_paused` is still false.
+    async fn pause_and_detach_sender(
+        ingest_mutex: &Arc<Mutex<()>>,
+        is_paused: &Arc<AtomicBool>,
+        batch_tx: &BatchSender,
+    ) {
+        let _guard = ingest_mutex.lock().await;
+        is_paused.store(true, Ordering::Relaxed);
+        let mut tx = batch_tx.lock().await;
+        *tx = None;
     }
 
     /// Moves all pending batches to the failed batches list.
@@ -1063,6 +1132,7 @@ impl ZerobusArrowStream {
         last_acked_records: Arc<AtomicU64>,
         is_paused: Arc<AtomicBool>,
         options: &ArrowStreamConfigurationOptions,
+        #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
     ) -> ZerobusResult<()> {
         let mut pause_deadline: Option<tokio::time::Instant> = None;
 
@@ -1167,8 +1237,16 @@ impl ZerobusArrowStream {
                                 "Received acknowledgment"
                             );
 
-                            // Update last_acked_records for recovery slicing.
-                            last_acked_records.store(acked_records, Ordering::Relaxed);
+                            // Release so the watermark is observed cross-task (reconnect / drain).
+                            last_acked_records.store(acked_records, Ordering::Release);
+
+                            // Test seam: let a test await a landed partial ack.
+                            #[cfg(feature = "test-hooks")]
+                            if acked_records > 0 {
+                                if let Some(notify) = ack_applied_gate.lock().await.as_ref() {
+                                    notify.notify_one();
+                                }
+                            }
 
                             // Find and remove batches that are fully acknowledged.
                             // A batch is fully acked when ack_up_to_records >= batch.end_record.
@@ -1361,11 +1439,12 @@ impl ZerobusArrowStream {
         let sender = match sender {
             Some(s) => s,
             None => {
-                // Narrow recovery-handoff window (sender nulled before reconnect). The
-                // batch intentionally stays in pending_batches (holding its permit) so
-                // it remains recoverable/replayable, even though this attempt returns
-                // an error. Permit is freed when the batch is later acked, moved to the
-                // failed set, or the stream closes.
+                // Unreachable in safe Rust use: `close()` takes `&mut self` so it can't
+                // run concurrently with `ingest_batch` (`&self`), and the recovery
+                // handoff detaches the sender under `ingest_mutex`
+                // (`pause_and_detach_sender`). Defensive fallback for an unsupported
+                // concurrent FFI call: FFI callers must serialize close and ingest; this
+                // branch only reports a detached sender if that contract is violated.
                 if let Some(server_error) = self.server_error_rx.borrow().clone() {
                     return Err(server_error);
                 }
@@ -1745,6 +1824,34 @@ impl ZerobusArrowStream {
         self.is_closed.load(Ordering::Relaxed)
     }
 
+    /// Test-only: arms the reconnect rebuild barrier. The next `reconnect` pauses after
+    /// establishing the connection but before rebuilding pending ranges/watermark,
+    /// firing the returned `reached` notify, then waits on `proceed`. A test either
+    /// releases `proceed` to let recovery finish, or drives a concurrent `close()`
+    /// (which reaps the paused supervisor) without releasing it.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_reconnect_rebuild_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {
+        let reached = Arc::new(Notify::new());
+        let proceed = Arc::new(Notify::new());
+        *self.reconnect_rebuild_gate.lock().await = Some(ReconnectRebuildBarrier {
+            reached: Arc::clone(&reached),
+            proceed: Arc::clone(&proceed),
+        });
+        (reached, proceed)
+    }
+
+    /// Test-only: arms a notify that fires each time `process_acks` applies a non-empty
+    /// ack (after storing `last_acked_records`). Lets a test wait until a partial ack has
+    /// been processed before proceeding.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_ack_applied_notify(&self) -> Arc<Notify> {
+        let notify = Arc::new(Notify::new());
+        *self.ack_applied_gate.lock().await = Some(Arc::clone(&notify));
+        notify
+    }
+
     /// Returns the table name for this stream.
     pub fn table_name(&self) -> &str {
         &self.table_properties.table_name
@@ -1848,14 +1955,17 @@ mod tests {
             "two permits held by pending batches"
         );
 
-        // Stale value that must be overwritten with the reinstalled ranges' total.
+        // Stale values that must be overwritten by the atomic install.
         let cumulative = Arc::new(AtomicU64::new(999));
+        let last_acked = Arc::new(AtomicU64::new(7));
 
         // Receiver dropped -> every send fails.
         let (tx, rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
         drop(rx);
 
-        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, &last_acked, 0)
+                .await;
         assert!(res.is_err(), "replay must surface the send failure");
 
         let guard = pending.lock().await;
@@ -1872,6 +1982,11 @@ mod tests {
             cumulative.load(Ordering::Relaxed),
             5,
             "cumulative_records_sent must match the reinstalled ranges, not the stale value"
+        );
+        assert_eq!(
+            last_acked.load(Ordering::Relaxed),
+            0,
+            "watermark must be rebased to 0 atomically with the ranges"
         );
         assert_eq!(
             sem.available_permits(),
@@ -1891,14 +2006,18 @@ mod tests {
             pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
         ]));
         let cumulative = Arc::new(AtomicU64::new(0));
+        let last_acked = Arc::new(AtomicU64::new(9));
 
         let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
 
-        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 0).await;
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, &last_acked, 0)
+                .await;
         assert!(res.is_ok());
 
         assert_eq!(pending.lock().await.len(), 2);
         assert_eq!(cumulative.load(Ordering::Relaxed), 5);
+        assert_eq!(last_acked.load(Ordering::Relaxed), 0);
 
         // Both batches were sent, in order.
         let first = rx.try_recv().expect("first replay batch");
@@ -1921,9 +2040,12 @@ mod tests {
         ]));
         assert_eq!(sem.available_permits(), 2);
         let cumulative = Arc::new(AtomicU64::new(0));
+        let last_acked = Arc::new(AtomicU64::new(4));
         let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
 
-        let res = ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, 4).await;
+        let res =
+            ZerobusArrowStream::replay_pending_batches(&tx, &pending, &cumulative, &last_acked, 4)
+                .await;
         assert!(res.is_ok());
 
         // Only the partially-acked batch remains, rebuilt from cumulative 0.
@@ -1932,11 +2054,47 @@ mod tests {
         assert_eq!((guard[0].start_record, guard[0].end_record), (0, 2));
         drop(guard);
         assert_eq!(cumulative.load(Ordering::Relaxed), 2);
+        assert_eq!(last_acked.load(Ordering::Relaxed), 0);
         // Fully-acked batch's permit was released; one remains.
         assert_eq!(sem.available_permits(), 3);
 
         let replayed = rx.try_recv().expect("suffix replay batch");
         assert_eq!(replayed.unwrap().num_rows(), 2);
         assert!(rx.try_recv().is_err(), "only one batch should be replayed");
+    }
+
+    /// `pause_and_detach_sender` must block while an ingest holds `ingest_mutex`, so an
+    /// ingest can never observe `is_paused == false` together with a detached sender.
+    #[tokio::test]
+    async fn pause_and_detach_waits_for_in_flight_ingest() {
+        let ingest_mutex = Arc::new(Mutex::new(()));
+        let is_paused = Arc::new(AtomicBool::new(false));
+        let (tx, _rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(1);
+        let batch_tx: BatchSender = Arc::new(Mutex::new(Some(tx)));
+
+        // Deterministic sync point: hold ingest_mutex to represent an ingest in its
+        // critical section, past the is_paused observation and about to read the sender.
+        let guard = ingest_mutex.lock().await;
+
+        let fut = ZerobusArrowStream::pause_and_detach_sender(&ingest_mutex, &is_paused, &batch_tx);
+        tokio::pin!(fut);
+
+        // Polling the future while the ingest holds ingest_mutex must return Pending
+        // (it is actively driven, not merely unscheduled) and must not have flipped
+        // is_paused or detached the sender.
+        assert!(
+            futures::poll!(fut.as_mut()).is_pending(),
+            "pause_and_detach_sender must block while an ingest holds ingest_mutex"
+        );
+        assert!(!is_paused.load(Ordering::Relaxed), "is_paused flipped mid-ingest");
+        assert!(batch_tx.lock().await.is_some(), "sender detached mid-ingest");
+
+        // Once the ingest leaves its critical section, the transition completes.
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), fut)
+            .await
+            .expect("pause_and_detach_sender should proceed after ingest_mutex is released");
+        assert!(is_paused.load(Ordering::Relaxed));
+        assert!(batch_tx.lock().await.is_none());
     }
 }

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -19,9 +19,9 @@ use arrow_flight::{FlightClient, PutResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
 #[cfg(feature = "test-hooks")]
 use tokio::sync::Notify;
+use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{sleep, Duration};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
@@ -2086,8 +2086,14 @@ mod tests {
             futures::poll!(fut.as_mut()).is_pending(),
             "pause_and_detach_sender must block while an ingest holds ingest_mutex"
         );
-        assert!(!is_paused.load(Ordering::Relaxed), "is_paused flipped mid-ingest");
-        assert!(batch_tx.lock().await.is_some(), "sender detached mid-ingest");
+        assert!(
+            !is_paused.load(Ordering::Relaxed),
+            "is_paused flipped mid-ingest"
+        );
+        assert!(
+            batch_tx.lock().await.is_some(),
+            "sender detached mid-ingest"
+        );
 
         // Once the ingest leaves its critical section, the transition completes.
         drop(guard);

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1049,23 +1049,6 @@ impl ZerobusArrowStream {
             cumulative_records_sent.store(new_cumulative, Ordering::Relaxed);
             last_acked_records.store(0, Ordering::Release);
 
-            // Debug-only: rebuilt ranges must be contiguous from 0. Guards a rebuild
-            // regression or an orphaned batch from the pause-gate handoff.
-            #[cfg(debug_assertions)]
-            {
-                let mut expected_start: u64 = 0;
-                for pb in pending.iter() {
-                    debug_assert_eq!(
-                        pb.start_record, expected_start,
-                        "pending_batches has non-contiguous record ranges after recovery \
-                         (expected start_record = {}, found {} for offset_id {}); \
-                         possible orphaned buffered batch from pause-gate handoff race",
-                        expected_start, pb.start_record, pb.offset_id,
-                    );
-                    expected_start = pb.end_record;
-                }
-            }
-
             replay
         };
 

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -31,7 +31,7 @@ tonic = { workspace = true, features = ["tls-native-roots", "transport"] }
 tonic-prost.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "arrow-flight", "zeroparser"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "test-hooks", "arrow-flight", "zeroparser"] }
 
 # Arrow Flight test dependencies
 arrow-flight.workspace = true

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1136,6 +1136,79 @@ mod arrow_flight_tests {
             Ok(())
         }
 
+        /// close() while a reconnect is parked at the rebuild barrier must tear the stream
+        /// down and move pending batches to the failed set, without panicking or hanging
+        /// beyond the flush timeout.
+        #[tokio::test]
+        async fn test_close_during_reconnect_window_moves_pending_to_failed(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_close_during_reconnect_window_moves_pending_to_failed");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // A retriable error triggers the reconnect we park at the rebuild barrier.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::Error {
+                        status: tonic::Status::unavailable("Connection lost"),
+                        delay_ms: 0,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .flush_timeout_ms(200)
+                .build_arrow()
+                .await?;
+
+            // Park the reconnect; do not release it — close() reaps it instead.
+            let (reached, _proceed) = stream.arm_reconnect_rebuild_barrier().await;
+
+            let batch = create_test_record_batch(schema.clone(), vec![1], vec![Some("a")]);
+            stream.ingest_batch(batch).await?;
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), reached.notified())
+                .await
+                .expect("reconnect should reach the rebuild barrier");
+
+            // close() must return (its flush times out at 200ms) without hanging or
+            // panicking, reaping the parked supervisor along the way.
+            let close_result =
+                tokio::time::timeout(std::time::Duration::from_secs(5), stream.close())
+                    .await
+                    .expect("close() must not hang while a reconnect is parked");
+            assert!(
+                close_result.is_err(),
+                "close() should surface the flush timeout"
+            );
+
+            // The un-acked batch was moved to the failed set and is retrievable.
+            let unacked = stream.get_unacked_batches().await?;
+            assert_eq!(
+                unacked.len(),
+                1,
+                "pending batch must be moved to the failed set"
+            );
+
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_supervisor_recovery_after_retriable_error(
         ) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -701,7 +701,7 @@ mod arrow_flight_tests {
     mod backpressure_tests {
         use super::*;
 
-        /// #6: `max_inflight_batches` bounds batches awaiting ACK, not just batches
+        /// `max_inflight_batches` bounds batches awaiting ACK, not just batches
         /// buffered before the encoder drains. With capacity 1 the second ingest must
         /// block until the first is acked.
         #[tokio::test]
@@ -1023,6 +1023,114 @@ mod arrow_flight_tests {
                 acks.iter().all(|&r| r == 3),
                 "auto-ack must exclude rows from the first connection (expected all == 3), got {:?}",
                 acks
+            );
+
+            Ok(())
+        }
+
+        /// A record ingested during the reconnect rebuild window must be replayed, not
+        /// silently dropped. A partial ack (1 of 3 records) lands, a retriable error
+        /// triggers recovery, and a barrier parks reconnect after the new connection is up
+        /// but before it takes ingest_mutex and rebuilds ranges. While parked
+        /// (is_paused == true) a record is ingested and buffered; after the barrier is
+        /// released it must be replayed and acknowledged on the recovered connection.
+        #[tokio::test]
+        async fn test_ingest_during_reconnect_window_is_not_dropped(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_ingest_during_reconnect_window_is_not_dropped");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            // Connection 1: partial-ack A (1 of 3 records) so last_acked_records == 1, then
+            // a retriable error on B triggers the reconnect we park at the barrier. B (a
+            // second batch) makes the error fire promptly on connection 1 — relying on A
+            // alone would instead reconnect via the slow ack timeout and let the scripted
+            // error fire on a later connection.
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 1,
+                        },
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("Connection lost"),
+                            delay_ms: 0,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .build_arrow()
+                .await?;
+
+            let ack_applied = stream.arm_ack_applied_notify().await;
+            let (reached, proceed) = stream.arm_reconnect_rebuild_barrier().await;
+
+            let batch_a = create_test_record_batch(
+                schema.clone(),
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("c")],
+            );
+            stream.ingest_batch(batch_a).await?;
+
+            // Wait until A's partial ack (1 of 3) is applied (last_acked_records == 1),
+            // otherwise the ack and error can arrive back-to-back and the watermark is 0.
+            tokio::time::timeout(std::time::Duration::from_secs(5), ack_applied.notified())
+                .await
+                .expect("A's partial ack should be applied");
+
+            // B triggers the retriable error on connection 1, kicking off recovery.
+            let batch_b = create_test_record_batch(schema.clone(), vec![50], vec![Some("y")]);
+            stream.ingest_batch(batch_b).await?;
+
+            // Wait until reconnect is parked: connection up, ingest_mutex free, counters
+            // and ranges not yet rebuilt.
+            tokio::time::timeout(std::time::Duration::from_secs(5), reached.notified())
+                .await
+                .expect("reconnect should reach the rebuild barrier");
+
+            // Ingest while parked. is_paused is set, so the record buffers (Ok) after
+            // computing its range against the still-pre-reconnect counter.
+            let batch_c = create_test_record_batch(schema.clone(), vec![99], vec![Some("z")]);
+            let c_offset = stream.ingest_batch(batch_c).await?;
+
+            // Release reconnect: it takes ingest_mutex and rebuilds/replays, rebasing the
+            // buffered record consistently and sending it on the recovered connection.
+            proceed.notify_one();
+
+            // The buffered record must be replayed and acknowledged, not silently dropped.
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                stream.wait_for_offset(c_offset),
+            )
+            .await
+            .expect("record ingested during the reconnect window must not be dropped")?;
+
+            // Global observation: conn1 decodes A (3) + B (1) = 4; the recovered connection
+            // replays A's un-acked suffix (2) + B (1) + C (1) = 4, so 8 total.
+            assert_eq!(
+                mock_server.get_total_records_received().await,
+                8,
+                "recovered connection must replay A's un-acked suffix, B, and the windowed record"
             );
 
             Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Two recovery-handoff races let a concurrent ingest_batch mishandle a batch it had already queued into pending_batches:
* Spurious ingest error: the supervisor set is_paused = true and detached batch_tx as two steps without ingest_mutex, so an in-flight ingest could see is_paused == false, then batch_tx == None, and return "stream sender is closed" for a batch recovery would replay. Extracted pause_and_detach_sender, which does both under ingest_mutex; ingest now either sends before the transition or observes is_paused == true and buffers (Ok).
* Dropped-on-replay: reconnect reset the recovery counters before rebuilding the pending ranges, so a record ingested in that window got a stale range and was skipped by replay as already acked. The reset and range rebuild are now atomic (under the pending_batches lock); the watermark uses Acquire/Release.

## How is this tested?

* New deterministic tests (both verified red first): pause_and_detach_waits_for_in_flight_ingest (unit) and test_ingest_during_reconnect_window_is_not_dropped (integration, uses a test-only barrier to park reconnect in the rebuild window).
* Added a test-only test-hooks Cargo feature for the barriers (zero footprint; not enabled by FFI).