### PR TITLE
[ArrowFlight] On reconnect, fail immediately for non retryable errors

### DIFF
--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -727,9 +727,14 @@ impl ZerobusArrowStream {
                                 max_retries = options.recovery_retries,
                                 "Supervisor: Max recovery retries exceeded"
                             );
-                            is_closed.store(true, Ordering::Relaxed);
-                            // Move pending batches to failed and fail the ack futures.
-                            Self::move_pending_to_failed(&pending_batches, &failed_batches).await;
+                            Self::fail_and_close(
+                                error,
+                                &is_closed,
+                                &headers_provider,
+                                &pending_batches,
+                                &failed_batches,
+                            )
+                            .await;
                             return result;
                         }
 
@@ -784,10 +789,42 @@ impl ZerobusArrowStream {
                                 // Loop continues with new stream.
                             }
                             Ok(Err(e)) => {
-                                // Mirror the initial-connect path: drop the cached
-                                // token on auth rejection so recovery re-mints.
                                 if e.is_auth_rejection() {
+                                    // Mirror the initial-connect path: drop the cached
+                                    // token on auth rejection so recovery re-mints, then
+                                    // fall through to retry with the fresh token.
                                     headers_provider.invalidate().await;
+                                } else if !e.is_retryable() {
+                                    // A non-retriable reconnection failure (e.g. the
+                                    // table schema changed) will never succeed on retry:
+                                    // retrying would just burn the recovery budget and
+                                    // bury the real cause under a generic "Reconnection
+                                    // failed". Terminate now and surface the real error
+                                    // to waiters.
+                                    error!(
+                                        "Supervisor: Non-retriable reconnection error, closing stream: {}",
+                                        e
+                                    );
+                                    // Terminate first so `is_closed` is set, then publish
+                                    // the error. wait_for_offset_internal only returns the
+                                    // published error once it observes `is_closed`, and it
+                                    // won't wake again after this single error_rx change —
+                                    // so the store must precede the send. Unlike the
+                                    // terminal arm below (whose error came from
+                                    // process_acks, which already published it), this error
+                                    // is generated in reconnect() and was never sent on
+                                    // this channel; the pre-reconnect send(None) above also
+                                    // cleared any prior error.
+                                    Self::fail_and_close(
+                                        &e,
+                                        &is_closed,
+                                        &headers_provider,
+                                        &pending_batches,
+                                        &failed_batches,
+                                    )
+                                    .await;
+                                    let _ = server_error_tx.send(Some(e.clone()));
+                                    return Err(e);
                                 }
                                 warn!("Supervisor: Reconnection failed: {}", e);
                                 // Loop continues, will retry if retries remain.
@@ -812,14 +849,14 @@ impl ZerobusArrowStream {
                     Err(error) => {
                         // Non-retriable error or recovery disabled.
                         error!("Supervisor: Non-retriable error, closing stream: {}", error);
-                        is_closed.store(true, Ordering::Relaxed);
-                        // A mid-stream auth rejection means the cached token is no
-                        // longer accepted; drop it so the next stream re-mints.
-                        if error.is_auth_rejection() {
-                            headers_provider.invalidate().await;
-                        }
-                        // Move pending batches to failed and fail the ack futures.
-                        Self::move_pending_to_failed(&pending_batches, &failed_batches).await;
+                        Self::fail_and_close(
+                            &error,
+                            &is_closed,
+                            &headers_provider,
+                            &pending_batches,
+                            &failed_batches,
+                        )
+                        .await;
                         return Err(error);
                     }
                 }
@@ -1095,6 +1132,28 @@ impl ZerobusArrowStream {
         for pb in pending {
             failed.push(pb.batch);
         }
+    }
+
+    /// Terminally shuts the stream down after an unrecoverable failure.
+    ///
+    /// Marks the stream closed, drops cached credentials on an auth rejection so
+    /// the next stream re-mints them, and moves any pending batches to the failed
+    /// set (failing their ack futures, retrievable via `get_unacked_batches()`).
+    /// Callers log their own context and return the originating error.
+    async fn fail_and_close(
+        error: &ZerobusError,
+        is_closed: &Arc<AtomicBool>,
+        headers_provider: &Arc<dyn HeadersProvider>,
+        pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
+        failed_batches: &Arc<Mutex<Vec<RecordBatch>>>,
+    ) {
+        is_closed.store(true, Ordering::Relaxed);
+        // A mid-stream auth rejection means the cached token is no longer
+        // accepted; drop it so the next stream re-mints.
+        if error.is_auth_rejection() {
+            headers_provider.invalidate().await;
+        }
+        Self::move_pending_to_failed(pending_batches, failed_batches).await;
     }
 
     /// Processes acknowledgments from the server response stream.

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1272,6 +1272,94 @@ mod arrow_flight_tests {
             Ok(())
         }
 
+        /// A *non-retriable* failure on the reconnect path must terminate the
+        /// stream immediately and surface the real error to a blocked
+        /// `wait_for_offset`, rather than retrying with a dummy stream until the
+        /// recovery budget drains. Sequence on the one table: ack batch 0 → drop
+        /// the connection (retriable, triggers recovery) → reject the reconnect
+        /// during setup with a non-retriable `InvalidArgument`.
+        #[tokio::test]
+        async fn test_non_retriable_reconnect_error_terminates_immediately(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_non_retriable_reconnect_error_terminates_immediately");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        // First connection: ack batch 0, then drop the connection
+                        // (retriable) to trigger recovery.
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 1,
+                        },
+                        MockFlightResponse::CloseStream { delay_ms: 0 },
+                        // Second connection (the reconnect): reject during setup
+                        // with a non-retriable InvalidArgument.
+                        MockFlightResponse::SetupError {
+                            status: tonic::Status::invalid_argument("schema changed"),
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            // Generous retry budget + backoff: if the supervisor wrongly retried
+            // the non-retriable error, the wait would either succeed or block for
+            // seconds. Terminating immediately means it returns well under that.
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_timeout_ms(5000)
+                .recovery_backoff_ms(1000)
+                .recovery_retries(5)
+                .build_arrow()
+                .await?;
+
+            // Batch 0 is acked on the first connection.
+            let batch1 = create_test_record_batch(schema.clone(), vec![1], vec![Some("first")]);
+            let offset1 = stream.ingest_batch(batch1).await?;
+            stream.wait_for_offset(offset1).await?;
+
+            // Batch 1 is in flight when the connection drops; recovery reconnects
+            // and is rejected with the non-retriable error.
+            let batch2 = create_test_record_batch(schema.clone(), vec![2], vec![Some("second")]);
+            let offset2 = stream.ingest_batch(batch2).await?;
+
+            let start = std::time::Instant::now();
+            let result = stream.wait_for_offset(offset2).await;
+            let elapsed = start.elapsed();
+
+            assert!(
+                result.is_err(),
+                "Expected non-retriable reconnect error, got Ok"
+            );
+            // Terminated on the first reconnect failure: one backoff (1s) at most,
+            // nowhere near the 5-retry budget (~5s) or the flush timeout.
+            assert!(
+                elapsed < std::time::Duration::from_secs(3),
+                "Expected immediate termination, took {:?} (looks like it retried)",
+                elapsed
+            );
+            // The stream is closed and the un-acked batch is retained for the caller.
+            assert!(stream.is_closed());
+
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_recreate_arrow_stream() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -59,6 +59,12 @@ pub enum MockFlightResponse {
     },
     /// Error response - sent immediately when a batch arrives.
     Error { status: Status, delay_ms: u64 },
+    /// Error response sent *during stream setup*, before the ready signal — in
+    /// place of confirming the stream. Models the real server rejecting setup
+    /// (auth failure, schema mismatch, blocked table), which the SDK classifies
+    /// on the setup / reconnect paths. Unlike [`MockFlightResponse::Error`], this
+    /// fires on the schema message rather than on the first data batch.
+    SetupError { status: Status },
     /// Close stream (drop the connection) - useful for testing recovery.
     CloseStream { delay_ms: u64 },
     /// Graceful close signal - sends a close signal with grace period duration.
@@ -258,6 +264,25 @@ impl FlightService for MockFlightServer {
                 if is_first_message {
                     is_first_message = false;
                     if flight_data.app_metadata.is_empty() {
+                        // If the next configured response is a setup-time error,
+                        // fail the stream now instead of confirming it — mirrors
+                        // the real server rejecting during setup (auth, schema
+                        // mismatch, blocked table). Consumes the response so the
+                        // next connection (e.g. a reconnect) advances past it.
+                        if let Some(MockFlightResponse::SetupError { status }) =
+                            stream_responses.get(response_index)
+                        {
+                            info!("Sending setup error response: {:?}", status);
+                            let status = status.clone();
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
+                            let _ = tx.send(Err(status)).await;
+                            return;
+                        }
+
                         debug!("Received schema message, sending ready signal");
                         // Send ready signal to confirm setup succeeded.
                         // This mirrors real server behavior where the server sends this after
@@ -445,6 +470,17 @@ impl FlightService for MockFlightServer {
                             // Continue processing - the main loop waits for more batches.
                             // During grace period the client won't send new batches,
                             // so this effectively waits until the client disconnects.
+                        }
+                        MockFlightResponse::SetupError { .. } => {
+                            // Only meaningful at setup (handled on the schema
+                            // message above). If it reaches the batch loop it was
+                            // misconfigured after a successful setup; skip it.
+                            warn!("SetupError encountered in batch loop; skipping");
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## What changes are proposed in this pull request?

When the supervisor needs to reconnect and the error is non-retryable, then close the stream immediately rather than re-trying hopelessly. This will be necessary for when we introduce schema errors.

Note that auth rejections just force a new token, so won't cause the stream to be closed immediately.

## How is this tested?

Added test.