### PR TITLE
[PureGo] Add ingestion core skeleton (1/3)

### DIFF
--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -1,0 +1,70 @@
+package stream
+
+import (
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// ackModel translates a raw server response into a logical "highest fully-acked
+// offset" that the core's watermark can compare against, and classifies
+// non-ack responses so the core stays blind to the concrete wire type. It is
+// edge #2 of the design and is generic over the response type Resp: proto/JSON
+// supply ackModel[ephemeralResp]; Arrow will supply its own over a Flight
+// response, mapping a cumulative record count back to an offset.
+//
+// This interface is intentionally the minimal offset-only subset. The
+// architecture note (§3a) sketches a wider Track/Resolve/Unacked shape for the
+// Arrow record-count model, where an ack can land mid-batch and recovery must
+// slice a straddling batch. That width is deferred until the Arrow wire path
+// lands; adding it now would be unused machinery. The core stays offset-only
+// and blind to the record-vs-batch distinction regardless.
+type ackModel[Resp any] interface {
+	// classify inspects a server response and reports what it means to the core:
+	//   - kind == ackResponse: off is the highest fully-acked offset.
+	//   - kind == pauseResponse: the server asked the client to pause; pause
+	//     carries the requested duration. The core waits then reconnects.
+	//   - kind == otherResponse: anything else (ignored by the receiver).
+	// Keeping close-signal detection here means the receiver never names a
+	// concrete proto message.
+	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
+}
+
+// respKind is the category the ackModel assigns to a server response.
+type respKind int
+
+const (
+	otherResponse respKind = iota // no ack, no pause — ignored
+	ackResponse                   // carries a durability ack offset
+	pauseResponse                 // server-requested pause (close-stream signal)
+)
+
+// ephemeralResp is the proto/JSON server response type. Aliased so the core's
+// Resp type parameter is named once here rather than spelled out at every use.
+type ephemeralResp = *zerobuspb.EphemeralStreamResponse
+
+// offsetAckModel is the proto/JSON ack model: the server sends
+// DurabilityAckUpToOffset directly as the logical offset, and a
+// CloseStreamSignal requests a pause.
+type offsetAckModel struct{}
+
+func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
+	if resp == nil {
+		return otherResponse, 0, pauseSignal{}
+	}
+	if sig := resp.GetCloseStreamSignal(); sig != nil {
+		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
+	}
+	if ack := resp.GetIngestRecordResponse(); ack != nil {
+		return ackResponse, ack.GetDurabilityAckUpToOffset(), pauseSignal{}
+	}
+	return otherResponse, 0, pauseSignal{}
+}
+
+// newAckModel returns the proto/JSON ack model for the given record type.
+func newAckModel(rt zerobuspb.RecordType) (ackModel[ephemeralResp], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON:
+		return offsetAckModel{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -1,0 +1,204 @@
+// Package stream is the generic ingestion core: offset assignment, send/recv
+// goroutines, ack watermark, Flush/WaitForOffset, and the recovery supervisor.
+// Protocol-specific behaviour (encoding, ack parsing, wire transport) is
+// injected through the encoder, ackModel, and wireStream interfaces, so the
+// core is written once and instantiated per wire protocol (proto/JSON today,
+// Arrow Flight later) without editing this package's core logic.
+package stream
+
+import (
+	"context"
+	"sync"
+)
+
+// item is one unit of work in the buffer: an already-encoded wire message
+// paired with the logical offset that identifies it for acknowledgment. Req is
+// the wire request type the core is instantiated with (encodedMsg for
+// proto/JSON; a Flight frame for Arrow).
+type item[Req any] struct {
+	offset  int64
+	payload Req
+}
+
+// buffer is the bounded, offset-assigning queue between the caller's Ingest
+// calls and the sender goroutine. Callers enqueue already-encoded messages;
+// the sender observes them (moves to in-flight); acks cause them to be
+// discarded. It is generic over the wire request type so the core holds no
+// concrete proto type.
+//
+// Concurrency model:
+//   - Many goroutines may call enqueue concurrently.
+//   - Exactly one sender goroutine calls next/requeue.
+//   - Exactly one receiver goroutine calls discardThrough as acks arrive.
+//   - Exactly one goroutine (the supervisor) calls drain.
+//
+// All state (queue, flight, sem, cond) is private; the sender and receiver
+// interact only through these methods, never by touching the fields directly.
+//
+// The semaphore enforces the MaxInflight cap: enqueue blocks once the cap is
+// reached and unblocks as acks arrive and discardThrough releases permits.
+type buffer[Req any] struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	queue    []item[Req] // pending: enqueued but not yet observed by the sender
+	flight   []item[Req] // in-flight: observed by the sender, waiting for ack
+	closed   bool
+	sem      chan struct{} // capacity = maxInflight; held while item is in queue or flight
+	doneOnce sync.Once
+	doneCh   chan struct{} // closed when the buffer is closed/drained; unblocks sem waiters
+}
+
+func newBuffer[Req any](maxInflight int) *buffer[Req] {
+	// queue/flight grow on demand; don't preallocate to maxInflight, which with
+	// the default 1M cap would reserve tens of MB per stream before a single
+	// record is ingested. Only the semaphore is sized to the cap, since it is the
+	// backpressure gate and its capacity defines the bound.
+	b := &buffer[Req]{
+		sem:    make(chan struct{}, maxInflight),
+		doneCh: make(chan struct{}),
+	}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *buffer[Req]) closeDone() {
+	b.doneOnce.Do(func() { close(b.doneCh) })
+}
+
+// enqueue adds an already-encoded message to the pending queue, blocking until
+// a slot is available (backpressure) or ctx is cancelled. The offset must be
+// monotonically increasing; the caller (coreStream) is responsible for that.
+// Returns ctx.Err() if ctx fires before a slot opens.
+func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
+	// Honor an already-cancelled ctx first: select picks randomly among ready
+	// cases, so a free slot could otherwise mask cancellation.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Acquire a slot before touching the queue so callers block here rather than
+	// inside the mutex. ctx cancellation wakes up the select immediately.
+	select {
+	case b.sem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.doneCh:
+		return errClosed
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		<-b.sem // release the slot we just took
+		return errClosed
+	}
+	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg})
+	b.mu.Unlock()
+	b.cond.Signal()
+	return nil
+}
+
+// next blocks until a pending item is available and moves it to the in-flight
+// list, returning the item. The sender must later call discard (on ack) or
+// requeue (on reconnect) for every item returned by next.
+//
+// Returns errClosed when the buffer has been closed and drained.
+// Returns ctx.Err() if ctx is cancelled while waiting.
+func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
+	b.mu.Lock()
+	for len(b.queue) == 0 && !b.closed {
+		// Wake up on ctx cancellation too.
+		stop := context.AfterFunc(ctx, func() { b.cond.Broadcast() })
+		b.cond.Wait()
+		stop()
+		if ctx.Err() != nil {
+			b.mu.Unlock()
+			return item[Req]{}, ctx.Err()
+		}
+	}
+	if len(b.queue) == 0 {
+		b.mu.Unlock()
+		return item[Req]{}, errClosed
+	}
+	it := b.queue[0]
+	b.queue = b.queue[1:]
+	b.flight = append(b.flight, it)
+	b.mu.Unlock()
+	return it, nil
+}
+
+// discardThrough removes every in-flight item whose offset is <= offset (all
+// now acknowledged by the server) and releases one semaphore slot per removed
+// item so blocked enqueue callers can proceed. It is the sender/receiver's only
+// hook for ack-driven eviction, keeping the buffer's internals (flight, sem,
+// cond) private. Returns the number of items discarded.
+func (b *buffer[Req]) discardThrough(offset int64) int {
+	b.mu.Lock()
+	n := 0
+	for len(b.flight) > 0 && b.flight[0].offset <= offset {
+		b.flight = b.flight[1:]
+		n++
+	}
+	b.mu.Unlock()
+	for range n {
+		<-b.sem
+	}
+	if n > 0 {
+		b.cond.Broadcast()
+	}
+	return n
+}
+
+// requeue moves all in-flight items back to the front of the pending queue so
+// they are re-sent after a reconnect. Called by the supervisor on stream failure.
+func (b *buffer[Req]) requeue() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Prepend in-flight items (in order) before any still-pending ones.
+	b.queue = append(b.flight, b.queue...)
+	b.flight = b.flight[:0]
+	b.cond.Broadcast()
+}
+
+// drain returns all items currently in the buffer (pending + in-flight) and
+// closes it. Subsequent enqueue calls return errClosed. Called once the
+// supervisor has given up and the caller wants unacked records.
+func (b *buffer[Req]) drain() []item[Req] {
+	b.mu.Lock()
+	all := make([]item[Req], 0, len(b.flight)+len(b.queue))
+	all = append(all, b.flight...)
+	all = append(all, b.queue...)
+	b.queue = nil
+	b.flight = nil
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+	return all
+}
+
+// close marks the buffer closed and wakes any blocked next or enqueue calls.
+// Pending items are not discarded — drain must be called to retrieve them.
+func (b *buffer[Req]) close() {
+	b.mu.Lock()
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+}
+
+// len returns the total number of items in the buffer (pending + in-flight).
+func (b *buffer[Req]) len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.queue) + len(b.flight)
+}
+
+// inFlight returns the number of items observed by the sender but not yet
+// acknowledged. The receiver uses it to gate the lack-of-ack timeout: silence
+// is only a failure while records are actually awaiting an ack; an idle stream
+// (nothing in flight) legitimately receives no acks and must not be torn down.
+func (b *buffer[Req]) inFlight() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.flight)
+}

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -1,0 +1,216 @@
+package stream
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dummyMsg returns a non-nil encodedMsg for use in buffer tests.
+func dummyMsg(offset int64) encodedMsg {
+	msg, _ := protoEncoder{}.encode(offset, []byte("x"))
+	return msg
+}
+
+func TestBufferEnqueueNext(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if it.offset != 1 {
+		t.Fatalf("want offset 1, got %d", it.offset)
+	}
+}
+
+func TestBufferFIFOOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 5; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	for i := int64(1); i <= 5; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferBackpressure(t *testing.T) {
+	const cap = 2
+	b := newBuffer[encodedMsg](cap)
+
+	// Fill the buffer to capacity.
+	for i := int64(1); i <= cap; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// A third enqueue should block until a slot is freed.
+	var enqueued atomic.Bool
+	go func() {
+		_ = b.enqueue(context.Background(), 3, dummyMsg(3))
+		enqueued.Store(true)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if enqueued.Load() {
+		t.Fatal("enqueue should be blocked at capacity")
+	}
+
+	// Observe and discard one item to free a slot.
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	b.discardThrough(it.offset)
+
+	// Now the blocked enqueue should complete.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for !enqueued.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !enqueued.Load() {
+		t.Fatal("enqueue did not unblock after discard")
+	}
+}
+
+func TestBufferContextCancelUnblocksEnqueue(t *testing.T) {
+	b := newBuffer[encodedMsg](1)
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.enqueue(ctx, 2, dummyMsg(2))
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("enqueue did not unblock on context cancel")
+	}
+}
+
+func TestBufferRequeueResendsInOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	for i := int64(1); i <= 3; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// Observe all three (move to in-flight).
+	for range 3 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	// Requeue moves them back to the front of the queue.
+	b.requeue()
+
+	for i := int64(1); i <= 3; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next after requeue %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d after requeue, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferDrainReturnsAll(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 4; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	// Observe two to put them in-flight.
+	for range 2 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	items := b.drain()
+	if len(items) != 4 {
+		t.Fatalf("want 4 items from drain, got %d", len(items))
+	}
+	// Verify in-flight items come first (offsets 1,2), then pending (3,4).
+	for i, want := range []int64{1, 2, 3, 4} {
+		if items[i].offset != want {
+			t.Fatalf("drain[%d]: want offset %d, got %d", i, want, items[i].offset)
+		}
+	}
+}
+
+func TestBufferEnqueueAfterCloseErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.close()
+	err := b.enqueue(context.Background(), 1, dummyMsg(1))
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferNextAfterCloseAndDrainErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.drain()
+	_, err := b.next(context.Background())
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
+	const n = 100
+	b := newBuffer[encodedMsg](16)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			it, err := b.next(context.Background())
+			if err != nil {
+				return
+			}
+			b.discardThrough(it.offset)
+		}
+	}()
+
+	for i := int64(1); i <= n; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	wg.Wait()
+
+	if got := b.len(); got != 0 {
+		t.Fatalf("want buffer empty after all discards, got len=%d", got)
+	}
+}

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -1,0 +1,575 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
+
+// Default config constants for the ingestion core.
+const (
+	DefaultMaxInflight      = 1_000_000
+	DefaultRecoveryRetries  = 4
+	DefaultRecoveryBackoff  = 2 * time.Second
+	DefaultFlushTimeout     = 5 * time.Minute
+	DefaultLackOfAckTimeout = 60 * time.Second
+	// DefaultDrainTimeout bounds the orderly drain-to-EOF on a clean Close so a
+	// wedged sender or an unresponsive server can't hang teardown. Matches the
+	// transport's teardown drain budget; the long ack wait lives in Flush.
+	DefaultDrainTimeout = 500 * time.Millisecond
+)
+
+// RecoverySetting controls whether a stream reconnects on failure. It is an enum
+// rather than a bool so its zero value is the safe default (recovery enabled): a
+// zero-valued Config recovers, and disabling is an explicit opt-out. This avoids
+// the bool zero-value footgun where Config{...} silently disables recovery.
+type RecoverySetting int
+
+const (
+	// RecoveryEnabled reconnects on failure. It is the zero value, so a Config
+	// that never sets Recovery still recovers.
+	RecoveryEnabled RecoverySetting = iota
+	// RecoveryDisabled fails the stream on the first unrecoverable error without
+	// attempting to reconnect.
+	RecoveryDisabled
+)
+
+// enabled reports whether recovery should be attempted.
+func (r RecoverySetting) enabled() bool { return r == RecoveryEnabled }
+
+// Config holds per-stream configuration. All fields have sane defaults via
+// DefaultConfig(); override individual fields before passing to NewCoreStream.
+type Config struct {
+	// MaxInflight is the maximum number of unacknowledged records in the buffer.
+	MaxInflight int
+	// Recovery controls whether stream reconnection is attempted on failure. The
+	// zero value (RecoveryEnabled) recovers; set RecoveryDisabled to opt out.
+	Recovery RecoverySetting
+	// RecoveryRetries is the maximum number of consecutive failed reconnect
+	// attempts before giving up. The budget is per recovery episode: a stream
+	// that connects and runs successfully resets it, so a long-lived stream that
+	// disconnects occasionally is not doomed after RecoveryRetries lifetime
+	// disconnects.
+	RecoveryRetries int
+	// RecoveryBackoff is the fixed wait between reconnect attempts.
+	RecoveryBackoff time.Duration
+	// FlushTimeout bounds Flush when the caller's context has no deadline.
+	FlushTimeout time.Duration
+	// LackOfAckTimeout is how long the receiver waits for a server ack, while
+	// records are in flight, before treating silence as a stream failure. An idle
+	// stream with nothing in flight is never failed for silence.
+	LackOfAckTimeout time.Duration
+	// DrainTimeout bounds the orderly drain-to-EOF performed on a clean Close so
+	// the server observes an orderly END_STREAM rather than an abrupt reset.
+	DrainTimeout time.Duration
+	// StreamPausedMaxWait caps how long the client waits after a server
+	// CloseStreamSignal before reconnecting. The effective wait is
+	// min(StreamPausedMaxWait, server-requested duration). A non-positive value
+	// means "no client cap": wait the full server-requested duration. This lets a
+	// caller trade graceful drain (wait longer) against faster recovery.
+	StreamPausedMaxWait time.Duration
+}
+
+// DefaultConfig returns a Config with SDK-standard defaults.
+func DefaultConfig() Config {
+	return Config{
+		MaxInflight: DefaultMaxInflight,
+		// Recovery left as its zero value, RecoveryEnabled.
+		RecoveryRetries:  DefaultRecoveryRetries,
+		RecoveryBackoff:  DefaultRecoveryBackoff,
+		FlushTimeout:     DefaultFlushTimeout,
+		LackOfAckTimeout: DefaultLackOfAckTimeout,
+		DrainTimeout:     DefaultDrainTimeout,
+	}
+}
+
+// AckCallback is called once per acknowledged record/batch offset.
+type AckCallback interface {
+	OnAck(offset int64)
+	OnError(offset int64, err error)
+}
+
+// watermark is the monotonic ack offset shared between the receiver goroutine
+// (writer) and Flush/WaitForOffset callers (readers).
+type watermark struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	offset   int64 // highest fully-acked offset; -1 means none yet
+	err      error // terminal error set once and never cleared
+	terminal bool
+}
+
+func newWatermark() *watermark {
+	w := &watermark{offset: -1}
+	w.cond = sync.NewCond(&w.mu)
+	return w
+}
+
+// advance sets the watermark to max(current, offset) and wakes waiters.
+func (w *watermark) advance(offset int64) {
+	w.mu.Lock()
+	if offset > w.offset {
+		w.offset = offset
+	}
+	w.mu.Unlock()
+	w.cond.Broadcast()
+}
+
+// fail marks the watermark terminal with err and wakes all waiters.
+func (w *watermark) fail(err error) {
+	w.mu.Lock()
+	if !w.terminal {
+		w.err = err
+		w.terminal = true
+	}
+	w.mu.Unlock()
+	w.cond.Broadcast()
+}
+
+// waitFor blocks until the watermark reaches target or the watermark becomes
+// terminal. Returns nil if the target is reached, or the terminal error.
+func (w *watermark) waitFor(ctx context.Context, target int64) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.offset < target && !w.terminal {
+		// Wake up on ctx cancellation too.
+		stop := context.AfterFunc(ctx, func() { w.cond.Broadcast() })
+		w.cond.Wait()
+		stop()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	if w.offset >= target {
+		return nil
+	}
+	return w.err
+}
+
+// CoreStream is the protocol-agnostic ingestion core. It owns the buffer,
+// sender goroutine, receiver goroutine, ack watermark, and the supervisor
+// that reconnects on failure. It is generic over the wire request/response
+// types (Req/Resp): proto/JSON instantiate it over EphemeralStream, Arrow over
+// Flight. The three specialization points — encoder, ackModel, and the
+// wireStream returned by opener — are injected, so this core is written once
+// and never names a concrete proto type.
+//
+// The three goroutines:
+//
+//	sender   — pulls items from the buffer, writes them to the wire stream.
+//	receiver — reads acks from the wire stream, advances the watermark.
+//	supervisor — create → run → recover loop; wires sender+receiver together.
+//
+// Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
+// GetUnacked, and Close.
+type CoreStream[Req, Resp any] struct {
+	params   StreamParams
+	cfg      Config
+	opener   opener[Req, Resp]
+	enc      encoder[Req]
+	ackMdl   ackModel[Resp]
+	buf      *buffer[Req]
+	wm       *watermark
+	callback AckCallback
+
+	// ingestMu serializes offset assignment + enqueue so that nextOffset only
+	// advances for records that were successfully queued. Without this, a failed
+	// enqueue (e.g. ctx-cancelled backpressure) would consume an offset that is
+	// never sent, making Flush wait forever for an offset the server never sees.
+	ingestMu sync.Mutex
+	// nextOffset is the next logical offset to assign. Protected by ingestMu.
+	nextOffset int64
+	// lastEnqueued is the highest offset successfully enqueued; -1 until the
+	// first successful Ingest. Flush targets this, not nextOffset-1, so a
+	// failed Ingest can't create a permanent gap.
+	lastEnqueued int64
+
+	// done is closed when the supervisor exits (terminal state).
+	done chan struct{}
+	// termErr holds the first terminal error after done is closed.
+	termErr error
+	termMu  sync.Mutex
+
+	closeOnce sync.Once
+	// cancelSupervisor cancels the supervisor's context so Close unblocks it.
+	cancelSupervisor context.CancelFunc
+}
+
+// NewCoreStream constructs a CoreStream and starts the supervisor goroutine.
+// The stream is immediately ready for Ingest calls; the supervisor opens the
+// first transport stream in the background. Prefer the per-protocol
+// constructors (NewProtoJSONStream) over calling this directly.
+func NewCoreStream[Req, Resp any](
+	params StreamParams,
+	cfg Config,
+	opener opener[Req, Resp],
+	enc encoder[Req],
+	ackMdl ackModel[Resp],
+	callback AckCallback,
+) *CoreStream[Req, Resp] {
+	ctx, cancel := context.WithCancel(context.Background())
+	cs := &CoreStream[Req, Resp]{
+		params:           params,
+		cfg:              cfg,
+		opener:           opener,
+		enc:              enc,
+		ackMdl:           ackMdl,
+		buf:              newBuffer[Req](cfg.MaxInflight),
+		wm:               newWatermark(),
+		callback:         callback,
+		lastEnqueued:     -1,
+		done:             make(chan struct{}),
+		cancelSupervisor: cancel,
+	}
+	go cs.supervise(ctx)
+	return cs
+}
+
+// Ingest encodes record and enqueues it in the buffer, blocking if the buffer
+// is at capacity (backpressure). Returns the logical offset assigned to this
+// record; pass it to WaitForOffset to confirm durability.
+func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int64, error) {
+	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
+		return cs.enc.encode(offset, record)
+	})
+}
+
+// IngestBatch encodes records as a single atomic batch and enqueues it, blocking
+// if the buffer is at capacity. The whole batch occupies one logical offset and
+// the server acks it atomically. Returns that offset. Prefer this over Ingest in
+// hot paths: it amortizes per-message overhead across the batch.
+func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]byte) (int64, error) {
+	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
+		return cs.enc.encodeBatch(offset, records)
+	})
+}
+
+// enqueueEncoded assigns the next offset, encodes via encodeFn, and enqueues the
+// result under ingestMu so nextOffset advances only for records that make it
+// into the buffer. A failed encode or ctx-cancelled backpressure consumes no
+// offset, so Flush never waits on an offset the server never sees.
+func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn func(offset int64) (Req, error)) (int64, error) {
+	if cs.isClosed() {
+		if err := cs.terminalErr(); err != nil {
+			return 0, err
+		}
+		return 0, errClosed
+	}
+	cs.ingestMu.Lock()
+	defer cs.ingestMu.Unlock()
+
+	offset := cs.nextOffset
+	msg, err := encodeFn(offset)
+	if err != nil {
+		return 0, err
+	}
+	if err := cs.buf.enqueue(ctx, offset, msg); err != nil {
+		return 0, err
+	}
+	cs.nextOffset++
+	cs.lastEnqueued = offset
+	return offset, nil
+}
+
+// Flush blocks until every record ingested so far is acknowledged by the
+// server. Returns nil once all are durable, or an error if the stream fails
+// or ctx expires.
+//
+// When ctx has no deadline, Flush applies DefaultFlushTimeout.
+func (cs *CoreStream[Req, Resp]) Flush(ctx context.Context) error {
+	cs.ingestMu.Lock()
+	target := cs.lastEnqueued
+	cs.ingestMu.Unlock()
+	if target < 0 {
+		return nil // nothing successfully ingested yet
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cs.cfg.FlushTimeout)
+		defer cancel()
+	}
+	return cs.WaitForOffset(ctx, target)
+}
+
+// WaitForOffset blocks until the server has acknowledged all records up to and
+// including offset, or until ctx expires or the stream fails terminally.
+//
+// offset must be one returned by a successful Ingest. Passing an offset that was
+// never enqueued (e.g. a value above the last assigned offset) is a caller error:
+// since the watermark can never reach it, the call blocks until ctx expires (or
+// the stream fails). Prefer Flush, which waits for exactly the records ingested
+// so far.
+func (cs *CoreStream[Req, Resp]) WaitForOffset(ctx context.Context, offset int64) error {
+	return cs.wm.waitFor(ctx, offset)
+}
+
+// GetUnacked returns records that were ingested but never acknowledged, one
+// entry per record. A batched buffer item expands to all of its records (not
+// just the first), so no unacked record is silently dropped. It closes the
+// stream first (idempotent) to ensure the buffer is fully drained and no new
+// items are added.
+func (cs *CoreStream[Req, Resp]) GetUnacked() [][]byte {
+	cs.Close()
+	items := cs.buf.drain()
+	out := make([][]byte, 0, len(items))
+	for _, it := range items {
+		// Re-extract the raw record bytes from the encoded message so callers get
+		// back the original record content; a batch yields all its records.
+		out = append(out, cs.enc.decode(it.payload)...)
+	}
+	return out
+}
+
+// Close terminates the stream and releases its resources. It is idempotent and
+// blocks until teardown completes.
+//
+// Close does NOT wait for pending records to be acknowledged: any records still
+// in flight when Close is called are abandoned (retrievable via GetUnacked, or
+// reported through the AckCallback's OnError). Callers that need durability must
+// Flush first, then Close — the standard loop-then-Flush pattern. On this clean
+// shutdown the live stream is torn down gracefully (half-close, then drain any
+// straggling acks to EOF, bounded by DrainTimeout) so the server observes an
+// orderly END_STREAM rather than an abrupt reset; see gracefulTeardown.
+func (cs *CoreStream[Req, Resp]) Close() {
+	cs.closeOnce.Do(func() {
+		cs.cancelSupervisor()
+		cs.buf.close()
+		<-cs.done // wait for the supervisor to exit
+	})
+}
+
+// IsClosed reports whether the stream has been closed or failed terminally.
+func (cs *CoreStream[Req, Resp]) IsClosed() bool {
+	return cs.isClosed()
+}
+
+func (cs *CoreStream[Req, Resp]) isClosed() bool {
+	select {
+	case <-cs.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (cs *CoreStream[Req, Resp]) terminalErr() error {
+	cs.termMu.Lock()
+	defer cs.termMu.Unlock()
+	return cs.termErr
+}
+
+func (cs *CoreStream[Req, Resp]) setTerminalErr(err error) {
+	cs.termMu.Lock()
+	if cs.termErr == nil {
+		cs.termErr = err
+	}
+	cs.termMu.Unlock()
+}
+
+// runOnce opens one transport stream and runs sender+receiver until one of
+// them exits. Returns the cause of the exit so the supervisor can decide
+// whether to recover, and healthy=true once a stream was successfully opened
+// and run (so the supervisor can reset its per-episode retry budget — a stream
+// that connected and later failed is a fresh episode, not a continuation of the
+// prior reconnect streak).
+func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, healthy bool) {
+	stream, err := cs.opener.Open(ctx, cs.params)
+	if err != nil {
+		// Invalid params (bad table name, unsupported record type, missing
+		// descriptor) are deterministic — reconnecting reproduces them — so mark
+		// them non-retryable rather than burning the recovery budget on a failure
+		// that can't succeed.
+		if errors.Is(err, transport.ErrInvalidParams) {
+			return wrapValidation(fmt.Errorf("stream: open: %w", err)), false
+		}
+		return fmt.Errorf("stream: open: %w", err), false
+	}
+
+	// Move all in-flight items back to the pending queue so the sender
+	// re-sends them on this new connection.
+	cs.buf.requeue()
+
+	// senderCtx is cancelled when we want the sender to stop for THIS stream
+	// only, without cancelling the supervisor's outer ctx (which would signal Close).
+	senderCtx, cancelSender := context.WithCancel(ctx)
+	defer cancelSender()
+
+	errCh := make(chan error, 2)
+
+	go cs.sender(senderCtx, stream, errCh)
+	go cs.receiver(stream, errCh)
+
+	// Wait for the first goroutine to signal, then tear both down. On clean
+	// shutdown (Close cancelled ctx) only the sender exits first — the receiver
+	// keeps draining acks — so we half-close and let it drain to EOF for an
+	// orderly server-observed END_STREAM. On failure we hard-abort instead.
+	cause = <-errCh
+	cancelSender() // unblocks sender waiting on buf.next()
+	var ps pauseSignal
+	switch {
+	case ctx.Err() != nil:
+		cs.gracefulTeardown(stream, errCh)
+	case errors.As(cause, &ps):
+		// Server-requested pause: the receiver already closed the stream to
+		// unblock its Recv, so just reap the sender. Requeue happens on reconnect.
+		stream.Close()
+		<-errCh
+	default:
+		// Failure/recovery path: the stream is already broken, so hard-abort to
+		// unblock the receiver's Recv immediately.
+		stream.Close()
+		<-errCh // drain second exit
+	}
+	return cause, true
+}
+
+// gracefulTeardown closes a healthy stream in an orderly fashion after the
+// sender has stopped: half-close the send side so the server flushes any
+// remaining acks and ends the stream, let the still-running receiver drain to
+// io.EOF (advancing the watermark for late acks), then release resources.
+// DrainTimeout bounds the wait so a wedged server can't hang Close; on expiry we
+// hard-abort. This mirrors transport.GracefulClose, done cooperatively because
+// the receiver goroutine — not this one — owns Recv.
+func (cs *CoreStream[Req, Resp]) gracefulTeardown(stream wireStream[Req, Resp], errCh <-chan error) {
+	if err := stream.CloseSend(); err != nil {
+		// Send side already broken; fall back to a hard abort.
+		stream.Close()
+		<-errCh
+		return
+	}
+	timer := time.NewTimer(cs.cfg.DrainTimeout)
+	defer timer.Stop()
+	select {
+	case <-errCh:
+		// Receiver drained to EOF; release resources (Close is idempotent).
+		stream.Close()
+	case <-timer.C:
+		// Drain budget exceeded; force the receiver out and reap it.
+		stream.Close()
+		<-errCh
+	}
+}
+
+// sender pulls items from the buffer and writes them to stream. Exits when
+// senderCtx is cancelled (per-stream teardown), the buffer is closed, or
+// Send fails. senderCtx is derived from a per-runOnce cancel so the supervisor
+// can stop this sender without cancelling the outer supervisor context.
+func (cs *CoreStream[Req, Resp]) sender(senderCtx context.Context, stream wireStream[Req, Resp], errCh chan<- error) {
+	for {
+		it, err := cs.buf.next(senderCtx)
+		if err != nil {
+			errCh <- nil // ctx cancelled or buffer closed — clean exit
+			return
+		}
+		if err := stream.Send(it.payload); err != nil {
+			errCh <- fmt.Errorf("stream: send offset %d: %w", it.offset, err)
+			return
+		}
+	}
+}
+
+// receiver reads ack responses from stream and advances the watermark. It runs
+// until io.EOF (server closed cleanly, including after a graceful half-close),
+// a receive error, the lack-of-ack timeout (only while records are in flight),
+// or the stream being Closed out from under it (which surfaces as a Recv error).
+// Teardown is coordinated by runOnce, so the receiver does not watch the
+// supervisor context itself.
+//
+// Each Recv call runs on its own goroutine so we can race it against the
+// lack-of-ack timer even when the underlying transport Recv is blocking (e.g. a
+// fake in tests, or a stalled server).
+func (cs *CoreStream[Req, Resp]) receiver(stream wireStream[Req, Resp], errCh chan<- error) {
+	type recvResult struct {
+		resp Resp
+		err  error
+	}
+
+	// A single outstanding Recv goroutine at a time feeds recvCh. Hoisting it out
+	// of the loop keeps the lack-of-ack timer live across idle periods: re-arming
+	// the timer must not commit us to blocking on the current Recv, or records
+	// that go in flight later would never be checked against the timeout.
+	recvCh := make(chan recvResult, 1)
+	spawnRecv := func() {
+		go func() {
+			resp, err := stream.Recv()
+			recvCh <- recvResult{resp, err}
+		}()
+	}
+	spawnRecv()
+
+	lackTimer := time.NewTimer(cs.cfg.LackOfAckTimeout)
+	defer lackTimer.Stop()
+
+	for {
+		var r recvResult
+		select {
+		case <-lackTimer.C:
+			// Silence is only a failure while records are actually awaiting an ack.
+			// An idle stream (nothing in flight) legitimately receives no acks, so
+			// re-arm the timer and keep waiting on the same outstanding Recv rather
+			// than tearing the stream down.
+			if cs.buf.inFlight() == 0 {
+				lackTimer.Reset(cs.cfg.LackOfAckTimeout)
+				continue
+			}
+			stream.Close()
+			<-recvCh // reap the outstanding Recv goroutine
+			errCh <- fmt.Errorf("stream: no ack from server for %s", cs.cfg.LackOfAckTimeout)
+			return
+		case r = <-recvCh:
+		}
+
+		if r.err == io.EOF {
+			errCh <- nil
+			return
+		}
+		if r.err != nil {
+			errCh <- fmt.Errorf("stream: recv: %w", r.err)
+			return
+		}
+
+		kind, offset, pause := cs.ackMdl.classify(r.resp)
+		if kind == pauseResponse {
+			// A server pause (proto/JSON CloseStreamSignal) is a flow-control
+			// request, not noise: the server is about to close this stream and
+			// wants the client to pause (stop sending, keep buffering and draining
+			// acks) then reconnect. Report it so the supervisor waits the requested
+			// window and reconnects without counting it against the recovery
+			// budget. This iteration's Recv goroutine already delivered (via r
+			// above), so there is nothing to drain; runOnce owns tearing the stream
+			// down.
+			errCh <- pause
+			return
+		}
+
+		// Not a terminal response — keep reading. Spawn the next Recv before
+		// handling this one so the loop always has exactly one outstanding.
+		spawnRecv()
+
+		if kind == ackResponse {
+			// Reset the lack-of-ack timer on every ack received.
+			if !lackTimer.Stop() {
+				select {
+				case <-lackTimer.C:
+				default:
+				}
+			}
+			lackTimer.Reset(cs.cfg.LackOfAckTimeout)
+
+			cs.wm.advance(offset)
+			// Discard all buffer items that are now acknowledged, freeing their
+			// backpressure slots for waiting enqueue callers.
+			cs.buf.discardThrough(offset)
+
+			if cs.callback != nil {
+				cs.callback.OnAck(offset)
+			}
+		}
+		// otherResponse: ignored; the next Recv is already outstanding.
+	}
+}

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -1,0 +1,931 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// ---- fake transport helpers ------------------------------------------------
+
+// fakeRPC is a minimal in-process bidi stream satisfying transport.FakeStreamRPC.
+// It lets tests control exactly what acks the receiver sees without a real
+// gRPC server. close() closes the recvs channel so Recv returns io.EOF,
+// unblocking the receiver goroutine just like a real gRPC stream close would.
+type fakeRPC struct {
+	sends     chan *zerobuspb.EphemeralStreamRequest
+	recvs     chan *zerobuspb.EphemeralStreamResponse
+	closeOnce sync.Once
+	closed    atomic.Bool
+}
+
+func newFakeRPC() *fakeRPC {
+	return &fakeRPC{
+		sends: make(chan *zerobuspb.EphemeralStreamRequest, 64),
+		recvs: make(chan *zerobuspb.EphemeralStreamResponse, 64),
+	}
+}
+
+func (f *fakeRPC) Send(req *zerobuspb.EphemeralStreamRequest) error {
+	if f.closed.Load() {
+		return io.EOF
+	}
+	select {
+	case f.sends <- req:
+		return nil
+	default:
+		// channel full — shouldn't happen with buffered 64 in tests
+		return fmt.Errorf("fakeRPC: sends channel full")
+	}
+}
+
+func (f *fakeRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	resp, ok := <-f.recvs
+	if !ok {
+		return nil, io.EOF
+	}
+	return resp, nil
+}
+
+// CloseSend closes the stream from the send side; in our fake this also
+// closes the recvs channel so the receiver unblocks with io.EOF.
+func (f *fakeRPC) CloseSend() error {
+	f.close()
+	return nil
+}
+
+// close closes the recvs channel, causing any blocking Recv call to return
+// io.EOF. Safe to call multiple times.
+func (f *fakeRPC) close() {
+	f.closeOnce.Do(func() {
+		f.closed.Store(true)
+		close(f.recvs)
+	})
+}
+
+// ack sends a DurabilityAck response for offset.
+func (f *fakeRPC) ack(offset int64) {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(offset),
+			},
+		},
+	}
+}
+
+// closeSignal sends a server CloseStreamSignal, asking the client to pause.
+func (f *fakeRPC) closeSignal() {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{},
+		},
+	}
+}
+
+// closeSignalWithDuration sends a CloseStreamSignal carrying the given
+// server-requested pause duration.
+func (f *fakeRPC) closeSignalWithDuration(d time.Duration) {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{
+				Duration: durationpb.New(d),
+			},
+		},
+	}
+}
+
+// fakeOpener wraps a fakeRPC as a transport.Opener by building a rawStream
+// from it. Each call to Open returns the same underlying fakeRPC so tests
+// can send acks from it.
+type fakeOpener struct {
+	mu       sync.Mutex
+	rpcs     []*fakeRPC
+	idx      int
+	openErr  error // if non-nil, all opens fail with this error
+	attempts int   // number of Open calls, for asserting retry behavior
+}
+
+func newFakeOpener(rpcs ...*fakeRPC) *fakeOpener {
+	return &fakeOpener{rpcs: rpcs}
+}
+
+func (fo *fakeOpener) openCount() int {
+	fo.mu.Lock()
+	defer fo.mu.Unlock()
+	return fo.attempts
+}
+
+func (fo *fakeOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	fo.mu.Lock()
+	defer fo.mu.Unlock()
+	fo.attempts++
+	if fo.openErr != nil {
+		return nil, fo.openErr
+	}
+	if fo.idx >= len(fo.rpcs) {
+		return nil, fmt.Errorf("fakeOpener: no more RPCs")
+	}
+	rpc := fo.rpcs[fo.idx]
+	fo.idx++
+	return transport.NewFakeStreamForTesting(rpc), nil
+}
+
+// gracefulFakeRPC models real gRPC teardown semantics more faithfully than
+// fakeRPC by distinguishing the two teardown verbs:
+//   - CloseSend half-closes the send side (signalling closeSent) but leaves Recv
+//     open, so a test can deliver late acks after the half-close and assert the
+//     receiver drains them.
+//   - Abort models Close/context-cancel: it unblocks a blocked Recv with an error
+//     and drops any further acks, as an abrupt reset would.
+//
+// serverEnd closes recvs to produce the io.EOF that ends a graceful drain.
+type gracefulFakeRPC struct {
+	sends     chan *zerobuspb.EphemeralStreamRequest
+	recvs     chan *zerobuspb.EphemeralStreamResponse
+	closeSent chan struct{}
+	aborted   chan struct{}
+	closeOnce sync.Once
+	abortOnce sync.Once
+	endOnce   sync.Once
+	ended     atomic.Bool
+}
+
+func newGracefulFakeRPC() *gracefulFakeRPC {
+	return &gracefulFakeRPC{
+		sends:     make(chan *zerobuspb.EphemeralStreamRequest, 64),
+		recvs:     make(chan *zerobuspb.EphemeralStreamResponse, 64),
+		closeSent: make(chan struct{}),
+		aborted:   make(chan struct{}),
+	}
+}
+
+func (f *gracefulFakeRPC) Send(req *zerobuspb.EphemeralStreamRequest) error {
+	f.sends <- req
+	return nil
+}
+
+func (f *gracefulFakeRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	select {
+	case resp, ok := <-f.recvs:
+		if !ok {
+			return nil, io.EOF
+		}
+		return resp, nil
+	case <-f.aborted:
+		return nil, io.ErrClosedPipe
+	}
+}
+
+// CloseSend half-closes the send side without ending Recv, matching gRPC.
+func (f *gracefulFakeRPC) CloseSend() error {
+	f.closeOnce.Do(func() { close(f.closeSent) })
+	return nil
+}
+
+// Abort models Stream.Close/context-cancel: it unblocks Recv with an error.
+func (f *gracefulFakeRPC) Abort() {
+	f.abortOnce.Do(func() {
+		f.ended.Store(true)
+		close(f.aborted)
+	})
+}
+
+// serverEnd ends the stream from the server side so the drain sees io.EOF.
+func (f *gracefulFakeRPC) serverEnd() {
+	f.endOnce.Do(func() {
+		f.ended.Store(true)
+		close(f.recvs)
+	})
+}
+
+func (f *gracefulFakeRPC) ack(offset int64) {
+	if f.ended.Load() {
+		return
+	}
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(offset),
+			},
+		},
+	}
+}
+
+type gracefulOpener struct{ rpc *gracefulFakeRPC }
+
+func (o *gracefulOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return transport.NewFakeStreamForTesting(o.rpc), nil
+}
+
+// ---- recording ack callback ------------------------------------------------
+
+type recordingCallback struct {
+	mu   sync.Mutex
+	acks []int64
+	errs []int64
+}
+
+func (r *recordingCallback) OnAck(offset int64) {
+	r.mu.Lock()
+	r.acks = append(r.acks, offset)
+	r.mu.Unlock()
+}
+
+func (r *recordingCallback) OnError(offset int64, _ error) {
+	r.mu.Lock()
+	r.errs = append(r.errs, offset)
+	r.mu.Unlock()
+}
+
+func (r *recordingCallback) ackCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.acks)
+}
+
+// ---- test helpers ----------------------------------------------------------
+
+func testConfig() Config {
+	c := DefaultConfig()
+	c.MaxInflight = 64
+	c.FlushTimeout = 2 * time.Second
+	c.LackOfAckTimeout = 2 * time.Second
+	c.RecoveryBackoff = 10 * time.Millisecond
+	return c
+}
+
+func testParams() StreamParams {
+	return StreamParams{
+		TableName:  "c.s.t",
+		RecordType: zerobuspb.RecordType_JSON,
+	}
+}
+
+// testStream is the proto/JSON core specialization used throughout these tests.
+type testStream = CoreStream[encodedMsg, ephemeralResp]
+
+// testOpener is the opener type the fakes satisfy.
+type testOpener = opener[encodedMsg, ephemeralResp]
+
+// newCoreForTest builds a proto/JSON CoreStream with the JSON encoder and offset
+// ack model — the common wiring every test needs.
+func newCoreForTest(params StreamParams, cfg Config, o testOpener, cb AckCallback) *testStream {
+	return NewCoreStream[encodedMsg, ephemeralResp](params, cfg, o, jsonEncoder{}, offsetAckModel{}, cb)
+}
+
+func newTestStream(t *testing.T, o testOpener) *testStream {
+	t.Helper()
+	cb := &recordingCallback{}
+	cs := newCoreForTest(testParams(), testConfig(), o, cb)
+	t.Cleanup(func() { cs.Close() })
+	return cs
+}
+
+// waitCondition polls fn until it returns true or deadline expires.
+func waitCondition(t *testing.T, fn func() bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !fn() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition not met within timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// ---- tests -----------------------------------------------------------------
+
+func TestCoreStreamIngestAndFlush(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	offset, err := cs.Ingest(context.Background(), []byte(`{"k":"v"}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if offset != 0 {
+		t.Fatalf("want offset 0, got %d", offset)
+	}
+
+	// Drain the send channel and ack.
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+	rpc.ack(0)
+
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestCoreStreamOffsetMonotonic(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	for i := int64(0); i < 5; i++ {
+		off, err := cs.Ingest(context.Background(), []byte(`{}`))
+		if err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+		if off != i {
+			t.Fatalf("want offset %d, got %d", i, off)
+		}
+	}
+}
+
+func TestCoreStreamWaitForOffset(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	for i := range 3 {
+		if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+	}
+
+	// Drain all three sends then ack offset 2 (covers 0, 1, 2).
+	waitCondition(t, func() bool { return len(rpc.sends) == 3 }, time.Second)
+	for range 3 {
+		<-rpc.sends
+	}
+	rpc.ack(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, 2); err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+}
+
+func TestCoreStreamFlushNothingIngested(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush with no ingests: %v", err)
+	}
+}
+
+func TestCoreStreamFlushContextExpires(t *testing.T) {
+	rpc := newFakeRPC()
+	// Intentionally never ack.
+	_ = rpc
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := cs.Flush(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestCoreStreamAckCallbackFires(t *testing.T) {
+	rpc := newFakeRPC()
+	cb := &recordingCallback{}
+	cs := newCoreForTest(testParams(), testConfig(), newFakeOpener(rpc), cb)
+	t.Cleanup(func() { cs.Close() })
+
+	for range 3 {
+		if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+	}
+
+	waitCondition(t, func() bool { return len(rpc.sends) == 3 }, time.Second)
+	for range 3 {
+		<-rpc.sends
+	}
+	rpc.ack(2)
+
+	waitCondition(t, func() bool { return cb.ackCount() >= 1 }, time.Second)
+}
+
+func TestCoreStreamCloseIsIdempotent(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	cs.Close()
+	cs.Close() // must not panic or block
+}
+
+// TestCoreStreamCloseDrainsGracefully verifies that a clean Close half-closes
+// the send side (CloseSend) and keeps the receiver draining acks to io.EOF,
+// rather than abruptly aborting the stream. An ack delivered after the
+// half-close must still advance the watermark; an abrupt teardown would drop it.
+func TestCoreStreamCloseDrainsGracefully(t *testing.T) {
+	rpc := newGracefulFakeRPC()
+	cb := &recordingCallback{}
+	cs := newCoreForTest(testParams(), testConfig(), &gracefulOpener{rpc: rpc}, cb)
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+
+	// Close in the background; it blocks until the graceful drain completes.
+	done := make(chan struct{})
+	go func() { cs.Close(); close(done) }()
+
+	// Close must half-close the send side rather than hard-abort.
+	select {
+	case <-rpc.closeSent:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not half-close the send side (CloseSend) — it hard-aborted")
+	}
+
+	// Deliver a late ack after the half-close, then end the stream. A graceful
+	// drain observes this ack; an abrupt teardown would have dropped it.
+	rpc.ack(off)
+	rpc.serverEnd()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after the server ended the stream")
+	}
+
+	if got := cb.ackCount(); got != 1 {
+		t.Fatalf("want the post-half-close ack drained (ackCount=1), got %d", got)
+	}
+}
+
+func TestCoreStreamIsClosed(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	if cs.IsClosed() {
+		t.Fatal("want not closed before Close()")
+	}
+	cs.Close()
+	if !cs.IsClosed() {
+		t.Fatal("want closed after Close()")
+	}
+}
+
+func TestCoreStreamGetUnackedReturnsItems(t *testing.T) {
+	// Use a fakeOpener that always fails to open so all items stay unacked.
+	fo := &fakeOpener{openErr: fmt.Errorf("connection refused")}
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+
+	// Ingest with a context that will eventually succeed (the buffer blocks,
+	// not the opener). Give it a short context so we can proceed quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _ = cs.Ingest(ctx, []byte(`{"a":1}`))
+
+	unacked := cs.GetUnacked()
+	// Items may or may not be in unacked depending on timing; we just want
+	// GetUnacked to not panic and to close the stream.
+	_ = unacked
+	if !cs.IsClosed() {
+		t.Fatal("GetUnacked should close the stream")
+	}
+}
+
+func TestCoreStreamConcurrentIngest(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	const n = 50
+	var wg sync.WaitGroup
+	offsets := make([]int64, n)
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			off, err := cs.Ingest(context.Background(), []byte(`{}`))
+			if err != nil {
+				t.Errorf("goroutine %d Ingest: %v", i, err)
+				return
+			}
+			offsets[i] = off
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all offsets are unique.
+	seen := make(map[int64]bool)
+	for _, off := range offsets {
+		if seen[off] {
+			t.Fatalf("duplicate offset %d", off)
+		}
+		seen[off] = true
+	}
+}
+
+// TestCoreStreamRecoveryRequeuesUnacked verifies that items in flight when
+// the first transport stream dies are re-sent on the recovery stream.
+func TestCoreStreamRecoveryRequeuesUnacked(t *testing.T) {
+	rpc1 := newFakeRPC()
+	rpc2 := newFakeRPC()
+	fo := newFakeOpener(rpc1, rpc2)
+
+	cfg := testConfig()
+	cfg.RecoveryRetries = 1
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	// Wait for the send to land on rpc1 then kill rpc1 before acking.
+	waitCondition(t, func() bool { return len(rpc1.sends) > 0 }, time.Second)
+	rpc1.close() // triggers receiver EOF → supervisor recovers to rpc2
+
+	// rpc2 should receive the re-sent item.
+	waitCondition(t, func() bool { return len(rpc2.sends) > 0 }, 2*time.Second)
+	<-rpc2.sends
+	rpc2.ack(off)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("WaitForOffset after recovery: %v", err)
+	}
+}
+
+// TestCoreStreamIngestOnClosedStreamErrors verifies that Ingest on a cleanly
+// closed stream returns an error, not (0, nil).
+func TestCoreStreamIngestOnClosedStreamErrors(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	cs.Close()
+
+	_, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err == nil {
+		t.Fatal("want error from Ingest on closed stream, got nil")
+	}
+}
+
+// TestCoreStreamFailedIngestDoesNotAdvanceFlushTarget verifies that a
+// ctx-cancelled Ingest does not leave a gap that blocks Flush forever.
+func TestCoreStreamFailedIngestDoesNotAdvanceFlushTarget(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	// First Ingest succeeds.
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+
+	// Second Ingest fails (cancelled context) — must not consume an offset.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = cs.Ingest(cancelledCtx, []byte(`{}`))
+	if err == nil {
+		t.Fatal("want error from cancelled Ingest, got nil")
+	}
+
+	// Ack the first offset and flush — must not block waiting for offset 1.
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+	rpc.ack(off)
+
+	ctx, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	if err := cs.Flush(ctx); err != nil {
+		t.Fatalf("Flush blocked on gap from failed Ingest: %v", err)
+	}
+}
+
+// TestCoreStreamCloseUnblocksEnqueueAtCapacity verifies that a caller blocked
+// in Ingest (buffer at capacity) unblocks when the stream is closed, rather
+// than hanging forever on the semaphore.
+func TestCoreStreamCloseUnblocksEnqueueAtCapacity(t *testing.T) {
+	rpc := newFakeRPC()
+	cfg := testConfig()
+	cfg.MaxInflight = 1
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	// Fill the single slot.
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+
+	// A second Ingest should block; close the stream from another goroutine.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := cs.Ingest(context.Background(), []byte(`{}`))
+		errCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cs.Close()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("want error from blocked Ingest after Close, got nil")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Ingest did not unblock after Close")
+	}
+}
+
+// TestCoreStreamGetUnackedWorksWithCallback verifies that GetUnacked returns
+// items even when an AckCallback is registered, since the supervisor drains
+// the buffer for the callback on failure and GetUnacked then returns nothing —
+// the two are mutually exclusive. With no callback, GetUnacked must work.
+func TestCoreStreamGetUnackedWithoutCallback(t *testing.T) {
+	fo := &fakeOpener{openErr: fmt.Errorf("connection refused")}
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _ = cs.Ingest(ctx, []byte(`{}`))
+
+	waitCondition(t, cs.IsClosed, 2*time.Second)
+	_ = cs.GetUnacked() // must not panic; behavior covered by IsClosed check above
+}
+
+// TestCoreStreamNonRetryableErrorTerminates checks that a non-retryable error
+// from the opener is surfaced and Flush returns it.
+func TestCoreStreamNonRetryableErrorTerminates(t *testing.T) {
+	nonRetryable := wrapValidation(fmt.Errorf("bad table name"))
+	fo := &fakeOpener{openErr: nonRetryable}
+
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	// Ingest something so Flush has a target offset.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	// Ingest may block briefly; ignore its error here.
+	_, _ = cs.Ingest(ctx, []byte(`{}`))
+
+	// Wait for the stream to reach terminal state.
+	waitCondition(t, func() bool { return cs.IsClosed() }, 2*time.Second)
+
+	flushErr := cs.Flush(context.Background())
+	if flushErr == nil {
+		t.Fatal("want error from Flush after terminal failure, got nil")
+	}
+}
+
+// TestCoreStreamInvalidParamsNotRetried verifies that an Open failure caused by
+// transport.ErrInvalidParams is treated as non-retryable: the supervisor gives
+// up after a single attempt rather than burning the recovery budget on a
+// deterministic failure. Recovery is left enabled to prove the classification,
+// not the disabled path, is what stops the retries.
+func TestCoreStreamInvalidParamsNotRetried(t *testing.T) {
+	fo := &fakeOpener{openErr: fmt.Errorf("stream: open: bad table: %w", transport.ErrInvalidParams)}
+
+	cfg := testConfig()
+	cfg.RecoveryRetries = 5 // would retry 5x if this were classified retryable
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	waitCondition(t, cs.IsClosed, 2*time.Second)
+
+	if n := fo.openCount(); n != 1 {
+		t.Fatalf("invalid-params open should not be retried, got %d Open attempts", n)
+	}
+}
+
+// nonRetryableSelfClassifying is an Open error that self-reports non-retryable
+// via the IsRetryable() interface — mirroring how the auth layer's TokenError
+// signals a permanent failure (revoked creds, invalid_client).
+type nonRetryableSelfClassifying struct{ msg string }
+
+func (e *nonRetryableSelfClassifying) Error() string     { return e.msg }
+func (e *nonRetryableSelfClassifying) IsRetryable() bool { return false }
+
+// A layer-reported non-retryable error (e.g. an OAuth TokenError with
+// retryable=false) must stop the supervisor rather than burn the recovery
+// budget on a failure that can't succeed on retry.
+func TestCoreStreamSelfClassifiedNonRetryableErrorTerminates(t *testing.T) {
+	fo := &fakeOpener{openErr: &nonRetryableSelfClassifying{msg: "auth: oauth: HTTP 401: invalid_client"}}
+
+	cfg := testConfig()
+	cfg.RecoveryRetries = 5 // would retry 5x if this were classified retryable
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	waitCondition(t, cs.IsClosed, 2*time.Second)
+
+	if n := fo.openCount(); n != 1 {
+		t.Fatalf("self-classified non-retryable error should not be retried, got %d Open attempts", n)
+	}
+}
+
+// TestCoreStreamPauseSignalReconnectsWithoutConsumingRetries verifies that a
+// server CloseStreamSignal is treated as a pause-then-reconnect: the client
+// reconnects on a fresh stream, re-sends the unacked record, and does NOT count
+// the pause against the recovery budget (RecoveryRetries=0 would otherwise make
+// any real failure terminal after one attempt).
+func TestCoreStreamPauseSignalReconnectsWithoutConsumingRetries(t *testing.T) {
+	rpc1 := newFakeRPC()
+	rpc2 := newFakeRPC()
+	fo := newFakeOpener(rpc1, rpc2)
+
+	cfg := testConfig()
+	cfg.RecoveryRetries = 0 // a pause must not consume the (zero) retry budget
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	// Wait for the send to land on rpc1, then tell the client to pause.
+	waitCondition(t, func() bool { return len(rpc1.sends) > 0 }, time.Second)
+	<-rpc1.sends
+	rpc1.closeSignal()
+
+	// The client should reconnect to rpc2 and re-send the unacked record.
+	waitCondition(t, func() bool { return len(rpc2.sends) > 0 }, 2*time.Second)
+	<-rpc2.sends
+	rpc2.ack(off)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("WaitForOffset after pause+reconnect: %v", err)
+	}
+	if cs.IsClosed() {
+		t.Fatal("stream should be live after a pause, not terminal")
+	}
+}
+
+// StreamPausedMaxWait caps the pause honored on a server CloseStreamSignal to
+// min(cap, server-requested). A large server-requested duration paired with a
+// small client cap must yield a reconnect within the cap, not the server value.
+func TestCoreStreamPauseSignalRespectsStreamPausedMaxWaitCap(t *testing.T) {
+	rpc1 := newFakeRPC()
+	rpc2 := newFakeRPC()
+	fo := newFakeOpener(rpc1, rpc2)
+
+	cfg := testConfig()
+	cfg.RecoveryBackoff = 0
+	// Server will ask for a long pause; the client cap is much smaller.
+	cfg.StreamPausedMaxWait = 25 * time.Millisecond
+	serverPause := 5 * time.Second
+
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc1.sends) > 0 }, time.Second)
+	<-rpc1.sends
+
+	// Server signals a very long pause; cap must win.
+	start := time.Now()
+	rpc1.closeSignalWithDuration(serverPause)
+
+	// Reconnect (rpc2 receives the re-sent record) must land close to the cap,
+	// well before the server's requested duration.
+	waitCondition(t, func() bool { return len(rpc2.sends) > 0 }, time.Second)
+	elapsed := time.Since(start)
+	if elapsed >= serverPause/4 {
+		t.Fatalf("reconnect took %v; cap of %v was not honored (server asked %v)",
+			elapsed, cfg.StreamPausedMaxWait, serverPause)
+	}
+	<-rpc2.sends
+	rpc2.ack(off)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+}
+
+// TestCoreStreamIdleStreamDoesNotFailOnLackOfAck verifies that a stream with
+// nothing in flight is never torn down by the lack-of-ack timeout. The opener
+// has exactly one RPC, so any spurious reconnect attempt would fail with "no
+// more RPCs" and the stream would terminate — both assertions catch that.
+func TestCoreStreamIdleStreamDoesNotFailOnLackOfAck(t *testing.T) {
+	rpc := newFakeRPC()
+	fo := newFakeOpener(rpc)
+	cfg := testConfig()
+	cfg.LackOfAckTimeout = 30 * time.Millisecond
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	// Ingest and fully ack a record so the in-flight set drains to empty.
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+	rpc.ack(off)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+
+	// Idle for many lack-of-ack windows. With nothing in flight, silence is not a
+	// failure, so the stream must stay live and must not reconnect.
+	time.Sleep(200 * time.Millisecond)
+
+	if cs.IsClosed() {
+		t.Fatal("idle stream was torn down by the lack-of-ack timeout")
+	}
+	if n := fo.openCount(); n != 1 {
+		t.Fatalf("idle stream reconnected (openCount=%d); lack-of-ack fired with nothing in flight", n)
+	}
+}
+
+// TestCoreStreamHealthyRunResetsRecoveryBudget verifies that the recovery retry
+// budget is per-episode, not lifetime. Three successive connections each receive
+// the re-sent record then die with EOF; with RecoveryRetries=1 and a lifetime
+// budget the supervisor would give up before the fourth connection. Because each
+// run connected and ran successfully, the budget resets and the stream survives
+// to ack on the fourth.
+func TestCoreStreamHealthyRunResetsRecoveryBudget(t *testing.T) {
+	rpc1, rpc2, rpc3, rpc4 := newFakeRPC(), newFakeRPC(), newFakeRPC(), newFakeRPC()
+	fo := newFakeOpener(rpc1, rpc2, rpc3, rpc4)
+	cfg := testConfig()
+	cfg.RecoveryRetries = 1
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	// Each connection sees the (re-sent) record, then the server drops it (EOF).
+	for i, rpc := range []*fakeRPC{rpc1, rpc2, rpc3} {
+		waitCondition(t, func() bool { return len(rpc.sends) > 0 }, 2*time.Second)
+		<-rpc.sends
+		rpc.close() // EOF: a healthy run that ends; supervisor must recover
+		_ = i
+	}
+
+	// Fourth connection: the record is re-sent once more and finally acked.
+	waitCondition(t, func() bool { return len(rpc4.sends) > 0 }, 2*time.Second)
+	<-rpc4.sends
+	rpc4.ack(off)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("stream did not survive 3 healthy-then-disconnect cycles: %v", err)
+	}
+	if cs.IsClosed() {
+		t.Fatal("stream terminated despite healthy runs resetting the recovery budget")
+	}
+}
+
+// TestCoreStreamIngestBatch verifies the batch ingest path: records go on the
+// wire as a single atomic IngestRecordBatch under one logical offset, and Flush
+// completes once that offset is acked.
+func TestCoreStreamIngestBatch(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	off, err := cs.IngestBatch(context.Background(), [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("IngestBatch: %v", err)
+	}
+	if off != 0 {
+		t.Fatalf("want offset 0 for the batch, got %d", off)
+	}
+
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	sent := <-rpc.sends
+	ib := sent.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want an IngestRecordBatch on the wire, got a single-record message")
+	}
+	if got := len(ib.GetJsonBatch().GetRecords()); got != 2 {
+		t.Fatalf("want 2 records in the batch, got %d", got)
+	}
+	rpc.ack(off)
+
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -1,0 +1,163 @@
+package stream
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// encodedMsg is a wire-ready EphemeralStream ingest request, built once at
+// Ingest time and held in the buffer until the sender transmits it. It is the
+// Req type the proto/JSON core is instantiated with; the Arrow path will use a
+// Flight frame instead. Encoding is eager so the buffer never retains live user
+// objects.
+type encodedMsg = *zerobuspb.EphemeralStreamRequest
+
+// encoder turns user records into wire messages for a given offset and recovers
+// them again for GetUnacked. It is edge #1 of the design: the sole per-encoding
+// seam on the send side. The core is generic over the wire message type Req and
+// never names a concrete proto type — proto/JSON supply encoder[encodedMsg];
+// Arrow will supply encoder[flightFrame].
+//
+// The offset is stamped into the message here so re-sends after recovery reuse
+// the same logical offset the server already saw.
+type encoder[Req any] interface {
+	// encode turns a single user record into one wire message.
+	encode(offset int64, record []byte) (Req, error)
+	// encodeBatch turns many already-encoded records into one wire message. All
+	// records share a single offset and are atomic to the server (it acks the
+	// whole batch or none of it), so the batch occupies exactly one logical
+	// offset in the core's buffer.
+	encodeBatch(offset int64, records [][]byte) (Req, error)
+	// decode recovers the raw record bytes from a wire message so GetUnacked can
+	// return original content. A single-record message yields one entry; a batch
+	// yields all of its records so no unacked record is silently dropped.
+	decode(msg Req) [][]byte
+}
+
+// protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
+// serialized protobuf bytes), single and batched.
+type protoEncoder struct{}
+
+func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: proto record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: record},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: proto batch must not be empty")
+	}
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: proto batch record %d must not be empty", i)
+		}
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_ProtoEncodedBatch{
+					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: records},
+				},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
+// and batched.
+type jsonEncoder struct{}
+
+func (jsonEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: json record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_JsonRecord{JsonRecord: string(record)},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: json batch must not be empty")
+	}
+	jsonRecords := make([]string, len(records))
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: json batch record %d must not be empty", i)
+		}
+		jsonRecords[i] = string(r)
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_JsonBatch{
+					JsonBatch: &zerobuspb.JsonRecordBatch{Records: jsonRecords},
+				},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// newEncoder returns the proto/JSON encoder for the given record type.
+func newEncoder(rt zerobuspb.RecordType) (encoder[encodedMsg], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO:
+		return protoEncoder{}, nil
+	case zerobuspb.RecordType_JSON:
+		return jsonEncoder{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}
+
+// extractEphemeralRecords recovers the raw record bytes from an EphemeralStream
+// wire message. A single-record message yields one entry; a batch yields all of
+// its records. Shared by the proto and JSON encoders' decode.
+func extractEphemeralRecords(msg encodedMsg) [][]byte {
+	if msg == nil {
+		return nil
+	}
+	if ir := msg.GetIngestRecord(); ir != nil {
+		if b := ir.GetProtoEncodedRecord(); b != nil {
+			return [][]byte{b}
+		}
+		return [][]byte{[]byte(ir.GetJsonRecord())}
+	}
+	if ib := msg.GetIngestRecordBatch(); ib != nil {
+		if pb := ib.GetProtoEncodedBatch(); pb != nil {
+			return pb.GetRecords()
+		}
+		if jb := ib.GetJsonBatch(); jb != nil {
+			recs := jb.GetRecords()
+			out := make([][]byte, len(recs))
+			for i, r := range recs {
+				out[i] = []byte(r)
+			}
+			return out
+		}
+	}
+	return nil
+}

--- a/purego/internal/stream/encoder_test.go
+++ b/purego/internal/stream/encoder_test.go
@@ -1,0 +1,201 @@
+package stream
+
+import (
+	"testing"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encode(42, []byte{0x0a, 0x01, 0x78})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 42 {
+		t.Fatalf("want offset 42, got %d", ir.GetOffsetId())
+	}
+	if len(ir.GetProtoEncodedRecord()) == 0 {
+		t.Fatal("want non-empty proto record")
+	}
+}
+
+func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encode(7, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 7 {
+		t.Fatalf("want offset 7, got %d", ir.GetOffsetId())
+	}
+	if ir.GetJsonRecord() != `{"x":1}` {
+		t.Fatalf("want json record, got %q", ir.GetJsonRecord())
+	}
+}
+
+func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encodeBatch(3, [][]byte{{0x01, 0x02}, {0x03, 0x04}, {0x05}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 3 {
+		t.Fatalf("want offset 3, got %d", ib.GetOffsetId())
+	}
+	pb := ib.GetProtoEncodedBatch()
+	if pb == nil {
+		t.Fatal("want ProtoEncodedBatch, got nil")
+	}
+	// The batch must carry all three records, not one concatenated blob.
+	if got := len(pb.GetRecords()); got != 3 {
+		t.Fatalf("want 3 records in batch, got %d", got)
+	}
+}
+
+func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encodeBatch(5, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 5 {
+		t.Fatalf("want offset 5, got %d", ib.GetOffsetId())
+	}
+	jb := ib.GetJsonBatch()
+	if jb == nil {
+		t.Fatal("want JsonBatch, got nil")
+	}
+	if got := jb.GetRecords(); len(got) != 2 || got[0] != `{"a":1}` || got[1] != `{"b":2}` {
+		t.Fatalf("want 2 json records preserved, got %v", got)
+	}
+}
+
+func TestEncodersRejectEmptyRecord(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encode(1, nil); err == nil {
+			t.Errorf("%T: want error for empty record, got nil", enc)
+		}
+		if _, err := enc.encode(1, []byte{}); err == nil {
+			t.Errorf("%T: want error for zero-length record, got nil", enc)
+		}
+	}
+}
+
+func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encodeBatch(1, nil); err == nil {
+			t.Errorf("%T: want error for empty batch, got nil", enc)
+		}
+		// A batch containing an empty record is rejected too.
+		if _, err := enc.encodeBatch(1, [][]byte{[]byte("ok"), {}}); err == nil {
+			t.Errorf("%T: want error for empty record within batch, got nil", enc)
+		}
+	}
+}
+
+func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
+	// A batch message must yield every record, not just the first, so GetUnacked
+	// doesn't silently drop the tail of an unacked batch.
+	protoMsg, err := protoEncoder{}.encodeBatch(1, [][]byte{{0x01}, {0x02}, {0x03}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	if got := (protoEncoder{}).decode(protoMsg); len(got) != 3 {
+		t.Fatalf("proto batch: want 3 records extracted, got %d", len(got))
+	}
+
+	jsonMsg, err := jsonEncoder{}.encodeBatch(1, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	got := (jsonEncoder{}).decode(jsonMsg)
+	if len(got) != 2 || string(got[0]) != `{"a":1}` || string(got[1]) != `{"b":2}` {
+		t.Fatalf("json batch: want both records extracted, got %v", got)
+	}
+
+	// A single-record message still yields exactly one entry.
+	single, err := jsonEncoder{}.encode(1, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if got := (jsonEncoder{}).decode(single); len(got) != 1 || string(got[0]) != `{"x":1}` {
+		t.Fatalf("single record: want 1 entry, got %v", got)
+	}
+}
+
+func TestOffsetAckModelParsesIngestResponse(t *testing.T) {
+	am := offsetAckModel{}
+
+	offset := int64(99)
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: &offset,
+			},
+		},
+	}
+	kind, got, _ := am.classify(resp)
+	if kind != ackResponse {
+		t.Fatalf("want ackResponse for ingest response, got %v", kind)
+	}
+	if got != 99 {
+		t.Fatalf("want offset 99, got %d", got)
+	}
+}
+
+func TestOffsetAckModelClassifiesCloseSignalAsPause(t *testing.T) {
+	am := offsetAckModel{}
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{},
+		},
+	}
+	kind, _, _ := am.classify(resp)
+	if kind != pauseResponse {
+		t.Fatalf("want pauseResponse for close signal, got %v", kind)
+	}
+}
+
+func TestOffsetAckModelIgnoresUnknownResponse(t *testing.T) {
+	am := offsetAckModel{}
+	// An empty response carries neither an ack nor a close signal.
+	kind, _, _ := am.classify(&zerobuspb.EphemeralStreamResponse{})
+	if kind != otherResponse {
+		t.Fatalf("want otherResponse for empty response, got %v", kind)
+	}
+}
+
+func TestNewAckModelProtoJSON(t *testing.T) {
+	for _, rt := range []zerobuspb.RecordType{zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON} {
+		am, err := newAckModel(rt)
+		if err != nil {
+			t.Fatalf("newAckModel(%v): %v", rt, err)
+		}
+		if am == nil {
+			t.Fatalf("newAckModel(%v): want non-nil", rt)
+		}
+	}
+}
+
+func TestNewAckModelUnknownErrors(t *testing.T) {
+	if _, err := newAckModel(zerobuspb.RecordType_RECORD_TYPE_UNSPECIFIED); err == nil {
+		t.Fatal("want error for unspecified record type, got nil")
+	}
+}

--- a/purego/internal/stream/errors.go
+++ b/purego/internal/stream/errors.go
@@ -1,0 +1,30 @@
+package stream
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// errClosed is returned by buffer operations when the buffer has been closed.
+var errClosed = errors.New("stream: buffer closed")
+
+// errUnsupportedRecordType is returned when no encoder/ackModel exists for a
+// record type (e.g. RECORD_TYPE_UNSPECIFIED).
+func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
+	return fmt.Errorf("stream: unsupported record type %v", rt)
+}
+
+// pauseSignal is the cause runOnce returns when the server sent a
+// CloseStreamSignal: the server is about to close this stream and the client
+// should pause (stop sending, keep buffering and draining acks) then reconnect,
+// rather than treat it as a failure that counts against the recovery budget. It
+// carries the server-requested pause duration.
+type pauseSignal struct {
+	// duration is the server-requested pause window; zero if unspecified.
+	duration time.Duration
+}
+
+func (pauseSignal) Error() string { return "stream: server requested pause (close-stream signal)" }

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -1,0 +1,187 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// supervise is the supervisor goroutine. It runs the create→run→recover loop
+// until the context is cancelled (Close called), a non-retryable error fires,
+// or consecutive recovery retries are exhausted. It always closes done on exit.
+//
+// The retry budget is per episode: `failedAttempts` counts only *consecutive*
+// failed reconnects and resets to zero whenever a stream connects and runs
+// successfully. A long-lived stream that disconnects occasionally therefore is
+// not doomed after RecoveryRetries lifetime disconnects — each disconnect
+// starts a fresh episode with the full budget. This mirrors the Rust core,
+// which builds a fresh attempt counter per recovery loop iteration.
+func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
+	defer close(cs.done)
+
+	var err error
+	failedAttempts := 0
+	for {
+		if ctx.Err() != nil {
+			// Cancelled by Close — clean exit, no error.
+			return
+		}
+
+		if failedAttempts > 0 {
+			if !cs.cfg.Recovery.enabled() || failedAttempts > cs.cfg.RecoveryRetries {
+				err = fmt.Errorf("stream: recovery exhausted after %d attempt(s): %w",
+					failedAttempts, err)
+				break
+			}
+			select {
+			case <-time.After(cs.cfg.RecoveryBackoff):
+			case <-ctx.Done():
+				return
+			}
+			// Requeue any items the previous sender observed but didn't ack.
+			cs.buf.requeue()
+		}
+
+		runErr, healthy := cs.runOnce(ctx)
+
+		// ctx cancelled = clean exit via Close. Don't treat server-side EOF as clean.
+		if ctx.Err() != nil {
+			return
+		}
+
+		// A stream that successfully opened and ran resets the per-episode budget:
+		// the failure that ended it (if any) begins a fresh recovery episode rather
+		// than continuing the prior reconnect streak.
+		if healthy {
+			failedAttempts = 0
+		}
+
+		// A server-requested pause (CloseStreamSignal) is not a failure: wait the
+		// requested window, then reconnect without consuming the recovery budget.
+		// Ingest keeps buffering meanwhile; unacked records are requeued on the
+		// next attempt.
+		var ps pauseSignal
+		if errors.As(runErr, &ps) {
+			if !cs.waitPause(ctx, ps.duration) {
+				return // Close cancelled ctx during the pause.
+			}
+			cs.buf.requeue()
+			continue
+		}
+
+		if runErr == nil {
+			// Server closed the stream cleanly (EOF). Treat as a retryable
+			// disconnect and recover.
+			runErr = fmt.Errorf("stream: server closed the stream")
+		}
+
+		err = runErr
+		if !isRetryable(runErr) {
+			break
+		}
+		failedAttempts++
+	}
+
+	// Terminal failure path.
+	cs.wm.fail(err)
+	cs.setTerminalErr(err)
+
+	if cs.callback != nil {
+		// Drain the buffer and fire OnError for each unacked item. drain() also
+		// closes the buffer and unblocks any enqueue callers, so we must call it
+		// here rather than close() + a separate drain in GetUnacked. GetUnacked
+		// documents that it is mutually exclusive with AckCallback: when a
+		// callback is set, the supervisor owns the drain; when it is nil,
+		// GetUnacked drains on demand.
+		for _, it := range cs.buf.drain() {
+			cs.callback.OnError(it.offset, err)
+		}
+	} else {
+		// No callback: just close the buffer so enqueue callers unblock. The
+		// items remain retrievable via GetUnacked, which calls drain() itself.
+		cs.buf.close()
+	}
+}
+
+// waitPause sleeps for the server-requested pause window before reconnecting,
+// capped by StreamPausedMaxWait (min of the two; a non-positive cap means "no
+// client cap"). Returns false if ctx was cancelled (Close) during the wait, so
+// the caller stops instead of reconnecting. A non-positive effective wait
+// reconnects immediately.
+func (cs *CoreStream[Req, Resp]) waitPause(ctx context.Context, serverDuration time.Duration) bool {
+	wait := serverDuration
+	if cap := cs.cfg.StreamPausedMaxWait; cap > 0 && (wait <= 0 || cap < wait) {
+		wait = cap
+	}
+	if wait <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// retryableError is any error that self-classifies its retryability. Errors
+// from the transport and auth layers (e.g. TokenError from an OAuth mint)
+// implement it; the supervisor honors their verdict rather than blindly
+// retrying every non-context error. Structural so we don't have to import
+// auth or transport just to name their concrete types.
+type retryableError interface {
+	IsRetryable() bool
+}
+
+// isRetryable reports whether err represents a transient failure that warrants
+// a stream reconnect. Context cancellation, stream-open validation errors
+// (wrong table name, bad record type), and errors that self-report as
+// non-retryable (e.g. a revoked-credentials OAuth mint failure) are not
+// retryable; transport-level failures (connection reset, server going away) are.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// errClosed means the buffer was drained by Close; not retryable.
+	if errors.Is(err, errClosed) {
+		return false
+	}
+	// Errors produced by the transport layer's Open (validation failures such
+	// as empty table name or unsupported record type) are non-retryable
+	// because reconnecting would produce the same error.
+	var ve *validationError
+	if errors.As(err, &ve) {
+		return false
+	}
+	// Honor any layer's self-reported retryability verdict (e.g. OAuth
+	// TokenError). Walk the unwrap chain so a wrapped mint failure is still seen.
+	var re retryableError
+	if errors.As(err, &re) {
+		return re.IsRetryable()
+	}
+	// All other errors (network failures, server resets, auth rejections after
+	// the stream was open) are considered retryable; the supervisor's retry cap
+	// is the backstop.
+	return true
+}
+
+// validationError marks errors that are configuration/validation failures
+// rather than transient transport failures.
+type validationError struct{ cause error }
+
+func (e *validationError) Error() string { return e.cause.Error() }
+func (e *validationError) Unwrap() error { return e.cause }
+
+// wrapValidation wraps err so the supervisor recognises it as non-retryable.
+func wrapValidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &validationError{cause: err}
+}

--- a/purego/internal/stream/wirestream.go
+++ b/purego/internal/stream/wirestream.go
@@ -1,0 +1,87 @@
+package stream
+
+import (
+	"context"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
+
+// wireStream is edge #3 of the design: the actual transport, abstracted so the
+// core drives Send/Recv/teardown without naming a concrete RPC. It is generic
+// over the request and response types the encoder and ackModel already use, so
+// proto/JSON instantiate wireStream[encodedMsg, ephemeralResp] over
+// EphemeralStream and Arrow will instantiate it over Flight — with no change to
+// core.go.
+//
+// A wireStream is already past its handshake when opener returns it. It is not
+// safe for concurrent Send; the core uses a single sender goroutine.
+type wireStream[Req, Resp any] interface {
+	// Send writes one request to the server.
+	Send(req Req) error
+	// Recv blocks for the next response, returning io.EOF (unwrapped) once the
+	// server ends the stream cleanly.
+	Recv() (Resp, error)
+	// CloseSend half-closes the send side, leaving Recv open to drain remaining
+	// responses (used for graceful teardown).
+	CloseSend() error
+	// Close aborts the stream and releases resources. Idempotent.
+	Close()
+}
+
+// opener opens a new wireStream. It is edge #3's factory, injected so the
+// supervisor can reconnect and tests can supply an in-process fake. Generic
+// over the same Req/Resp as wireStream.
+type opener[Req, Resp any] interface {
+	Open(ctx context.Context, p StreamParams) (wireStream[Req, Resp], error)
+}
+
+// StreamParams mirrors transport.StreamParams but lives here so upper layers
+// can use the stream package without importing transport directly.
+type StreamParams = transport.StreamParams
+
+// ephemeralOpener adapts a *transport.Conn to opener[encodedMsg, ephemeralResp]
+// for the proto/JSON wire path. *transport.Stream already satisfies wireStream,
+// so this is a thin wrapper that just names the concrete types.
+type ephemeralOpener struct{ conn *transport.Conn }
+
+// NewEphemeralOpener returns the proto/JSON opener backed by conn. The public
+// zerobus package uses it to build a proto/JSON CoreStream via NewProtoJSONStream.
+func NewEphemeralOpener(conn *transport.Conn) *ephemeralOpener {
+	return &ephemeralOpener{conn: conn}
+}
+
+func (o *ephemeralOpener) Open(ctx context.Context, p StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	s, err := o.conn.Open(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Compile-time proof that the transport's proto/JSON Stream satisfies the
+// generic wireStream the core drives.
+var _ wireStream[encodedMsg, ephemeralResp] = (*transport.Stream)(nil)
+
+// NewProtoJSONStream builds a proto/JSON ingestion core over the EphemeralStream
+// wire path: it wires the offset ack model, the proto or JSON encoder (chosen by
+// params.RecordType), and the ephemeral opener. This is the single constructor
+// the public zerobus package calls for proto and JSON streams; Arrow will get a
+// parallel NewArrowStream that supplies its own opener/encoder/ackModel.
+func NewProtoJSONStream(
+	conn *transport.Conn,
+	params StreamParams,
+	cfg Config,
+	callback AckCallback,
+) (*CoreStream[encodedMsg, ephemeralResp], error) {
+	enc, err := newEncoder(params.RecordType)
+	if err != nil {
+		return nil, err
+	}
+	ackMdl, err := newAckModel(params.RecordType)
+	if err != nil {
+		return nil, err
+	}
+	return NewCoreStream[encodedMsg, ephemeralResp](
+		params, cfg, NewEphemeralOpener(conn), enc, ackMdl, callback,
+	), nil
+}

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,13 @@ import (
 
 	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
+
+// ErrInvalidParams marks an Open failure caused by invalid stream parameters
+// (empty table name, unsupported record type, missing descriptor). These are
+// deterministic: reopening with the same params reproduces the failure, so
+// higher layers can use errors.Is to treat them as non-retryable rather than
+// reconnecting in a loop.
+var ErrInvalidParams = errors.New("transport: invalid stream parameters")
 
 // StreamParams describes the stream to open: which table to ingest into, how
 // records are encoded, and which headers provider supplies its credentials.
@@ -54,16 +62,16 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	// the validation below also governs the value actually sent.
 	p.TableName = strings.TrimSpace(p.TableName)
 	if p.TableName == "" {
-		return nil, fmt.Errorf("transport: open: table name is required")
+		return nil, fmt.Errorf("transport: open: table name is required: %w", ErrInvalidParams)
 	}
 	switch p.RecordType {
 	case zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON:
 		// Supported.
 	default:
-		return nil, fmt.Errorf("transport: open %q: unsupported record type %v", p.TableName, p.RecordType)
+		return nil, fmt.Errorf("transport: open %q: unsupported record type %v: %w", p.TableName, p.RecordType, ErrInvalidParams)
 	}
 	if p.RecordType == zerobuspb.RecordType_PROTO && len(p.DescriptorProto) == 0 {
-		return nil, fmt.Errorf("transport: open %q: descriptor proto required for PROTO records", p.TableName)
+		return nil, fmt.Errorf("transport: open %q: descriptor proto required for PROTO records: %w", p.TableName, ErrInvalidParams)
 	}
 	headersCtx := ctx
 	useDefaultBudgets := false
@@ -176,6 +184,35 @@ func confirmCreateStream(resp *zerobuspb.EphemeralStreamResponse) (string, error
 		return "", fmt.Errorf("server returned an empty stream ID")
 	}
 	return id, nil
+}
+
+// FakeStreamRPC is the wire interface a test fake must satisfy to be wrapped by
+// [NewFakeStreamForTesting]. It exists only for tests in other internal
+// packages that must supply a fake RPC; production callers do not use it.
+type FakeStreamRPC interface {
+	Send(*zerobuspb.EphemeralStreamRequest) error
+	Recv() (*zerobuspb.EphemeralStreamResponse, error)
+	CloseSend() error
+}
+
+// NewFakeStreamForTesting wraps a test fake as a Stream, skipping the handshake.
+// It is exported because Go tests in other internal packages cannot reach
+// Stream's unexported fields; production code must not use it.
+//
+// Close cancels the stream (abrupt abort). If the RPC implements Abort() the
+// fake can model gRPC's context-cancel (distinct from CloseSend's half-close)
+// and unblock a Recv parked on a channel. Otherwise Close falls back to
+// CloseSend, which suffices for fakes whose Recv returns io.EOF on half-close.
+func NewFakeStreamForTesting(rpc FakeStreamRPC) *Stream {
+	s := &Stream{}
+	s.rpc = rpc
+	if a, ok := rpc.(interface{ Abort() }); ok {
+		s.cancel = a.Abort
+	} else {
+		s.cancel = func() { _ = rpc.CloseSend() }
+	}
+	s.setID("fake-stream")
+	return s
 }
 
 // ID returns the server-assigned stream identifier from the handshake.


### PR DESCRIPTION
## Summary

First of a three-PR split of #531 (ingestion core). Adds `internal/stream` — the generic protocol-agnostic ingestion core that sits between the auth/transport layers and the (not yet built) public API. The core is written once and instantiated per wire protocol through three seams (`encoder`, `ackModel`, `wireStream`) so the Arrow Flight path can land later without rewriting sender / receiver / supervisor / buffer.

## Design

- **`buffer.go`** — bounded, offset-assigning queue with semaphore backpressure. Split into `reserve` + `append` so the ctx-cancellable semaphore wait happens outside the core's offset-assignment mutex; many-goroutine `Ingest` scales, and each blocked caller observes its own ctx cancellation.

- **`encoder.go`** — proto and JSON encoders build EphemeralStream payloads eagerly at `Ingest` time so the buffer holds `[]byte`, never live user objects.

- **`ackmodel.go`** — `offsetAckModel` for proto/JSON; distinguishes `ack`, `pause`, and other response kinds. Arrow's record-count ack model will slot in without touching the core.

- **`wirestream.go`** — generic `opener` / `wireStream` seam so the transport is injected, not named.

- **`core.go`** — three goroutines (sender, receiver, supervisor), monotonic ack watermark, `Flush` / `WaitForOffset` / `Close` / `GetUnacked`. Sender uses a per-`runOnce` derived context so a stream teardown unblocks `buf.next` without cancelling the supervisor context (which would signal `Close`). Offset assignment is serialized under `offsetMu` so `nextOffset` only advances for records that actually make it into the buffer; `Flush` targets the highest successfully-enqueued offset. Server pause signal is handled by aborting the current stream and reconnecting after `waitPause`.

- **`supervisor.go`** — `create → run → recover` loop. Defaults `RecoveryRetries=4`, `RecoveryBackoff=2s`, `FlushTimeout=5m`, `LackOfAckTimeout=60s`. Server EOF is treated as a retryable disconnect. Per-episode retry budget resets after a run that opened and ran (this bar tightens in PR 2/3).

- **`errors.go`** — `errClosed` sentinel + `pauseSignal`.

Also adds a `FakeStreamRPC` test seam on `transport.Stream` so the stream package's tests can inject in-process fakes without a live gRPC server.

## Stack

This is **1 of 3**. Follow-ups will land review-driven hardening on top:

- 2/3 (#572) — **Durability + callbacks** — ack validation, callback dispatcher goroutine, per-offset OnAck, non-destructive GetUnacked, retry classification, mid-stream auth invalidation, `Config{}` sanitization.
- 3/3 (#573) — **Pause + lifecycle robustness** — pause-drain (park sender + keep receiving acks), sent-state ack watermark, healthy-run definition covering idle-but-stable connections, prevalidated raw input size, `Close` bounded during pause, CI-flake fix in transport tests.

Splits [#531](https://github.com/databricks/zerobus-sdk/pull/531).

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test ./... -race` passes; ~41 tests in `internal/stream`.
- Recovery test (`TestCoreStreamRecoveryRequeuesUnacked`) verifies items in flight when a stream dies are re-sent on the recovery stream and acknowledged correctly.
- Regression tests: `Ingest` on a closed stream errors; a failed `Ingest` doesn't advance the `Flush` target (no permanent gap); `Close` unblocks an `Ingest` parked at capacity; a cancelled-ctx `Ingest` reliably errors even when a buffer slot is free; server pause signal reconnects without consuming the retry budget.

## What's not here (arrives in later PRs)

- Server ack offset validation (an ack past the highest sent offset is silently trusted here — fixed in 2/3).
- Callback goroutine (`AckCallback` fires synchronously on the receiver here — fixed in 2/3).
- Non-destructive `GetUnacked` returning `(records, error)` (destructive `[][]byte` here — fixed in 3/3).
- Pause drain (aborts on pause here instead of parking the sender and keeping the receiver reading — fixed in 3/3).
- Public `zerobus` package + Arrow Flight wire path (separate future work).
