### PR TITLE
[Python] Patch Rust extension dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,13 @@ updates:
     labels:
       - dependencies
 
+  - package-ecosystem: cargo
+    directory: /python/rust
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
   - package-ecosystem: gomod
     directory: /go
     schedule:

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -84,6 +84,6 @@ The public Python API is defined by the classes and functions in `zerobus/`. Cha
 ## Config
 
 - Python >= 3.9 required; tested through 3.14 (free-threaded builds are not supported)
-- Rust >= 1.83 required for the wrapper crate (PyO3 0.29 MSRV)
+- Rust >= 1.88 required for the wrapper crate (Tonic 0.14.6 MSRV)
 - Line length: 120 (black)
 - Formatter: black, isort

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This document covers Python-specific development setup and workflow.
 
 - **Python 3.9 through 3.14**
 - **Git**
-- **Rust toolchain** (required for building the native extension)
+- Rust toolchain 1.88 or newer (required for building the native extension)
   - Install from [rustup.rs](https://rustup.rs/)
   - Verify: `rustc --version`
 - **maturin** (for building Rust-Python bindings)

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -26,6 +26,8 @@
   bound before, which is what let pip pick the `abi3` wheel on 3.14 and crash
   rather than report that the version is unsupported. The bound moves up as each
   new CPython version is added to CI.
+- Updated the native extension's transitive `quinn-proto`, `rustls-webpki`, and
+  `rand` dependencies to patched releases.
 
 ### Documentation
 
@@ -41,11 +43,12 @@
   the interpreter to copy the `ack_callback` handle. This avoids PyO3's `py-clone`
   feature, which panics when the interpreter is detached — the exact state of the
   async stream-builder paths.
-- The wrapper crate now declares `rust-version = "1.83"`, the PyO3 0.29 MSRV. This
-  does not change the Rust core SDK's own MSRV.
+- The wrapper crate now declares `rust-version = "1.88"`, matching the effective
+  requirement from Tonic 0.14.6. This does not change the Rust core SDK's own MSRV.
 - The Arrow test module now skips itself when `pyarrow` is absent. `pyarrow` is an
   optional dependency, but the module imported it at the top level, so the whole
   test suite failed to collect on an install without the `arrow` extra.
+- Added Dependabot coverage for the Python extension's Rust crate under `python/rust`.
 
 ### Breaking Changes
 

--- a/python/README.md
+++ b/python/README.md
@@ -559,7 +559,7 @@ export RUST_LOG=zerobus_sdk=debug  # Only SDK components
 
 ## Building from Source
 
-Building from source requires the **Rust toolchain** (install from [rustup.rs](https://rustup.rs/)).
+Building from source requires the Rust toolchain 1.88 or newer (install from [rustup.rs](https://rustup.rs/)).
 
 ```bash
 git clone https://github.com/databricks/zerobus-sdk.git

--- a/python/rust/Cargo.lock
+++ b/python/rust/Cargo.lock
@@ -306,6 +306,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +378,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -631,11 +651,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -645,10 +663,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1653,14 +1674,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1709,23 +1731,24 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1739,16 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,11 +1772,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1946,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2086,7 +2105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2097,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2328,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 

--- a/python/rust/Cargo.toml
+++ b/python/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zerobus-python"
 version = "1.4.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.88"
 
 [lib]
 name = "_zerobus_core"


### PR DESCRIPTION
## What changes are proposed in this pull request?

This updates the Python native extension's Cargo lockfile to patched releases of
`quinn-proto`, `rustls-webpki`, and `rand`. The resolved graph now uses
`quinn-proto` 0.11.16, `rustls-webpki` 0.103.13, `rand` 0.8.6, and the current
0.10.x `rand` path required by Quinn. These updates address the known security
advisories affecting the extension's locked dependency graph.

The PR also adds weekly Dependabot coverage for the Rust crate under
`python/rust` so future advisories and compatible updates are surfaced
automatically.

Finally, it corrects the wrapper crate's declared and documented source-build
requirement from Rust 1.83 to Rust 1.88. Tonic 0.14.6 already requires Rust 1.88,
so this makes the manifest and documentation match the effective requirement.
There are no Python API or pre-built wheel compatibility changes.

## How is this tested?

- `cargo check --locked --manifest-path rust/Cargo.toml` passed with the refreshed
  dependency graph.
- `make develop-rust` rebuilt and installed the native extension.
- `make test` passed all 154 existing tests.

No tests were added because this PR changes dependency resolution, automation,
and source-build documentation without changing runtime logic.
