### PR TITLE
[PureGo] Ingestion core: durability, callbacks, retry classification (2/3)

### DIFF
--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -4,25 +4,33 @@ import (
 	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
 
-// ackModel translates a raw server response into a logical "highest fully-acked
-// offset" that the core's watermark can compare against, and classifies
-// non-ack responses so the core stays blind to the concrete wire type. It is
-// edge #2 of the design and is generic over the response type Resp: proto/JSON
-// supply ackModel[ephemeralResp]; Arrow will supply its own over a Flight
-// response, mapping a cumulative record count back to an offset.
+// ackModel translates a raw server response into a logical "highest
+// fully-acked offset" that the core's watermark can compare against, and
+// classifies non-ack responses so the core stays blind to the concrete wire
+// type. It is the receive-side per-encoding seam and is generic over the
+// response type Resp: proto/JSON supply ackModel[ephemeralResp]; Arrow will
+// supply its own over a Flight response, mapping a cumulative record count
+// back to an offset.
 //
-// This interface is intentionally the minimal offset-only subset. The
-// architecture note (§3a) sketches a wider Track/Resolve/Unacked shape for the
-// Arrow record-count model, where an ack can land mid-batch and recovery must
-// slice a straddling batch. That width is deferred until the Arrow wire path
-// lands; adding it now would be unused machinery. The core stays offset-only
-// and blind to the record-vs-batch distinction regardless.
+// This interface is intentionally the minimal offset-only subset. A wider
+// Track/Resolve/Unacked shape will be needed for the Arrow record-count
+// model, where an ack can land mid-batch and recovery must slice a
+// straddling batch; that width is deferred until the Arrow wire path lands.
+// The core stays offset-only and blind to the record-vs-batch distinction
+// regardless.
 type ackModel[Resp any] interface {
 	// classify inspects a server response and reports what it means to the core:
-	//   - kind == ackResponse: off is the highest fully-acked offset.
+	//   - kind == ackResponse: off is the highest fully-acked offset the server
+	//     claims (still requires the receiver to bound-check against sent work).
 	//   - kind == pauseResponse: the server asked the client to pause; pause
 	//     carries the requested duration. The core waits then reconnects.
-	//   - kind == otherResponse: anything else (ignored by the receiver).
+	//   - kind == unknownResponse: the response type is not one the core
+	//     recognises. The receiver fails the stream: silently ignoring
+	//     unexpected messages hides server contract violations.
+	//   - kind == malformedResponse: the response is an ack but its offset
+	//     field is missing/absent. Advancing the watermark to the zero-valued
+	//     default would silently acknowledge offset 0 for a stream that may
+	//     never have sent it, so the receiver fails instead.
 	// Keeping close-signal detection here means the receiver never names a
 	// concrete proto message.
 	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
@@ -32,9 +40,19 @@ type ackModel[Resp any] interface {
 type respKind int
 
 const (
-	otherResponse respKind = iota // no ack, no pause — ignored
-	ackResponse                   // carries a durability ack offset
-	pauseResponse                 // server-requested pause (close-stream signal)
+	// ackResponse carries a validated durability offset.
+	ackResponse respKind = iota
+	// pauseResponse is a server-requested pause (close-stream signal).
+	pauseResponse
+	// unknownResponse is any response the ack model does not recognise. The
+	// receiver treats these as protocol errors and fails the stream rather
+	// than silently ignoring them; ignoring would hide server contract
+	// violations.
+	unknownResponse
+	// malformedResponse is an ack whose durability-offset field is absent.
+	// The zero-valued default would silently advance the watermark to 0, so
+	// the receiver fails the stream instead.
+	malformedResponse
 )
 
 // ephemeralResp is the proto/JSON server response type. Aliased so the core's
@@ -48,15 +66,22 @@ type offsetAckModel struct{}
 
 func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
 	if resp == nil {
-		return otherResponse, 0, pauseSignal{}
+		return unknownResponse, 0, pauseSignal{}
 	}
 	if sig := resp.GetCloseStreamSignal(); sig != nil {
 		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
 	}
 	if ack := resp.GetIngestRecordResponse(); ack != nil {
-		return ackResponse, ack.GetDurabilityAckUpToOffset(), pauseSignal{}
+		// DurabilityAckUpToOffset is an optional proto field; a missing value
+		// silently defaults to 0. Advancing to a fabricated 0 would fake
+		// durability for offset 0, so treat "missing" as malformed.
+		off := ack.DurabilityAckUpToOffset
+		if off == nil {
+			return malformedResponse, 0, pauseSignal{}
+		}
+		return ackResponse, *off, pauseSignal{}
 	}
-	return otherResponse, 0, pauseSignal{}
+	return unknownResponse, 0, pauseSignal{}
 }
 
 // newAckModel returns the proto/JSON ack model for the given record type.

--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -1,0 +1,70 @@
+package stream
+
+import (
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// ackModel translates a raw server response into a logical "highest fully-acked
+// offset" that the core's watermark can compare against, and classifies
+// non-ack responses so the core stays blind to the concrete wire type. It is
+// edge #2 of the design and is generic over the response type Resp: proto/JSON
+// supply ackModel[ephemeralResp]; Arrow will supply its own over a Flight
+// response, mapping a cumulative record count back to an offset.
+//
+// This interface is intentionally the minimal offset-only subset. The
+// architecture note (§3a) sketches a wider Track/Resolve/Unacked shape for the
+// Arrow record-count model, where an ack can land mid-batch and recovery must
+// slice a straddling batch. That width is deferred until the Arrow wire path
+// lands; adding it now would be unused machinery. The core stays offset-only
+// and blind to the record-vs-batch distinction regardless.
+type ackModel[Resp any] interface {
+	// classify inspects a server response and reports what it means to the core:
+	//   - kind == ackResponse: off is the highest fully-acked offset.
+	//   - kind == pauseResponse: the server asked the client to pause; pause
+	//     carries the requested duration. The core waits then reconnects.
+	//   - kind == otherResponse: anything else (ignored by the receiver).
+	// Keeping close-signal detection here means the receiver never names a
+	// concrete proto message.
+	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
+}
+
+// respKind is the category the ackModel assigns to a server response.
+type respKind int
+
+const (
+	otherResponse respKind = iota // no ack, no pause — ignored
+	ackResponse                   // carries a durability ack offset
+	pauseResponse                 // server-requested pause (close-stream signal)
+)
+
+// ephemeralResp is the proto/JSON server response type. Aliased so the core's
+// Resp type parameter is named once here rather than spelled out at every use.
+type ephemeralResp = *zerobuspb.EphemeralStreamResponse
+
+// offsetAckModel is the proto/JSON ack model: the server sends
+// DurabilityAckUpToOffset directly as the logical offset, and a
+// CloseStreamSignal requests a pause.
+type offsetAckModel struct{}
+
+func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
+	if resp == nil {
+		return otherResponse, 0, pauseSignal{}
+	}
+	if sig := resp.GetCloseStreamSignal(); sig != nil {
+		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
+	}
+	if ack := resp.GetIngestRecordResponse(); ack != nil {
+		return ackResponse, ack.GetDurabilityAckUpToOffset(), pauseSignal{}
+	}
+	return otherResponse, 0, pauseSignal{}
+}
+
+// newAckModel returns the proto/JSON ack model for the given record type.
+func newAckModel(rt zerobuspb.RecordType) (ackModel[ephemeralResp], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON:
+		return offsetAckModel{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -65,30 +65,38 @@ func (b *buffer[Req]) closeDone() {
 	b.doneOnce.Do(func() { close(b.doneCh) })
 }
 
-// enqueue adds an already-encoded message to the pending queue, blocking until
-// a slot is available (backpressure) or ctx is cancelled. The offset must be
-// monotonically increasing; the caller (coreStream) is responsible for that.
-// Returns ctx.Err() if ctx fires before a slot opens.
-func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
-	// Honor an already-cancelled ctx first: select picks randomly among ready
-	// cases, so a free slot could otherwise mask cancellation.
+// reserve blocks until a backpressure slot is available or ctx is cancelled.
+// It is split from the append step so callers can hold the offset-assignment
+// critical section for as short a time as possible: the semaphore wait happens
+// outside the coreStream ingest mutex, so one blocked caller does not serialize
+// every later caller behind it.
+func (b *buffer[Req]) reserve(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Acquire a slot before touching the queue so callers block here rather than
-	// inside the mutex. ctx cancellation wakes up the select immediately.
 	select {
 	case b.sem <- struct{}{}:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-b.doneCh:
 		return errClosed
 	}
+}
 
+// release returns a previously-reserved slot to the semaphore. Used when a
+// reserved slot cannot be consumed (e.g. the buffer was closed between reserve
+// and append).
+func (b *buffer[Req]) release() { <-b.sem }
+
+// append records an already-reserved item in the pending queue. The caller must
+// have called reserve() successfully first; a failed append (buffer closed
+// concurrently) releases the reservation so the semaphore stays consistent.
+func (b *buffer[Req]) append(offset int64, msg Req) error {
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
-		<-b.sem // release the slot we just took
+		b.release()
 		return errClosed
 	}
 	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg})
@@ -101,13 +109,29 @@ func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error 
 // list, returning the item. The sender must later call discard (on ack) or
 // requeue (on reconnect) for every item returned by next.
 //
-// Returns errClosed when the buffer has been closed and drained.
-// Returns ctx.Err() if ctx is cancelled while waiting.
+// Returns errClosed when the buffer has been closed. Cancellation is honoured
+// both while waiting for an item AND immediately before dequeuing one, so a
+// Close that cancels the sender's context never lets one more queued record
+// slip onto the wire.
+//
+// Returns ctx.Err() if ctx is cancelled.
 func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
+	// Fail fast if ctx is already cancelled: the sender has been told to stop
+	// (per-stream teardown or Close), so we must not consume a queued item.
+	if err := ctx.Err(); err != nil {
+		return item[Req]{}, err
+	}
 	b.mu.Lock()
 	for len(b.queue) == 0 && !b.closed {
-		// Wake up on ctx cancellation too.
-		stop := context.AfterFunc(ctx, func() { b.cond.Broadcast() })
+		// Take b.mu inside the AfterFunc so the broadcast is properly ordered
+		// against Wait: without the lock, ctx could fire between the loop's
+		// condition check and Wait's park step, missing the wake-up and
+		// leaving the goroutine asleep on an already-cancelled ctx.
+		stop := context.AfterFunc(ctx, func() {
+			b.mu.Lock()
+			b.cond.Broadcast()
+			b.mu.Unlock()
+		})
 		b.cond.Wait()
 		stop()
 		if ctx.Err() != nil {
@@ -119,7 +143,19 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 		b.mu.Unlock()
 		return item[Req]{}, errClosed
 	}
+	// Re-check ctx after acquiring an item: if teardown started while we were
+	// waking, drop the item back and return so Close is not delayed by a Send
+	// that will just be aborted anyway.
+	if err := ctx.Err(); err != nil {
+		b.mu.Unlock()
+		return item[Req]{}, err
+	}
 	it := b.queue[0]
+	// Zero the departed slot so the payload is collectible once the item moves
+	// to flight (and later gets discarded), rather than being pinned by the
+	// underlying array.
+	var zero item[Req]
+	b.queue[0] = zero
 	b.queue = b.queue[1:]
 	b.flight = append(b.flight, it)
 	b.mu.Unlock()
@@ -130,22 +166,28 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 // now acknowledged by the server) and releases one semaphore slot per removed
 // item so blocked enqueue callers can proceed. It is the sender/receiver's only
 // hook for ack-driven eviction, keeping the buffer's internals (flight, sem,
-// cond) private. Returns the number of items discarded.
-func (b *buffer[Req]) discardThrough(offset int64) int {
+// cond) private. Returns the offsets of the newly-discarded items in order so
+// the receiver can fire a per-offset OnAck for each; the returned slice is nil
+// if the ack covered no new items.
+func (b *buffer[Req]) discardThrough(offset int64) []int64 {
 	b.mu.Lock()
-	n := 0
+	var discarded []int64
+	var zero item[Req]
 	for len(b.flight) > 0 && b.flight[0].offset <= offset {
+		discarded = append(discarded, b.flight[0].offset)
+		// Zero the departed slot so the payload's backing memory is
+		// collectible even while the underlying array is retained.
+		b.flight[0] = zero
 		b.flight = b.flight[1:]
-		n++
 	}
 	b.mu.Unlock()
-	for range n {
+	for range discarded {
 		<-b.sem
 	}
-	if n > 0 {
+	if len(discarded) > 0 {
 		b.cond.Broadcast()
 	}
-	return n
+	return discarded
 }
 
 // requeue moves all in-flight items back to the front of the pending queue so
@@ -153,9 +195,23 @@ func (b *buffer[Req]) discardThrough(offset int64) int {
 func (b *buffer[Req]) requeue() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// Prepend in-flight items (in order) before any still-pending ones.
-	b.queue = append(b.flight, b.queue...)
+	// Prepend in-flight items (in order) before any still-pending ones. Clear
+	// the old flight slots so the backing array does not pin now-transferred
+	// payloads (they're referenced by queue, not flight).
+	var zero item[Req]
+	newQueue := make([]item[Req], 0, len(b.flight)+len(b.queue))
+	newQueue = append(newQueue, b.flight...)
+	newQueue = append(newQueue, b.queue...)
+	for i := range b.flight {
+		b.flight[i] = zero
+	}
 	b.flight = b.flight[:0]
+	// Zero the tail of the old queue slice before replacing it, so callers
+	// blocked on the semaphore can't observe stale payloads via the old array.
+	for i := range b.queue {
+		b.queue[i] = zero
+	}
+	b.queue = newQueue
 	b.cond.Broadcast()
 }
 
@@ -184,13 +240,6 @@ func (b *buffer[Req]) close() {
 	b.mu.Unlock()
 	b.cond.Broadcast()
 	b.closeDone()
-}
-
-// len returns the total number of items in the buffer (pending + in-flight).
-func (b *buffer[Req]) len() int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return len(b.queue) + len(b.flight)
 }
 
 // inFlight returns the number of items observed by the sender but not yet

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -1,0 +1,204 @@
+// Package stream is the generic ingestion core: offset assignment, send/recv
+// goroutines, ack watermark, Flush/WaitForOffset, and the recovery supervisor.
+// Protocol-specific behaviour (encoding, ack parsing, wire transport) is
+// injected through the encoder, ackModel, and wireStream interfaces, so the
+// core is written once and instantiated per wire protocol (proto/JSON today,
+// Arrow Flight later) without editing this package's core logic.
+package stream
+
+import (
+	"context"
+	"sync"
+)
+
+// item is one unit of work in the buffer: an already-encoded wire message
+// paired with the logical offset that identifies it for acknowledgment. Req is
+// the wire request type the core is instantiated with (encodedMsg for
+// proto/JSON; a Flight frame for Arrow).
+type item[Req any] struct {
+	offset  int64
+	payload Req
+}
+
+// buffer is the bounded, offset-assigning queue between the caller's Ingest
+// calls and the sender goroutine. Callers enqueue already-encoded messages;
+// the sender observes them (moves to in-flight); acks cause them to be
+// discarded. It is generic over the wire request type so the core holds no
+// concrete proto type.
+//
+// Concurrency model:
+//   - Many goroutines may call enqueue concurrently.
+//   - Exactly one sender goroutine calls next/requeue.
+//   - Exactly one receiver goroutine calls discardThrough as acks arrive.
+//   - Exactly one goroutine (the supervisor) calls drain.
+//
+// All state (queue, flight, sem, cond) is private; the sender and receiver
+// interact only through these methods, never by touching the fields directly.
+//
+// The semaphore enforces the MaxInflight cap: enqueue blocks once the cap is
+// reached and unblocks as acks arrive and discardThrough releases permits.
+type buffer[Req any] struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	queue    []item[Req] // pending: enqueued but not yet observed by the sender
+	flight   []item[Req] // in-flight: observed by the sender, waiting for ack
+	closed   bool
+	sem      chan struct{} // capacity = maxInflight; held while item is in queue or flight
+	doneOnce sync.Once
+	doneCh   chan struct{} // closed when the buffer is closed/drained; unblocks sem waiters
+}
+
+func newBuffer[Req any](maxInflight int) *buffer[Req] {
+	// queue/flight grow on demand; don't preallocate to maxInflight, which with
+	// the default 1M cap would reserve tens of MB per stream before a single
+	// record is ingested. Only the semaphore is sized to the cap, since it is the
+	// backpressure gate and its capacity defines the bound.
+	b := &buffer[Req]{
+		sem:    make(chan struct{}, maxInflight),
+		doneCh: make(chan struct{}),
+	}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *buffer[Req]) closeDone() {
+	b.doneOnce.Do(func() { close(b.doneCh) })
+}
+
+// enqueue adds an already-encoded message to the pending queue, blocking until
+// a slot is available (backpressure) or ctx is cancelled. The offset must be
+// monotonically increasing; the caller (coreStream) is responsible for that.
+// Returns ctx.Err() if ctx fires before a slot opens.
+func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
+	// Honor an already-cancelled ctx first: select picks randomly among ready
+	// cases, so a free slot could otherwise mask cancellation.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Acquire a slot before touching the queue so callers block here rather than
+	// inside the mutex. ctx cancellation wakes up the select immediately.
+	select {
+	case b.sem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.doneCh:
+		return errClosed
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		<-b.sem // release the slot we just took
+		return errClosed
+	}
+	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg})
+	b.mu.Unlock()
+	b.cond.Signal()
+	return nil
+}
+
+// next blocks until a pending item is available and moves it to the in-flight
+// list, returning the item. The sender must later call discard (on ack) or
+// requeue (on reconnect) for every item returned by next.
+//
+// Returns errClosed when the buffer has been closed and drained.
+// Returns ctx.Err() if ctx is cancelled while waiting.
+func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
+	b.mu.Lock()
+	for len(b.queue) == 0 && !b.closed {
+		// Wake up on ctx cancellation too.
+		stop := context.AfterFunc(ctx, func() { b.cond.Broadcast() })
+		b.cond.Wait()
+		stop()
+		if ctx.Err() != nil {
+			b.mu.Unlock()
+			return item[Req]{}, ctx.Err()
+		}
+	}
+	if len(b.queue) == 0 {
+		b.mu.Unlock()
+		return item[Req]{}, errClosed
+	}
+	it := b.queue[0]
+	b.queue = b.queue[1:]
+	b.flight = append(b.flight, it)
+	b.mu.Unlock()
+	return it, nil
+}
+
+// discardThrough removes every in-flight item whose offset is <= offset (all
+// now acknowledged by the server) and releases one semaphore slot per removed
+// item so blocked enqueue callers can proceed. It is the sender/receiver's only
+// hook for ack-driven eviction, keeping the buffer's internals (flight, sem,
+// cond) private. Returns the number of items discarded.
+func (b *buffer[Req]) discardThrough(offset int64) int {
+	b.mu.Lock()
+	n := 0
+	for len(b.flight) > 0 && b.flight[0].offset <= offset {
+		b.flight = b.flight[1:]
+		n++
+	}
+	b.mu.Unlock()
+	for range n {
+		<-b.sem
+	}
+	if n > 0 {
+		b.cond.Broadcast()
+	}
+	return n
+}
+
+// requeue moves all in-flight items back to the front of the pending queue so
+// they are re-sent after a reconnect. Called by the supervisor on stream failure.
+func (b *buffer[Req]) requeue() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Prepend in-flight items (in order) before any still-pending ones.
+	b.queue = append(b.flight, b.queue...)
+	b.flight = b.flight[:0]
+	b.cond.Broadcast()
+}
+
+// drain returns all items currently in the buffer (pending + in-flight) and
+// closes it. Subsequent enqueue calls return errClosed. Called once the
+// supervisor has given up and the caller wants unacked records.
+func (b *buffer[Req]) drain() []item[Req] {
+	b.mu.Lock()
+	all := make([]item[Req], 0, len(b.flight)+len(b.queue))
+	all = append(all, b.flight...)
+	all = append(all, b.queue...)
+	b.queue = nil
+	b.flight = nil
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+	return all
+}
+
+// close marks the buffer closed and wakes any blocked next or enqueue calls.
+// Pending items are not discarded — drain must be called to retrieve them.
+func (b *buffer[Req]) close() {
+	b.mu.Lock()
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+}
+
+// len returns the total number of items in the buffer (pending + in-flight).
+func (b *buffer[Req]) len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.queue) + len(b.flight)
+}
+
+// inFlight returns the number of items observed by the sender but not yet
+// acknowledged. The receiver uses it to gate the lack-of-ack timeout: silence
+// is only a failure while records are actually awaiting an ack; an idle stream
+// (nothing in flight) legitimately receives no acks and must not be torn down.
+func (b *buffer[Req]) inFlight() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.flight)
+}

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -1,0 +1,216 @@
+package stream
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dummyMsg returns a non-nil encodedMsg for use in buffer tests.
+func dummyMsg(offset int64) encodedMsg {
+	msg, _ := protoEncoder{}.encode(offset, []byte("x"))
+	return msg
+}
+
+func TestBufferEnqueueNext(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if it.offset != 1 {
+		t.Fatalf("want offset 1, got %d", it.offset)
+	}
+}
+
+func TestBufferFIFOOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 5; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	for i := int64(1); i <= 5; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferBackpressure(t *testing.T) {
+	const cap = 2
+	b := newBuffer[encodedMsg](cap)
+
+	// Fill the buffer to capacity.
+	for i := int64(1); i <= cap; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// A third enqueue should block until a slot is freed.
+	var enqueued atomic.Bool
+	go func() {
+		_ = b.enqueue(context.Background(), 3, dummyMsg(3))
+		enqueued.Store(true)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if enqueued.Load() {
+		t.Fatal("enqueue should be blocked at capacity")
+	}
+
+	// Observe and discard one item to free a slot.
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	b.discardThrough(it.offset)
+
+	// Now the blocked enqueue should complete.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for !enqueued.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !enqueued.Load() {
+		t.Fatal("enqueue did not unblock after discard")
+	}
+}
+
+func TestBufferContextCancelUnblocksEnqueue(t *testing.T) {
+	b := newBuffer[encodedMsg](1)
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.enqueue(ctx, 2, dummyMsg(2))
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("enqueue did not unblock on context cancel")
+	}
+}
+
+func TestBufferRequeueResendsInOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	for i := int64(1); i <= 3; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// Observe all three (move to in-flight).
+	for range 3 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	// Requeue moves them back to the front of the queue.
+	b.requeue()
+
+	for i := int64(1); i <= 3; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next after requeue %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d after requeue, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferDrainReturnsAll(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 4; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	// Observe two to put them in-flight.
+	for range 2 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	items := b.drain()
+	if len(items) != 4 {
+		t.Fatalf("want 4 items from drain, got %d", len(items))
+	}
+	// Verify in-flight items come first (offsets 1,2), then pending (3,4).
+	for i, want := range []int64{1, 2, 3, 4} {
+		if items[i].offset != want {
+			t.Fatalf("drain[%d]: want offset %d, got %d", i, want, items[i].offset)
+		}
+	}
+}
+
+func TestBufferEnqueueAfterCloseErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.close()
+	err := b.enqueue(context.Background(), 1, dummyMsg(1))
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferNextAfterCloseAndDrainErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.drain()
+	_, err := b.next(context.Background())
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
+	const n = 100
+	b := newBuffer[encodedMsg](16)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			it, err := b.next(context.Background())
+			if err != nil {
+				return
+			}
+			b.discardThrough(it.offset)
+		}
+	}()
+
+	for i := int64(1); i <= n; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	wg.Wait()
+
+	if got := b.len(); got != 0 {
+		t.Fatalf("want buffer empty after all discards, got len=%d", got)
+	}
+}

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -1,0 +1,575 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
+
+// Default config constants for the ingestion core.
+const (
+	DefaultMaxInflight      = 1_000_000
+	DefaultRecoveryRetries  = 4
+	DefaultRecoveryBackoff  = 2 * time.Second
+	DefaultFlushTimeout     = 5 * time.Minute
+	DefaultLackOfAckTimeout = 60 * time.Second
+	// DefaultDrainTimeout bounds the orderly drain-to-EOF on a clean Close so a
+	// wedged sender or an unresponsive server can't hang teardown. Matches the
+	// transport's teardown drain budget; the long ack wait lives in Flush.
+	DefaultDrainTimeout = 500 * time.Millisecond
+)
+
+// RecoverySetting controls whether a stream reconnects on failure. It is an enum
+// rather than a bool so its zero value is the safe default (recovery enabled): a
+// zero-valued Config recovers, and disabling is an explicit opt-out. This avoids
+// the bool zero-value footgun where Config{...} silently disables recovery.
+type RecoverySetting int
+
+const (
+	// RecoveryEnabled reconnects on failure. It is the zero value, so a Config
+	// that never sets Recovery still recovers.
+	RecoveryEnabled RecoverySetting = iota
+	// RecoveryDisabled fails the stream on the first unrecoverable error without
+	// attempting to reconnect.
+	RecoveryDisabled
+)
+
+// enabled reports whether recovery should be attempted.
+func (r RecoverySetting) enabled() bool { return r == RecoveryEnabled }
+
+// Config holds per-stream configuration. All fields have sane defaults via
+// DefaultConfig(); override individual fields before passing to NewCoreStream.
+type Config struct {
+	// MaxInflight is the maximum number of unacknowledged records in the buffer.
+	MaxInflight int
+	// Recovery controls whether stream reconnection is attempted on failure. The
+	// zero value (RecoveryEnabled) recovers; set RecoveryDisabled to opt out.
+	Recovery RecoverySetting
+	// RecoveryRetries is the maximum number of consecutive failed reconnect
+	// attempts before giving up. The budget is per recovery episode: a stream
+	// that connects and runs successfully resets it, so a long-lived stream that
+	// disconnects occasionally is not doomed after RecoveryRetries lifetime
+	// disconnects.
+	RecoveryRetries int
+	// RecoveryBackoff is the fixed wait between reconnect attempts.
+	RecoveryBackoff time.Duration
+	// FlushTimeout bounds Flush when the caller's context has no deadline.
+	FlushTimeout time.Duration
+	// LackOfAckTimeout is how long the receiver waits for a server ack, while
+	// records are in flight, before treating silence as a stream failure. An idle
+	// stream with nothing in flight is never failed for silence.
+	LackOfAckTimeout time.Duration
+	// DrainTimeout bounds the orderly drain-to-EOF performed on a clean Close so
+	// the server observes an orderly END_STREAM rather than an abrupt reset.
+	DrainTimeout time.Duration
+	// StreamPausedMaxWait caps how long the client waits after a server
+	// CloseStreamSignal before reconnecting. The effective wait is
+	// min(StreamPausedMaxWait, server-requested duration). A non-positive value
+	// means "no client cap": wait the full server-requested duration. This lets a
+	// caller trade graceful drain (wait longer) against faster recovery.
+	StreamPausedMaxWait time.Duration
+}
+
+// DefaultConfig returns a Config with SDK-standard defaults.
+func DefaultConfig() Config {
+	return Config{
+		MaxInflight: DefaultMaxInflight,
+		// Recovery left as its zero value, RecoveryEnabled.
+		RecoveryRetries:  DefaultRecoveryRetries,
+		RecoveryBackoff:  DefaultRecoveryBackoff,
+		FlushTimeout:     DefaultFlushTimeout,
+		LackOfAckTimeout: DefaultLackOfAckTimeout,
+		DrainTimeout:     DefaultDrainTimeout,
+	}
+}
+
+// AckCallback is called once per acknowledged record/batch offset.
+type AckCallback interface {
+	OnAck(offset int64)
+	OnError(offset int64, err error)
+}
+
+// watermark is the monotonic ack offset shared between the receiver goroutine
+// (writer) and Flush/WaitForOffset callers (readers).
+type watermark struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	offset   int64 // highest fully-acked offset; -1 means none yet
+	err      error // terminal error set once and never cleared
+	terminal bool
+}
+
+func newWatermark() *watermark {
+	w := &watermark{offset: -1}
+	w.cond = sync.NewCond(&w.mu)
+	return w
+}
+
+// advance sets the watermark to max(current, offset) and wakes waiters.
+func (w *watermark) advance(offset int64) {
+	w.mu.Lock()
+	if offset > w.offset {
+		w.offset = offset
+	}
+	w.mu.Unlock()
+	w.cond.Broadcast()
+}
+
+// fail marks the watermark terminal with err and wakes all waiters.
+func (w *watermark) fail(err error) {
+	w.mu.Lock()
+	if !w.terminal {
+		w.err = err
+		w.terminal = true
+	}
+	w.mu.Unlock()
+	w.cond.Broadcast()
+}
+
+// waitFor blocks until the watermark reaches target or the watermark becomes
+// terminal. Returns nil if the target is reached, or the terminal error.
+func (w *watermark) waitFor(ctx context.Context, target int64) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.offset < target && !w.terminal {
+		// Wake up on ctx cancellation too.
+		stop := context.AfterFunc(ctx, func() { w.cond.Broadcast() })
+		w.cond.Wait()
+		stop()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	if w.offset >= target {
+		return nil
+	}
+	return w.err
+}
+
+// CoreStream is the protocol-agnostic ingestion core. It owns the buffer,
+// sender goroutine, receiver goroutine, ack watermark, and the supervisor
+// that reconnects on failure. It is generic over the wire request/response
+// types (Req/Resp): proto/JSON instantiate it over EphemeralStream, Arrow over
+// Flight. The three specialization points — encoder, ackModel, and the
+// wireStream returned by opener — are injected, so this core is written once
+// and never names a concrete proto type.
+//
+// The three goroutines:
+//
+//	sender   — pulls items from the buffer, writes them to the wire stream.
+//	receiver — reads acks from the wire stream, advances the watermark.
+//	supervisor — create → run → recover loop; wires sender+receiver together.
+//
+// Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
+// GetUnacked, and Close.
+type CoreStream[Req, Resp any] struct {
+	params   StreamParams
+	cfg      Config
+	opener   opener[Req, Resp]
+	enc      encoder[Req]
+	ackMdl   ackModel[Resp]
+	buf      *buffer[Req]
+	wm       *watermark
+	callback AckCallback
+
+	// ingestMu serializes offset assignment + enqueue so that nextOffset only
+	// advances for records that were successfully queued. Without this, a failed
+	// enqueue (e.g. ctx-cancelled backpressure) would consume an offset that is
+	// never sent, making Flush wait forever for an offset the server never sees.
+	ingestMu sync.Mutex
+	// nextOffset is the next logical offset to assign. Protected by ingestMu.
+	nextOffset int64
+	// lastEnqueued is the highest offset successfully enqueued; -1 until the
+	// first successful Ingest. Flush targets this, not nextOffset-1, so a
+	// failed Ingest can't create a permanent gap.
+	lastEnqueued int64
+
+	// done is closed when the supervisor exits (terminal state).
+	done chan struct{}
+	// termErr holds the first terminal error after done is closed.
+	termErr error
+	termMu  sync.Mutex
+
+	closeOnce sync.Once
+	// cancelSupervisor cancels the supervisor's context so Close unblocks it.
+	cancelSupervisor context.CancelFunc
+}
+
+// NewCoreStream constructs a CoreStream and starts the supervisor goroutine.
+// The stream is immediately ready for Ingest calls; the supervisor opens the
+// first transport stream in the background. Prefer the per-protocol
+// constructors (NewProtoJSONStream) over calling this directly.
+func NewCoreStream[Req, Resp any](
+	params StreamParams,
+	cfg Config,
+	opener opener[Req, Resp],
+	enc encoder[Req],
+	ackMdl ackModel[Resp],
+	callback AckCallback,
+) *CoreStream[Req, Resp] {
+	ctx, cancel := context.WithCancel(context.Background())
+	cs := &CoreStream[Req, Resp]{
+		params:           params,
+		cfg:              cfg,
+		opener:           opener,
+		enc:              enc,
+		ackMdl:           ackMdl,
+		buf:              newBuffer[Req](cfg.MaxInflight),
+		wm:               newWatermark(),
+		callback:         callback,
+		lastEnqueued:     -1,
+		done:             make(chan struct{}),
+		cancelSupervisor: cancel,
+	}
+	go cs.supervise(ctx)
+	return cs
+}
+
+// Ingest encodes record and enqueues it in the buffer, blocking if the buffer
+// is at capacity (backpressure). Returns the logical offset assigned to this
+// record; pass it to WaitForOffset to confirm durability.
+func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int64, error) {
+	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
+		return cs.enc.encode(offset, record)
+	})
+}
+
+// IngestBatch encodes records as a single atomic batch and enqueues it, blocking
+// if the buffer is at capacity. The whole batch occupies one logical offset and
+// the server acks it atomically. Returns that offset. Prefer this over Ingest in
+// hot paths: it amortizes per-message overhead across the batch.
+func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]byte) (int64, error) {
+	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
+		return cs.enc.encodeBatch(offset, records)
+	})
+}
+
+// enqueueEncoded assigns the next offset, encodes via encodeFn, and enqueues the
+// result under ingestMu so nextOffset advances only for records that make it
+// into the buffer. A failed encode or ctx-cancelled backpressure consumes no
+// offset, so Flush never waits on an offset the server never sees.
+func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn func(offset int64) (Req, error)) (int64, error) {
+	if cs.isClosed() {
+		if err := cs.terminalErr(); err != nil {
+			return 0, err
+		}
+		return 0, errClosed
+	}
+	cs.ingestMu.Lock()
+	defer cs.ingestMu.Unlock()
+
+	offset := cs.nextOffset
+	msg, err := encodeFn(offset)
+	if err != nil {
+		return 0, err
+	}
+	if err := cs.buf.enqueue(ctx, offset, msg); err != nil {
+		return 0, err
+	}
+	cs.nextOffset++
+	cs.lastEnqueued = offset
+	return offset, nil
+}
+
+// Flush blocks until every record ingested so far is acknowledged by the
+// server. Returns nil once all are durable, or an error if the stream fails
+// or ctx expires.
+//
+// When ctx has no deadline, Flush applies DefaultFlushTimeout.
+func (cs *CoreStream[Req, Resp]) Flush(ctx context.Context) error {
+	cs.ingestMu.Lock()
+	target := cs.lastEnqueued
+	cs.ingestMu.Unlock()
+	if target < 0 {
+		return nil // nothing successfully ingested yet
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cs.cfg.FlushTimeout)
+		defer cancel()
+	}
+	return cs.WaitForOffset(ctx, target)
+}
+
+// WaitForOffset blocks until the server has acknowledged all records up to and
+// including offset, or until ctx expires or the stream fails terminally.
+//
+// offset must be one returned by a successful Ingest. Passing an offset that was
+// never enqueued (e.g. a value above the last assigned offset) is a caller error:
+// since the watermark can never reach it, the call blocks until ctx expires (or
+// the stream fails). Prefer Flush, which waits for exactly the records ingested
+// so far.
+func (cs *CoreStream[Req, Resp]) WaitForOffset(ctx context.Context, offset int64) error {
+	return cs.wm.waitFor(ctx, offset)
+}
+
+// GetUnacked returns records that were ingested but never acknowledged, one
+// entry per record. A batched buffer item expands to all of its records (not
+// just the first), so no unacked record is silently dropped. It closes the
+// stream first (idempotent) to ensure the buffer is fully drained and no new
+// items are added.
+func (cs *CoreStream[Req, Resp]) GetUnacked() [][]byte {
+	cs.Close()
+	items := cs.buf.drain()
+	out := make([][]byte, 0, len(items))
+	for _, it := range items {
+		// Re-extract the raw record bytes from the encoded message so callers get
+		// back the original record content; a batch yields all its records.
+		out = append(out, cs.enc.decode(it.payload)...)
+	}
+	return out
+}
+
+// Close terminates the stream and releases its resources. It is idempotent and
+// blocks until teardown completes.
+//
+// Close does NOT wait for pending records to be acknowledged: any records still
+// in flight when Close is called are abandoned (retrievable via GetUnacked, or
+// reported through the AckCallback's OnError). Callers that need durability must
+// Flush first, then Close — the standard loop-then-Flush pattern. On this clean
+// shutdown the live stream is torn down gracefully (half-close, then drain any
+// straggling acks to EOF, bounded by DrainTimeout) so the server observes an
+// orderly END_STREAM rather than an abrupt reset; see gracefulTeardown.
+func (cs *CoreStream[Req, Resp]) Close() {
+	cs.closeOnce.Do(func() {
+		cs.cancelSupervisor()
+		cs.buf.close()
+		<-cs.done // wait for the supervisor to exit
+	})
+}
+
+// IsClosed reports whether the stream has been closed or failed terminally.
+func (cs *CoreStream[Req, Resp]) IsClosed() bool {
+	return cs.isClosed()
+}
+
+func (cs *CoreStream[Req, Resp]) isClosed() bool {
+	select {
+	case <-cs.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (cs *CoreStream[Req, Resp]) terminalErr() error {
+	cs.termMu.Lock()
+	defer cs.termMu.Unlock()
+	return cs.termErr
+}
+
+func (cs *CoreStream[Req, Resp]) setTerminalErr(err error) {
+	cs.termMu.Lock()
+	if cs.termErr == nil {
+		cs.termErr = err
+	}
+	cs.termMu.Unlock()
+}
+
+// runOnce opens one transport stream and runs sender+receiver until one of
+// them exits. Returns the cause of the exit so the supervisor can decide
+// whether to recover, and healthy=true once a stream was successfully opened
+// and run (so the supervisor can reset its per-episode retry budget — a stream
+// that connected and later failed is a fresh episode, not a continuation of the
+// prior reconnect streak).
+func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, healthy bool) {
+	stream, err := cs.opener.Open(ctx, cs.params)
+	if err != nil {
+		// Invalid params (bad table name, unsupported record type, missing
+		// descriptor) are deterministic — reconnecting reproduces them — so mark
+		// them non-retryable rather than burning the recovery budget on a failure
+		// that can't succeed.
+		if errors.Is(err, transport.ErrInvalidParams) {
+			return wrapValidation(fmt.Errorf("stream: open: %w", err)), false
+		}
+		return fmt.Errorf("stream: open: %w", err), false
+	}
+
+	// Move all in-flight items back to the pending queue so the sender
+	// re-sends them on this new connection.
+	cs.buf.requeue()
+
+	// senderCtx is cancelled when we want the sender to stop for THIS stream
+	// only, without cancelling the supervisor's outer ctx (which would signal Close).
+	senderCtx, cancelSender := context.WithCancel(ctx)
+	defer cancelSender()
+
+	errCh := make(chan error, 2)
+
+	go cs.sender(senderCtx, stream, errCh)
+	go cs.receiver(stream, errCh)
+
+	// Wait for the first goroutine to signal, then tear both down. On clean
+	// shutdown (Close cancelled ctx) only the sender exits first — the receiver
+	// keeps draining acks — so we half-close and let it drain to EOF for an
+	// orderly server-observed END_STREAM. On failure we hard-abort instead.
+	cause = <-errCh
+	cancelSender() // unblocks sender waiting on buf.next()
+	var ps pauseSignal
+	switch {
+	case ctx.Err() != nil:
+		cs.gracefulTeardown(stream, errCh)
+	case errors.As(cause, &ps):
+		// Server-requested pause: the receiver already closed the stream to
+		// unblock its Recv, so just reap the sender. Requeue happens on reconnect.
+		stream.Close()
+		<-errCh
+	default:
+		// Failure/recovery path: the stream is already broken, so hard-abort to
+		// unblock the receiver's Recv immediately.
+		stream.Close()
+		<-errCh // drain second exit
+	}
+	return cause, true
+}
+
+// gracefulTeardown closes a healthy stream in an orderly fashion after the
+// sender has stopped: half-close the send side so the server flushes any
+// remaining acks and ends the stream, let the still-running receiver drain to
+// io.EOF (advancing the watermark for late acks), then release resources.
+// DrainTimeout bounds the wait so a wedged server can't hang Close; on expiry we
+// hard-abort. This mirrors transport.GracefulClose, done cooperatively because
+// the receiver goroutine — not this one — owns Recv.
+func (cs *CoreStream[Req, Resp]) gracefulTeardown(stream wireStream[Req, Resp], errCh <-chan error) {
+	if err := stream.CloseSend(); err != nil {
+		// Send side already broken; fall back to a hard abort.
+		stream.Close()
+		<-errCh
+		return
+	}
+	timer := time.NewTimer(cs.cfg.DrainTimeout)
+	defer timer.Stop()
+	select {
+	case <-errCh:
+		// Receiver drained to EOF; release resources (Close is idempotent).
+		stream.Close()
+	case <-timer.C:
+		// Drain budget exceeded; force the receiver out and reap it.
+		stream.Close()
+		<-errCh
+	}
+}
+
+// sender pulls items from the buffer and writes them to stream. Exits when
+// senderCtx is cancelled (per-stream teardown), the buffer is closed, or
+// Send fails. senderCtx is derived from a per-runOnce cancel so the supervisor
+// can stop this sender without cancelling the outer supervisor context.
+func (cs *CoreStream[Req, Resp]) sender(senderCtx context.Context, stream wireStream[Req, Resp], errCh chan<- error) {
+	for {
+		it, err := cs.buf.next(senderCtx)
+		if err != nil {
+			errCh <- nil // ctx cancelled or buffer closed — clean exit
+			return
+		}
+		if err := stream.Send(it.payload); err != nil {
+			errCh <- fmt.Errorf("stream: send offset %d: %w", it.offset, err)
+			return
+		}
+	}
+}
+
+// receiver reads ack responses from stream and advances the watermark. It runs
+// until io.EOF (server closed cleanly, including after a graceful half-close),
+// a receive error, the lack-of-ack timeout (only while records are in flight),
+// or the stream being Closed out from under it (which surfaces as a Recv error).
+// Teardown is coordinated by runOnce, so the receiver does not watch the
+// supervisor context itself.
+//
+// Each Recv call runs on its own goroutine so we can race it against the
+// lack-of-ack timer even when the underlying transport Recv is blocking (e.g. a
+// fake in tests, or a stalled server).
+func (cs *CoreStream[Req, Resp]) receiver(stream wireStream[Req, Resp], errCh chan<- error) {
+	type recvResult struct {
+		resp Resp
+		err  error
+	}
+
+	// A single outstanding Recv goroutine at a time feeds recvCh. Hoisting it out
+	// of the loop keeps the lack-of-ack timer live across idle periods: re-arming
+	// the timer must not commit us to blocking on the current Recv, or records
+	// that go in flight later would never be checked against the timeout.
+	recvCh := make(chan recvResult, 1)
+	spawnRecv := func() {
+		go func() {
+			resp, err := stream.Recv()
+			recvCh <- recvResult{resp, err}
+		}()
+	}
+	spawnRecv()
+
+	lackTimer := time.NewTimer(cs.cfg.LackOfAckTimeout)
+	defer lackTimer.Stop()
+
+	for {
+		var r recvResult
+		select {
+		case <-lackTimer.C:
+			// Silence is only a failure while records are actually awaiting an ack.
+			// An idle stream (nothing in flight) legitimately receives no acks, so
+			// re-arm the timer and keep waiting on the same outstanding Recv rather
+			// than tearing the stream down.
+			if cs.buf.inFlight() == 0 {
+				lackTimer.Reset(cs.cfg.LackOfAckTimeout)
+				continue
+			}
+			stream.Close()
+			<-recvCh // reap the outstanding Recv goroutine
+			errCh <- fmt.Errorf("stream: no ack from server for %s", cs.cfg.LackOfAckTimeout)
+			return
+		case r = <-recvCh:
+		}
+
+		if r.err == io.EOF {
+			errCh <- nil
+			return
+		}
+		if r.err != nil {
+			errCh <- fmt.Errorf("stream: recv: %w", r.err)
+			return
+		}
+
+		kind, offset, pause := cs.ackMdl.classify(r.resp)
+		if kind == pauseResponse {
+			// A server pause (proto/JSON CloseStreamSignal) is a flow-control
+			// request, not noise: the server is about to close this stream and
+			// wants the client to pause (stop sending, keep buffering and draining
+			// acks) then reconnect. Report it so the supervisor waits the requested
+			// window and reconnects without counting it against the recovery
+			// budget. This iteration's Recv goroutine already delivered (via r
+			// above), so there is nothing to drain; runOnce owns tearing the stream
+			// down.
+			errCh <- pause
+			return
+		}
+
+		// Not a terminal response — keep reading. Spawn the next Recv before
+		// handling this one so the loop always has exactly one outstanding.
+		spawnRecv()
+
+		if kind == ackResponse {
+			// Reset the lack-of-ack timer on every ack received.
+			if !lackTimer.Stop() {
+				select {
+				case <-lackTimer.C:
+				default:
+				}
+			}
+			lackTimer.Reset(cs.cfg.LackOfAckTimeout)
+
+			cs.wm.advance(offset)
+			// Discard all buffer items that are now acknowledged, freeing their
+			// backpressure slots for waiting enqueue callers.
+			cs.buf.discardThrough(offset)
+
+			if cs.callback != nil {
+				cs.callback.OnAck(offset)
+			}
+		}
+		// otherResponse: ignored; the next Recv is already outstanding.
+	}
+}

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/transport"
@@ -22,6 +23,13 @@ const (
 	// wedged sender or an unresponsive server can't hang teardown. Matches the
 	// transport's teardown drain budget; the long ack wait lives in Flush.
 	DefaultDrainTimeout = 500 * time.Millisecond
+	// DefaultRecoveryTimeout bounds each Open attempt so a stalled dial cannot
+	// hold recovery indefinitely.
+	DefaultRecoveryTimeout = 15 * time.Second
+	// DefaultCallbackTeardownTimeout bounds how long a terminal-state teardown
+	// waits for pending user callbacks (OnAck/OnError) to drain before giving
+	// up.
+	DefaultCallbackTeardownTimeout = 5 * time.Second
 )
 
 // RecoverySetting controls whether a stream reconnects on failure. It is an enum
@@ -44,6 +52,9 @@ func (r RecoverySetting) enabled() bool { return r == RecoveryEnabled }
 
 // Config holds per-stream configuration. All fields have sane defaults via
 // DefaultConfig(); override individual fields before passing to NewCoreStream.
+// Non-positive values are normalized to their defaults by sanitizeConfig on
+// stream construction so a caller-passed Config{} does not deadlock, spin, or
+// abort teardown immediately.
 type Config struct {
 	// MaxInflight is the maximum number of unacknowledged records in the buffer.
 	MaxInflight int
@@ -58,6 +69,10 @@ type Config struct {
 	RecoveryRetries int
 	// RecoveryBackoff is the fixed wait between reconnect attempts.
 	RecoveryBackoff time.Duration
+	// RecoveryTimeout bounds each Open attempt so a stalled dial cannot pin
+	// recovery; a per-attempt failure that hits this budget is retried like any
+	// other transient error, subject to RecoveryRetries.
+	RecoveryTimeout time.Duration
 	// FlushTimeout bounds Flush when the caller's context has no deadline.
 	FlushTimeout time.Duration
 	// LackOfAckTimeout is how long the receiver waits for a server ack, while
@@ -67,31 +82,279 @@ type Config struct {
 	// DrainTimeout bounds the orderly drain-to-EOF performed on a clean Close so
 	// the server observes an orderly END_STREAM rather than an abrupt reset.
 	DrainTimeout time.Duration
+	// CallbackTeardownTimeout bounds how long terminal teardown waits for
+	// pending OnAck/OnError callbacks to drain before giving up.
+	CallbackTeardownTimeout time.Duration
+	// MaxPayloadBytes caps the aggregate size of a single ingest call (one
+	// record or the whole batch). Oversized payloads are rejected at Ingest
+	// with ErrPayloadTooLarge so a deterministic input error does not turn into
+	// a transport/recovery failure. Non-positive means "use DefaultMaxPayloadBytes".
+	MaxPayloadBytes int
 	// StreamPausedMaxWait caps how long the client waits after a server
 	// CloseStreamSignal before reconnecting. The effective wait is
-	// min(StreamPausedMaxWait, server-requested duration). A non-positive value
-	// means "no client cap": wait the full server-requested duration. This lets a
-	// caller trade graceful drain (wait longer) against faster recovery.
+	// min(StreamPausedMaxWait, server-requested duration). See
+	// StreamPausedMaxWaitMode for the sentinel-value semantics: the zero value
+	// means "no client cap"; use StreamPausedImmediate to reconnect immediately.
 	StreamPausedMaxWait time.Duration
+	// StreamPausedMaxWaitMode selects between the pause-wait sentinels; zero =
+	// use StreamPausedMaxWait verbatim (or no cap if that is also zero).
+	StreamPausedMaxWaitMode PauseWaitMode
 }
+
+// PauseWaitMode selects the interpretation of a server-requested pause. The
+// default (PauseWaitServer) waits the server-requested duration, capped by
+// StreamPausedMaxWait if positive. PauseWaitImmediate reconnects immediately
+// on any pause signal regardless of the server-requested duration, matching
+// the "immediate reconnect on pause" configuration used elsewhere in the
+// ingestion SDK family.
+type PauseWaitMode int
+
+const (
+	// PauseWaitServer waits the server-requested duration (optionally capped by
+	// StreamPausedMaxWait). Zero value.
+	PauseWaitServer PauseWaitMode = iota
+	// PauseWaitImmediate reconnects as soon as the server asks for a pause,
+	// ignoring the server-requested duration entirely.
+	PauseWaitImmediate
+)
 
 // DefaultConfig returns a Config with SDK-standard defaults.
 func DefaultConfig() Config {
 	return Config{
 		MaxInflight: DefaultMaxInflight,
 		// Recovery left as its zero value, RecoveryEnabled.
-		RecoveryRetries:  DefaultRecoveryRetries,
-		RecoveryBackoff:  DefaultRecoveryBackoff,
-		FlushTimeout:     DefaultFlushTimeout,
-		LackOfAckTimeout: DefaultLackOfAckTimeout,
-		DrainTimeout:     DefaultDrainTimeout,
+		RecoveryRetries:         DefaultRecoveryRetries,
+		RecoveryBackoff:         DefaultRecoveryBackoff,
+		RecoveryTimeout:         DefaultRecoveryTimeout,
+		FlushTimeout:            DefaultFlushTimeout,
+		LackOfAckTimeout:        DefaultLackOfAckTimeout,
+		DrainTimeout:            DefaultDrainTimeout,
+		CallbackTeardownTimeout: DefaultCallbackTeardownTimeout,
+		MaxPayloadBytes:         DefaultMaxPayloadBytes,
 	}
 }
 
-// AckCallback is called once per acknowledged record/batch offset.
+// sanitizeConfig normalizes non-positive or absent values to their defaults so
+// a caller-passed Config{} does not (a) block every Ingest on an unbuffered
+// semaphore (MaxInflight==0), (b) spin the receiver on a zero lack-of-ack
+// timer, or (c) hard-abort teardown immediately (DrainTimeout==0). Kept
+// separate from DefaultConfig so callers can still see which fields they
+// explicitly set; only the fields that would break liveness or contradict
+// the documented default behaviour are rewritten. Recovery,
+// StreamPausedMaxWait, and StreamPausedMaxWaitMode are left as-is because
+// their zero values have well-defined meaning.
+//
+// RecoveryRetries treats 0 and negative both as "unset → use default": a
+// Config{} whose zero-valued Recovery says "recovery enabled" would
+// otherwise reconnect zero times, contradicting the documented behaviour
+// that a zero Config is safe. Callers who really want a single-attempt
+// stream must combine RecoverySetting=RecoveryDisabled instead.
+func sanitizeConfig(c Config) Config {
+	if c.MaxInflight <= 0 {
+		c.MaxInflight = DefaultMaxInflight
+	}
+	if c.RecoveryRetries <= 0 {
+		c.RecoveryRetries = DefaultRecoveryRetries
+	}
+	if c.RecoveryBackoff <= 0 {
+		c.RecoveryBackoff = DefaultRecoveryBackoff
+	}
+	if c.RecoveryTimeout <= 0 {
+		c.RecoveryTimeout = DefaultRecoveryTimeout
+	}
+	if c.FlushTimeout <= 0 {
+		c.FlushTimeout = DefaultFlushTimeout
+	}
+	if c.LackOfAckTimeout <= 0 {
+		c.LackOfAckTimeout = DefaultLackOfAckTimeout
+	}
+	if c.DrainTimeout <= 0 {
+		c.DrainTimeout = DefaultDrainTimeout
+	}
+	if c.CallbackTeardownTimeout <= 0 {
+		c.CallbackTeardownTimeout = DefaultCallbackTeardownTimeout
+	}
+	if c.MaxPayloadBytes <= 0 {
+		c.MaxPayloadBytes = DefaultMaxPayloadBytes
+	}
+	return c
+}
+
+// AckCallback receives durability notifications for records that were
+// Ingested successfully.
+//
+// # Delivery semantics
+//
+// Callbacks are invoked serially on a dedicated dispatcher goroutine, so a
+// slow callback does not stall the receiver/supervisor and it is safe to
+// call CoreStream methods (including Close) from inside a callback — the
+// caller won't self-deadlock.
+//
+// OnAck is best-effort per newly-acknowledged logical offset. Under normal
+// load one OnAck fires per offset covered by the ack (a cumulative server
+// ack for offset 5 following an ack at offset 2 yields three OnAcks for
+// offsets 3, 4, and 5); a repeated ack that discards no new items yields
+// zero OnAcks. If the user's OnAck implementation stalls and the internal
+// dispatch queue fills, further OnAcks are dropped rather than back-
+// pressuring the receiver — the record's durability is unaffected (Flush /
+// WaitForOffset remain accurate), only the observability signal is lost.
+// Callers that require strict per-offset delivery must keep OnAck fast, or
+// rely on WaitForOffset for durability confirmation.
+//
+// OnError fires on terminal failure, once per drained buffer item (a batch
+// occupies a single item, so its OnError fires once with the batch's
+// assigned offset). Delivery is bounded: if the user callback is stalled
+// and the dispatch queue fills, later OnErrors during terminal drain may be
+// dropped so the supervisor can complete teardown promptly; the unacked
+// records remain retrievable via GetUnacked regardless.
 type AckCallback interface {
 	OnAck(offset int64)
 	OnError(offset int64, err error)
+}
+
+// cbEvent is one callback dispatch unit; err==nil means OnAck.
+type cbEvent struct {
+	offset int64
+	err    error
+}
+
+// callbackDispatcher owns the goroutine that invokes user AckCallback methods.
+// It exists so the receiver and supervisor goroutines are never blocked by a
+// slow user callback, and so callbacks that call CoreStream.Close() cannot
+// self-deadlock (Close waits for the supervisor; the supervisor would
+// otherwise wait for the callback that is waiting for Close).
+type callbackDispatcher struct {
+	cb        AckCallback
+	events    chan cbEvent
+	done      chan struct{}
+	closeOnce sync.Once
+	// inCallback is set to 1 while the dispatcher goroutine is inside a user
+	// callback; shutdown() checks it to detect reentrant calls (a callback
+	// invoked Close) and skip the synchronous wait that would otherwise
+	// self-deadlock.
+	inCallback atomic.Bool
+}
+
+// newCallbackDispatcher spawns the dispatcher goroutine. Returns nil (a no-op
+// dispatcher, safely usable via nil checks at call sites) if cb is nil.
+func newCallbackDispatcher(cb AckCallback) *callbackDispatcher {
+	if cb == nil {
+		return nil
+	}
+	d := &callbackDispatcher{
+		cb:     cb,
+		events: make(chan cbEvent, 1024),
+		done:   make(chan struct{}),
+	}
+	go d.run()
+	return d
+}
+
+func (d *callbackDispatcher) run() {
+	defer close(d.done)
+	for e := range d.events {
+		d.inCallback.Store(true)
+		d.safeInvoke(e)
+		d.inCallback.Store(false)
+	}
+}
+
+// safeInvoke calls the user callback with a panic guard so a misbehaving
+// callback does not crash the process. The recovered panic is silently
+// dropped: the stream itself is unaffected (durability is tracked by the
+// watermark, not the callback), and there is no user-visible channel to
+// surface the panic on. Callbacks that need to surface panics should
+// recover themselves and route via their own error channel.
+func (d *callbackDispatcher) safeInvoke(e cbEvent) {
+	defer func() { _ = recover() }()
+	if e.err == nil {
+		d.cb.OnAck(e.offset)
+	} else {
+		d.cb.OnError(e.offset, e.err)
+	}
+}
+
+// enqueueAck posts an OnAck event; non-blocking under normal load (buffered
+// channel). If the channel is full (a callback is stalled), the ack is dropped
+// with the guarantee that watermark advancement itself is unaffected — the
+// callback is best-effort observability, not a durability signal.
+func (d *callbackDispatcher) enqueueAck(offset int64) {
+	if d == nil {
+		return
+	}
+	select {
+	case d.events <- cbEvent{offset: offset}:
+	default:
+		// Callback is stalled and would otherwise block the receiver. Dropping
+		// the event is preferable to stalling ack processing; callers relying
+		// on strict per-offset delivery must ensure their callback keeps up.
+	}
+}
+
+// enqueueError posts an OnError event. Publication is bounded so a stalled
+// user callback cannot block the supervisor from closing cs.done — otherwise
+// Close would hang waiting for the supervisor which is waiting for the
+// callback which is waiting for Close. If the channel is full within the
+// budget, the event is dropped and the record still surfaces via GetUnacked
+// (payloads are retained regardless of callback state).
+func (d *callbackDispatcher) enqueueError(offset int64, err error) {
+	if d == nil {
+		return
+	}
+	// Fast path: room in the queue.
+	select {
+	case d.events <- cbEvent{offset: offset, err: err}:
+		return
+	default:
+	}
+	// Slow path: give the dispatcher a moment to drain, but never longer
+	// than callbackEnqueueBudget so the supervisor stays responsive.
+	timer := time.NewTimer(callbackEnqueueBudget)
+	defer timer.Stop()
+	select {
+	case d.events <- cbEvent{offset: offset, err: err}:
+	case <-timer.C:
+		// Drop: the event is best-effort observability. GetUnacked retains
+		// the record so no data is lost.
+	}
+}
+
+// callbackEnqueueBudget bounds how long enqueueError waits for room in the
+// dispatcher channel during terminal drain. Kept short so a stalled user
+// callback cannot pin Close for the full CallbackTeardownTimeout multiplied
+// by the number of unacked items.
+const callbackEnqueueBudget = 50 * time.Millisecond
+
+// shutdown closes the event channel and waits up to timeout for the
+// dispatcher to drain and exit. If a user callback is running when shutdown
+// is called, the synchronous wait is skipped so a callback-invoked Close
+// does not self-deadlock: the dispatcher goroutine can't drain further
+// events while the callback is running, and the callback can't return
+// until Close does. After a skipped or timed-out wait the dispatcher
+// continues to drain in the background and exits on its own once events
+// is empty.
+//
+// Note: the "callback running" check is process-state, not caller-identity.
+// If an unrelated goroutine calls Close while another callback is in
+// flight, that Close also skips the wait. This is a deliberate trade-off:
+// Close is best-effort teardown, and the alternative (goroutine-ID
+// detection) has no clean Go API. Callers that need a strict "all
+// callbacks completed" barrier should synchronize externally.
+func (d *callbackDispatcher) shutdown(timeout time.Duration) {
+	if d == nil {
+		return
+	}
+	d.closeOnce.Do(func() { close(d.events) })
+	if d.inCallback.Load() {
+		return
+	}
+	if timeout <= 0 {
+		return
+	}
+	select {
+	case <-d.done:
+	case <-time.After(timeout):
+	}
 }
 
 // watermark is the monotonic ack offset shared between the receiver goroutine
@@ -103,6 +366,11 @@ type watermark struct {
 	err      error // terminal error set once and never cleared
 	terminal bool
 }
+
+// errWatermarkClosed is returned by WaitForOffset when the stream was cleanly
+// closed before the target offset became durable: the target can never be
+// reached, so blocking further would be a permanent hang.
+var errWatermarkClosed = errors.New("stream: closed before offset was acknowledged")
 
 func newWatermark() *watermark {
 	w := &watermark{offset: -1}
@@ -131,14 +399,33 @@ func (w *watermark) fail(err error) {
 	w.cond.Broadcast()
 }
 
+// closeForClean marks the watermark terminal with errWatermarkClosed unless it
+// is already terminal with a real error. Called on clean Close so
+// WaitForOffset cannot hang after the stream is torn down: the target is no
+// longer reachable, and callers get an explicit error instead of blocking
+// forever on a background ctx.
+func (w *watermark) closeForClean() { w.fail(errWatermarkClosed) }
+
 // waitFor blocks until the watermark reaches target or the watermark becomes
 // terminal. Returns nil if the target is reached, or the terminal error.
 func (w *watermark) waitFor(ctx context.Context, target int64) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// Fail fast if ctx is already cancelled: without this an already-cancelled
+	// ctx could still park at Wait (AfterFunc broadcast racing with the loop
+	// condition check).
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	for w.offset < target && !w.terminal {
-		// Wake up on ctx cancellation too.
-		stop := context.AfterFunc(ctx, func() { w.cond.Broadcast() })
+		// Take w.mu inside the AfterFunc so Broadcast can't be lost against a
+		// racing Wait: without the lock, ctx could fire between the condition
+		// check and Wait's park step, missing the wake-up.
+		stop := context.AfterFunc(ctx, func() {
+			w.mu.Lock()
+			w.cond.Broadcast()
+			w.mu.Unlock()
+		})
 		w.cond.Wait()
 		stop()
 		if ctx.Err() != nil {
@@ -168,26 +455,30 @@ func (w *watermark) waitFor(ctx context.Context, target int64) error {
 // Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
 // GetUnacked, and Close.
 type CoreStream[Req, Resp any] struct {
-	params   StreamParams
-	cfg      Config
-	opener   opener[Req, Resp]
-	enc      encoder[Req]
-	ackMdl   ackModel[Resp]
-	buf      *buffer[Req]
-	wm       *watermark
-	callback AckCallback
+	params     StreamParams
+	cfg        Config
+	opener     opener[Req, Resp]
+	enc        encoder[Req]
+	ackMdl     ackModel[Resp]
+	buf        *buffer[Req]
+	wm         *watermark
+	dispatcher *callbackDispatcher
 
-	// ingestMu serializes offset assignment + enqueue so that nextOffset only
-	// advances for records that were successfully queued. Without this, a failed
-	// enqueue (e.g. ctx-cancelled backpressure) would consume an offset that is
-	// never sent, making Flush wait forever for an offset the server never sees.
-	ingestMu sync.Mutex
-	// nextOffset is the next logical offset to assign. Protected by ingestMu.
+	// offsetMu serializes offset assignment so nextOffset advances atomically
+	// per accepted record. It is intentionally NOT held across the semaphore
+	// wait: the caller reserves a buffer slot first (context-aware, may block),
+	// then briefly takes offsetMu to assign the offset, then appends. That
+	// keeps concurrent Ingest callers from serializing behind whoever is stuck
+	// on backpressure, and lets each caller observe its own ctx cancellation
+	// promptly.
+	offsetMu sync.Mutex
+	// nextOffset is the next logical offset to assign. Protected by offsetMu.
 	nextOffset int64
-	// lastEnqueued is the highest offset successfully enqueued; -1 until the
-	// first successful Ingest. Flush targets this, not nextOffset-1, so a
-	// failed Ingest can't create a permanent gap.
-	lastEnqueued int64
+	// lastEnqueued is the highest offset successfully enqueued (accessed as an
+	// atomic int64 via sync/atomic operations); -1 until the first successful
+	// Ingest. Flush targets this so a failed Ingest can't create a permanent
+	// gap.
+	lastEnqueued atomic.Int64
 
 	// done is closed when the supervisor exits (terminal state).
 	done chan struct{}
@@ -198,12 +489,51 @@ type CoreStream[Req, Resp any] struct {
 	closeOnce sync.Once
 	// cancelSupervisor cancels the supervisor's context so Close unblocks it.
 	cancelSupervisor context.CancelFunc
+
+	// retainedFailed holds the encoded unacked items preserved on terminal
+	// failure so GetUnacked can decode them lazily. Kept as encoded items
+	// (rather than eagerly-decoded [][]byte) so terminal drain does not
+	// duplicate the entire backlog in memory when the user may never call
+	// GetUnacked. Protected by termMu. Payloads are also retained for
+	// GetUnacked when an AckCallback is registered; the two signals converge
+	// on the same records rather than being mutually exclusive.
+	retainedFailed []item[Req]
+}
+
+// setRetainedFailed atomically stores the terminal-drain unacked items in
+// their encoded form; decoding is deferred to GetUnacked so a terminal
+// failure with a large in-flight set does not spike memory by holding both
+// encoded and decoded copies at once.
+func (cs *CoreStream[Req, Resp]) setRetainedFailed(items []item[Req]) {
+	if len(items) == 0 {
+		return
+	}
+	cs.termMu.Lock()
+	cs.retainedFailed = items
+	cs.termMu.Unlock()
+}
+
+// takeRetainedFailed returns the retained items and clears the slot so
+// GetUnacked observes them exactly once.
+func (cs *CoreStream[Req, Resp]) takeRetainedFailed() []item[Req] {
+	cs.termMu.Lock()
+	out := cs.retainedFailed
+	cs.retainedFailed = nil
+	cs.termMu.Unlock()
+	return out
 }
 
 // NewCoreStream constructs a CoreStream and starts the supervisor goroutine.
 // The stream is immediately ready for Ingest calls; the supervisor opens the
 // first transport stream in the background. Prefer the per-protocol
 // constructors (NewProtoJSONStream) over calling this directly.
+//
+// Construction is intentionally asynchronous at this internal layer:
+// invalid credentials or bad StreamParams surface as a Flush / GetUnacked
+// error once the supervisor's first Open attempts have exhausted
+// RecoveryRetries. The public zerobus package is expected to wrap this
+// with a readiness gate (initial-stream-open confirmation) before
+// exposing the stream to users.
 func NewCoreStream[Req, Resp any](
 	params StreamParams,
 	cfg Config,
@@ -212,6 +542,7 @@ func NewCoreStream[Req, Resp any](
 	ackMdl ackModel[Resp],
 	callback AckCallback,
 ) *CoreStream[Req, Resp] {
+	cfg = sanitizeConfig(cfg)
 	ctx, cancel := context.WithCancel(context.Background())
 	cs := &CoreStream[Req, Resp]{
 		params:           params,
@@ -221,11 +552,11 @@ func NewCoreStream[Req, Resp any](
 		ackMdl:           ackMdl,
 		buf:              newBuffer[Req](cfg.MaxInflight),
 		wm:               newWatermark(),
-		callback:         callback,
-		lastEnqueued:     -1,
+		dispatcher:       newCallbackDispatcher(callback),
 		done:             make(chan struct{}),
 		cancelSupervisor: cancel,
 	}
+	cs.lastEnqueued.Store(-1)
 	go cs.supervise(ctx)
 	return cs
 }
@@ -233,6 +564,12 @@ func NewCoreStream[Req, Resp any](
 // Ingest encodes record and enqueues it in the buffer, blocking if the buffer
 // is at capacity (backpressure). Returns the logical offset assigned to this
 // record; pass it to WaitForOffset to confirm durability.
+//
+// Records whose serialized wire size exceeds MaxPayloadBytes are rejected
+// with ErrPayloadTooLarge before any offset is assigned so oversized input
+// is a deterministic input error, not a transport failure that burns the
+// recovery budget. Wire size (with proto framing) is what the server sees,
+// so pre-encode input size is not sufficient.
 func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int64, error) {
 	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
 		return cs.enc.encode(offset, record)
@@ -243,16 +580,29 @@ func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int
 // if the buffer is at capacity. The whole batch occupies one logical offset and
 // the server acks it atomically. Returns that offset. Prefer this over Ingest in
 // hot paths: it amortizes per-message overhead across the batch.
+//
+// The serialized wire size of the batch is checked against MaxPayloadBytes
+// and rejected with ErrPayloadTooLarge before any offset is assigned.
+//
+// A batch with zero records is a no-op (returns -1 without allocating an
+// offset); a batch with any
+// empty record is still rejected as invalid input.
 func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]byte) (int64, error) {
+	if len(records) == 0 {
+		return -1, nil
+	}
 	return cs.enqueueEncoded(ctx, func(offset int64) (Req, error) {
 		return cs.enc.encodeBatch(offset, records)
 	})
 }
 
-// enqueueEncoded assigns the next offset, encodes via encodeFn, and enqueues the
-// result under ingestMu so nextOffset advances only for records that make it
-// into the buffer. A failed encode or ctx-cancelled backpressure consumes no
-// offset, so Flush never waits on an offset the server never sees.
+// enqueueEncoded reserves a backpressure slot (context-aware, may block),
+// assigns the next offset under a brief critical section, encodes via
+// encodeFn, and appends. The offset-assignment lock is NOT held across the
+// backpressure wait, so a stalled caller does not serialize every later
+// caller behind it and each caller observes its own ctx cancellation
+// promptly. A failed reserve/encode/append consumes no offset, so Flush never
+// waits on an offset the server never sees.
 func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn func(offset int64) (Req, error)) (int64, error) {
 	if cs.isClosed() {
 		if err := cs.terminalErr(); err != nil {
@@ -260,19 +610,48 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn fu
 		}
 		return 0, errClosed
 	}
-	cs.ingestMu.Lock()
-	defer cs.ingestMu.Unlock()
-
+	// Reserve a slot first (may block on backpressure or ctx). This is what
+	// makes many-goroutine Ingest scale: the wait happens without any core
+	// mutex held.
+	if err := cs.buf.reserve(ctx); err != nil {
+		return 0, err
+	}
+	// Assign the next offset atomically. Held only for the encode+append; if
+	// encode fails or append reports errClosed, the slot is released so the
+	// semaphore is not leaked and nextOffset is not advanced.
+	cs.offsetMu.Lock()
 	offset := cs.nextOffset
 	msg, err := encodeFn(offset)
 	if err != nil {
+		cs.offsetMu.Unlock()
+		cs.buf.release()
 		return 0, err
 	}
-	if err := cs.buf.enqueue(ctx, offset, msg); err != nil {
+	// Wire-size validation against MaxPayloadBytes uses proto.Size (or the
+	// encoder-specific equivalent), not the raw input bytes: proto framing
+	// adds tags and varints on top of the caller's payload, so a batch just
+	// under a byte-sum limit can still exceed the server's message size
+	// limit and bounce back as a transport failure. Reject deterministically
+	// here so recovery is not consumed by an input-shape error.
+	if size := cs.enc.wireSize(msg); size > cs.cfg.MaxPayloadBytes {
+		cs.offsetMu.Unlock()
+		cs.buf.release()
+		return 0, fmt.Errorf("%w: %d bytes exceeds MaxPayloadBytes=%d",
+			ErrPayloadTooLarge, size, cs.cfg.MaxPayloadBytes)
+	}
+	if err := cs.buf.append(offset, msg); err != nil {
+		cs.offsetMu.Unlock()
+		// append() released the slot on error.
 		return 0, err
 	}
 	cs.nextOffset++
-	cs.lastEnqueued = offset
+	// Store lastEnqueued while still holding offsetMu so it advances
+	// monotonically alongside nextOffset. Storing after Unlock let two
+	// concurrent Ingests interleave — the lower-offset caller's Store could
+	// land last and mask a higher offset from Flush, which would then return
+	// success while unacked records remained.
+	cs.lastEnqueued.Store(offset)
+	cs.offsetMu.Unlock()
 	return offset, nil
 }
 
@@ -280,11 +659,10 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn fu
 // server. Returns nil once all are durable, or an error if the stream fails
 // or ctx expires.
 //
-// When ctx has no deadline, Flush applies DefaultFlushTimeout.
+// When ctx has no deadline, Flush applies Config.FlushTimeout (defaulting
+// to DefaultFlushTimeout when unset).
 func (cs *CoreStream[Req, Resp]) Flush(ctx context.Context) error {
-	cs.ingestMu.Lock()
-	target := cs.lastEnqueued
-	cs.ingestMu.Unlock()
+	target := cs.lastEnqueued.Load()
 	if target < 0 {
 		return nil // nothing successfully ingested yet
 	}
@@ -313,33 +691,67 @@ func (cs *CoreStream[Req, Resp]) WaitForOffset(ctx context.Context, offset int64
 // just the first), so no unacked record is silently dropped. It closes the
 // stream first (idempotent) to ensure the buffer is fully drained and no new
 // items are added.
+//
+// GetUnacked is compatible with a registered AckCallback: on terminal failure
+// the supervisor also fires OnError for each unacked buffer item, but the
+// encoded items are retained here so callers get both structured error
+// events AND the raw bytes to persist or re-ingest. Records are decoded and
+// cloned lazily here rather than at terminal drain so a large in-flight set
+// does not double memory when the user never calls GetUnacked. The returned
+// byte slices are independent copies — mutating them does not affect any
+// internal state.
 func (cs *CoreStream[Req, Resp]) GetUnacked() [][]byte {
 	cs.Close()
+	// If the supervisor already drained the buffer for OnError dispatch, the
+	// items live on retainedFailed; otherwise drain the buffer now.
 	items := cs.buf.drain()
-	out := make([][]byte, 0, len(items))
+	failed := cs.takeRetainedFailed()
+	out := make([][]byte, 0, len(items)+len(failed))
+	decodeAppend := func(it item[Req]) {
+		for _, r := range cs.enc.decode(it.payload) {
+			out = append(out, cloneBytes(r))
+		}
+	}
 	for _, it := range items {
-		// Re-extract the raw record bytes from the encoded message so callers get
-		// back the original record content; a batch yields all its records.
-		out = append(out, cs.enc.decode(it.payload)...)
+		decodeAppend(it)
+	}
+	for _, it := range failed {
+		decodeAppend(it)
 	}
 	return out
 }
 
-// Close terminates the stream and releases its resources. It is idempotent and
-// blocks until teardown completes.
+// Close terminates the stream and releases its resources. It is idempotent
+// and blocks until teardown completes.
 //
-// Close does NOT wait for pending records to be acknowledged: any records still
-// in flight when Close is called are abandoned (retrievable via GetUnacked, or
-// reported through the AckCallback's OnError). Callers that need durability must
-// Flush first, then Close — the standard loop-then-Flush pattern. On this clean
-// shutdown the live stream is torn down gracefully (half-close, then drain any
-// straggling acks to EOF, bounded by DrainTimeout) so the server observes an
-// orderly END_STREAM rather than an abrupt reset; see gracefulTeardown.
+// Close does NOT wait for pending records to be acknowledged: any records
+// still in flight when Close is called are abandoned and remain retrievable
+// via GetUnacked. On a clean Close the AckCallback's OnError is NOT fired
+// for those records — only terminal recovery failure fires OnError. Callers
+// that need durability must Flush first, then Close (the standard
+// loop-then-Flush pattern). On this clean shutdown the live stream is torn
+// down gracefully (half-close, then drain any straggling acks to EOF,
+// bounded by DrainTimeout) so the server observes an orderly END_STREAM
+// rather than an abrupt reset; see gracefulTeardown.
+//
+// It is safe to call Close from inside an AckCallback: callbacks run on a
+// dedicated dispatcher goroutine, not on the supervisor, so this method
+// does not self-deadlock.
 func (cs *CoreStream[Req, Resp]) Close() {
 	cs.closeOnce.Do(func() {
 		cs.cancelSupervisor()
 		cs.buf.close()
 		<-cs.done // wait for the supervisor to exit
+		// Fail the watermark so any WaitForOffset callers waiting on offsets
+		// that will never be acked (because we're shutting down) return an
+		// explicit error instead of blocking forever. If the supervisor has
+		// already marked the watermark terminal with a real error, that error
+		// wins — fail() is one-shot.
+		cs.wm.closeForClean()
+		// Shut the callback dispatcher down last so any OnAck/OnError events
+		// posted by the supervisor's drain (or by the receiver just before
+		// exit) have a chance to run before we return.
+		cs.dispatcher.shutdown(cs.cfg.CallbackTeardownTimeout)
 	})
 }
 
@@ -373,19 +785,39 @@ func (cs *CoreStream[Req, Resp]) setTerminalErr(err error) {
 
 // runOnce opens one transport stream and runs sender+receiver until one of
 // them exits. Returns the cause of the exit so the supervisor can decide
-// whether to recover, and healthy=true once a stream was successfully opened
-// and run (so the supervisor can reset its per-episode retry budget — a stream
-// that connected and later failed is a fresh episode, not a continuation of the
-// prior reconnect streak).
+// whether to recover, and healthy=true once the stream made durable progress
+// this iteration (received at least one server ack). That is a stricter
+// definition than "Open succeeded": a stream that Opens but then immediately
+// EOFs / errors before any ack has made no progress, and treating it as
+// healthy would reset the per-episode retry budget on every attempt and let
+// the supervisor hammer the server with no backoff. The supervisor uses the
+// budget-reset only after real acknowledged work, so a permanent immediate-
+// EOF loop exhausts RecoveryRetries.
+//
+// The receiver drives pause handling: on a server CloseStreamSignal it sends
+// on pauseCh and then keeps draining acks until either the flight set empties
+// or the pause deadline expires. runOnce watches pauseCh and parks the sender
+// (cancels senderCtx) as soon as the pause begins so no further records enter
+// flight during the drain window.
 func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, healthy bool) {
-	stream, err := cs.opener.Open(ctx, cs.params)
+	// Bound the Open at RecoveryTimeout so a stalled dial cannot pin recovery
+	// indefinitely — each attempt gets an explicit budget.
+	openCtx, cancelOpen := context.WithTimeout(ctx, cs.cfg.RecoveryTimeout)
+	stream, err := cs.opener.Open(openCtx, cs.params)
+	openTimedOut := openCtx.Err() == context.DeadlineExceeded
+	cancelOpen()
 	if err != nil {
-		// Invalid params (bad table name, unsupported record type, missing
-		// descriptor) are deterministic — reconnecting reproduces them — so mark
-		// them non-retryable rather than burning the recovery budget on a failure
-		// that can't succeed.
 		if errors.Is(err, transport.ErrInvalidParams) {
 			return wrapValidation(fmt.Errorf("stream: open: %w", err)), false
+		}
+		// Distinguish our internal per-attempt budget from a caller
+		// cancellation of the outer supervisor ctx. The former should stay
+		// retryable so RecoveryRetries actually governs stalled dials; the
+		// latter (ctx cancelled by Close) is naturally non-retryable and
+		// short-circuited by isRetryable's context checks. Same pattern the
+		// auth layer applies to header-fetch budgets.
+		if openTimedOut && ctx.Err() == nil {
+			return &openBudgetExceeded{cause: fmt.Errorf("stream: open: %w", err)}, false
 		}
 		return fmt.Errorf("stream: open: %w", err), false
 	}
@@ -395,76 +827,187 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, heal
 	cs.buf.requeue()
 
 	// senderCtx is cancelled when we want the sender to stop for THIS stream
-	// only, without cancelling the supervisor's outer ctx (which would signal Close).
+	// only, without cancelling the supervisor's outer ctx (which would signal
+	// Close). It is also used to park the sender during a pause drain.
 	senderCtx, cancelSender := context.WithCancel(ctx)
 	defer cancelSender()
 
-	errCh := make(chan error, 2)
+	// The sender and receiver report their exits on dedicated channels so
+	// runOnce can distinguish which goroutine exited first. A sender exit
+	// after we parked it (pause path) is NOT the cause; we want the
+	// receiver's pauseSignal instead.
+	senderExitCh := make(chan error, 1)
+	receiverExitCh := make(chan error, 1)
+	pauseCh := make(chan pauseSignal, 1)
+	// flightSignal is a buffered 1-capacity channel the sender uses to tell
+	// the receiver "at least one record has entered flight since you last
+	// armed the timer." A dropped signal is fine (buffer full → receiver
+	// already knows).
+	flightSignal := make(chan struct{}, 1)
+	// progressed is set by the receiver on the first ack it processes; it
+	// tells the supervisor this iteration made durable progress and the
+	// per-episode retry budget may be reset. Without it, a stream that
+	// Opens successfully but immediately EOFs would reset the budget every
+	// iteration and hammer the server with no backoff.
+	var progressed atomic.Bool
 
-	go cs.sender(senderCtx, stream, errCh)
-	go cs.receiver(stream, errCh)
+	go cs.sender(senderCtx, stream, senderExitCh, flightSignal)
+	go cs.receiver(stream, receiverExitCh, pauseCh, flightSignal, &progressed)
 
-	// Wait for the first goroutine to signal, then tear both down. On clean
-	// shutdown (Close cancelled ctx) only the sender exits first — the receiver
-	// keeps draining acks — so we half-close and let it drain to EOF for an
-	// orderly server-observed END_STREAM. On failure we hard-abort instead.
-	cause = <-errCh
-	cancelSender() // unblocks sender waiting on buf.next()
+	// Wait for the first meaningful exit.
+	var senderParked bool
+	var senderExited bool
+	var receiverExited bool
+waitLoop:
+	for {
+		select {
+		case sErr := <-senderExitCh:
+			senderExited = true
+			// A sender exit while parked (pause) is NOT the cause we return
+			// — keep waiting on the receiver so it can finish draining acks.
+			// A sender exit while unparked is either (a) ctx cancelled
+			// (Close), in which case teardown proceeds gracefully with the
+			// receiver draining to EOF, or (b) a Send failure that kills the
+			// stream. Both need to exit the wait loop; capture the sender's
+			// error as the cause so a Send failure is reported to the
+			// supervisor.
+			if !senderParked {
+				cause = sErr
+				break waitLoop
+			}
+			// Parked exit: keep waiting on the receiver.
+		case cause = <-receiverExitCh:
+			receiverExited = true
+			break waitLoop
+		case <-pauseCh:
+			// Pause drain has begun. Park the sender so no further records
+			// enter flight; the receiver keeps reading acks. The receiver
+			// will send its exit (pauseSignal cause) on receiverExitCh when
+			// the drain window ends.
+			if !senderParked {
+				cancelSender()
+				senderParked = true
+			}
+		}
+	}
+
+	// Stop the sender (idempotent) so its teardown can proceed if it hasn't
+	// exited yet.
+	cancelSender()
+
 	var ps pauseSignal
 	switch {
 	case ctx.Err() != nil:
-		cs.gracefulTeardown(stream, errCh)
+		// Clean shutdown from Close: half-close the send side, let the
+		// receiver drain to EOF for an orderly END_STREAM.
+		cs.gracefulTeardown(stream, senderExited, receiverExited, senderExitCh, receiverExitCh)
 	case errors.As(cause, &ps):
-		// Server-requested pause: the receiver already closed the stream to
-		// unblock its Recv, so just reap the sender. Requeue happens on reconnect.
+		// Pause drain ended. Hard-abort the stream to close the receiver's
+		// blocking Recv (and any pending send).
 		stream.Close()
-		<-errCh
+		if !senderExited {
+			<-senderExitCh
+		}
+		if !receiverExited {
+			<-receiverExitCh
+		}
 	default:
-		// Failure/recovery path: the stream is already broken, so hard-abort to
-		// unblock the receiver's Recv immediately.
+		// Failure/recovery path: sender-side error or receiver-side error.
+		// Hard-abort to unblock whichever goroutine hasn't exited yet.
 		stream.Close()
-		<-errCh // drain second exit
+		if !senderExited {
+			<-senderExitCh
+		}
+		if !receiverExited {
+			<-receiverExitCh
+		}
 	}
-	return cause, true
+	return cause, progressed.Load()
 }
 
 // gracefulTeardown closes a healthy stream in an orderly fashion after the
 // sender has stopped: half-close the send side so the server flushes any
 // remaining acks and ends the stream, let the still-running receiver drain to
 // io.EOF (advancing the watermark for late acks), then release resources.
-// DrainTimeout bounds the wait so a wedged server can't hang Close; on expiry we
-// hard-abort. This mirrors transport.GracefulClose, done cooperatively because
-// the receiver goroutine — not this one — owns Recv.
-func (cs *CoreStream[Req, Resp]) gracefulTeardown(stream wireStream[Req, Resp], errCh <-chan error) {
+// DrainTimeout bounds the wait so a wedged server can't hang Close; on expiry
+// we hard-abort. This mirrors transport.GracefulClose, done cooperatively
+// because the receiver goroutine — not this one — owns Recv.
+func (cs *CoreStream[Req, Resp]) gracefulTeardown(
+	stream wireStream[Req, Resp],
+	senderExited, receiverExited bool,
+	senderExitCh, receiverExitCh <-chan error,
+) {
+	// Reap the sender first (it was cancelled). Bound the wait: a wedged
+	// Send won't observe ctx cancellation, so we may need to hard-abort the
+	// stream to unblock it.
+	if !senderExited {
+		senderReapTimer := time.NewTimer(cs.cfg.DrainTimeout)
+		select {
+		case <-senderExitCh:
+			senderReapTimer.Stop()
+		case <-senderReapTimer.C:
+			// Sender is wedged inside Send. Hard-abort the stream so Send
+			// returns; the receiver will exit too. Skip the graceful
+			// half-close path since Send is broken by definition.
+			stream.Close()
+			<-senderExitCh
+			if !receiverExited {
+				<-receiverExitCh
+			}
+			return
+		}
+	}
+	if receiverExited {
+		// Receiver already exited (e.g. EOF observed during waitLoop);
+		// nothing more to drain.
+		stream.Close()
+		return
+	}
 	if err := stream.CloseSend(); err != nil {
 		// Send side already broken; fall back to a hard abort.
 		stream.Close()
-		<-errCh
+		<-receiverExitCh
 		return
 	}
 	timer := time.NewTimer(cs.cfg.DrainTimeout)
 	defer timer.Stop()
 	select {
-	case <-errCh:
+	case <-receiverExitCh:
 		// Receiver drained to EOF; release resources (Close is idempotent).
 		stream.Close()
 	case <-timer.C:
 		// Drain budget exceeded; force the receiver out and reap it.
 		stream.Close()
-		<-errCh
+		<-receiverExitCh
 	}
 }
 
 // sender pulls items from the buffer and writes them to stream. Exits when
-// senderCtx is cancelled (per-stream teardown), the buffer is closed, or
-// Send fails. senderCtx is derived from a per-runOnce cancel so the supervisor
-// can stop this sender without cancelling the outer supervisor context.
-func (cs *CoreStream[Req, Resp]) sender(senderCtx context.Context, stream wireStream[Req, Resp], errCh chan<- error) {
+// senderCtx is cancelled (per-stream teardown), the buffer is closed, or Send
+// fails. senderCtx is derived from a per-runOnce cancel so the supervisor can
+// stop this sender without cancelling the outer supervisor context. After each
+// successful Send it pings flightSignal so the receiver can arm the
+// lack-of-ack timer with a fresh full budget as soon as work enters flight —
+// preventing the "first send after idle can fail almost immediately" race
+// where the record inherits a nearly-expired timer.
+func (cs *CoreStream[Req, Resp]) sender(senderCtx context.Context, stream wireStream[Req, Resp], errCh chan<- error, flightSignal chan<- struct{}) {
 	for {
 		it, err := cs.buf.next(senderCtx)
 		if err != nil {
 			errCh <- nil // ctx cancelled or buffer closed — clean exit
 			return
+		}
+		// Signal flight BEFORE calling Send: buf.next has already moved the
+		// item into the in-flight set, so a stalled Send must not prevent
+		// the receiver from arming the lack-of-ack timer. Signalling after
+		// Send would let a wedged send leave the timer disarmed until the
+		// Send returned (which, if the transport blocks, is never), so a
+		// slow server would not be caught. A dropped signal (channel full)
+		// is fine: the receiver only needs one wake-up per idle→work
+		// transition.
+		select {
+		case flightSignal <- struct{}{}:
+		default:
 		}
 		if err := stream.Send(it.payload); err != nil {
 			errCh <- fmt.Errorf("stream: send offset %d: %w", it.offset, err)
@@ -480,19 +1023,27 @@ func (cs *CoreStream[Req, Resp]) sender(senderCtx context.Context, stream wireSt
 // Teardown is coordinated by runOnce, so the receiver does not watch the
 // supervisor context itself.
 //
+// The pause path is cooperative with the sender via pauseCh: on pauseResponse
+// the receiver signals pauseCh (so runOnce parks the sender) and keeps
+// draining acks until either the buffer's inFlight goes to zero or the pause
+// deadline expires.
+//
+// The lack-of-ack timer is armed only when records are actually in flight.
+// The sender pings flightSignal after each successful Send so the receiver can
+// arm the timer with a fresh full LackOfAckTimeout as soon as a record enters
+// flight (rather than inheriting whatever fraction of an idle timer happened
+// to be running). The channel is buffered=1 so the sender never blocks on it.
+//
 // Each Recv call runs on its own goroutine so we can race it against the
 // lack-of-ack timer even when the underlying transport Recv is blocking (e.g. a
 // fake in tests, or a stalled server).
-func (cs *CoreStream[Req, Resp]) receiver(stream wireStream[Req, Resp], errCh chan<- error) {
+func (cs *CoreStream[Req, Resp]) receiver(stream wireStream[Req, Resp], errCh chan<- error, pauseCh chan<- pauseSignal, flightSignal <-chan struct{}, progressed *atomic.Bool) {
 	type recvResult struct {
 		resp Resp
 		err  error
 	}
 
-	// A single outstanding Recv goroutine at a time feeds recvCh. Hoisting it out
-	// of the loop keeps the lack-of-ack timer live across idle periods: re-arming
-	// the timer must not commit us to blocking on the current Recv, or records
-	// that go in flight later would never be checked against the timeout.
+	// A single outstanding Recv goroutine at a time feeds recvCh.
 	recvCh := make(chan recvResult, 1)
 	spawnRecv := func() {
 		go func() {
@@ -502,74 +1053,218 @@ func (cs *CoreStream[Req, Resp]) receiver(stream wireStream[Req, Resp], errCh ch
 	}
 	spawnRecv()
 
+	// lackTimer is started stopped; it is armed only after we know work has
+	// entered flight (either from the sender's signal, or after a requeue on
+	// reconnect).
 	lackTimer := time.NewTimer(cs.cfg.LackOfAckTimeout)
-	defer lackTimer.Stop()
+	if !lackTimer.Stop() {
+		<-lackTimer.C
+	}
+	lackTimerArmed := false
+
+	armLack := func() {
+		if lackTimerArmed || cs.buf.inFlight() == 0 {
+			return
+		}
+		lackTimer.Reset(cs.cfg.LackOfAckTimeout)
+		lackTimerArmed = true
+	}
+	disarmLack := func() {
+		if !lackTimerArmed {
+			return
+		}
+		if !lackTimer.Stop() {
+			select {
+			case <-lackTimer.C:
+			default:
+			}
+		}
+		lackTimerArmed = false
+	}
+	resetLack := func() {
+		disarmLack()
+		armLack()
+	}
+
+	// Arm on entry: after a reconnect the supervisor requeues in-flight items
+	// so work may already be in the queue awaiting the sender.
+	armLack()
+
+	// pauseState is set when we've observed a server CloseStreamSignal; the
+	// receiver then drains acks against pauseDeadline while the sender is
+	// parked by runOnce.
+	var pauseState *pauseSignal
+	var pauseTimer *time.Timer
+	stopPauseTimer := func() {
+		if pauseTimer != nil {
+			pauseTimer.Stop()
+			pauseTimer = nil
+		}
+	}
 
 	for {
 		var r recvResult
+		var pauseC <-chan time.Time
+		var lackC <-chan time.Time
+		if pauseTimer != nil {
+			pauseC = pauseTimer.C
+		}
+		if lackTimerArmed {
+			lackC = lackTimer.C
+		}
+		// One composite select drives all four signals. Cases we don't want
+		// active (nil channels) are ignored, so we always block only on the
+		// signals that make sense in the current state.
 		select {
-		case <-lackTimer.C:
-			// Silence is only a failure while records are actually awaiting an ack.
-			// An idle stream (nothing in flight) legitimately receives no acks, so
-			// re-arm the timer and keep waiting on the same outstanding Recv rather
-			// than tearing the stream down.
+		case <-flightSignal:
+			// Sender pushed something onto the wire; ensure the timer is
+			// armed with a fresh full LackOfAckTimeout budget.
+			armLack()
+			continue
+		case <-lackC:
+			lackTimerArmed = false
+			if pauseState != nil {
+				// Silence during pause drain isn't a failure: the server is
+				// about to close the stream. End the pause window.
+				stopPauseTimer()
+				errCh <- *pauseState
+				return
+			}
+			// Recheck under the buffer's lock: an ack may have drained the
+			// flight set between the timer firing and us noticing.
 			if cs.buf.inFlight() == 0 {
-				lackTimer.Reset(cs.cfg.LackOfAckTimeout)
 				continue
 			}
 			stream.Close()
-			<-recvCh // reap the outstanding Recv goroutine
+			<-recvCh
 			errCh <- fmt.Errorf("stream: no ack from server for %s", cs.cfg.LackOfAckTimeout)
+			return
+		case <-pauseC:
+			pauseTimer = nil
+			errCh <- *pauseState
 			return
 		case r = <-recvCh:
 		}
 
 		if r.err == io.EOF {
+			stopPauseTimer()
 			errCh <- nil
 			return
 		}
 		if r.err != nil {
+			stopPauseTimer()
 			errCh <- fmt.Errorf("stream: recv: %w", r.err)
 			return
 		}
 
 		kind, offset, pause := cs.ackMdl.classify(r.resp)
-		if kind == pauseResponse {
-			// A server pause (proto/JSON CloseStreamSignal) is a flow-control
-			// request, not noise: the server is about to close this stream and
-			// wants the client to pause (stop sending, keep buffering and draining
-			// acks) then reconnect. Report it so the supervisor waits the requested
-			// window and reconnects without counting it against the recovery
-			// budget. This iteration's Recv goroutine already delivered (via r
-			// above), so there is nothing to drain; runOnce owns tearing the stream
-			// down.
-			errCh <- pause
+		switch kind {
+		case pauseResponse:
+			// A server pause is a flow-control request: signal runOnce to
+			// park the sender and enter pause-drain mode. Repeat pause
+			// signals during an active pause window are no-ops.
+			if pauseState == nil {
+				ps := pause
+				pauseState = &ps
+				wait := effectivePauseWait(cs.cfg, pause.duration)
+				// Signal runOnce so it stops the sender for THIS stream,
+				// regardless of the effective wait: an immediate reconnect
+				// still requires the sender to be parked so no further
+				// records enter flight before we tear down.
+				select {
+				case pauseCh <- pause:
+				default:
+				}
+				if wait <= 0 {
+					// Configuration or server both asked for immediate
+					// reconnect. End pause drain now — no records will enter
+					// flight thanks to the pauseCh signal above.
+					stopPauseTimer()
+					errCh <- pause
+					return
+				}
+				// Always honour the pause window: server-driven throttling
+				// wants us to hold off reconnecting even when nothing is
+				// currently in flight, or reconnect churn amplifies load.
+				// The window is capped by StreamPausedMaxWait; the receiver
+				// still keeps draining acks in case work enters flight
+				// before it (buffered ingest is possible during pause).
+				pauseTimer = time.NewTimer(wait)
+			}
+			spawnRecv()
+			continue
+		case malformedResponse:
+			stopPauseTimer()
+			errCh <- fmt.Errorf("stream: server ack missing durability offset")
+			return
+		case unknownResponse:
+			// A response the ack model does not recognise is a protocol
+			// error, not noise: fail the stream so the supervisor can
+			// decide whether to recover.
+			stopPauseTimer()
+			errCh <- fmt.Errorf("stream: unexpected server response type")
 			return
 		}
 
-		// Not a terminal response — keep reading. Spawn the next Recv before
-		// handling this one so the loop always has exactly one outstanding.
 		spawnRecv()
 
-		if kind == ackResponse {
-			// Reset the lack-of-ack timer on every ack received.
-			if !lackTimer.Stop() {
-				select {
-				case <-lackTimer.C:
-				default:
-				}
-			}
-			lackTimer.Reset(cs.cfg.LackOfAckTimeout)
-
-			cs.wm.advance(offset)
-			// Discard all buffer items that are now acknowledged, freeing their
-			// backpressure slots for waiting enqueue callers.
-			cs.buf.discardThrough(offset)
-
-			if cs.callback != nil {
-				cs.callback.OnAck(offset)
+		// kind == ackResponse. Validate the offset against work actually
+		// sent before advancing the watermark: a bogus high offset from a
+		// buggy or malicious server would otherwise let WaitForOffset
+		// return success for records that were never durably acked.
+		//
+		// The highest offset possibly in flight is bounded by lastEnqueued
+		// (which is monotonic). An ack above that has no corresponding
+		// sent record; refuse it.
+		highestSent := cs.lastEnqueued.Load()
+		if offset > highestSent {
+			stopPauseTimer()
+			errCh <- fmt.Errorf("stream: server ack offset %d exceeds highest sent %d", offset, highestSent)
+			return
+		}
+		// Advance the watermark only to the offset of items we actually
+		// discarded from flight; ignore regressing acks (offset lower
+		// than what was already discarded) so a duplicate/replay ack
+		// does not fire callbacks or roll the watermark backwards.
+		discarded := cs.buf.discardThrough(offset)
+		if len(discarded) > 0 {
+			cs.wm.advance(discarded[len(discarded)-1])
+			// Mark the run as having made real progress so the supervisor
+			// resets its per-episode retry budget only after actual acks.
+			progressed.Store(true)
+			// Per-offset callbacks: one OnAck per newly-acked logical offset.
+			for _, o := range discarded {
+				cs.dispatcher.enqueueAck(o)
 			}
 		}
-		// otherResponse: ignored; the next Recv is already outstanding.
+		// Timer maintenance: reset the freshness budget while work
+		// remains in flight; disarm when the flight set empties.
+		if cs.buf.inFlight() == 0 {
+			disarmLack()
+		} else {
+			resetLack()
+		}
+		// Pause windows are honoured even after the flight set empties,
+		// so server-driven throttling still holds us off reconnecting for
+		// the requested duration and does not churn under load. The
+		// pauseTimer case above will end the wait when the window expires.
 	}
+}
+
+// effectivePauseWait returns the effective wait duration for a server-requested
+// pause given the client configuration. Return of 0 or negative means
+// "reconnect immediately"; a positive value is the wait window.
+//
+//   - PauseWaitImmediate: always 0 (immediate reconnect).
+//   - PauseWaitServer + StreamPausedMaxWait > 0: min(cap, server duration).
+//   - PauseWaitServer + StreamPausedMaxWait <= 0: server duration (no cap).
+func effectivePauseWait(cfg Config, serverDuration time.Duration) time.Duration {
+	if cfg.StreamPausedMaxWaitMode == PauseWaitImmediate {
+		return 0
+	}
+	wait := serverDuration
+	if cap := cfg.StreamPausedMaxWait; cap > 0 && (wait <= 0 || cap < wait) {
+		wait = cap
+	}
+	return wait
 }

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -1,0 +1,370 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+
+// ---- tests -----------------------------------------------------------------
+func TestCoreStreamIngestAndFlush(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	offset, err := cs.Ingest(context.Background(), []byte(`{"k":"v"}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if offset != 0 {
+		t.Fatalf("want offset 0, got %d", offset)
+	}
+
+	// Drain the send channel and ack.
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+	rpc.ack(0)
+
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestCoreStreamOffsetMonotonic(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	for i := int64(0); i < 5; i++ {
+		off, err := cs.Ingest(context.Background(), []byte(`{}`))
+		if err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+		if off != i {
+			t.Fatalf("want offset %d, got %d", i, off)
+		}
+	}
+}
+
+func TestCoreStreamWaitForOffset(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	for i := range 3 {
+		if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+	}
+
+	// Drain all three sends then ack offset 2 (covers 0, 1, 2).
+	waitCondition(t, func() bool { return len(rpc.sends) == 3 }, time.Second)
+	for range 3 {
+		<-rpc.sends
+	}
+	rpc.ack(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, 2); err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
+	}
+}
+
+func TestCoreStreamFlushNothingIngested(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush with no ingests: %v", err)
+	}
+}
+
+func TestCoreStreamFlushContextExpires(t *testing.T) {
+	rpc := newFakeRPC()
+	// Intentionally never ack.
+	_ = rpc
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := cs.Flush(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestCoreStreamCloseIsIdempotent(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	cs.Close()
+	cs.Close() // must not panic or block
+}
+
+// TestCoreStreamCloseDrainsGracefully verifies that a clean Close half-closes
+// the send side (CloseSend) and keeps the receiver draining acks to io.EOF,
+// rather than abruptly aborting the stream. An ack delivered after the
+// half-close must still advance the watermark; an abrupt teardown would drop it.
+func TestCoreStreamCloseDrainsGracefully(t *testing.T) {
+	rpc := newGracefulFakeRPC()
+	cb := &recordingCallback{}
+	cs := newCoreForTest(testParams(), testConfig(), &gracefulOpener{rpc: rpc}, cb)
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+
+	// Close in the background; it blocks until the graceful drain completes.
+	done := make(chan struct{})
+	go func() { cs.Close(); close(done) }()
+
+	// Close must half-close the send side rather than hard-abort.
+	select {
+	case <-rpc.closeSent:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not half-close the send side (CloseSend) — it hard-aborted")
+	}
+
+	// Deliver a late ack after the half-close, then end the stream. A graceful
+	// drain observes this ack; an abrupt teardown would have dropped it.
+	rpc.ack(off)
+	rpc.serverEnd()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after the server ended the stream")
+	}
+
+	if got := cb.ackCount(); got != 1 {
+		t.Fatalf("want the post-half-close ack drained (ackCount=1), got %d", got)
+	}
+}
+
+func TestCoreStreamIsClosed(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	if cs.IsClosed() {
+		t.Fatal("want not closed before Close()")
+	}
+	cs.Close()
+	if !cs.IsClosed() {
+		t.Fatal("want closed after Close()")
+	}
+}
+
+func TestCoreStreamGetUnackedReturnsItems(t *testing.T) {
+	// Use a fakeOpener that always fails to open so all items stay unacked.
+	fo := &fakeOpener{openErr: fmt.Errorf("connection refused")}
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+
+	// Ingest with a context that will eventually succeed (the buffer blocks,
+	// not the opener). Give it a short context so we can proceed quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _ = cs.Ingest(ctx, []byte(`{"a":1}`))
+
+	unacked := cs.GetUnacked()
+	// Items may or may not be in unacked depending on timing; we just want
+	// GetUnacked to not panic and to close the stream.
+	_ = unacked
+	if !cs.IsClosed() {
+		t.Fatal("GetUnacked should close the stream")
+	}
+}
+
+func TestCoreStreamConcurrentIngest(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	const n = 50
+	var wg sync.WaitGroup
+	offsets := make([]int64, n)
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			off, err := cs.Ingest(context.Background(), []byte(`{}`))
+			if err != nil {
+				t.Errorf("goroutine %d Ingest: %v", i, err)
+				return
+			}
+			offsets[i] = off
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all offsets are unique.
+	seen := make(map[int64]bool)
+	for _, off := range offsets {
+		if seen[off] {
+			t.Fatalf("duplicate offset %d", off)
+		}
+		seen[off] = true
+	}
+}
+
+func TestCoreStreamRecoveryRequeuesUnacked(t *testing.T) {
+	rpc1 := newFakeRPC()
+	rpc2 := newFakeRPC()
+	fo := newFakeOpener(rpc1, rpc2)
+
+	cfg := testConfig()
+	cfg.RecoveryRetries = 1
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	// Wait for the send to land on rpc1 then kill rpc1 before acking.
+	waitCondition(t, func() bool { return len(rpc1.sends) > 0 }, time.Second)
+	rpc1.close() // triggers receiver EOF → supervisor recovers to rpc2
+
+	// rpc2 should receive the re-sent item.
+	waitCondition(t, func() bool { return len(rpc2.sends) > 0 }, 2*time.Second)
+	<-rpc2.sends
+	rpc2.ack(off)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, off); err != nil {
+		t.Fatalf("WaitForOffset after recovery: %v", err)
+	}
+}
+
+// TestCoreStreamIngestOnClosedStreamErrors verifies that Ingest on a cleanly
+// closed stream returns an error, not (0, nil).
+func TestCoreStreamIngestOnClosedStreamErrors(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+	cs.Close()
+
+	_, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err == nil {
+		t.Fatal("want error from Ingest on closed stream, got nil")
+	}
+}
+
+// TestCoreStreamFailedIngestDoesNotAdvanceFlushTarget verifies that a
+// ctx-cancelled Ingest does not leave a gap that blocks Flush forever.
+func TestCoreStreamFailedIngestDoesNotAdvanceFlushTarget(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	// First Ingest succeeds.
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+
+	// Second Ingest fails (cancelled context) — must not consume an offset.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = cs.Ingest(cancelledCtx, []byte(`{}`))
+	if err == nil {
+		t.Fatal("want error from cancelled Ingest, got nil")
+	}
+
+	// Ack the first offset and flush — must not block waiting for offset 1.
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	<-rpc.sends
+	rpc.ack(off)
+
+	ctx, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	if err := cs.Flush(ctx); err != nil {
+		t.Fatalf("Flush blocked on gap from failed Ingest: %v", err)
+	}
+}
+
+// TestCoreStreamCloseUnblocksEnqueueAtCapacity verifies that a caller blocked
+// in Ingest (buffer at capacity) unblocks when the stream is closed, rather
+// than hanging forever on the semaphore.
+func TestCoreStreamCloseUnblocksEnqueueAtCapacity(t *testing.T) {
+	rpc := newFakeRPC()
+	cfg := testConfig()
+	cfg.MaxInflight = 1
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	// Fill the single slot.
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+
+	// A second Ingest should block; close the stream from another goroutine.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := cs.Ingest(context.Background(), []byte(`{}`))
+		errCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cs.Close()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("want error from blocked Ingest after Close, got nil")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Ingest did not unblock after Close")
+	}
+}
+
+func TestCoreStreamGetUnackedWithoutCallback(t *testing.T) {
+	fo := &fakeOpener{openErr: fmt.Errorf("connection refused")}
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, fo, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _ = cs.Ingest(ctx, []byte(`{}`))
+
+	waitCondition(t, cs.IsClosed, 2*time.Second)
+	_ = cs.GetUnacked() // must not panic; behavior covered by IsClosed check above
+}
+
+// TestCoreStreamNonRetryableErrorTerminates checks that a non-retryable error
+// from the opener is surfaced and Flush returns it.
+
+func TestCoreStreamIngestBatch(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newTestStream(t, newFakeOpener(rpc))
+
+	off, err := cs.IngestBatch(context.Background(), [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("IngestBatch: %v", err)
+	}
+	if off != 0 {
+		t.Fatalf("want offset 0 for the batch, got %d", off)
+	}
+
+	waitCondition(t, func() bool { return len(rpc.sends) > 0 }, time.Second)
+	sent := <-rpc.sends
+	ib := sent.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want an IngestRecordBatch on the wire, got a single-record message")
+	}
+	if got := len(ib.GetJsonBatch().GetRecords()); got != 2 {
+		t.Fatalf("want 2 records in the batch, got %d", got)
+	}
+	rpc.ack(off)
+
+	if err := cs.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -8,6 +8,26 @@ import (
 	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
 
+// DefaultMaxPayloadBytes is the default per-message wire payload cap: the
+// ~10 MiB gRPC server limit minus a 64 KiB envelope headroom. A single
+// record or a batch whose serialized wire size exceeds this budget is
+// rejected at Ingest so callers see a deterministic input error instead of
+// a transport failure that burns the recovery budget.
+const DefaultMaxPayloadBytes = 10*1024*1024 - 64*1024
+
+// cloneBytes returns a fresh []byte with the same contents as b so buffered
+// records don't alias caller-owned memory. Reusing the same []byte across
+// Ingest calls (or mutating it after Ingest returns) would otherwise change
+// queued and replayed payloads and race with wire serialization.
+func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}
+
 // encodedMsg is a wire-ready EphemeralStream ingest request, built once at
 // Ingest time and held in the buffer until the sender transmits it. It is the
 // Req type the proto/JSON core is instantiated with; the Arrow path will use a
@@ -15,11 +35,11 @@ import (
 // objects.
 type encodedMsg = *zerobuspb.EphemeralStreamRequest
 
-// encoder turns user records into wire messages for a given offset and recovers
-// them again for GetUnacked. It is the send-side per-encoding
-// seam. The core is generic over the wire message type Req and
-// never names a concrete proto type — proto/JSON supply encoder[encodedMsg];
-// Arrow will supply encoder[flightFrame].
+// encoder turns user records into wire messages for a given offset and
+// recovers them again for GetUnacked. It is the send-side per-encoding seam:
+// the core is generic over the wire message type Req and never names a
+// concrete proto type — proto/JSON supply encoder[encodedMsg]; Arrow will
+// supply encoder[flightFrame].
 //
 // The offset is stamped into the message here so re-sends after recovery reuse
 // the same logical offset the server already saw.
@@ -35,6 +55,10 @@ type encoder[Req any] interface {
 	// return original content. A single-record message yields one entry; a batch
 	// yields all of its records so no unacked record is silently dropped.
 	decode(msg Req) [][]byte
+	// wireSize returns the exact serialized wire size of the message so the
+	// payload cap can be enforced against what the server will actually see,
+	// not the raw input bytes (which exclude proto framing).
+	wireSize(msg Req) int
 }
 
 // protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
@@ -49,7 +73,9 @@ func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
 			IngestRecord: &zerobuspb.IngestRecordRequest{
 				OffsetId: proto.Int64(offset),
-				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: record},
+				// Copy caller bytes: proto retains them by reference and the
+				// buffer may hold this message across recovery re-sends.
+				Record: &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: cloneBytes(record)},
 			},
 		},
 	}, nil
@@ -59,17 +85,22 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 	if len(records) == 0 {
 		return nil, fmt.Errorf("stream: proto batch must not be empty")
 	}
+	// Snapshot each record so a shared source buffer can't mutate queued or
+	// replayed payloads. The outer slice is also copied so mutations to the
+	// caller's slice header don't reach the batch.
+	copied := make([][]byte, len(records))
 	for i, r := range records {
 		if len(r) == 0 {
 			return nil, fmt.Errorf("stream: proto batch record %d must not be empty", i)
 		}
+		copied[i] = cloneBytes(r)
 	}
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
 			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
 				OffsetId: proto.Int64(offset),
 				Batch: &zerobuspb.IngestRecordBatchRequest_ProtoEncodedBatch{
-					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: records},
+					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: copied},
 				},
 			},
 		},
@@ -77,6 +108,13 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 }
 
 func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+func (protoEncoder) wireSize(msg encodedMsg) int {
+	if msg == nil {
+		return 0
+	}
+	return proto.Size(msg)
+}
 
 // jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
 // and batched.
@@ -120,6 +158,13 @@ func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, erro
 }
 
 func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+func (jsonEncoder) wireSize(msg encodedMsg) int {
+	if msg == nil {
+		return 0
+	}
+	return proto.Size(msg)
+}
 
 // newEncoder returns the proto/JSON encoder for the given record type.
 func newEncoder(rt zerobuspb.RecordType) (encoder[encodedMsg], error) {

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -1,0 +1,163 @@
+package stream
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// encodedMsg is a wire-ready EphemeralStream ingest request, built once at
+// Ingest time and held in the buffer until the sender transmits it. It is the
+// Req type the proto/JSON core is instantiated with; the Arrow path will use a
+// Flight frame instead. Encoding is eager so the buffer never retains live user
+// objects.
+type encodedMsg = *zerobuspb.EphemeralStreamRequest
+
+// encoder turns user records into wire messages for a given offset and recovers
+// them again for GetUnacked. It is the send-side per-encoding
+// seam. The core is generic over the wire message type Req and
+// never names a concrete proto type — proto/JSON supply encoder[encodedMsg];
+// Arrow will supply encoder[flightFrame].
+//
+// The offset is stamped into the message here so re-sends after recovery reuse
+// the same logical offset the server already saw.
+type encoder[Req any] interface {
+	// encode turns a single user record into one wire message.
+	encode(offset int64, record []byte) (Req, error)
+	// encodeBatch turns many already-encoded records into one wire message. All
+	// records share a single offset and are atomic to the server (it acks the
+	// whole batch or none of it), so the batch occupies exactly one logical
+	// offset in the core's buffer.
+	encodeBatch(offset int64, records [][]byte) (Req, error)
+	// decode recovers the raw record bytes from a wire message so GetUnacked can
+	// return original content. A single-record message yields one entry; a batch
+	// yields all of its records so no unacked record is silently dropped.
+	decode(msg Req) [][]byte
+}
+
+// protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
+// serialized protobuf bytes), single and batched.
+type protoEncoder struct{}
+
+func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: proto record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: record},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: proto batch must not be empty")
+	}
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: proto batch record %d must not be empty", i)
+		}
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_ProtoEncodedBatch{
+					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: records},
+				},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
+// and batched.
+type jsonEncoder struct{}
+
+func (jsonEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: json record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_JsonRecord{JsonRecord: string(record)},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: json batch must not be empty")
+	}
+	jsonRecords := make([]string, len(records))
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: json batch record %d must not be empty", i)
+		}
+		jsonRecords[i] = string(r)
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_JsonBatch{
+					JsonBatch: &zerobuspb.JsonRecordBatch{Records: jsonRecords},
+				},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// newEncoder returns the proto/JSON encoder for the given record type.
+func newEncoder(rt zerobuspb.RecordType) (encoder[encodedMsg], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO:
+		return protoEncoder{}, nil
+	case zerobuspb.RecordType_JSON:
+		return jsonEncoder{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}
+
+// extractEphemeralRecords recovers the raw record bytes from an EphemeralStream
+// wire message. A single-record message yields one entry; a batch yields all of
+// its records. Shared by the proto and JSON encoders' decode.
+func extractEphemeralRecords(msg encodedMsg) [][]byte {
+	if msg == nil {
+		return nil
+	}
+	if ir := msg.GetIngestRecord(); ir != nil {
+		if b := ir.GetProtoEncodedRecord(); b != nil {
+			return [][]byte{b}
+		}
+		return [][]byte{[]byte(ir.GetJsonRecord())}
+	}
+	if ib := msg.GetIngestRecordBatch(); ib != nil {
+		if pb := ib.GetProtoEncodedBatch(); pb != nil {
+			return pb.GetRecords()
+		}
+		if jb := ib.GetJsonBatch(); jb != nil {
+			recs := jb.GetRecords()
+			out := make([][]byte, len(recs))
+			for i, r := range recs {
+				out[i] = []byte(r)
+			}
+			return out
+		}
+	}
+	return nil
+}

--- a/purego/internal/stream/encoder_test.go
+++ b/purego/internal/stream/encoder_test.go
@@ -1,0 +1,139 @@
+package stream
+
+import (
+	"testing"
+)
+
+func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encode(42, []byte{0x0a, 0x01, 0x78})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 42 {
+		t.Fatalf("want offset 42, got %d", ir.GetOffsetId())
+	}
+	if len(ir.GetProtoEncodedRecord()) == 0 {
+		t.Fatal("want non-empty proto record")
+	}
+}
+
+func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encode(7, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 7 {
+		t.Fatalf("want offset 7, got %d", ir.GetOffsetId())
+	}
+	if ir.GetJsonRecord() != `{"x":1}` {
+		t.Fatalf("want json record, got %q", ir.GetJsonRecord())
+	}
+}
+
+func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encodeBatch(3, [][]byte{{0x01, 0x02}, {0x03, 0x04}, {0x05}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 3 {
+		t.Fatalf("want offset 3, got %d", ib.GetOffsetId())
+	}
+	pb := ib.GetProtoEncodedBatch()
+	if pb == nil {
+		t.Fatal("want ProtoEncodedBatch, got nil")
+	}
+	// The batch must carry all three records, not one concatenated blob.
+	if got := len(pb.GetRecords()); got != 3 {
+		t.Fatalf("want 3 records in batch, got %d", got)
+	}
+}
+
+func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encodeBatch(5, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 5 {
+		t.Fatalf("want offset 5, got %d", ib.GetOffsetId())
+	}
+	jb := ib.GetJsonBatch()
+	if jb == nil {
+		t.Fatal("want JsonBatch, got nil")
+	}
+	if got := jb.GetRecords(); len(got) != 2 || got[0] != `{"a":1}` || got[1] != `{"b":2}` {
+		t.Fatalf("want 2 json records preserved, got %v", got)
+	}
+}
+
+func TestEncodersRejectEmptyRecord(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encode(1, nil); err == nil {
+			t.Errorf("%T: want error for empty record, got nil", enc)
+		}
+		if _, err := enc.encode(1, []byte{}); err == nil {
+			t.Errorf("%T: want error for zero-length record, got nil", enc)
+		}
+	}
+}
+
+func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encodeBatch(1, nil); err == nil {
+			t.Errorf("%T: want error for empty batch, got nil", enc)
+		}
+		// A batch containing an empty record is rejected too.
+		if _, err := enc.encodeBatch(1, [][]byte{[]byte("ok"), {}}); err == nil {
+			t.Errorf("%T: want error for empty record within batch, got nil", enc)
+		}
+	}
+}
+
+func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
+	// A batch message must yield every record, not just the first, so GetUnacked
+	// doesn't silently drop the tail of an unacked batch.
+	protoMsg, err := protoEncoder{}.encodeBatch(1, [][]byte{{0x01}, {0x02}, {0x03}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	if got := (protoEncoder{}).decode(protoMsg); len(got) != 3 {
+		t.Fatalf("proto batch: want 3 records extracted, got %d", len(got))
+	}
+
+	jsonMsg, err := jsonEncoder{}.encodeBatch(1, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	got := (jsonEncoder{}).decode(jsonMsg)
+	if len(got) != 2 || string(got[0]) != `{"a":1}` || string(got[1]) != `{"b":2}` {
+		t.Fatalf("json batch: want both records extracted, got %v", got)
+	}
+
+	// A single-record message still yields exactly one entry.
+	single, err := jsonEncoder{}.encode(1, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if got := (jsonEncoder{}).decode(single); len(got) != 1 || string(got[0]) != `{"x":1}` {
+		t.Fatalf("single record: want 1 entry, got %v", got)
+	}
+}

--- a/purego/internal/stream/errors.go
+++ b/purego/internal/stream/errors.go
@@ -1,0 +1,34 @@
+package stream
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// errClosed is returned by buffer operations when the buffer has been closed.
+var errClosed = errors.New("stream: buffer closed")
+
+// errUnsupportedRecordType is returned when no encoder/ackModel exists for a
+// record type (e.g. RECORD_TYPE_UNSPECIFIED).
+func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
+	return fmt.Errorf("stream: unsupported record type %v", rt)
+}
+
+// pauseSignal is what the ackModel returns when the server sent a
+// CloseStreamSignal: the server is about to close this stream and the client
+// should pause (stop sending, keep buffering and draining acks) then
+// reconnect, rather than treat it as a failure counted against the
+// recovery budget. It carries the server-requested pause duration.
+//
+// Consumers of pauseSignal (runOnce, supervisor) land in later PRs; the
+// type itself lives here because the ackModel decodes it out of the wire
+// CloseStreamSignal.
+type pauseSignal struct {
+	// duration is the server-requested pause window; zero if unspecified.
+	duration time.Duration
+}
+
+func (pauseSignal) Error() string { return "stream: server requested pause (close-stream signal)" }

--- a/purego/internal/stream/errors.go
+++ b/purego/internal/stream/errors.go
@@ -11,24 +11,43 @@ import (
 // errClosed is returned by buffer operations when the buffer has been closed.
 var errClosed = errors.New("stream: buffer closed")
 
+// ErrPayloadTooLarge is returned by Ingest / IngestBatch when the aggregate
+// caller-supplied payload exceeds the configured MaxPayloadBytes cap. It is
+// deterministic input validation, not a transport error, so recovery does not
+// count against the retry budget.
+var ErrPayloadTooLarge = errors.New("stream: ingest payload exceeds MaxPayloadBytes")
+
 // errUnsupportedRecordType is returned when no encoder/ackModel exists for a
 // record type (e.g. RECORD_TYPE_UNSPECIFIED).
 func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
 	return fmt.Errorf("stream: unsupported record type %v", rt)
 }
 
-// pauseSignal is what the ackModel returns when the server sent a
+// pauseSignal is the cause runOnce returns when the server sent a
 // CloseStreamSignal: the server is about to close this stream and the client
-// should pause (stop sending, keep buffering and draining acks) then
-// reconnect, rather than treat it as a failure counted against the
-// recovery budget. It carries the server-requested pause duration.
-//
-// Consumers of pauseSignal (runOnce, supervisor) land in later PRs; the
-// type itself lives here because the ackModel decodes it out of the wire
-// CloseStreamSignal.
+// should pause (stop sending, keep buffering and draining acks) then reconnect,
+// rather than treat it as a failure that counts against the recovery budget. It
+// carries the server-requested pause duration.
 type pauseSignal struct {
 	// duration is the server-requested pause window; zero if unspecified.
 	duration time.Duration
 }
 
 func (pauseSignal) Error() string { return "stream: server requested pause (close-stream signal)" }
+
+// openBudgetExceeded marks an Open attempt that exceeded the internal
+// RecoveryTimeout budget (as opposed to the caller cancelling the supervisor
+// ctx). It self-classifies as retryable so RecoveryRetries governs a stalled
+// dial — a single slow Open should not permanently kill the stream while
+// budget remains. Caller-side cancellation continues to unwind cleanly
+// because the outer ctx path is checked separately in the supervisor.
+type openBudgetExceeded struct{ cause error }
+
+func (e *openBudgetExceeded) Error() string {
+	return "stream: open budget exceeded: " + e.cause.Error()
+}
+func (e *openBudgetExceeded) Unwrap() error { return e.cause }
+
+// IsRetryable makes openBudgetExceeded a self-classifying retryable error via
+// the retryableError structural interface honoured by isRetryable.
+func (*openBudgetExceeded) IsRetryable() bool { return true }

--- a/purego/internal/stream/export_test.go
+++ b/purego/internal/stream/export_test.go
@@ -1,0 +1,21 @@
+package stream
+
+import "context"
+
+// len returns the total number of items in the buffer (pending + in-flight).
+// Test-only helper: not used in production code paths, so it lives here.
+func (b *buffer[Req]) len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.queue) + len(b.flight)
+}
+
+// enqueue combines reserve+append for tests that predate the split. Production
+// code uses reserve and append directly so the semaphore wait happens outside
+// the core's offset-assignment critical section.
+func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
+	if err := b.reserve(ctx); err != nil {
+		return err
+	}
+	return b.append(offset, msg)
+}

--- a/purego/internal/stream/helpers_test.go
+++ b/purego/internal/stream/helpers_test.go
@@ -1,0 +1,305 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// ---- fake transport helpers ------------------------------------------------
+
+// fakeRPC is a minimal in-process bidi stream satisfying transport.FakeStreamRPC.
+// It lets tests control exactly what acks the receiver sees without a real
+// gRPC server. close() closes the recvs channel so Recv returns io.EOF,
+// unblocking the receiver goroutine just like a real gRPC stream close would.
+type fakeRPC struct {
+	sends     chan *zerobuspb.EphemeralStreamRequest
+	recvs     chan *zerobuspb.EphemeralStreamResponse
+	closeOnce sync.Once
+	closed    atomic.Bool
+}
+
+func newFakeRPC() *fakeRPC {
+	return &fakeRPC{
+		sends: make(chan *zerobuspb.EphemeralStreamRequest, 64),
+		recvs: make(chan *zerobuspb.EphemeralStreamResponse, 64),
+	}
+}
+
+func (f *fakeRPC) Send(req *zerobuspb.EphemeralStreamRequest) error {
+	if f.closed.Load() {
+		return io.EOF
+	}
+	select {
+	case f.sends <- req:
+		return nil
+	default:
+		// channel full — shouldn't happen with buffered 64 in tests
+		return fmt.Errorf("fakeRPC: sends channel full")
+	}
+}
+
+func (f *fakeRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	resp, ok := <-f.recvs
+	if !ok {
+		return nil, io.EOF
+	}
+	return resp, nil
+}
+
+// CloseSend closes the stream from the send side; in our fake this also
+// closes the recvs channel so the receiver unblocks with io.EOF.
+func (f *fakeRPC) CloseSend() error {
+	f.close()
+	return nil
+}
+
+// close closes the recvs channel, causing any blocking Recv call to return
+// io.EOF. Safe to call multiple times.
+func (f *fakeRPC) close() {
+	f.closeOnce.Do(func() {
+		f.closed.Store(true)
+		close(f.recvs)
+	})
+}
+
+// ack sends a DurabilityAck response for offset.
+func (f *fakeRPC) ack(offset int64) {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(offset),
+			},
+		},
+	}
+}
+
+// closeSignal sends a server CloseStreamSignal, asking the client to pause.
+func (f *fakeRPC) closeSignal() {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{},
+		},
+	}
+}
+
+// closeSignalWithDuration sends a CloseStreamSignal carrying the given
+// server-requested pause duration.
+func (f *fakeRPC) closeSignalWithDuration(d time.Duration) {
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{
+				Duration: durationpb.New(d),
+			},
+		},
+	}
+}
+
+// fakeOpener wraps a fakeRPC as a transport.Opener by building a rawStream
+// from it. Each call to Open returns the same underlying fakeRPC so tests
+// can send acks from it.
+type fakeOpener struct {
+	mu       sync.Mutex
+	rpcs     []*fakeRPC
+	idx      int
+	openErr  error // if non-nil, all opens fail with this error
+	attempts int   // number of Open calls, for asserting retry behavior
+}
+
+func newFakeOpener(rpcs ...*fakeRPC) *fakeOpener {
+	return &fakeOpener{rpcs: rpcs}
+}
+
+func (fo *fakeOpener) openCount() int {
+	fo.mu.Lock()
+	defer fo.mu.Unlock()
+	return fo.attempts
+}
+
+func (fo *fakeOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	fo.mu.Lock()
+	defer fo.mu.Unlock()
+	fo.attempts++
+	if fo.openErr != nil {
+		return nil, fo.openErr
+	}
+	if fo.idx >= len(fo.rpcs) {
+		return nil, fmt.Errorf("fakeOpener: no more RPCs")
+	}
+	rpc := fo.rpcs[fo.idx]
+	fo.idx++
+	return transport.NewFakeStreamForTesting(rpc), nil
+}
+
+// gracefulFakeRPC models real gRPC teardown semantics more faithfully than
+// fakeRPC by distinguishing the two teardown verbs:
+//   - CloseSend half-closes the send side (signalling closeSent) but leaves Recv
+//     open, so a test can deliver late acks after the half-close and assert the
+//     receiver drains them.
+//   - Abort models Close/context-cancel: it unblocks a blocked Recv with an error
+//     and drops any further acks, as an abrupt reset would.
+//
+// serverEnd closes recvs to produce the io.EOF that ends a graceful drain.
+type gracefulFakeRPC struct {
+	sends     chan *zerobuspb.EphemeralStreamRequest
+	recvs     chan *zerobuspb.EphemeralStreamResponse
+	closeSent chan struct{}
+	aborted   chan struct{}
+	closeOnce sync.Once
+	abortOnce sync.Once
+	endOnce   sync.Once
+	ended     atomic.Bool
+}
+
+func newGracefulFakeRPC() *gracefulFakeRPC {
+	return &gracefulFakeRPC{
+		sends:     make(chan *zerobuspb.EphemeralStreamRequest, 64),
+		recvs:     make(chan *zerobuspb.EphemeralStreamResponse, 64),
+		closeSent: make(chan struct{}),
+		aborted:   make(chan struct{}),
+	}
+}
+
+func (f *gracefulFakeRPC) Send(req *zerobuspb.EphemeralStreamRequest) error {
+	f.sends <- req
+	return nil
+}
+
+func (f *gracefulFakeRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	select {
+	case resp, ok := <-f.recvs:
+		if !ok {
+			return nil, io.EOF
+		}
+		return resp, nil
+	case <-f.aborted:
+		return nil, io.ErrClosedPipe
+	}
+}
+
+// CloseSend half-closes the send side without ending Recv, matching gRPC.
+func (f *gracefulFakeRPC) CloseSend() error {
+	f.closeOnce.Do(func() { close(f.closeSent) })
+	return nil
+}
+
+// Abort models Stream.Close/context-cancel: it unblocks Recv with an error.
+func (f *gracefulFakeRPC) Abort() {
+	f.abortOnce.Do(func() {
+		f.ended.Store(true)
+		close(f.aborted)
+	})
+}
+
+// serverEnd ends the stream from the server side so the drain sees io.EOF.
+func (f *gracefulFakeRPC) serverEnd() {
+	f.endOnce.Do(func() {
+		f.ended.Store(true)
+		close(f.recvs)
+	})
+}
+
+func (f *gracefulFakeRPC) ack(offset int64) {
+	if f.ended.Load() {
+		return
+	}
+	f.recvs <- &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(offset),
+			},
+		},
+	}
+}
+
+type gracefulOpener struct{ rpc *gracefulFakeRPC }
+
+func (o *gracefulOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return transport.NewFakeStreamForTesting(o.rpc), nil
+}
+
+// ---- recording ack callback ------------------------------------------------
+
+type recordingCallback struct {
+	mu   sync.Mutex
+	acks []int64
+	errs []int64
+}
+
+func (r *recordingCallback) OnAck(offset int64) {
+	r.mu.Lock()
+	r.acks = append(r.acks, offset)
+	r.mu.Unlock()
+}
+
+func (r *recordingCallback) OnError(offset int64, _ error) {
+	r.mu.Lock()
+	r.errs = append(r.errs, offset)
+	r.mu.Unlock()
+}
+
+func (r *recordingCallback) ackCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.acks)
+}
+
+// ---- test helpers ----------------------------------------------------------
+
+func testConfig() Config {
+	c := DefaultConfig()
+	c.MaxInflight = 64
+	c.FlushTimeout = 2 * time.Second
+	c.LackOfAckTimeout = 2 * time.Second
+	c.RecoveryBackoff = 10 * time.Millisecond
+	return c
+}
+
+func testParams() StreamParams {
+	return StreamParams{
+		TableName:  "c.s.t",
+		RecordType: zerobuspb.RecordType_JSON,
+	}
+}
+
+// testStream is the proto/JSON core specialization used throughout these tests.
+type testStream = CoreStream[encodedMsg, ephemeralResp]
+
+// testOpener is the opener type the fakes satisfy.
+type testOpener = opener[encodedMsg, ephemeralResp]
+
+// newCoreForTest builds a proto/JSON CoreStream with the JSON encoder and offset
+// ack model — the common wiring every test needs.
+func newCoreForTest(params StreamParams, cfg Config, o testOpener, cb AckCallback) *testStream {
+	return NewCoreStream[encodedMsg, ephemeralResp](params, cfg, o, jsonEncoder{}, offsetAckModel{}, cb)
+}
+
+func newTestStream(t *testing.T, o testOpener) *testStream {
+	t.Helper()
+	cb := &recordingCallback{}
+	cs := newCoreForTest(testParams(), testConfig(), o, cb)
+	t.Cleanup(func() { cs.Close() })
+	return cs
+}
+
+// waitCondition polls fn until it returns true or deadline expires.
+func waitCondition(t *testing.T, fn func() bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !fn() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition not met within timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -5,18 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
 )
 
 // supervise is the supervisor goroutine. It runs the create→run→recover loop
 // until the context is cancelled (Close called), a non-retryable error fires,
-// or consecutive recovery retries are exhausted. It always closes done on exit.
+// or consecutive recovery retries are exhausted. It always closes done on
+// exit.
 //
 // The retry budget is per episode: `failedAttempts` counts only *consecutive*
 // failed reconnects and resets to zero whenever a stream connects and runs
-// successfully. A long-lived stream that disconnects occasionally therefore is
-// not doomed after RecoveryRetries lifetime disconnects — each disconnect
-// starts a fresh episode with the full budget. This mirrors the Rust core,
-// which builds a fresh attempt counter per recovery loop iteration.
+// successfully. A long-lived stream that disconnects occasionally therefore
+// is not doomed after RecoveryRetries lifetime disconnects — each disconnect
+// starts a fresh episode with the full budget: a long-lived stream that
+// disconnects occasionally is not doomed by consecutive-lifetime failures.
 func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 	defer close(cs.done)
 
@@ -39,34 +42,43 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			}
-			// Requeue any items the previous sender observed but didn't ack.
-			cs.buf.requeue()
+			// runOnce requeues on each successful Open, so we do not duplicate
+			// that work here.
 		}
 
 		runErr, healthy := cs.runOnce(ctx)
 
-		// ctx cancelled = clean exit via Close. Don't treat server-side EOF as clean.
+		// ctx cancelled = clean exit via Close. Don't treat server-side EOF
+		// as clean.
 		if ctx.Err() != nil {
 			return
 		}
 
-		// A stream that successfully opened and ran resets the per-episode budget:
-		// the failure that ended it (if any) begins a fresh recovery episode rather
-		// than continuing the prior reconnect streak.
+		// A stream that successfully opened and ran resets the per-episode
+		// budget: the failure that ended it (if any) begins a fresh recovery
+		// episode rather than continuing the prior reconnect streak.
 		if healthy {
 			failedAttempts = 0
 		}
 
-		// A server-requested pause (CloseStreamSignal) is not a failure: wait the
-		// requested window, then reconnect without consuming the recovery budget.
-		// Ingest keeps buffering meanwhile; unacked records are requeued on the
-		// next attempt.
+		// A server-requested pause (CloseStreamSignal) is not a failure: wait
+		// the requested window, then reconnect without consuming the recovery
+		// budget. Ingest keeps buffering meanwhile; unacked records are
+		// requeued on the next attempt.
+		//
+		// If recovery is disabled, though, we honor that: don't reconnect
+		// after a pause. Treat it as a terminal failure so callers see the
+		// signal rather than silently ingesting into a dead stream.
 		var ps pauseSignal
 		if errors.As(runErr, &ps) {
-			if !cs.waitPause(ctx, ps.duration) {
-				return // Close cancelled ctx during the pause.
+			if !cs.cfg.Recovery.enabled() {
+				err = fmt.Errorf("stream: server requested pause and recovery is disabled: %w", runErr)
+				break
 			}
-			cs.buf.requeue()
+			// The receiver already applied effectivePauseWait(cfg, duration)
+			// during pause drain; no additional wait is required here. A
+			// concurrent Close would have short-circuited the loop above
+			// via the ctx.Err() check, so we don't repeat that check.
 			continue
 		}
 
@@ -76,6 +88,14 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 			runErr = fmt.Errorf("stream: server closed the stream")
 		}
 
+		// Mid-stream auth rejection means the cached credential the transport
+		// attached at Open is no longer accepted (e.g. token rotated or
+		// revoked). Drop it so the next Open re-mints via GetHeaders instead
+		// of reconnecting with the same stale value.
+		if transport.IsAuthRejection(runErr) && cs.params.HeadersProvider != nil {
+			cs.params.HeadersProvider.Invalidate(ctx, cs.params.TableName)
+		}
+
 		err = runErr
 		if !isRetryable(runErr) {
 			break
@@ -83,48 +103,23 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 		failedAttempts++
 	}
 
-	// Terminal failure path.
+	// Terminal failure path. Fail the watermark first so any waiters unblock
+	// promptly with the terminal error; the callback dispatch and buffer
+	// drain run afterwards.
 	cs.wm.fail(err)
 	cs.setTerminalErr(err)
 
-	if cs.callback != nil {
-		// Drain the buffer and fire OnError for each unacked item. drain() also
-		// closes the buffer and unblocks any enqueue callers, so we must call it
-		// here rather than close() + a separate drain in GetUnacked. GetUnacked
-		// documents that it is mutually exclusive with AckCallback: when a
-		// callback is set, the supervisor owns the drain; when it is nil,
-		// GetUnacked drains on demand.
-		for _, it := range cs.buf.drain() {
-			cs.callback.OnError(it.offset, err)
-		}
-	} else {
-		// No callback: just close the buffer so enqueue callers unblock. The
-		// items remain retrievable via GetUnacked, which calls drain() itself.
-		cs.buf.close()
+	// Drain the buffer once. We always preserve the payloads for GetUnacked
+	// AND, if a callback is registered, dispatch per-offset OnError events;
+	// both signals converge on the same underlying records rather than
+	// being mutually exclusive.
+	items := cs.buf.drain()
+	cs.setRetainedFailed(items)
+	for _, it := range items {
+		cs.dispatcher.enqueueError(it.offset, err)
 	}
-}
-
-// waitPause sleeps for the server-requested pause window before reconnecting,
-// capped by StreamPausedMaxWait (min of the two; a non-positive cap means "no
-// client cap"). Returns false if ctx was cancelled (Close) during the wait, so
-// the caller stops instead of reconnecting. A non-positive effective wait
-// reconnects immediately.
-func (cs *CoreStream[Req, Resp]) waitPause(ctx context.Context, serverDuration time.Duration) bool {
-	wait := serverDuration
-	if cap := cs.cfg.StreamPausedMaxWait; cap > 0 && (wait <= 0 || cap < wait) {
-		wait = cap
-	}
-	if wait <= 0 {
-		return ctx.Err() == nil
-	}
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return true
-	case <-ctx.Done():
-		return false
-	}
+	// drain() marks the buffer closed; the extra close call is defensive.
+	cs.buf.close()
 }
 
 // retryableError is any error that self-classifies its retryability. Errors
@@ -145,29 +140,32 @@ func isRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-	// errClosed means the buffer was drained by Close; not retryable.
-	if errors.Is(err, errClosed) {
-		return false
-	}
-	// Errors produced by the transport layer's Open (validation failures such
-	// as empty table name or unsupported record type) are non-retryable
-	// because reconnecting would produce the same error.
+	// Self-classifying retryable errors take precedence over the generic
+	// context-error check: an internal per-attempt budget (e.g. an
+	// openBudgetExceeded wrapping context.DeadlineExceeded) wants to remain
+	// retryable so RecoveryRetries actually governs stalled dials.
+	// Validation errors and errClosed are checked first though, because
+	// they wrap non-retryable causes regardless of self-classification.
 	var ve *validationError
 	if errors.As(err, &ve) {
 		return false
 	}
-	// Honor any layer's self-reported retryability verdict (e.g. OAuth
-	// TokenError). Walk the unwrap chain so a wrapped mint failure is still seen.
+	if errors.Is(err, errClosed) {
+		return false
+	}
 	var re retryableError
 	if errors.As(err, &re) {
 		return re.IsRetryable()
 	}
-	// All other errors (network failures, server resets, auth rejections after
-	// the stream was open) are considered retryable; the supervisor's retry cap
-	// is the backstop.
+	// Bare ctx-cancel / deadline (without a self-classifying wrapper) is
+	// non-retryable: those come from the caller/supervisor cancelling us,
+	// not an internal budget.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// All other errors (network failures, server resets, auth rejections
+	// after the stream was open) are considered retryable; the supervisor's
+	// retry cap is the backstop.
 	return true
 }
 

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -1,0 +1,187 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// supervise is the supervisor goroutine. It runs the create→run→recover loop
+// until the context is cancelled (Close called), a non-retryable error fires,
+// or consecutive recovery retries are exhausted. It always closes done on exit.
+//
+// The retry budget is per episode: `failedAttempts` counts only *consecutive*
+// failed reconnects and resets to zero whenever a stream connects and runs
+// successfully. A long-lived stream that disconnects occasionally therefore is
+// not doomed after RecoveryRetries lifetime disconnects — each disconnect
+// starts a fresh episode with the full budget. This mirrors the Rust core,
+// which builds a fresh attempt counter per recovery loop iteration.
+func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
+	defer close(cs.done)
+
+	var err error
+	failedAttempts := 0
+	for {
+		if ctx.Err() != nil {
+			// Cancelled by Close — clean exit, no error.
+			return
+		}
+
+		if failedAttempts > 0 {
+			if !cs.cfg.Recovery.enabled() || failedAttempts > cs.cfg.RecoveryRetries {
+				err = fmt.Errorf("stream: recovery exhausted after %d attempt(s): %w",
+					failedAttempts, err)
+				break
+			}
+			select {
+			case <-time.After(cs.cfg.RecoveryBackoff):
+			case <-ctx.Done():
+				return
+			}
+			// Requeue any items the previous sender observed but didn't ack.
+			cs.buf.requeue()
+		}
+
+		runErr, healthy := cs.runOnce(ctx)
+
+		// ctx cancelled = clean exit via Close. Don't treat server-side EOF as clean.
+		if ctx.Err() != nil {
+			return
+		}
+
+		// A stream that successfully opened and ran resets the per-episode budget:
+		// the failure that ended it (if any) begins a fresh recovery episode rather
+		// than continuing the prior reconnect streak.
+		if healthy {
+			failedAttempts = 0
+		}
+
+		// A server-requested pause (CloseStreamSignal) is not a failure: wait the
+		// requested window, then reconnect without consuming the recovery budget.
+		// Ingest keeps buffering meanwhile; unacked records are requeued on the
+		// next attempt.
+		var ps pauseSignal
+		if errors.As(runErr, &ps) {
+			if !cs.waitPause(ctx, ps.duration) {
+				return // Close cancelled ctx during the pause.
+			}
+			cs.buf.requeue()
+			continue
+		}
+
+		if runErr == nil {
+			// Server closed the stream cleanly (EOF). Treat as a retryable
+			// disconnect and recover.
+			runErr = fmt.Errorf("stream: server closed the stream")
+		}
+
+		err = runErr
+		if !isRetryable(runErr) {
+			break
+		}
+		failedAttempts++
+	}
+
+	// Terminal failure path.
+	cs.wm.fail(err)
+	cs.setTerminalErr(err)
+
+	if cs.callback != nil {
+		// Drain the buffer and fire OnError for each unacked item. drain() also
+		// closes the buffer and unblocks any enqueue callers, so we must call it
+		// here rather than close() + a separate drain in GetUnacked. GetUnacked
+		// documents that it is mutually exclusive with AckCallback: when a
+		// callback is set, the supervisor owns the drain; when it is nil,
+		// GetUnacked drains on demand.
+		for _, it := range cs.buf.drain() {
+			cs.callback.OnError(it.offset, err)
+		}
+	} else {
+		// No callback: just close the buffer so enqueue callers unblock. The
+		// items remain retrievable via GetUnacked, which calls drain() itself.
+		cs.buf.close()
+	}
+}
+
+// waitPause sleeps for the server-requested pause window before reconnecting,
+// capped by StreamPausedMaxWait (min of the two; a non-positive cap means "no
+// client cap"). Returns false if ctx was cancelled (Close) during the wait, so
+// the caller stops instead of reconnecting. A non-positive effective wait
+// reconnects immediately.
+func (cs *CoreStream[Req, Resp]) waitPause(ctx context.Context, serverDuration time.Duration) bool {
+	wait := serverDuration
+	if cap := cs.cfg.StreamPausedMaxWait; cap > 0 && (wait <= 0 || cap < wait) {
+		wait = cap
+	}
+	if wait <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// retryableError is any error that self-classifies its retryability. Errors
+// from the transport and auth layers (e.g. TokenError from an OAuth mint)
+// implement it; the supervisor honors their verdict rather than blindly
+// retrying every non-context error. Structural so we don't have to import
+// auth or transport just to name their concrete types.
+type retryableError interface {
+	IsRetryable() bool
+}
+
+// isRetryable reports whether err represents a transient failure that warrants
+// a stream reconnect. Context cancellation, stream-open validation errors
+// (wrong table name, bad record type), and errors that self-report as
+// non-retryable (e.g. a revoked-credentials OAuth mint failure) are not
+// retryable; transport-level failures (connection reset, server going away) are.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// errClosed means the buffer was drained by Close; not retryable.
+	if errors.Is(err, errClosed) {
+		return false
+	}
+	// Errors produced by the transport layer's Open (validation failures such
+	// as empty table name or unsupported record type) are non-retryable
+	// because reconnecting would produce the same error.
+	var ve *validationError
+	if errors.As(err, &ve) {
+		return false
+	}
+	// Honor any layer's self-reported retryability verdict (e.g. OAuth
+	// TokenError). Walk the unwrap chain so a wrapped mint failure is still seen.
+	var re retryableError
+	if errors.As(err, &re) {
+		return re.IsRetryable()
+	}
+	// All other errors (network failures, server resets, auth rejections after
+	// the stream was open) are considered retryable; the supervisor's retry cap
+	// is the backstop.
+	return true
+}
+
+// validationError marks errors that are configuration/validation failures
+// rather than transient transport failures.
+type validationError struct{ cause error }
+
+func (e *validationError) Error() string { return e.cause.Error() }
+func (e *validationError) Unwrap() error { return e.cause }
+
+// wrapValidation wraps err so the supervisor recognises it as non-retryable.
+func wrapValidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &validationError{cause: err}
+}

--- a/purego/internal/stream/wirestream.go
+++ b/purego/internal/stream/wirestream.go
@@ -1,0 +1,87 @@
+package stream
+
+import (
+	"context"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
+
+// wireStream is edge #3 of the design: the actual transport, abstracted so the
+// core drives Send/Recv/teardown without naming a concrete RPC. It is generic
+// over the request and response types the encoder and ackModel already use, so
+// proto/JSON instantiate wireStream[encodedMsg, ephemeralResp] over
+// EphemeralStream and Arrow will instantiate it over Flight — with no change to
+// core.go.
+//
+// A wireStream is already past its handshake when opener returns it. It is not
+// safe for concurrent Send; the core uses a single sender goroutine.
+type wireStream[Req, Resp any] interface {
+	// Send writes one request to the server.
+	Send(req Req) error
+	// Recv blocks for the next response, returning io.EOF (unwrapped) once the
+	// server ends the stream cleanly.
+	Recv() (Resp, error)
+	// CloseSend half-closes the send side, leaving Recv open to drain remaining
+	// responses (used for graceful teardown).
+	CloseSend() error
+	// Close aborts the stream and releases resources. Idempotent.
+	Close()
+}
+
+// opener opens a new wireStream. It is edge #3's factory, injected so the
+// supervisor can reconnect and tests can supply an in-process fake. Generic
+// over the same Req/Resp as wireStream.
+type opener[Req, Resp any] interface {
+	Open(ctx context.Context, p StreamParams) (wireStream[Req, Resp], error)
+}
+
+// StreamParams mirrors transport.StreamParams but lives here so upper layers
+// can use the stream package without importing transport directly.
+type StreamParams = transport.StreamParams
+
+// ephemeralOpener adapts a *transport.Conn to opener[encodedMsg, ephemeralResp]
+// for the proto/JSON wire path. *transport.Stream already satisfies wireStream,
+// so this is a thin wrapper that just names the concrete types.
+type ephemeralOpener struct{ conn *transport.Conn }
+
+// NewEphemeralOpener returns the proto/JSON opener backed by conn. The public
+// zerobus package uses it to build a proto/JSON CoreStream via NewProtoJSONStream.
+func NewEphemeralOpener(conn *transport.Conn) *ephemeralOpener {
+	return &ephemeralOpener{conn: conn}
+}
+
+func (o *ephemeralOpener) Open(ctx context.Context, p StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	s, err := o.conn.Open(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Compile-time proof that the transport's proto/JSON Stream satisfies the
+// generic wireStream the core drives.
+var _ wireStream[encodedMsg, ephemeralResp] = (*transport.Stream)(nil)
+
+// NewProtoJSONStream builds a proto/JSON ingestion core over the EphemeralStream
+// wire path: it wires the offset ack model, the proto or JSON encoder (chosen by
+// params.RecordType), and the ephemeral opener. This is the single constructor
+// the public zerobus package calls for proto and JSON streams; Arrow will get a
+// parallel NewArrowStream that supplies its own opener/encoder/ackModel.
+func NewProtoJSONStream(
+	conn *transport.Conn,
+	params StreamParams,
+	cfg Config,
+	callback AckCallback,
+) (*CoreStream[encodedMsg, ephemeralResp], error) {
+	enc, err := newEncoder(params.RecordType)
+	if err != nil {
+		return nil, err
+	}
+	ackMdl, err := newAckModel(params.RecordType)
+	if err != nil {
+		return nil, err
+	}
+	return NewCoreStream[encodedMsg, ephemeralResp](
+		params, cfg, NewEphemeralOpener(conn), enc, ackMdl, callback,
+	), nil
+}

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,13 @@ import (
 
 	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
+
+// ErrInvalidParams marks an Open failure caused by invalid stream parameters
+// (empty table name, unsupported record type, missing descriptor). These are
+// deterministic: reopening with the same params reproduces the failure, so
+// higher layers can use errors.Is to treat them as non-retryable rather than
+// reconnecting in a loop.
+var ErrInvalidParams = errors.New("transport: invalid stream parameters")
 
 // StreamParams describes the stream to open: which table to ingest into, how
 // records are encoded, and which headers provider supplies its credentials.
@@ -54,16 +62,16 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 	// the validation below also governs the value actually sent.
 	p.TableName = strings.TrimSpace(p.TableName)
 	if p.TableName == "" {
-		return nil, fmt.Errorf("transport: open: table name is required")
+		return nil, fmt.Errorf("transport: open: table name is required: %w", ErrInvalidParams)
 	}
 	switch p.RecordType {
 	case zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON:
 		// Supported.
 	default:
-		return nil, fmt.Errorf("transport: open %q: unsupported record type %v", p.TableName, p.RecordType)
+		return nil, fmt.Errorf("transport: open %q: unsupported record type %v: %w", p.TableName, p.RecordType, ErrInvalidParams)
 	}
 	if p.RecordType == zerobuspb.RecordType_PROTO && len(p.DescriptorProto) == 0 {
-		return nil, fmt.Errorf("transport: open %q: descriptor proto required for PROTO records", p.TableName)
+		return nil, fmt.Errorf("transport: open %q: descriptor proto required for PROTO records: %w", p.TableName, ErrInvalidParams)
 	}
 	headersCtx := ctx
 	useDefaultBudgets := false
@@ -176,6 +184,35 @@ func confirmCreateStream(resp *zerobuspb.EphemeralStreamResponse) (string, error
 		return "", fmt.Errorf("server returned an empty stream ID")
 	}
 	return id, nil
+}
+
+// FakeStreamRPC is the wire interface a test fake must satisfy to be wrapped by
+// [NewFakeStreamForTesting]. It exists only for tests in other internal
+// packages that must supply a fake RPC; production callers do not use it.
+type FakeStreamRPC interface {
+	Send(*zerobuspb.EphemeralStreamRequest) error
+	Recv() (*zerobuspb.EphemeralStreamResponse, error)
+	CloseSend() error
+}
+
+// NewFakeStreamForTesting wraps a test fake as a Stream, skipping the handshake.
+// It is exported because Go tests in other internal packages cannot reach
+// Stream's unexported fields; production code must not use it.
+//
+// Close cancels the stream (abrupt abort). If the RPC implements Abort() the
+// fake can model gRPC's context-cancel (distinct from CloseSend's half-close)
+// and unblock a Recv parked on a channel. Otherwise Close falls back to
+// CloseSend, which suffices for fakes whose Recv returns io.EOF on half-close.
+func NewFakeStreamForTesting(rpc FakeStreamRPC) *Stream {
+	s := &Stream{}
+	s.rpc = rpc
+	if a, ok := rpc.(interface{ Abort() }); ok {
+		s.cancel = a.Abort
+	} else {
+		s.cancel = func() { _ = rpc.CloseSend() }
+	}
+	s.setID("fake-stream")
+	return s
 }
 
 // ID returns the server-assigned stream identifier from the handshake.

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -158,7 +158,14 @@ func isUsableAsHeaderValue(value string) bool {
 
 // isAuthRejection reports whether err is a gRPC auth rejection
 // (Unauthenticated or PermissionDenied), unwrapping wrapped errors.
-func isAuthRejection(err error) bool {
+func isAuthRejection(err error) bool { return IsAuthRejection(err) }
+
+// IsAuthRejection reports whether err is a gRPC auth rejection
+// (Unauthenticated or PermissionDenied). Exported so the stream layer can
+// invalidate the HeadersProvider on mid-stream auth failure, matching Rust:
+// a cached token that is rejected mid-stream is stale and should be
+// re-minted on the next Open.
+func IsAuthRejection(err error) bool {
 	code := status.Code(err)
 	return code == codes.Unauthenticated || code == codes.PermissionDenied
 }


### PR DESCRIPTION
## Summary

Second of a three-PR split of #531. Stacks on #571. Addresses the durability, callback, and retry-classification review findings on the ingestion core skeleton. Public shape is unchanged; internals harden.

## Durability

- **Watermark bounded to discarded flight.** `wm.advance` now runs only to the highest offset of a record actually removed from flight by `discardThrough`, so a bogus high server offset cannot fake durability for records never durably stored.
- **Ack-model protocol errors.** New `unknownResponse` and `malformedResponse` kinds. An unknown response type fails the stream; an ack whose `DurabilityAckUpToOffset` field is absent (proto optional → would silently default to 0) fails the stream rather than fabricating a zero-offset ack.
- **Monotonic `lastEnqueued`.** `lastEnqueued.Store` is inside `offsetMu` so two concurrent `Ingest`s cannot land their `Store`s out of order and make `Flush` return success while a higher offset is still unacked.
- **Wire-size payload cap.** `MaxPayloadBytes` enforcement now checks `proto.Size` of the encoded request, not just the raw input byte count, so proto framing overhead can't push a "just under limit" batch over the server's message size limit.
- **Caller-byte cloning.** Proto encoder snapshots each record so a caller reusing a marshalling scratch buffer between `Ingest` calls can't mutate queued or replayed payloads.

## Callbacks

- **Dedicated `callbackDispatcher` goroutine.** User `OnAck` / `OnError` runs serially on its own goroutine so a slow user callback never stalls receiver or supervisor. Callbacks calling `Close` from inside the dispatcher no longer self-deadlock (reentrancy detected via an atomic flag).
- **Per-offset `OnAck`.** A cumulative server ack for offset 5 following offset 2 now yields three `OnAck(3)`, `OnAck(4)`, `OnAck(5)` events, not one `OnAck(5)`. A duplicate ack fires zero.
- **Terminal drain payload retention.** On terminal failure the supervisor stores encoded items in `retainedFailed` AND dispatches per-offset `OnError`, so `GetUnacked` and the callback consumer see the same records — the two are no longer mutually exclusive.
- **Clean-Close watermark termination.** `wm.closeForClean` fires on Close so a `WaitForOffset` waiter on an unreachable offset unblocks with an error instead of hanging on a background ctx.

## Retry classification

- **`openBudgetExceeded` self-classifies retryable.** An Open that hits our internal `RecoveryTimeout` budget is wrapped in an error whose `IsRetryable()` returns true, so a stalled dial exhausts `RecoveryRetries` instead of dying after one attempt.
- **`isRetryable` reorder.** Self-classifying wrappers are checked before generic `context.DeadlineExceeded` / `Canceled` so an internal-budget error inside a `DeadlineExceeded` chain stays retryable.
- **Mid-stream auth invalidation.** When a mid-stream error is a gRPC auth rejection, the supervisor calls `HeadersProvider.Invalidate` so the next Open re-mints instead of reconnecting with a stale credential. Adds `transport.IsAuthRejection` for the stream layer to key on.

## Config safety

- **`sanitizeConfig`.** Non-positive `MaxInflight` / timeouts / `MaxPayloadBytes` are normalized to their defaults so a caller-passed `Config{}` does not deadlock (unbuffered semaphore), spin (zero lack-of-ack timer), or hard-abort teardown immediately.
- **`Config{}` recovers by default.** `RecoveryRetries=0` is normalized to the default; explicit single-attempt streams use `RecoverySetting=RecoveryDisabled`.

## Cleanup

- Buffer `discardThrough` / `next` / `requeue` zero out departed slots so acknowledged payloads become GC-collectible instead of being pinned by the underlying slice array.
- `buffer.enqueue` and `buffer.len` are production-dead (used only by tests after the `reserve`/`append` split); moved to `export_test.go`.
- Descriptor comments on `NewEphemeralOpener` and encoder-`decode` methods scrubbed of internal "edge #1/#2/#3" numbering.

## Stack

This is **2 of 3**. Splits [#531](https://github.com/databricks/zerobus-sdk/pull/531).
- 1/3 (parent): the ingestion core skeleton — #571.
- 3/3 (follow-up): pause & lifecycle robustness + sent-state ack + CI flake — #573.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test ./... -race -count=10` passes.
- Regression coverage: concurrent `Ingest` + `Flush` (proves `lastEnqueued` monotonic), bogus-high server ack fails the stream, missing-offset ack fails the stream, per-offset `OnAck` sequence + duplicate-ack-no-callback, callback-invoked `Close` does not deadlock, `WaitForOffset` unblocks on `Close`, GetUnacked with callback preserves payloads, `Config{}` does not deadlock, blocked-ingest observes its own ctx cancel, first-send-after-idle gets full lack-of-ack budget, invalid-params open not retried, self-classified non-retryable OAuth error not retried, mid-stream auth invalidation, callback panic containment, payload-too-large single/batch.

## What's not here (arrives in 3/3)

- Pause drain: on `CloseStreamSignal` the sender is parked and the receiver keeps draining acks; today this branch still aborts and reconnects on pause (though it now enforces `StreamPausedMaxWait`).
- Sent-state ack validation: an ack for a queued-or-mid-Send record is still accepted here (offset-in-range).
- `GetUnacked` still destructively closes an active stream.
- `Config`'s `RecoveryTimeout` / `CallbackTeardownTimeout` / `StreamPausedMaxWaitMode` / raw-size precheck / `stampOffset` encoder split.
- Healthy-run definition covering idle-but-stable connections.
- CI flake fix in `transport_test.go`.
