### PR TITLE
[PureGo] Harden stream lifecycle (4/4)

### DIFF
--- a/purego/internal/stream/benchmark_test.go
+++ b/purego/internal/stream/benchmark_test.go
@@ -1,0 +1,85 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkCoreStreamAckPath(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		batch bool
+	}{
+		{name: "single"},
+		{name: "batch", batch: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			rpc := newFakeRPC()
+			cfg := testConfig()
+			cfg.MaxInflight = 1024
+			cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
+			defer cs.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			ackErr := make(chan error, 1)
+			go func() {
+				for offset := range b.N {
+					select {
+					case <-rpc.sends:
+						rpc.ack(int64(offset))
+					case <-ctx.Done():
+						ackErr <- ctx.Err()
+						return
+					}
+				}
+				ackErr <- nil
+			}()
+
+			record := []byte(`{"value":1}`)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				var err error
+				if tc.batch {
+					_, err = cs.IngestBatch(ctx, [][]byte{record, record})
+				} else {
+					_, err = cs.Ingest(ctx, record)
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := cs.Flush(ctx); err != nil {
+				b.Fatal(err)
+			}
+			if err := <-ackErr; err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkBufferRequeue(b *testing.B) {
+	for _, depth := range []int{1_000, 100_000, 1_000_000} {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				b.StopTimer()
+				buf := newBuffer[encodedMsg](depth)
+				for i := range depth {
+					if err := buf.enqueue(context.Background(), int64(i), dummyMsg(int64(i))); err != nil {
+						b.Fatal(err)
+					}
+					if _, err := buf.next(context.Background()); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.StartTimer()
+				buf.requeue()
+			}
+		})
+	}
+}

--- a/purego/internal/stream/benchmark_test.go
+++ b/purego/internal/stream/benchmark_test.go
@@ -68,7 +68,7 @@ func BenchmarkBufferRequeue(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				b.StopTimer()
-				buf := newBuffer[encodedMsg](depth)
+				buf := newBuffer[encodedMsg](depth, 0)
 				for i := range depth {
 					if err := buf.enqueue(context.Background(), int64(i), dummyMsg(int64(i))); err != nil {
 						b.Fatal(err)

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -72,18 +72,19 @@ type buffer[Req any] struct {
 	maxBufferedBytes int64
 	usedItems        int
 	usedBytes        int64
+	accountingReset  bool
 	waiters          *list.List
 }
 
-func newBuffer[Req any](maxInflight int, byteLimit ...int64) *buffer[Req] {
+func newBuffer[Req any](maxInflight int, byteLimit int64) *buffer[Req] {
 	// Normalize a non-positive count cap, which would otherwise prevent every
 	// reservation from being granted.
 	if maxInflight <= 0 {
 		maxInflight = defaultMaxInflight
 	}
 	maxBufferedBytes := int64(math.MaxInt64)
-	if len(byteLimit) > 0 && byteLimit[0] > 0 {
-		maxBufferedBytes = byteLimit[0]
+	if byteLimit > 0 {
+		maxBufferedBytes = byteLimit
 	}
 	b := &buffer[Req]{
 		maxInflight:      maxInflight,
@@ -124,8 +125,12 @@ func (b *buffer[Req]) reserve(ctx context.Context, weight int64) error {
 	case <-ctx.Done():
 		b.mu.Lock()
 		if waiter.granted {
-			b.usedItems--
-			b.usedBytes -= weight
+			// drain may have closed the buffer and reset accounting after this
+			// reservation was granted but before cancellation won the select.
+			if !b.accountingReset {
+				b.usedItems--
+				b.usedBytes -= weight
+			}
 		} else if waiter.err == nil {
 			if waiter.elem != nil {
 				b.waiters.Remove(waiter.elem)
@@ -171,9 +176,11 @@ func (b *buffer[Req]) failWaitersLocked(err error) {
 
 func (b *buffer[Req]) release(weight int64) {
 	b.mu.Lock()
-	b.usedItems--
-	b.usedBytes -= weight
-	b.grantWaitersLocked()
+	if !b.accountingReset {
+		b.usedItems--
+		b.usedBytes -= weight
+		b.grantWaitersLocked()
+	}
 	b.mu.Unlock()
 }
 
@@ -181,8 +188,10 @@ func (b *buffer[Req]) release(weight int64) {
 func (b *buffer[Req]) append(offset int64, msg Req, weight int64) error {
 	b.mu.Lock()
 	if b.closed {
-		b.usedItems--
-		b.usedBytes -= weight
+		if !b.accountingReset {
+			b.usedItems--
+			b.usedBytes -= weight
+		}
 		b.mu.Unlock()
 		b.cond.Broadcast()
 		return errClosed
@@ -313,6 +322,7 @@ func (b *buffer[Req]) drain() []item[Req] {
 	b.queue = nil
 	b.flight = nil
 	b.closed = true
+	b.accountingReset = true
 	b.usedItems = 0
 	b.usedBytes = 0
 	b.failWaitersLocked(errClosed)

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -76,8 +76,8 @@ type buffer[Req any] struct {
 }
 
 func newBuffer[Req any](maxInflight int, byteLimit ...int64) *buffer[Req] {
-	// Normalize a non-positive cap, which would otherwise deadlock (0) or
-	// panic (<0) at the semaphore.
+	// Normalize a non-positive count cap, which would otherwise prevent every
+	// reservation from being granted.
 	if maxInflight <= 0 {
 		maxInflight = defaultMaxInflight
 	}
@@ -239,11 +239,10 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 }
 
 // discardThrough removes every in-flight item whose offset is <= offset (all
-// now acknowledged by the server) and releases one semaphore slot per removed
-// item so blocked enqueue callers can proceed. It is the sender/receiver's only
-// hook for ack-driven eviction, keeping the buffer's internals (flight, sem,
-// cond) private. Returns the contiguous discarded offset range without
-// allocating per-item callback metadata.
+// now acknowledged by the server), releases its count and byte capacity, and
+// grants queued admission waiters in FIFO order. It is the receiver's only hook
+// for ack-driven eviction. Returns the contiguous discarded offset range
+// without allocating per-item callback metadata.
 func (b *buffer[Req]) discardThrough(offset int64) discardResult {
 	b.mu.Lock()
 	var result discardResult

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -10,7 +10,10 @@
 package stream
 
 import (
+	"container/list"
 	"context"
+	"fmt"
+	"math"
 	"sync"
 )
 
@@ -25,12 +28,21 @@ const defaultMaxInflight = 1_000_000
 type item[Req any] struct {
 	offset  int64
 	payload Req
+	weight  int64
 }
 
 type discardResult struct {
 	first int64
 	last  int64
 	count int
+}
+
+type capacityWaiter struct {
+	weight  int64
+	ready   chan struct{}
+	granted bool
+	err     error
+	elem    *list.Element
 }
 
 // buffer is the bounded, offset-assigning queue between the caller's Ingest
@@ -46,72 +58,136 @@ type discardResult struct {
 //   - The supervisor calls requeue and drain, but only while the sender is
 //     stopped — so next never runs concurrently with requeue or drain.
 //
-// All state (queue, flight, sem, cond) is private; the sender and receiver
+// All state (queue, flight, capacity, cond) is private; the sender and receiver
 // interact only through these methods, never by touching the fields directly.
 //
-// The semaphore enforces the MaxInflight cap: enqueue blocks once the cap is
-// reached and unblocks as acks arrive and discardThrough releases permits.
+// Count and payload-byte limits apply to queued plus in-flight items.
 type buffer[Req any] struct {
-	mu       sync.Mutex
-	cond     *sync.Cond
-	queue    []item[Req] // pending: enqueued but not yet observed by the sender
-	flight   []item[Req] // in-flight: observed by the sender, waiting for ack
-	closed   bool
-	sem      chan struct{} // capacity = maxInflight; held while item is in queue or flight
-	doneOnce sync.Once
-	doneCh   chan struct{} // closed when the buffer is closed/drained; unblocks sem waiters
+	mu               sync.Mutex
+	cond             *sync.Cond
+	queue            []item[Req] // pending: enqueued but not yet observed by the sender
+	flight           []item[Req] // in-flight: observed by the sender, waiting for ack
+	closed           bool
+	maxInflight      int
+	maxBufferedBytes int64
+	usedItems        int
+	usedBytes        int64
+	waiters          *list.List
 }
 
-func newBuffer[Req any](maxInflight int) *buffer[Req] {
+func newBuffer[Req any](maxInflight int, byteLimit ...int64) *buffer[Req] {
 	// Normalize a non-positive cap, which would otherwise deadlock (0) or
 	// panic (<0) at the semaphore.
 	if maxInflight <= 0 {
 		maxInflight = defaultMaxInflight
 	}
-	// queue/flight grow on demand; don't preallocate to maxInflight, which with
-	// the default 1M cap would reserve tens of MB per stream before a single
-	// record is ingested. Only the semaphore is sized to the cap, since it is the
-	// backpressure gate and its capacity defines the bound.
+	maxBufferedBytes := int64(math.MaxInt64)
+	if len(byteLimit) > 0 && byteLimit[0] > 0 {
+		maxBufferedBytes = byteLimit[0]
+	}
 	b := &buffer[Req]{
-		sem:    make(chan struct{}, maxInflight),
-		doneCh: make(chan struct{}),
+		maxInflight:      maxInflight,
+		maxBufferedBytes: maxBufferedBytes,
+		waiters:          list.New(),
 	}
 	b.cond = sync.NewCond(&b.mu)
 	return b
 }
 
-func (b *buffer[Req]) closeDone() {
-	b.doneOnce.Do(func() { close(b.doneCh) })
-}
-
-// reserve acquires one backpressure slot.
-func (b *buffer[Req]) reserve(ctx context.Context) error {
+// reserve acquires one item slot and payload-byte weight.
+func (b *buffer[Req]) reserve(ctx context.Context, weight int64) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	select {
-	case b.sem <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-b.doneCh:
-		return errClosed
+	if weight < 0 || weight > b.maxBufferedBytes {
+		return fmt.Errorf("%w: buffered payload weight %d exceeds limit %d",
+			ErrPayloadTooLarge, weight, b.maxBufferedBytes)
 	}
-}
-
-func (b *buffer[Req]) release() {
-	<-b.sem
-}
-
-// append adds an item after reserve succeeds.
-func (b *buffer[Req]) append(offset int64, msg Req) error {
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
-		b.release()
 		return errClosed
 	}
-	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg})
+	if b.waiters.Len() == 0 && b.canReserveLocked(weight) {
+		b.usedItems++
+		b.usedBytes += weight
+		b.mu.Unlock()
+		return nil
+	}
+	waiter := &capacityWaiter{weight: weight, ready: make(chan struct{})}
+	waiter.elem = b.waiters.PushBack(waiter)
+	b.mu.Unlock()
+
+	select {
+	case <-waiter.ready:
+		return waiter.err
+	case <-ctx.Done():
+		b.mu.Lock()
+		if waiter.granted {
+			b.usedItems--
+			b.usedBytes -= weight
+		} else if waiter.err == nil {
+			if waiter.elem != nil {
+				b.waiters.Remove(waiter.elem)
+				waiter.elem = nil
+			}
+		}
+		b.grantWaitersLocked()
+		b.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (b *buffer[Req]) canReserveLocked(weight int64) bool {
+	return b.usedItems < b.maxInflight &&
+		weight <= b.maxBufferedBytes-b.usedBytes
+}
+
+func (b *buffer[Req]) grantWaitersLocked() {
+	for !b.closed && b.waiters.Len() > 0 {
+		front := b.waiters.Front()
+		waiter := front.Value.(*capacityWaiter)
+		if !b.canReserveLocked(waiter.weight) {
+			return
+		}
+		b.waiters.Remove(front)
+		waiter.elem = nil
+		b.usedItems++
+		b.usedBytes += waiter.weight
+		waiter.granted = true
+		close(waiter.ready)
+	}
+}
+
+func (b *buffer[Req]) failWaitersLocked(err error) {
+	for element := b.waiters.Front(); element != nil; element = element.Next() {
+		waiter := element.Value.(*capacityWaiter)
+		waiter.err = err
+		waiter.elem = nil
+		close(waiter.ready)
+	}
+	b.waiters.Init()
+}
+
+func (b *buffer[Req]) release(weight int64) {
+	b.mu.Lock()
+	b.usedItems--
+	b.usedBytes -= weight
+	b.grantWaitersLocked()
+	b.mu.Unlock()
+}
+
+// append adds an item after reserve succeeds.
+func (b *buffer[Req]) append(offset int64, msg Req, weight int64) error {
+	b.mu.Lock()
+	if b.closed {
+		b.usedItems--
+		b.usedBytes -= weight
+		b.mu.Unlock()
+		b.cond.Broadcast()
+		return errClosed
+	}
+	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg, weight: weight})
 	b.mu.Unlock()
 	b.cond.Signal()
 	return nil
@@ -171,22 +247,21 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 func (b *buffer[Req]) discardThrough(offset int64) discardResult {
 	b.mu.Lock()
 	var result discardResult
+	var releasedBytes int64
 	for len(b.flight) > 0 && b.flight[0].offset <= offset {
 		if result.count == 0 {
 			result.first = b.flight[0].offset
 		}
 		result.last = b.flight[0].offset
 		result.count++
+		releasedBytes += b.flight[0].weight
 		b.flight[0] = item[Req]{} // release the acked payload for GC
 		b.flight = b.flight[1:]
 	}
+	b.usedItems -= result.count
+	b.usedBytes -= releasedBytes
+	b.grantWaitersLocked()
 	b.mu.Unlock()
-	for range result.count {
-		<-b.sem
-	}
-	if result.count > 0 {
-		b.cond.Broadcast()
-	}
 	return result
 }
 
@@ -239,9 +314,11 @@ func (b *buffer[Req]) drain() []item[Req] {
 	b.queue = nil
 	b.flight = nil
 	b.closed = true
+	b.usedItems = 0
+	b.usedBytes = 0
+	b.failWaitersLocked(errClosed)
 	b.mu.Unlock()
 	b.cond.Broadcast()
-	b.closeDone()
 	return all
 }
 
@@ -250,9 +327,9 @@ func (b *buffer[Req]) drain() []item[Req] {
 func (b *buffer[Req]) close() {
 	b.mu.Lock()
 	b.closed = true
+	b.failWaitersLocked(errClosed)
 	b.mu.Unlock()
 	b.cond.Broadcast()
-	b.closeDone()
 }
 
 // inFlight returns the number of items observed by the sender but not yet

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -16,7 +16,7 @@ func dummyMsg(offset int64) encodedMsg {
 }
 
 func TestBufferEnqueueNext(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 
 	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
 		t.Fatalf("enqueue: %v", err)
@@ -32,7 +32,7 @@ func TestBufferEnqueueNext(t *testing.T) {
 }
 
 func TestBufferFIFOOrder(t *testing.T) {
-	b := newBuffer[encodedMsg](8)
+	b := newBuffer[encodedMsg](8, 0)
 	for i := int64(1); i <= 5; i++ {
 		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
 			t.Fatalf("enqueue %d: %v", i, err)
@@ -51,7 +51,7 @@ func TestBufferFIFOOrder(t *testing.T) {
 
 func TestBufferBackpressure(t *testing.T) {
 	const cap = 2
-	b := newBuffer[encodedMsg](cap)
+	b := newBuffer[encodedMsg](cap, 0)
 
 	// Fill the buffer to capacity.
 	for i := int64(1); i <= cap; i++ {
@@ -210,6 +210,62 @@ func TestBufferRecoveryDoesNotDoubleChargeBytes(t *testing.T) {
 	}
 }
 
+func TestBufferDrainMakesReservationRollbackIdempotent(t *testing.T) {
+	t.Run("release", func(t *testing.T) {
+		b := newBuffer[encodedMsg](4, 10)
+		if err := b.reserve(context.Background(), 7); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		b.drain()
+		b.release(7)
+		if items, bytes := b.usage(); items != 0 || bytes != 0 {
+			t.Fatalf("usage after drain and release = (%d, %d), want (0, 0)", items, bytes)
+		}
+	})
+
+	t.Run("append", func(t *testing.T) {
+		b := newBuffer[encodedMsg](4, 10)
+		if err := b.reserve(context.Background(), 7); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		b.drain()
+		if err := b.append(1, dummyMsg(1), 7); err != errClosed {
+			t.Fatalf("append after drain = %v, want errClosed", err)
+		}
+		if items, bytes := b.usage(); items != 0 || bytes != 0 {
+			t.Fatalf("usage after drain and append = (%d, %d), want (0, 0)", items, bytes)
+		}
+	})
+}
+
+func TestBufferClosePreservesReservationRollback(t *testing.T) {
+	t.Run("release", func(t *testing.T) {
+		b := newBuffer[encodedMsg](4, 10)
+		if err := b.reserve(context.Background(), 7); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		b.close()
+		b.release(7)
+		if items, bytes := b.usage(); items != 0 || bytes != 0 {
+			t.Fatalf("usage after close and release = (%d, %d), want (0, 0)", items, bytes)
+		}
+	})
+
+	t.Run("append", func(t *testing.T) {
+		b := newBuffer[encodedMsg](4, 10)
+		if err := b.reserve(context.Background(), 7); err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		b.close()
+		if err := b.append(1, dummyMsg(1), 7); err != errClosed {
+			t.Fatalf("append after close = %v, want errClosed", err)
+		}
+		if items, bytes := b.usage(); items != 0 || bytes != 0 {
+			t.Fatalf("usage after close and append = (%d, %d), want (0, 0)", items, bytes)
+		}
+	})
+}
+
 func TestBufferByteWaiterUnblocksOnClose(t *testing.T) {
 	b := newBuffer[encodedMsg](4, 1)
 	if err := b.reserve(context.Background(), 1); err != nil {
@@ -220,6 +276,7 @@ func TestBufferByteWaiterUnblocksOnClose(t *testing.T) {
 	}
 	errCh := make(chan error, 1)
 	go func() { errCh <- b.reserve(context.Background(), 1) }()
+	waitCondition(t, func() bool { return b.waiterCount() == 1 }, time.Second)
 	b.close()
 	select {
 	case err := <-errCh:
@@ -232,7 +289,7 @@ func TestBufferByteWaiterUnblocksOnClose(t *testing.T) {
 }
 
 func TestBufferContextCancelUnblocksEnqueue(t *testing.T) {
-	b := newBuffer[encodedMsg](1)
+	b := newBuffer[encodedMsg](1, 0)
 	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
@@ -257,7 +314,7 @@ func TestBufferContextCancelUnblocksEnqueue(t *testing.T) {
 }
 
 func TestBufferRequeueResendsInOrder(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 	for i := int64(1); i <= 3; i++ {
 		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
 			t.Fatalf("enqueue %d: %v", i, err)
@@ -286,7 +343,7 @@ func TestBufferRequeueResendsInOrder(t *testing.T) {
 }
 
 func TestBufferDrainReturnsAll(t *testing.T) {
-	b := newBuffer[encodedMsg](8)
+	b := newBuffer[encodedMsg](8, 0)
 	for i := int64(1); i <= 4; i++ {
 		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
 			t.Fatalf("enqueue: %v", err)
@@ -312,7 +369,7 @@ func TestBufferDrainReturnsAll(t *testing.T) {
 }
 
 func TestBufferEnqueueAfterCloseErrors(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 	b.close()
 	err := b.enqueue(context.Background(), 1, dummyMsg(1))
 	if err != errClosed {
@@ -321,7 +378,7 @@ func TestBufferEnqueueAfterCloseErrors(t *testing.T) {
 }
 
 func TestBufferNextAfterCloseAndDrainErrors(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 	b.drain()
 	_, err := b.next(context.Background())
 	if err != errClosed {
@@ -331,7 +388,7 @@ func TestBufferNextAfterCloseAndDrainErrors(t *testing.T) {
 
 func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
 	const n = 100
-	b := newBuffer[encodedMsg](16)
+	b := newBuffer[encodedMsg](16, 0)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -362,7 +419,7 @@ func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
 // The AfterFunc broadcast has to be ordered under b.mu against cond.Wait, or
 // the wake-up can be lost and next sleeps forever on a cancelled ctx.
 func TestBufferNextContextCancelUnblocks(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -387,7 +444,7 @@ func TestBufferNextContextCancelUnblocks(t *testing.T) {
 // next must return immediately on an already-cancelled ctx and leave a queued
 // item untouched, so a stopping sender never drains one more record.
 func TestBufferNextAlreadyCancelledCtx(t *testing.T) {
-	b := newBuffer[encodedMsg](4)
+	b := newBuffer[encodedMsg](4, 0)
 	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
@@ -405,7 +462,7 @@ func TestBufferNextAlreadyCancelledCtx(t *testing.T) {
 // or panicking (<0), so the primitive stays live on a bad value.
 func TestNewBufferNormalizesNonPositiveCap(t *testing.T) {
 	for _, cap := range []int{0, -1} {
-		b := newBuffer[encodedMsg](cap)
+		b := newBuffer[encodedMsg](cap, 0)
 		if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
 			t.Fatalf("cap %d: enqueue should not block/fail, got %v", cap, err)
 		}

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -10,7 +10,8 @@ import (
 
 // dummyMsg returns a non-nil encodedMsg for use in buffer tests.
 func dummyMsg(offset int64) encodedMsg {
-	msg, _ := protoEncoder{}.encode(offset, []byte("x"))
+	msg, _ := protoEncoder{}.encode([]byte("x"))
+	protoEncoder{}.stampOffset(msg, offset)
 	return msg
 }
 
@@ -85,6 +86,148 @@ func TestBufferBackpressure(t *testing.T) {
 	}
 	if !enqueued.Load() {
 		t.Fatal("enqueue did not unblock after discard")
+	}
+}
+
+func TestBufferByteBackpressureAndRelease(t *testing.T) {
+	b := newBuffer[encodedMsg](4, 3)
+	if err := b.reserve(context.Background(), 3); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := b.append(1, dummyMsg(1), 3); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		if err := b.reserve(context.Background(), 1); err != nil {
+			done <- err
+			return
+		}
+		done <- b.append(2, dummyMsg(2), 1)
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("byte-limited append completed early: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	b.discardThrough(it.offset)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("blocked append: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("byte-limited append did not unblock")
+	}
+	if items, bytes := b.usage(); items != 1 || bytes != 1 {
+		t.Fatalf("usage = (%d, %d), want (1, 1)", items, bytes)
+	}
+}
+
+func TestBufferCapacityWaitersAreFIFO(t *testing.T) {
+	b := newBuffer[encodedMsg](3, 3)
+	if err := b.reserve(context.Background(), 3); err != nil {
+		t.Fatalf("initial reserve: %v", err)
+	}
+	if err := b.append(0, dummyMsg(0), 3); err != nil {
+		t.Fatalf("initial append: %v", err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		if err := b.reserve(context.Background(), 3); err != nil {
+			firstDone <- err
+			return
+		}
+		firstDone <- b.append(1, dummyMsg(1), 3)
+	}()
+	waitCondition(t, func() bool { return b.waiterCount() == 1 }, time.Second)
+
+	secondDone := make(chan error, 1)
+	go func() {
+		if err := b.reserve(context.Background(), 1); err != nil {
+			secondDone <- err
+			return
+		}
+		secondDone <- b.append(2, dummyMsg(2), 1)
+	}()
+	waitCondition(t, func() bool { return b.waiterCount() == 2 }, time.Second)
+
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next initial: %v", err)
+	}
+	b.discardThrough(it.offset)
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first waiter: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first waiter did not unblock")
+	}
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second waiter bypassed FIFO order: %v", err)
+	default:
+	}
+
+	it, err = b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next first waiter: %v", err)
+	}
+	b.discardThrough(it.offset)
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("second waiter: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second waiter did not unblock")
+	}
+}
+
+func TestBufferRecoveryDoesNotDoubleChargeBytes(t *testing.T) {
+	b := newBuffer[encodedMsg](4, 10)
+	if err := b.reserve(context.Background(), 7); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := b.append(1, dummyMsg(1), 7); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := b.next(context.Background()); err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	b.requeue()
+	if items, bytes := b.usage(); items != 1 || bytes != 7 {
+		t.Fatalf("usage after requeue = (%d, %d), want (1, 7)", items, bytes)
+	}
+}
+
+func TestBufferByteWaiterUnblocksOnClose(t *testing.T) {
+	b := newBuffer[encodedMsg](4, 1)
+	if err := b.reserve(context.Background(), 1); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := b.append(1, dummyMsg(1), 1); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- b.reserve(context.Background(), 1) }()
+	b.close()
+	select {
+	case err := <-errCh:
+		if err != errClosed {
+			t.Fatalf("reserve after close = %v, want errClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("byte waiter did not unblock on close")
 	}
 }
 

--- a/purego/internal/stream/callback.go
+++ b/purego/internal/stream/callback.go
@@ -68,7 +68,10 @@ func (d *callbackDispatcher) run() {
 	}
 }
 
-// invoke prevents callback panics from stopping the stream.
+// invoke prevents callback panics from stopping later callback delivery.
+// Recovered values are intentionally discarded until the public SDK exposes a
+// logger or callback-error sink; this internal package must not write to the
+// process-global standard logger.
 func (d *callbackDispatcher) invoke(event callbackEvent) {
 	defer func() { _ = recover() }()
 	if event.err == nil {

--- a/purego/internal/stream/callback.go
+++ b/purego/internal/stream/callback.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"math"
 	"sync"
 	"time"
 )
@@ -89,7 +90,10 @@ func (d *callbackDispatcher) enqueueAcks(first, last int64) {
 		d.mu.Unlock()
 		return
 	}
-	if n := len(d.queue); n > 0 && d.queue[n-1].err == nil && d.queue[n-1].last+1 == first {
+	if n := len(d.queue); n > 0 &&
+		d.queue[n-1].err == nil &&
+		d.queue[n-1].last < math.MaxInt64 &&
+		d.queue[n-1].last+1 == first {
 		d.queue[n-1].last = last
 	} else {
 		d.queue = append(d.queue, callbackRange{first: first, last: last})

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -29,7 +29,8 @@ const (
 	DefaultLackOfAckTimeout   = 60 * time.Second
 	// DefaultMaxPayloadBytes leaves room below the 10 MiB service limit.
 	DefaultMaxPayloadBytes = 10*1024*1024 - 64*1024
-	// DefaultMaxBufferedPayloadBytes bounds raw queued and in-flight payload bytes.
+	// DefaultMaxBufferedPayloadBytes bounds estimated encoded memory retained by
+	// queued and in-flight payloads.
 	DefaultMaxBufferedPayloadBytes = 64 * 1024 * 1024
 	// DefaultMaxBatchRecords bounds per-batch allocation.
 	DefaultMaxBatchRecords = 100_000
@@ -60,8 +61,9 @@ func (r RecoverySetting) enabled() bool { return r == RecoveryEnabled }
 type Config struct {
 	// MaxInflight is the maximum number of unacknowledged buffer entries, not
 	// records: one Ingest or IngestBatch call occupies one entry regardless of
-	// how many records it carries. Total buffered bytes are bounded only by
-	// MaxInflight * MaxPayloadBytes.
+	// how many records it carries. MaxBufferedPayloadBytes bounds the same set
+	// by estimated retained size; whichever limit binds first applies
+	// backpressure.
 	MaxInflight int
 	// Recovery controls whether stream reconnection is attempted on failure. The
 	// zero value (RecoveryEnabled) recovers; set RecoveryDisabled to opt out.
@@ -89,7 +91,8 @@ type Config struct {
 	// MaxBatchRecords caps the number of records in one batch independently of
 	// byte size. Non-positive values use DefaultMaxBatchRecords.
 	MaxBatchRecords int
-	// MaxBufferedPayloadBytes caps raw payload bytes retained by the stream.
+	// MaxBufferedPayloadBytes caps estimated encoded memory retained by queued
+	// and in-flight payloads, including per-record and request-object overhead.
 	MaxBufferedPayloadBytes int64
 	// CallbackTeardownTimeout bounds asynchronous callback worker teardown.
 	CallbackTeardownTimeout time.Duration
@@ -258,8 +261,8 @@ func (w *watermark) waitFor(ctx context.Context, target int64) error {
 //	supervisor — create → run → recover loop; wires sender+receiver together.
 //	dispatcher — delivers AckCallback events off the receiver's path.
 //
-// The receiver also runs one short-lived goroutine per Recv so ack silence stays
-// observable while a Recv is blocked.
+// The receiver owns a persistent pump that keeps one Recv outstanding so ack
+// silence stays observable while a Recv is blocked.
 //
 // Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
 // GetUnacked, GetUnackedBatches, and Close.
@@ -387,12 +390,14 @@ func waitUntil(ctx context.Context, deadline time.Time) bool {
 
 // Ingest encodes record and enqueues it in the buffer, blocking if the buffer
 // is at capacity (backpressure). Returns the logical offset assigned to this
-// record; pass it to WaitForOffset to confirm durability.
+// record. For throughput, queue records in a loop and call Flush once; waiting
+// for every offset serializes ingestion on server round trips.
 func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int64, error) {
 	if err := cs.checkRawSize(len(record)); err != nil {
 		return 0, err
 	}
-	return cs.enqueueEncoded(ctx, int64(len(record)), func() (Req, error) {
+	weight := cs.enc.retainedSize(len(record), 1)
+	return cs.enqueueEncoded(ctx, weight, func() (Req, error) {
 		return cs.enc.encode(record)
 	})
 }
@@ -423,7 +428,8 @@ func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]by
 	if err := cs.checkRawSize(total); err != nil {
 		return 0, err
 	}
-	return cs.enqueueEncoded(ctx, int64(total), func() (Req, error) {
+	weight := cs.enc.retainedSize(total, len(records))
+	return cs.enqueueEncoded(ctx, weight, func() (Req, error) {
 		return cs.enc.encodeBatch(records)
 	})
 }
@@ -698,6 +704,7 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, rese
 
 	senderExitCh := make(chan error, 1)
 	receiverExitCh := make(chan error, 1)
+	receiverDone := make(chan struct{})
 	pauseCh := make(chan pauseSignal, 1)
 	flightSignal := make(chan struct{}, 1)
 	// cap 2: at most a {start, completed} pair for the one record in flight.
@@ -705,11 +712,14 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, rese
 	sendConsumed := make(chan struct{}, 1)
 
 	go cs.sender(senderCtx, stream, senderExitCh, flightSignal, sendEvents, sendConsumed)
-	go cs.receiver(stream, receiverExitCh, pauseCh, flightSignal, sendEvents, sendConsumed)
+	go func() {
+		defer close(receiverDone)
+		cs.receiver(stream, receiverExitCh, pauseCh, flightSignal, sendEvents, sendConsumed)
+	}()
 
 	var senderParked bool
 	var senderExited bool
-	var receiverExited bool
+	var receiverReported bool
 	var pauseObserved bool
 	recordPause := func() {
 		if !pauseObserved && cs.onPauseObserved != nil {
@@ -741,9 +751,20 @@ waitLoop:
 				continue
 			}
 			cause = senderErr
+			// A receiver-triggered teardown publishes its authoritative cause
+			// before closing the stream. If that close unblocked Send, the
+			// receiver cause is already available and must win arbitration.
+			select {
+			case receiverErr := <-receiverExitCh:
+				receiverReported = true
+				if receiverErr != nil && !errors.Is(receiverErr, context.Canceled) {
+					cause = receiverErr
+				}
+			default:
+			}
 			break waitLoop
 		case receiverErr := <-receiverExitCh:
-			receiverExited = true
+			receiverReported = true
 			drainPause()
 			// The receiver surfaces a pause as its own exit error, so whatever it
 			// reports is authoritative: a real failure still consumes the recovery
@@ -763,16 +784,24 @@ waitLoop:
 	switch {
 	case ctx.Err() != nil:
 		cs.gracefulTeardown(
-			stream, senderExited, receiverExited, senderExitCh, receiverExitCh,
+			stream, senderExited, senderExitCh, receiverDone,
 		)
+		// gracefulTeardown may have unblocked a Recv that was already
+		// returning a definitive rejection as Close cancelled the lifecycle.
+		// Preserve that result so the supervisor still invalidates credentials.
+		select {
+		case receiverErr := <-receiverExitCh:
+			if transport.IsAuthRejection(receiverErr) {
+				cause = receiverErr
+			}
+		default:
+		}
 	case errors.As(cause, &ps):
 		stream.Close()
 		if !senderExited {
 			<-senderExitCh
 		}
-		if !receiverExited {
-			<-receiverExitCh
-		}
+		<-receiverDone
 	default:
 		// gRPC reports a server-side abort to Send as an opaque io.EOF and carries
 		// the real status (auth, schema, protocol) on Recv, so an EOF cause is not
@@ -781,11 +810,11 @@ waitLoop:
 		// leaving recovery to retry a permanent rejection and skip credential
 		// invalidation. A failed send does not end the receiver, so it is still
 		// reading and the server's status is what unblocks it.
-		if !receiverExited && errors.Is(cause, io.EOF) {
+		if !receiverReported && errors.Is(cause, io.EOF) {
 			timer := time.NewTimer(cs.cfg.DrainTimeout)
 			select {
 			case receiverErr := <-receiverExitCh:
-				receiverExited = true
+				receiverReported = true
 				if receiverErr != nil && !errors.Is(receiverErr, context.Canceled) {
 					cause = receiverErr
 				}
@@ -799,9 +828,7 @@ waitLoop:
 		if !senderExited {
 			<-senderExitCh
 		}
-		if !receiverExited {
-			<-receiverExitCh
-		}
+		<-receiverDone
 	}
 	resetRecoveryBudget = cs.wm.current() > startAck ||
 		time.Since(openedAt) >= cs.cfg.RecoveryResetAfter
@@ -812,8 +839,9 @@ waitLoop:
 // DrainTimeout prevents shutdown from hanging.
 func (cs *CoreStream[Req, Resp]) gracefulTeardown(
 	stream wireStream[Req, Resp],
-	senderExited, receiverExited bool,
-	senderExitCh, receiverExitCh <-chan error,
+	senderExited bool,
+	senderExitCh <-chan error,
+	receiverDone <-chan struct{},
 ) {
 	// One shared deadline bounds the whole graceful shutdown, so the sender-exit
 	// wait and the receiver-drain wait can't each consume a full DrainTimeout.
@@ -827,30 +855,30 @@ func (cs *CoreStream[Req, Resp]) gracefulTeardown(
 			// Abort a blocked Send so Close can finish.
 			stream.Close()
 			<-senderExitCh
-			if !receiverExited {
-				<-receiverExitCh
-			}
+			<-receiverDone
 			return
 		}
 	}
-	if receiverExited {
+	select {
+	case <-receiverDone:
 		stream.Close()
 		return
+	default:
 	}
 	if err := stream.CloseSend(); err != nil {
 		// Send side already broken; fall back to a hard abort.
 		stream.Close()
-		<-receiverExitCh
+		<-receiverDone
 		return
 	}
 	select {
-	case <-receiverExitCh:
+	case <-receiverDone:
 		// Receiver drained to EOF; release resources (Close is idempotent).
 		stream.Close()
 	case <-timer.C:
 		// Drain budget exceeded; force the receiver out and reap it.
 		stream.Close()
-		<-receiverExitCh
+		<-receiverDone
 	}
 }
 
@@ -1108,14 +1136,22 @@ func (cs *CoreStream[Req, Resp]) receiver(
 		return handleSendEvent(<-sendEvents)
 	}
 	handleTerminal := func(err error) {
+		var ps pauseSignal
+		if err != nil && !errors.As(err, &ps) {
+			// Real receiver failures are authoritative. Publish before any
+			// operation that can close the transport and unblock Send.
+			errCh <- err
+			stopRecv()
+			return
+		}
 		if pendingErr := resolvePendingOnExit(); pendingErr != nil {
-			var ps pauseSignal
 			if err == nil || errors.As(err, &ps) {
 				err = pendingErr
 			}
 		}
-		stopRecv()
+		// Publish the resolved clean/pause outcome before final pump teardown.
 		errCh <- err
+		stopRecv()
 	}
 
 	for {
@@ -1175,8 +1211,7 @@ func (cs *CoreStream[Req, Resp]) receiver(
 			// A response the ack model can't interpret (unrecognized type, or an
 			// ack missing/with a negative offset) is a protocol violation. Tear the
 			// stream down rather than silently dropping it; the supervisor decides
-			// whether to reconnect. The current Recv already delivered and no new
-			// one is outstanding, so there's nothing to reap.
+			// whether to reconnect. handleTerminal reaps the pump's next Recv.
 			handleTerminal(fmt.Errorf("stream: unusable server response (kind %d)", kind))
 			return
 		}

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,8 @@ const (
 	DefaultLackOfAckTimeout   = 60 * time.Second
 	// DefaultMaxPayloadBytes leaves room below the 10 MiB service limit.
 	DefaultMaxPayloadBytes = 10*1024*1024 - 64*1024
+	// DefaultMaxBufferedPayloadBytes bounds raw queued and in-flight payload bytes.
+	DefaultMaxBufferedPayloadBytes = 64 * 1024 * 1024
 	// DefaultMaxBatchRecords bounds per-batch allocation.
 	DefaultMaxBatchRecords = 100_000
 	// DefaultCallbackTeardownTimeout bounds callback shutdown.
@@ -86,6 +89,8 @@ type Config struct {
 	// MaxBatchRecords caps the number of records in one batch independently of
 	// byte size. Non-positive values use DefaultMaxBatchRecords.
 	MaxBatchRecords int
+	// MaxBufferedPayloadBytes caps raw payload bytes retained by the stream.
+	MaxBufferedPayloadBytes int64
 	// CallbackTeardownTimeout bounds asynchronous callback worker teardown.
 	CallbackTeardownTimeout time.Duration
 	// StreamPausedMaxWait caps how long the client honors a server-requested
@@ -110,6 +115,7 @@ func DefaultConfig() Config {
 		DrainTimeout:            DefaultDrainTimeout,
 		MaxPayloadBytes:         DefaultMaxPayloadBytes,
 		MaxBatchRecords:         DefaultMaxBatchRecords,
+		MaxBufferedPayloadBytes: DefaultMaxBufferedPayloadBytes,
 		CallbackTeardownTimeout: DefaultCallbackTeardownTimeout,
 	}
 }
@@ -145,6 +151,9 @@ func sanitizeConfig(c Config) Config {
 	}
 	if c.MaxBatchRecords <= 0 {
 		c.MaxBatchRecords = DefaultMaxBatchRecords
+	}
+	if c.MaxBufferedPayloadBytes <= 0 {
+		c.MaxBufferedPayloadBytes = DefaultMaxBufferedPayloadBytes
 	}
 	if c.CallbackTeardownTimeout <= 0 {
 		c.CallbackTeardownTimeout = DefaultCallbackTeardownTimeout
@@ -255,14 +264,16 @@ func (w *watermark) waitFor(ctx context.Context, target int64) error {
 // Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
 // GetUnacked, GetUnackedBatches, and Close.
 type CoreStream[Req, Resp any] struct {
-	params     StreamParams
-	cfg        Config
-	opener     opener[Req, Resp]
-	enc        encoder[Req]
-	ackMdl     ackModel[Resp]
-	buf        *buffer[Req]
-	wm         *watermark
-	dispatcher *callbackDispatcher
+	params          StreamParams
+	cfg             Config
+	opener          opener[Req, Resp]
+	enc             encoder[Req]
+	ackMdl          ackModel[Resp]
+	buf             *buffer[Req]
+	wm              *watermark
+	dispatcher      *callbackDispatcher
+	pauseWait       func(context.Context, time.Time) bool
+	onPauseObserved func()
 
 	clientID string
 	serverID atomic.Pointer[string]
@@ -274,6 +285,8 @@ type CoreStream[Req, Resp any] struct {
 	// closing prevents new items from being admitted once Close snapshots its
 	// durability target. It is protected by offsetMu.
 	closing bool
+	// offsetExhausted is set after assigning math.MaxInt64.
+	offsetExhausted atomic.Bool
 	// lastEnqueued is the highest queued offset.
 	lastEnqueued atomic.Int64
 
@@ -316,6 +329,7 @@ func NewCoreStream[Req, Resp any](
 		pauseCap := *cfg.StreamPausedMaxWait
 		cfg.StreamPausedMaxWait = &pauseCap
 	}
+	params.TableName = strings.TrimSpace(params.TableName)
 	if len(params.DescriptorProto) > 0 {
 		params.DescriptorProto = bytes.Clone(params.DescriptorProto)
 	}
@@ -326,10 +340,11 @@ func NewCoreStream[Req, Resp any](
 		opener:           opener,
 		enc:              enc,
 		ackMdl:           ackMdl,
-		buf:              newBuffer[Req](cfg.MaxInflight),
+		buf:              newBuffer[Req](cfg.MaxInflight, cfg.MaxBufferedPayloadBytes),
 		wm:               newWatermark(),
 		dispatcher:       newCallbackDispatcher(callback),
 		clientID:         newClientStreamID(),
+		pauseWait:        waitUntil,
 		done:             make(chan struct{}),
 		cancelSupervisor: cancel,
 	}
@@ -356,6 +371,20 @@ func (cs *CoreStream[Req, Resp]) setServerID(id string) {
 	cs.serverID.Store(&id)
 }
 
+func waitUntil(ctx context.Context, deadline time.Time) bool {
+	if wait := time.Until(deadline); wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	return true
+}
+
 // Ingest encodes record and enqueues it in the buffer, blocking if the buffer
 // is at capacity (backpressure). Returns the logical offset assigned to this
 // record; pass it to WaitForOffset to confirm durability.
@@ -363,8 +392,8 @@ func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int
 	if err := cs.checkRawSize(len(record)); err != nil {
 		return 0, err
 	}
-	return cs.enqueueEncoded(ctx, func() (Req, error) {
-		return cs.enc.encode(math.MaxInt64, record)
+	return cs.enqueueEncoded(ctx, int64(len(record)), func() (Req, error) {
+		return cs.enc.encode(record)
 	})
 }
 
@@ -394,8 +423,8 @@ func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]by
 	if err := cs.checkRawSize(total); err != nil {
 		return 0, err
 	}
-	return cs.enqueueEncoded(ctx, func() (Req, error) {
-		return cs.enc.encodeBatch(math.MaxInt64, records)
+	return cs.enqueueEncoded(ctx, int64(total), func() (Req, error) {
+		return cs.enc.encodeBatch(records)
 	})
 }
 
@@ -408,7 +437,11 @@ func (cs *CoreStream[Req, Resp]) checkRawSize(size int) error {
 }
 
 // enqueueEncoded reserves capacity and encodes before assigning an offset.
-func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn func() (Req, error)) (int64, error) {
+func (cs *CoreStream[Req, Resp]) enqueueEncoded(
+	ctx context.Context,
+	weight int64,
+	encodeFn func() (Req, error),
+) (int64, error) {
 	if cs.isClosed() {
 		if err := cs.terminalErr(); err != nil {
 			return 0, err
@@ -421,19 +454,20 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn fu
 	if closing {
 		return 0, errClosed
 	}
-	if err := cs.buf.reserve(ctx); err != nil {
+	if cs.offsetExhausted.Load() {
+		return 0, ErrOffsetExhausted
+	}
+	if err := cs.buf.reserve(ctx, weight); err != nil {
 		return 0, err
 	}
 
-	// Encode with the largest possible wire offset so the size check remains
-	// valid after the sender stamps any connection-local physical offset.
 	msg, err := encodeFn()
 	if err != nil {
-		cs.buf.release()
+		cs.buf.release(weight)
 		return 0, err
 	}
-	if size := cs.enc.wireSize(msg); size > cs.cfg.MaxPayloadBytes {
-		cs.buf.release()
+	if size := cs.enc.maxWireSize(msg); size > cs.cfg.MaxPayloadBytes {
+		cs.buf.release(weight)
 		return 0, fmt.Errorf("%w: encoded size %d exceeds MaxPayloadBytes=%d",
 			ErrPayloadTooLarge, size, cs.cfg.MaxPayloadBytes)
 	}
@@ -441,16 +475,25 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(ctx context.Context, encodeFn fu
 	cs.offsetMu.Lock()
 	if cs.closing {
 		cs.offsetMu.Unlock()
-		cs.buf.release()
+		cs.buf.release(weight)
 		return 0, errClosed
+	}
+	if cs.offsetExhausted.Load() {
+		cs.offsetMu.Unlock()
+		cs.buf.release(weight)
+		return 0, ErrOffsetExhausted
 	}
 	offset := cs.nextOffset
 	cs.enc.stampOffset(msg, offset)
-	if err := cs.buf.append(offset, msg); err != nil {
+	if err := cs.buf.append(offset, msg, weight); err != nil {
 		cs.offsetMu.Unlock()
 		return 0, err
 	}
-	cs.nextOffset++
+	if offset == math.MaxInt64 {
+		cs.offsetExhausted.Store(true)
+	} else {
+		cs.nextOffset++
+	}
 	cs.lastEnqueued.Store(offset)
 	cs.offsetMu.Unlock()
 	return offset, nil
@@ -618,7 +661,6 @@ type sendEvent struct {
 	physicalOffset int64
 	completed      bool
 	err            error
-	consumed       chan struct{}
 }
 
 // runOnce operates one transport stream until a worker exits.
@@ -660,31 +702,32 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, rese
 	flightSignal := make(chan struct{}, 1)
 	// cap 2: at most a {start, completed} pair for the one record in flight.
 	sendEvents := make(chan sendEvent, 2)
+	sendConsumed := make(chan struct{}, 1)
 
-	go cs.sender(senderCtx, stream, senderExitCh, flightSignal, sendEvents)
-	go cs.receiver(stream, receiverExitCh, pauseCh, flightSignal, sendEvents)
+	go cs.sender(senderCtx, stream, senderExitCh, flightSignal, sendEvents, sendConsumed)
+	go cs.receiver(stream, receiverExitCh, pauseCh, flightSignal, sendEvents, sendConsumed)
 
 	var senderParked bool
 	var senderExited bool
 	var receiverExited bool
-	var observedPause *pauseSignal
-	recordPause := func(ps pauseSignal) {
-		if observedPause == nil {
-			pauseCopy := ps
-			observedPause = &pauseCopy
+	var pauseObserved bool
+	recordPause := func() {
+		if !pauseObserved && cs.onPauseObserved != nil {
+			cs.onPauseObserved()
 		}
+		pauseObserved = true
 		if !senderParked {
 			cancelSender()
 			senderParked = true
 		}
 	}
 	drainPause := func() {
-		if observedPause != nil {
+		if pauseObserved {
 			return
 		}
 		select {
-		case ps := <-pauseCh:
-			recordPause(ps)
+		case <-pauseCh:
+			recordPause()
 		default:
 		}
 	}
@@ -694,25 +737,22 @@ waitLoop:
 		case senderErr := <-senderExitCh:
 			senderExited = true
 			drainPause()
-			if !senderParked {
-				cause = senderErr
-				break waitLoop
+			if senderParked {
+				continue
 			}
+			cause = senderErr
+			break waitLoop
 		case receiverErr := <-receiverExitCh:
 			receiverExited = true
 			drainPause()
-			// Whatever the receiver reported wins, so a real failure still
-			// consumes the recovery budget and reaches credential invalidation.
-			// An earlier pause only stands in for a clean exit, which is how a
-			// server EOF after a pause signal surfaces.
-			if receiverErr != nil || observedPause == nil {
-				cause = receiverErr
-			} else {
-				cause = *observedPause
-			}
+			// The receiver surfaces a pause as its own exit error, so whatever it
+			// reports is authoritative: a real failure still consumes the recovery
+			// budget and reaches credential invalidation rather than being masked
+			// by an earlier pause.
+			cause = receiverErr
 			break waitLoop
-		case ps := <-pauseCh:
-			recordPause(ps)
+		case <-pauseCh:
+			recordPause()
 		case <-ctx.Done():
 			break waitLoop
 		}
@@ -821,6 +861,7 @@ func (cs *CoreStream[Req, Resp]) sender(
 	errCh chan<- error,
 	flightSignal chan<- struct{},
 	sendEvents chan<- sendEvent,
+	sendConsumed <-chan struct{},
 ) {
 	publish := func(event sendEvent) bool {
 		select {
@@ -831,7 +872,12 @@ func (cs *CoreStream[Req, Resp]) sender(
 		}
 	}
 	physicalOffset := int64(0)
+	physicalExhausted := false
 	for {
+		if physicalExhausted {
+			errCh <- fmt.Errorf("stream: physical offset space exhausted")
+			return
+		}
 		it, err := cs.buf.next(senderCtx)
 		if err != nil {
 			errCh <- nil // ctx cancelled or buffer closed — clean exit
@@ -850,21 +896,23 @@ func (cs *CoreStream[Req, Resp]) sender(
 		default:
 		}
 		err = stream.Send(it.payload)
-		consumed := make(chan struct{})
 		sendEvents <- sendEvent{
 			logicalOffset:  it.offset,
 			physicalOffset: physicalOffset,
 			completed:      true,
 			err:            err,
-			consumed:       consumed,
 		}
 		if err != nil {
 			errCh <- fmt.Errorf("stream: send offset %d: %w", it.offset, err)
 			return
 		}
-		physicalOffset++
+		if physicalOffset == math.MaxInt64 {
+			physicalExhausted = true
+		} else {
+			physicalOffset++
+		}
 		select {
-		case <-consumed:
+		case <-sendConsumed:
 		case <-senderCtx.Done():
 			errCh <- nil
 			return
@@ -873,28 +921,44 @@ func (cs *CoreStream[Req, Resp]) sender(
 }
 
 // receiver processes responses and advances the ack watermark.
-// Each Recv runs separately so the ack timer remains responsive.
 func (cs *CoreStream[Req, Resp]) receiver(
 	stream wireStream[Req, Resp],
 	errCh chan<- error,
 	pauseCh chan<- pauseSignal,
 	flightSignal <-chan struct{},
 	sendEvents <-chan sendEvent,
+	sendConsumed chan<- struct{},
 ) {
 	type recvResult struct {
 		resp Resp
 		err  error
 	}
 
-	// Keep exactly one Recv active.
-	recvCh := make(chan recvResult, 1)
-	spawnRecv := func() {
-		go func() {
+	recvCh := make(chan recvResult)
+	recvStop := make(chan struct{})
+	recvDone := make(chan struct{})
+	go func() {
+		defer close(recvDone)
+		for {
 			resp, err := stream.Recv()
-			recvCh <- recvResult{resp, err}
-		}()
+			select {
+			case recvCh <- recvResult{resp, err}:
+			case <-recvStop:
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	var stopRecvOnce sync.Once
+	stopRecv := func() {
+		stopRecvOnce.Do(func() {
+			close(recvStop)
+			stream.Close()
+		})
+		<-recvDone
 	}
-	spawnRecv()
 
 	lackTimer := time.NewTimer(cs.cfg.LackOfAckTimeout)
 	if !lackTimer.Stop() {
@@ -1008,16 +1072,17 @@ func (cs *CoreStream[Req, Resp]) receiver(
 			sendingLogical = event.logicalOffset
 			return nil
 		}
-		close(event.consumed)
+		var result error
 		if event.err == nil {
 			expected := sentBasePhysical + int64(len(sentLogical))
 			if event.physicalOffset != expected {
-				return fmt.Errorf(
+				result = fmt.Errorf(
 					"stream: physical send offset %d is not contiguous after %d",
 					event.physicalOffset, expected-1,
 				)
+			} else {
+				sentLogical = append(sentLogical, event.logicalOffset)
 			}
-			sentLogical = append(sentLogical, event.logicalOffset)
 		}
 		sendingPhysical = -1
 		sendingLogical = -1
@@ -1026,7 +1091,11 @@ func (cs *CoreStream[Req, Resp]) receiver(
 			ackErr = applyPhysicalAck(pendingPhysicalAck)
 		}
 		pendingPhysicalAck = -1
-		return ackErr
+		if result == nil {
+			result = ackErr
+		}
+		sendConsumed <- struct{}{}
+		return result
 	}
 	resolvePendingOnExit := func() error {
 		if pendingPhysicalAck < 0 || sendingPhysical < 0 {
@@ -1039,9 +1108,13 @@ func (cs *CoreStream[Req, Resp]) receiver(
 		return handleSendEvent(<-sendEvents)
 	}
 	handleTerminal := func(err error) {
-		if pendingErr := resolvePendingOnExit(); pendingErr != nil && err == nil {
-			err = pendingErr
+		if pendingErr := resolvePendingOnExit(); pendingErr != nil {
+			var ps pauseSignal
+			if err == nil || errors.As(err, &ps) {
+				err = pendingErr
+			}
 		}
+		stopRecv()
 		errCh <- err
 	}
 
@@ -1073,8 +1146,6 @@ func (cs *CoreStream[Req, Resp]) receiver(
 			if cs.buf.inFlight() == 0 {
 				continue
 			}
-			stream.Close()
-			<-recvCh // reap the outstanding Recv goroutine
 			handleTerminal(fmt.Errorf(
 				"stream: no ack from server for %s", cs.cfg.LackOfAckTimeout,
 			))
@@ -1087,7 +1158,11 @@ func (cs *CoreStream[Req, Resp]) receiver(
 		}
 
 		if r.err == io.EOF {
-			handleTerminal(nil)
+			if pauseState != nil {
+				handleTerminal(*pauseState)
+			} else {
+				handleTerminal(nil)
+			}
 			return
 		}
 		if r.err != nil {
@@ -1108,32 +1183,27 @@ func (cs *CoreStream[Req, Resp]) receiver(
 		if kind == pauseResponse {
 			if pauseState == nil {
 				pauseCopy := pause
+				wait := cs.effectivePauseWait(pause.duration)
+				pauseCopy.resumeAt = time.Now().Add(wait)
 				pauseState = &pauseCopy
 				select {
-				case pauseCh <- pause:
+				case pauseCh <- pauseCopy:
 				default:
 				}
 				if cs.buf.inFlight() == 0 {
-					// Recover immediately when nothing needs draining.
-					handleTerminal(pause)
+					handleTerminal(pauseCopy)
 					return
 				}
-				wait := cs.effectivePauseWait(pause.duration)
 				if wait <= 0 {
-					handleTerminal(pause)
+					handleTerminal(pauseCopy)
 					return
 				}
 				pauseTimer = time.NewTimer(wait)
 				disarmLackTimer()
 			}
 			// Drain late acks during the pause.
-			spawnRecv()
 			continue
 		}
-
-		// Not a terminal response — keep reading. Spawn the next Recv before
-		// handling this one so the loop always has exactly one outstanding.
-		spawnRecv()
 
 		if kind == ackResponse {
 			for {

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -267,16 +267,15 @@ func (w *watermark) waitFor(ctx context.Context, target int64) error {
 // Callers interact only through Ingest, IngestBatch, Flush, WaitForOffset,
 // GetUnacked, GetUnackedBatches, and Close.
 type CoreStream[Req, Resp any] struct {
-	params          StreamParams
-	cfg             Config
-	opener          opener[Req, Resp]
-	enc             encoder[Req]
-	ackMdl          ackModel[Resp]
-	buf             *buffer[Req]
-	wm              *watermark
-	dispatcher      *callbackDispatcher
-	pauseWait       func(context.Context, time.Time) bool
-	onPauseObserved func()
+	params     StreamParams
+	cfg        Config
+	opener     opener[Req, Resp]
+	enc        encoder[Req]
+	ackMdl     ackModel[Resp]
+	buf        *buffer[Req]
+	wm         *watermark
+	dispatcher *callbackDispatcher
+	pauseWait  func(context.Context, time.Time) bool
 
 	clientID string
 	serverID atomic.Pointer[string]
@@ -722,9 +721,6 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, rese
 	var receiverReported bool
 	var pauseObserved bool
 	recordPause := func() {
-		if !pauseObserved && cs.onPauseObserved != nil {
-			cs.onPauseObserved()
-		}
 		pauseObserved = true
 		if !senderParked {
 			cancelSender()
@@ -989,9 +985,7 @@ func (cs *CoreStream[Req, Resp]) receiver(
 	}
 
 	lackTimer := time.NewTimer(cs.cfg.LackOfAckTimeout)
-	if !lackTimer.Stop() {
-		<-lackTimer.C
-	}
+	lackTimer.Stop()
 	lackTimerArmed := false
 	armLackTimer := func() {
 		if lackTimerArmed || cs.buf.inFlight() == 0 {
@@ -1004,12 +998,8 @@ func (cs *CoreStream[Req, Resp]) receiver(
 		if !lackTimerArmed {
 			return
 		}
-		if !lackTimer.Stop() {
-			select {
-			case <-lackTimer.C:
-			default:
-			}
-		}
+		// Go 1.23+ guarantees that Stop prevents stale timer values.
+		lackTimer.Stop()
 		lackTimerArmed = false
 	}
 	// syncLackTimer realigns the ack-silence budget with the in-flight set. Only

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -849,6 +849,65 @@ func TestCoreStreamRecvPumpStaysOutstandingDuringClassification(t *testing.T) {
 	}
 }
 
+func TestCoreStreamReceiverFailureWinsWhileSendIsBlocked(t *testing.T) {
+	tests := []struct {
+		name       string
+		fail       func(*blockedSendTerminalRPC)
+		wantText   string
+		wantCode   codes.Code
+		wantAuthIn int64
+	}{
+		{
+			name: "authentication rejection",
+			fail: func(rpc *blockedSendTerminalRPC) {
+				rpc.recvErr <- status.Error(codes.Unauthenticated, "expired credentials")
+			},
+			wantText:   "expired credentials",
+			wantCode:   codes.Unauthenticated,
+			wantAuthIn: 1,
+		},
+		{
+			name:     "malformed response",
+			fail:     func(rpc *blockedSendTerminalRPC) { rpc.malformedAck() },
+			wantText: "unusable server response",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &countingHeadersProvider{}
+			params := testParams()
+			params.HeadersProvider = provider
+			rpc := newBlockedSendTerminalRPC()
+			cfg := testConfig()
+			cfg.Recovery = RecoveryDisabled
+			cs := newCoreForTest(params, cfg, &blockedSendTerminalOpener{rpc: rpc}, nil)
+
+			if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+				t.Fatalf("Ingest: %v", err)
+			}
+			select {
+			case <-rpc.started:
+			case <-time.After(time.Second):
+				t.Fatal("Send did not block")
+			}
+			tc.fail(rpc)
+
+			waitCondition(t, cs.IsClosed, time.Second)
+			err := cs.terminalErr()
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("terminal error = %v, want %q", err, tc.wantText)
+			}
+			if tc.wantCode != codes.OK && status.Code(err) != tc.wantCode {
+				t.Fatalf("status code = %v, want %v", status.Code(err), tc.wantCode)
+			}
+			if got := provider.invalidations.Load(); got != tc.wantAuthIn {
+				t.Fatalf("Invalidate calls = %d, want %d", got, tc.wantAuthIn)
+			}
+			cs.Close()
+		})
+	}
+}
+
 func TestCoreStreamDefersTranslatedAckAfterReconnect(t *testing.T) {
 	firstRPC := newFakeRPC()
 	secondRPC := newControlledSendRPC()
@@ -1032,6 +1091,51 @@ func TestCoreStreamCloseUnblocksEnqueueAtCapacity(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Ingest did not unblock after Close")
 	}
+}
+
+func TestCoreStreamByteBackpressureResumesAfterAck(t *testing.T) {
+	rpc := newFakeRPC()
+	cfg := testConfig()
+	record := []byte(`{"value":1}`)
+	cfg.MaxInflight = 2
+	cfg.MaxBufferedPayloadBytes = jsonEncoder{}.retainedSize(len(record), 1)
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	first, err := cs.Ingest(context.Background(), record)
+	if err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+	<-rpc.sends
+
+	secondResult := make(chan struct {
+		offset int64
+		err    error
+	}, 1)
+	go func() {
+		offset, ingestErr := cs.Ingest(context.Background(), record)
+		secondResult <- struct {
+			offset int64
+			err    error
+		}{offset: offset, err: ingestErr}
+	}()
+	waitCondition(t, func() bool { return cs.buf.waiterCount() == 1 }, time.Second)
+
+	rpc.ack(first)
+	var second int64
+	select {
+	case result := <-secondResult:
+		if result.err != nil {
+			t.Fatalf("second Ingest: %v", result.err)
+		}
+		second = result.offset
+	case <-time.After(time.Second):
+		t.Fatal("second Ingest did not resume after ack released byte capacity")
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+	<-rpc.sends
+	rpc.ack(second)
 }
 
 func TestCoreStreamGetUnackedWithoutCallback(t *testing.T) {
@@ -1240,6 +1344,50 @@ func TestCoreStreamOpenAuthRejectionInvalidatesOnce(t *testing.T) {
 	cs := newCoreForTest(params, cfg, &authRejectingOpener{}, nil)
 
 	waitCondition(t, cs.IsClosed, time.Second)
+	if got := provider.invalidations.Load(); got != 1 {
+		t.Fatalf("Invalidate calls = %d, want 1", got)
+	}
+}
+
+func TestCoreStreamCloseRacingAuthRejectionStillInvalidates(t *testing.T) {
+	provider := &countingHeadersProvider{}
+	params := testParams()
+	params.HeadersProvider = provider
+	opener := &cancelThenAuthOpener{started: make(chan struct{})}
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(params, cfg, opener, nil)
+
+	select {
+	case <-opener.started:
+	case <-time.After(time.Second):
+		t.Fatal("Open did not start")
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := provider.invalidations.Load(); got != 1 {
+		t.Fatalf("Invalidate calls = %d, want 1", got)
+	}
+}
+
+func TestCoreStreamCloseRacingLiveAuthRejectionStillInvalidates(t *testing.T) {
+	provider := &countingHeadersProvider{}
+	params := testParams()
+	params.HeadersProvider = provider
+	stream := newAuthOnCloseStream()
+	cs := newCoreForTest(
+		params, testConfig(), &authOnCloseOpener{stream: stream}, nil,
+	)
+
+	select {
+	case <-stream.recvStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Recv did not start")
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 	if got := provider.invalidations.Load(); got != 1 {
 		t.Fatalf("Invalidate calls = %d, want 1", got)
 	}
@@ -1532,6 +1680,21 @@ func TestCoreStreamIngestBatch(t *testing.T) {
 
 	if err := cs.Flush(context.Background()); err != nil {
 		t.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestCoreStreamEmptyBatchRecordsConsumeBufferedByteBudget(t *testing.T) {
+	cfg := testConfig()
+	cfg.MaxBufferedPayloadBytes = 1024
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(newFakeRPC()), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	records := make([][]byte, 100)
+	if _, err := cs.IngestBatch(context.Background(), records); !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("IngestBatch error = %v, want ErrPayloadTooLarge", err)
+	}
+	if items, bytes := cs.buf.usage(); items != 0 || bytes != 0 {
+		t.Fatalf("buffer usage after rejection = (%d, %d), want (0, 0)", items, bytes)
 	}
 }
 

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -2303,10 +2303,8 @@ func TestCoreStreamPauseOwnsConcurrentSendFailure(t *testing.T) {
 	rpc := newControlledSendRPC()
 	cfg := testConfig()
 	cfg.Recovery = RecoveryDisabled
-	cfg.StreamPausedMaxWait = durationPtr(20 * time.Millisecond)
+	cfg.StreamPausedMaxWait = durationPtr(time.Second)
 	cs := newCoreForTest(testParams(), cfg, &controlledSendOpener{rpc: rpc}, nil)
-	pauseObserved := make(chan struct{})
-	cs.onPauseObserved = func() { close(pauseObserved) }
 
 	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
 		t.Fatalf("Ingest: %v", err)
@@ -2316,12 +2314,16 @@ func TestCoreStreamPauseOwnsConcurrentSendFailure(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Send did not start")
 	}
-	rpc.closeSignalWithDuration(20 * time.Millisecond)
+	rpc.closeSignalWithDuration(time.Second)
 	select {
-	case <-pauseObserved:
+	case <-rpc.pauseRead:
 	case <-time.After(time.Second):
-		t.Fatal("pause was not observed")
+		t.Fatal("pause response was not read")
 	}
+	// The receive pump hands the response to the receiver immediately after
+	// Recv returns. Leave the send blocked long enough for the supervisor to
+	// observe the buffered pause before releasing the transport failure.
+	time.Sleep(10 * time.Millisecond)
 	rpc.result <- io.ErrClosedPipe
 
 	waitCondition(t, cs.IsClosed, time.Second)

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"slices"
 	"strings"
@@ -14,6 +15,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
 )
 
 // ---- tests -----------------------------------------------------------------
@@ -563,15 +566,20 @@ func TestCoreStreamConcurrentIngest(t *testing.T) {
 	}
 
 	waitCondition(t, func() bool { return len(rpc.sends) == n }, time.Second)
-	sentRecords := make(map[string]bool, n)
+	sentRecords := make(map[string]int64, n)
 	for range n {
 		msg := <-rpc.sends
-		sentRecords[msg.GetIngestRecord().GetJsonRecord()] = true
+		record := msg.GetIngestRecord()
+		sentRecords[record.GetJsonRecord()] = record.GetOffsetId()
 	}
 	for i := range n {
 		record := fmt.Sprintf(`{"record":%d}`, i)
-		if !sentRecords[record] {
+		got, ok := sentRecords[record]
+		if !ok {
 			t.Fatalf("record %q was not sent", record)
+		}
+		if got != offsets[i] {
+			t.Fatalf("record %q wire offset = %d, returned offset = %d", record, got, offsets[i])
 		}
 	}
 	rpc.ack(n - 1)
@@ -747,6 +755,97 @@ func TestCoreStreamDefersAckUntilSendSucceeds(t *testing.T) {
 	defer cancel()
 	if err := cs.WaitForOffset(ctx, offset); err != nil {
 		t.Fatalf("deferred ack after Send and EOF: %v", err)
+	}
+}
+
+func TestCoreStreamReusesSendCompletionSignal(t *testing.T) {
+	rpc := newControlledSendRPC()
+	cs := newCoreForTest(testParams(), testConfig(), &controlledSendOpener{rpc}, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	first, err := cs.Ingest(context.Background(), []byte(`{"first":true}`))
+	if err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+	second, err := cs.Ingest(context.Background(), []byte(`{"second":true}`))
+	if err != nil {
+		t.Fatalf("second Ingest: %v", err)
+	}
+	select {
+	case <-rpc.started:
+	case <-time.After(time.Second):
+		t.Fatal("first Send did not start")
+	}
+	rpc.ack(0)
+	rpc.result <- nil
+	waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+
+	rpc.result <- nil
+	waitCondition(t, func() bool { return len(rpc.sends) == 2 }, time.Second)
+	for range 2 {
+		<-rpc.sends
+	}
+	rpc.ack(1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, second); err != nil {
+		t.Fatalf("second WaitForOffset: %v", err)
+	}
+	if err := cs.WaitForOffset(ctx, first); err != nil {
+		t.Fatalf("first WaitForOffset: %v", err)
+	}
+}
+
+func TestCoreStreamRecvPumpStaysOutstandingDuringClassification(t *testing.T) {
+	rpc := newScriptedRPC()
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseModel := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseModel()
+	model := &blockingAckModel{entered: make(chan struct{}), release: release}
+	cs := NewCoreStream[encodedMsg, ephemeralResp](
+		testParams(),
+		testConfig(),
+		&scriptedOpener{rpc: rpc},
+		jsonEncoder{},
+		model,
+		nil,
+	)
+	t.Cleanup(func() { cs.Close() })
+
+	select {
+	case call := <-rpc.recvStarted:
+		if call != 1 {
+			t.Fatalf("first Recv call = %d", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first Recv did not start")
+	}
+	offset, err := cs.Ingest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+	<-rpc.sends
+	rpc.ack(0)
+	select {
+	case <-model.entered:
+	case <-time.After(time.Second):
+		t.Fatal("ack classification did not start")
+	}
+	select {
+	case call := <-rpc.recvStarted:
+		if call != 2 {
+			t.Fatalf("next Recv call = %d, want 2", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("next Recv was not outstanding during classification")
+	}
+	releaseModel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForOffset(ctx, offset); err != nil {
+		t.Fatalf("WaitForOffset: %v", err)
 	}
 }
 
@@ -1138,7 +1237,7 @@ func TestCoreStreamOpenAuthRejectionInvalidatesOnce(t *testing.T) {
 	params.HeadersProvider = provider
 	cfg := testConfig()
 	cfg.Recovery = RecoveryDisabled
-	cs := newCoreForTest(params, cfg, &authRejectingOpener{provider: provider}, nil)
+	cs := newCoreForTest(params, cfg, &authRejectingOpener{}, nil)
 
 	waitCondition(t, cs.IsClosed, time.Second)
 	if got := provider.invalidations.Load(); got != 1 {
@@ -1153,7 +1252,6 @@ func TestCoreStreamInitialAuthRejectionRefreshesOnce(t *testing.T) {
 			params := testParams()
 			params.HeadersProvider = provider
 			opener := &authRefreshOpener{
-				provider:   provider,
 				rpc:        newFakeRPC(),
 				rejections: 1,
 				code:       code,
@@ -1183,7 +1281,6 @@ func TestCoreStreamSecondInitialAuthRejectionIsTerminal(t *testing.T) {
 			params := testParams()
 			params.HeadersProvider = provider
 			opener := &authRefreshOpener{
-				provider:   provider,
 				rpc:        newFakeRPC(),
 				rejections: 2,
 				code:       code,
@@ -1211,7 +1308,6 @@ func TestCoreStreamInitialAuthRefreshAfterTransientOpenFailure(t *testing.T) {
 	params := testParams()
 	params.HeadersProvider = provider
 	opener := &scriptedOpenOpener{
-		provider: provider,
 		steps: []openStep{
 			{err: errors.New("temporary connection failure")},
 			{err: status.Error(codes.Unauthenticated, "stale credentials")},
@@ -1238,7 +1334,6 @@ func TestCoreStreamInitialAuthRefreshConsumesRetryBudget(t *testing.T) {
 	params := testParams()
 	params.HeadersProvider = provider
 	opener := &scriptedOpenOpener{
-		provider: provider,
 		steps: []openStep{
 			{err: status.Error(codes.Unauthenticated, "stale credentials")},
 			{err: errors.New("first transient failure")},
@@ -1286,7 +1381,6 @@ func TestCoreStreamAuthRejectionAfterPauseIsTerminal(t *testing.T) {
 	params.HeadersProvider = provider
 	rpc := newFakeRPC()
 	opener := &scriptedOpenOpener{
-		provider: provider,
 		steps: []openStep{
 			{rpc: rpc},
 			{err: status.Error(codes.Unauthenticated, "reconnect credentials rejected")},
@@ -1308,6 +1402,29 @@ func TestCoreStreamAuthRejectionAfterPauseIsTerminal(t *testing.T) {
 		t.Fatalf("Invalidate calls = %d, want 1", got)
 	}
 	cs.Close()
+}
+
+func TestCoreStreamHeadersAuthRejectionInvalidatesOnce(t *testing.T) {
+	provider := &countingHeadersProvider{
+		getErr: status.Error(codes.PermissionDenied, "header credentials rejected"),
+	}
+	params := testParams()
+	params.TableName = "  c.s.t  "
+	params.HeadersProvider = provider
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(params, cfg, &headersResolvingOpener{}, nil)
+
+	waitCondition(t, cs.IsClosed, time.Second)
+	if got := provider.invalidations.Load(); got != 1 {
+		t.Fatalf("Invalidate calls = %d, want 1", got)
+	}
+	if got, _ := provider.lastGet.Load().(string); got != "c.s.t" {
+		t.Fatalf("GetHeaders table = %q, want normalized table", got)
+	}
+	if got, _ := provider.lastInvalidate.Load().(string); got != "c.s.t" {
+		t.Fatalf("Invalidate table = %q, want normalized table", got)
+	}
 }
 
 func TestCoreStreamLiveAuthRejectionInvalidatesOnce(t *testing.T) {
@@ -1668,6 +1785,49 @@ func TestCoreStreamCumulativeAckDispatchesEveryOffset(t *testing.T) {
 	}
 }
 
+func TestCoreStreamCallbacksPreserveAckThenErrorOrder(t *testing.T) {
+	events := make(chan string, 4)
+	cb := &callbackFuncs{
+		onAck: func(offset int64) {
+			events <- fmt.Sprintf("ack:%d", offset)
+		},
+		onError: func(offset int64, _ error) {
+			events <- fmt.Sprintf("error:%d", offset)
+		},
+	}
+	rpc := newFakeRPC()
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), cb)
+
+	for range 4 {
+		if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+	}
+	waitCondition(t, func() bool { return len(rpc.sends) == 4 }, time.Second)
+	for range 4 {
+		<-rpc.sends
+	}
+	rpc.ack(1)
+	rpc.malformedAck()
+	waitCondition(t, cs.IsClosed, time.Second)
+
+	var got []string
+	for range 4 {
+		select {
+		case event := <-events:
+			got = append(got, event)
+		case <-time.After(time.Second):
+			t.Fatalf("callback events = %v, want four events", got)
+		}
+	}
+	want := []string{"ack:0", "ack:1", "error:2", "error:3"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("callback events = %v, want %v", got, want)
+	}
+}
+
 func TestCallbackDispatcherDoesNotDropLargeAckRange(t *testing.T) {
 	cb := &recordingCallback{}
 	dispatcher := newCallbackDispatcher(cb)
@@ -1914,6 +2074,100 @@ func TestCoreStreamPauseRemainsStickyAcrossEOF(t *testing.T) {
 	}
 }
 
+func TestCoreStreamPauseDoesNotMaskReceiverFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		queueFail func(*scriptedRPC)
+		want      string
+		wantCode  codes.Code
+		wantErr   error
+	}{
+		{
+			name:      "malformed response",
+			queueFail: func(rpc *scriptedRPC) { rpc.malformed() },
+			want:      "unusable server response",
+		},
+		{
+			name: "auth rejection",
+			queueFail: func(rpc *scriptedRPC) {
+				rpc.fail(status.Error(codes.Unauthenticated, "expired credentials"))
+			},
+			want:     "expired credentials",
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name:      "transport error",
+			queueFail: func(rpc *scriptedRPC) { rpc.fail(io.ErrUnexpectedEOF) },
+			want:      "unexpected EOF",
+			wantErr:   io.ErrUnexpectedEOF,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := newScriptedRPC()
+			cfg := testConfig()
+			cfg.Recovery = RecoveryDisabled
+			cs := newCoreForTest(testParams(), cfg, &scriptedOpener{rpc: rpc}, nil)
+
+			if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+				t.Fatalf("Ingest: %v", err)
+			}
+			waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+			<-rpc.sends
+			rpc.pause(time.Second)
+			tc.queueFail(rpc)
+
+			waitCondition(t, cs.IsClosed, time.Second)
+			err := cs.terminalErr()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("terminal error = %v, want %q", err, tc.want)
+			}
+			var ps pauseSignal
+			if errors.As(err, &ps) {
+				t.Fatalf("terminal error = %v, want receiver failure rather than pause", err)
+			}
+			if tc.wantCode != codes.OK && status.Code(err) != tc.wantCode {
+				t.Fatalf("status code = %v, want %v", status.Code(err), tc.wantCode)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("terminal error = %v, want errors.Is(%v)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCoreStreamPauseOwnsConcurrentSendFailure(t *testing.T) {
+	rpc := newControlledSendRPC()
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	cfg.StreamPausedMaxWait = durationPtr(20 * time.Millisecond)
+	cs := newCoreForTest(testParams(), cfg, &controlledSendOpener{rpc: rpc}, nil)
+	pauseObserved := make(chan struct{})
+	cs.onPauseObserved = func() { close(pauseObserved) }
+
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	select {
+	case <-rpc.started:
+	case <-time.After(time.Second):
+		t.Fatal("Send did not start")
+	}
+	rpc.closeSignalWithDuration(20 * time.Millisecond)
+	select {
+	case <-pauseObserved:
+	case <-time.After(time.Second):
+		t.Fatal("pause was not observed")
+	}
+	rpc.result <- io.ErrClosedPipe
+
+	waitCondition(t, cs.IsClosed, time.Second)
+	if err := cs.terminalErr(); err == nil ||
+		!strings.Contains(err.Error(), "server requested pause and recovery is disabled") {
+		t.Fatalf("terminal error = %v, want recovery-disabled pause", err)
+	}
+}
+
 // A real receiver failure after a pause must not be reported as the pause: it has
 // to surface to the caller and consume the recovery budget.
 func TestCoreStreamReceiverErrorAfterPauseWins(t *testing.T) {
@@ -2017,16 +2271,65 @@ func TestCoreStreamPauseRecoveryPreservesAckMapping(t *testing.T) {
 	}
 }
 
-func TestCoreStreamIdlePauseRecoversImmediately(t *testing.T) {
-	rpc1 := newFakeRPC()
+func TestCoreStreamIdlePauseHonorsDeadline(t *testing.T) {
+	rpc1 := newScriptedRPC()
 	rpc2 := newFakeRPC()
-	fo := newFakeOpener(rpc1, rpc2)
+	fo := &streamSequenceOpener{streams: []wireStream[encodedMsg, ephemeralResp]{
+		transport.NewFakeStreamForTesting(rpc1),
+		transport.NewFakeStreamForTesting(rpc2),
+	}}
 	cs := newCoreForTest(testParams(), testConfig(), fo, nil)
 	t.Cleanup(func() { cs.Close() })
+	waitStarted := make(chan time.Time, 1)
+	releaseWait := make(chan struct{})
+	cs.pauseWait = func(ctx context.Context, deadline time.Time) bool {
+		waitStarted <- deadline
+		select {
+		case <-releaseWait:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	waitCondition(t, func() bool { return fo.openCount() == 1 }, time.Second)
-	rpc1.closeSignalWithDuration(time.Second)
-	waitCondition(t, func() bool { return fo.openCount() == 2 }, 200*time.Millisecond)
+	rpc1.pause(time.Second)
+	var deadline time.Time
+	select {
+	case deadline = <-waitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not begin pause wait")
+	}
+	if time.Until(deadline) <= 0 {
+		t.Fatalf("pause deadline %v is not in the future", deadline)
+	}
+	if got := fo.openCount(); got != 1 {
+		t.Fatalf("reopened before pause deadline: %d opens", got)
+	}
+	close(releaseWait)
+	waitCondition(t, func() bool { return fo.openCount() == 2 }, time.Second)
+}
+
+func TestCoreStreamCloseInterruptsPauseDeadline(t *testing.T) {
+	rpc := newScriptedRPC()
+	cs := newCoreForTest(testParams(), testConfig(), &scriptedOpener{rpc: rpc}, nil)
+
+	rpc.pause(time.Hour)
+	select {
+	case <-rpc.aborted:
+	case <-time.After(time.Second):
+		t.Fatal("paused connection was not closed")
+	}
+	done := make(chan struct{})
+	go func() {
+		cs.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not interrupt pause deadline")
+	}
 }
 
 func TestCoreStreamLackOfAckBudgetStartsWithFlight(t *testing.T) {
@@ -2141,20 +2444,64 @@ func TestCoreStreamRejectsOversizedPayloadWithoutConsumingOffset(t *testing.T) {
 	if _, err := wireCS.Ingest(context.Background(), []byte(`{}`)); !errors.Is(err, ErrPayloadTooLarge) {
 		t.Fatalf("want encoded wire-size rejection, got %v", err)
 	}
+	if items, bytes := wireCS.buf.usage(); items != 0 || bytes != 0 {
+		t.Fatalf("buffer usage after rejection = (%d, %d), want (0, 0)", items, bytes)
+	}
+}
+
+func TestCoreStreamPreservesExplicitBufferedByteLimit(t *testing.T) {
+	cfg := testConfig()
+	cfg.MaxPayloadBytes = 64
+	cfg.MaxBufferedPayloadBytes = 1
+	cs := newCoreForTest(testParams(), cfg, newFakeOpener(newFakeRPC()), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	if cs.cfg.MaxBufferedPayloadBytes != 1 {
+		t.Fatalf("buffered byte limit = %d, want 1", cs.cfg.MaxBufferedPayloadBytes)
+	}
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("Ingest error = %v, want ErrPayloadTooLarge", err)
+	}
+}
+
+func TestCoreStreamEncoderErrorReleasesCapacity(t *testing.T) {
+	rpc := newFakeRPC()
+	cfg := testConfig()
+	cfg.MaxInflight = 1
+	cs := NewCoreStream[encodedMsg, ephemeralResp](
+		testParams(),
+		cfg,
+		newFakeOpener(rpc),
+		failingEncoder{err: errors.New("encode failed")},
+		offsetAckModel{},
+		nil,
+	)
+	t.Cleanup(func() { cs.Close() })
+
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err == nil {
+		t.Fatal("Ingest succeeded with failing encoder")
+	}
+	if items, bytes := cs.buf.usage(); items != 0 || bytes != 0 {
+		t.Fatalf("usage after encode error = (%d, %d), want (0, 0)", items, bytes)
+	}
+	// Capacity stays available even after repeated encode failures.
+	if _, err := cs.Ingest(context.Background(), []byte(`{}`)); err == nil {
+		t.Fatal("second Ingest unexpectedly succeeded with failing encoder")
+	}
 }
 
 func TestCoreStreamAcceptsPayloadAndBatchAtLimits(t *testing.T) {
 	t.Run("encoded payload", func(t *testing.T) {
 		record := []byte(`{"at":"limit"}`)
 		enc := jsonEncoder{}
-		msg, err := enc.encode(math.MaxInt64, record)
+		msg, err := enc.encode(record)
 		if err != nil {
 			t.Fatalf("encode: %v", err)
 		}
 
 		rpc := newFakeRPC()
 		cfg := testConfig()
-		cfg.MaxPayloadBytes = enc.wireSize(msg)
+		cfg.MaxPayloadBytes = enc.maxWireSize(msg)
 		cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
 		t.Cleanup(func() { cs.Close() })
 
@@ -2181,4 +2528,49 @@ func TestCoreStreamAcceptsPayloadAndBatchAtLimits(t *testing.T) {
 			t.Fatalf("IngestBatch at MaxBatchRecords: %v", err)
 		}
 	})
+}
+
+func TestCoreStreamLogicalOffsetExhaustion(t *testing.T) {
+	rpc := newFakeRPC()
+	cs := newCoreForTest(testParams(), testConfig(), newFakeOpener(rpc), nil)
+	t.Cleanup(func() { cs.Close() })
+
+	cs.offsetMu.Lock()
+	cs.nextOffset = math.MaxInt64
+	cs.offsetMu.Unlock()
+
+	offset, err := cs.Ingest(context.Background(), []byte(`{"last":true}`))
+	if err != nil {
+		t.Fatalf("last Ingest: %v", err)
+	}
+	if offset != math.MaxInt64 {
+		t.Fatalf("last offset = %d, want MaxInt64", offset)
+	}
+	if _, err := cs.Ingest(context.Background(), []byte(`{"overflow":true}`)); !errors.Is(err, ErrOffsetExhausted) {
+		t.Fatalf("post-exhaustion Ingest error = %v, want ErrOffsetExhausted", err)
+	}
+	if got := cs.lastEnqueued.Load(); got != math.MaxInt64 {
+		t.Fatalf("lastEnqueued = %d, want MaxInt64", got)
+	}
+
+	waitCondition(t, func() bool { return len(rpc.sends) == 1 }, time.Second)
+	<-rpc.sends
+	rpc.ack(0)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.Flush(ctx); err != nil {
+		t.Fatalf("Flush at MaxInt64: %v", err)
+	}
+}
+
+func TestCallbackDispatcherDoesNotCoalescePastMaxOffset(t *testing.T) {
+	cb := &recordingCallback{}
+	dispatcher := newCallbackDispatcher(cb)
+	dispatcher.enqueueAcks(math.MaxInt64, math.MaxInt64)
+	dispatcher.enqueueAcks(math.MinInt64, math.MinInt64)
+	dispatcher.shutdown(time.Second)
+
+	if got := cb.ackOffsets(); !slices.Equal(got, []int64{math.MaxInt64, math.MinInt64}) {
+		t.Fatalf("callback offsets = %v", got)
+	}
 }

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -17,9 +17,9 @@ import (
 // objects.
 type encodedMsg = *zerobuspb.EphemeralStreamRequest
 
-// encoder turns user records into wire messages for a given offset and recovers
-// them again for GetUnacked. It is the send-side per-encoding
-// seam. The core is generic over the wire message type Req and
+// encoder turns user records into offset-independent wire messages and recovers
+// them again for GetUnacked. It is the send-side per-encoding seam. The core is
+// generic over the wire message type Req and
 // never names a concrete proto type — proto/JSON supply encoder[encodedMsg];
 // Arrow will supply encoder[flightFrame].
 //
@@ -40,6 +40,20 @@ type encoder[Req any] interface {
 	decode(msg Req) [][]byte
 	// maxWireSize reports an upper bound across every offset stamp.
 	maxWireSize(msg Req) int
+	// retainedSize estimates the heap retained by an encoded message before it
+	// is built. It includes raw bytes, per-record containers, framing, and
+	// request-object overhead so aggregate backpressure cannot be bypassed by
+	// batches of tiny or empty records.
+	retainedSize(rawBytes, recordCount int) int64
+}
+
+const encodedRequestOverhead = int64(512)
+const encodedRecordOverhead = int64(32)
+
+func ephemeralRetainedSize(rawBytes, recordCount int) int64 {
+	return int64(rawBytes) +
+		int64(recordCount)*encodedRecordOverhead +
+		encodedRequestOverhead
 }
 
 // protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
@@ -96,6 +110,10 @@ func (protoEncoder) stampOffset(msg encodedMsg, offset int64) {
 	stampEphemeralOffset(msg, offset)
 }
 
+func (protoEncoder) retainedSize(rawBytes, recordCount int) int64 {
+	return ephemeralRetainedSize(rawBytes, recordCount)
+}
+
 // jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
 // and batched.
 type jsonEncoder struct{}
@@ -144,6 +162,10 @@ func (jsonEncoder) maxWireSize(msg encodedMsg) int {
 
 func (jsonEncoder) stampOffset(msg encodedMsg, offset int64) {
 	stampEphemeralOffset(msg, offset)
+}
+
+func (jsonEncoder) retainedSize(rawBytes, recordCount int) int64 {
+	return ephemeralRetainedSize(rawBytes, recordCount)
 }
 
 func stampEphemeralOffset(msg encodedMsg, offset int64) {

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"bytes"
 	"fmt"
+	"math"
 
 	"google.golang.org/protobuf/proto"
 
@@ -24,29 +25,29 @@ type encodedMsg = *zerobuspb.EphemeralStreamRequest
 //
 // The sender replaces the encoded offset with a connection-local wire offset.
 type encoder[Req any] interface {
-	// encode turns a single user record into one wire message.
-	encode(offset int64, record []byte) (Req, error)
+	// encode turns a single user record into an offset-independent wire message.
+	encode(record []byte) (Req, error)
 	// encodeBatch turns many already-encoded records into one wire message. All
 	// records share a single offset and are atomic to the server (it acks the
 	// whole batch or none of it), so the batch occupies exactly one logical
 	// offset in the core's buffer.
-	encodeBatch(offset int64, records [][]byte) (Req, error)
+	encodeBatch(records [][]byte) (Req, error)
 	// stampOffset assigns the connection-local wire offset.
 	stampOffset(msg Req, offset int64)
 	// decode recovers the raw record bytes from a wire message so GetUnacked can
 	// return original content. A single-record message yields one entry; a batch
 	// yields all of its records so no unacked record is silently dropped.
 	decode(msg Req) [][]byte
-	// wireSize reports the serialized message size (incl. proto framing) so a
-	// payload cap can be enforced against what the server actually receives.
-	wireSize(msg Req) int
+	// maxWireSize reports an upper bound across every offset stamp.
+	maxWireSize(msg Req) int
 }
 
 // protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
 // serialized protobuf bytes), single and batched.
 type protoEncoder struct{}
 
-func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+func (protoEncoder) encode(record []byte) (encodedMsg, error) {
+	offset := int64(math.MaxInt64)
 	// Empty is a valid proto encoding (all-default message). Clone so a reused
 	// caller buffer can't mutate the queued payload before it's serialized.
 	return &zerobuspb.EphemeralStreamRequest{
@@ -59,7 +60,7 @@ func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
 	}, nil
 }
 
-func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+func (protoEncoder) encodeBatch(records [][]byte) (encodedMsg, error) {
 	if len(records) == 0 {
 		return nil, fmt.Errorf("stream: proto batch must not be empty")
 	}
@@ -69,6 +70,7 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 	for i, r := range records {
 		copied[i] = bytes.Clone(r)
 	}
+	offset := int64(math.MaxInt64)
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
 			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
@@ -83,7 +85,7 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 
 func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
 
-func (protoEncoder) wireSize(msg encodedMsg) int {
+func (protoEncoder) maxWireSize(msg encodedMsg) int {
 	if msg == nil {
 		return 0
 	}
@@ -98,7 +100,8 @@ func (protoEncoder) stampOffset(msg encodedMsg, offset int64) {
 // and batched.
 type jsonEncoder struct{}
 
-func (jsonEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+func (jsonEncoder) encode(record []byte) (encodedMsg, error) {
+	offset := int64(math.MaxInt64)
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
 			IngestRecord: &zerobuspb.IngestRecordRequest{
@@ -109,7 +112,7 @@ func (jsonEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
 	}, nil
 }
 
-func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+func (jsonEncoder) encodeBatch(records [][]byte) (encodedMsg, error) {
 	if len(records) == 0 {
 		return nil, fmt.Errorf("stream: json batch must not be empty")
 	}
@@ -117,6 +120,7 @@ func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, erro
 	for i, r := range records {
 		jsonRecords[i] = string(r)
 	}
+	offset := int64(math.MaxInt64)
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
 			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
@@ -131,7 +135,7 @@ func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, erro
 
 func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
 
-func (jsonEncoder) wireSize(msg encodedMsg) int {
+func (jsonEncoder) maxWireSize(msg encodedMsg) int {
 	if msg == nil {
 		return 0
 	}
@@ -147,11 +151,19 @@ func stampEphemeralOffset(msg encodedMsg, offset int64) {
 		return
 	}
 	if record := msg.GetIngestRecord(); record != nil {
-		record.OffsetId = proto.Int64(offset)
+		if record.OffsetId == nil {
+			record.OffsetId = proto.Int64(offset)
+		} else {
+			*record.OffsetId = offset
+		}
 		return
 	}
 	if batch := msg.GetIngestRecordBatch(); batch != nil {
-		batch.OffsetId = proto.Int64(offset)
+		if batch.OffsetId == nil {
+			batch.OffsetId = proto.Int64(offset)
+		} else {
+			*batch.OffsetId = offset
+		}
 	}
 }
 

--- a/purego/internal/stream/encoder_test.go
+++ b/purego/internal/stream/encoder_test.go
@@ -1,12 +1,15 @@
 package stream
 
 import (
+	"math"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 )
 
 func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
 	enc := protoEncoder{}
-	msg, err := enc.encode(42, []byte{0x0a, 0x01, 0x78})
+	msg, err := enc.encode([]byte{0x0a, 0x01, 0x78})
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -14,12 +17,9 @@ func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
 	if ir == nil {
 		t.Fatal("want IngestRecord payload, got nil")
 	}
+	enc.stampOffset(msg, 42)
 	if ir.GetOffsetId() != 42 {
-		t.Fatalf("want offset 42, got %d", ir.GetOffsetId())
-	}
-	enc.stampOffset(msg, 0)
-	if ir.GetOffsetId() != 0 {
-		t.Fatalf("want stamped offset 0, got %d", ir.GetOffsetId())
+		t.Fatalf("want stamped offset 42, got %d", ir.GetOffsetId())
 	}
 	if len(ir.GetProtoEncodedRecord()) == 0 {
 		t.Fatal("want non-empty proto record")
@@ -28,7 +28,7 @@ func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
 
 func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
 	enc := jsonEncoder{}
-	msg, err := enc.encode(7, []byte(`{"x":1}`))
+	msg, err := enc.encode([]byte(`{"x":1}`))
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -36,9 +36,7 @@ func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
 	if ir == nil {
 		t.Fatal("want IngestRecord payload, got nil")
 	}
-	if ir.GetOffsetId() != 7 {
-		t.Fatalf("want offset 7, got %d", ir.GetOffsetId())
-	}
+	enc.stampOffset(msg, 7)
 	if ir.GetJsonRecord() != `{"x":1}` {
 		t.Fatalf("want json record, got %q", ir.GetJsonRecord())
 	}
@@ -46,7 +44,7 @@ func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
 
 func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 	enc := protoEncoder{}
-	msg, err := enc.encodeBatch(3, [][]byte{{0x01, 0x02}, {0x03, 0x04}, {0x05}})
+	msg, err := enc.encodeBatch([][]byte{{0x01, 0x02}, {0x03, 0x04}, {0x05}})
 	if err != nil {
 		t.Fatalf("encodeBatch: %v", err)
 	}
@@ -54,9 +52,7 @@ func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 	if ib == nil {
 		t.Fatal("want IngestRecordBatch payload, got nil")
 	}
-	if ib.GetOffsetId() != 3 {
-		t.Fatalf("want offset 3, got %d", ib.GetOffsetId())
-	}
+	enc.stampOffset(msg, 3)
 	pb := ib.GetProtoEncodedBatch()
 	if pb == nil {
 		t.Fatal("want ProtoEncodedBatch, got nil")
@@ -69,7 +65,7 @@ func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 
 func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 	enc := jsonEncoder{}
-	msg, err := enc.encodeBatch(5, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	msg, err := enc.encodeBatch([][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
 	if err != nil {
 		t.Fatalf("encodeBatch: %v", err)
 	}
@@ -77,12 +73,9 @@ func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 	if ib == nil {
 		t.Fatal("want IngestRecordBatch payload, got nil")
 	}
+	enc.stampOffset(msg, 5)
 	if ib.GetOffsetId() != 5 {
-		t.Fatalf("want offset 5, got %d", ib.GetOffsetId())
-	}
-	enc.stampOffset(msg, 0)
-	if ib.GetOffsetId() != 0 {
-		t.Fatalf("want stamped offset 0, got %d", ib.GetOffsetId())
+		t.Fatalf("want stamped offset 5, got %d", ib.GetOffsetId())
 	}
 	jb := ib.GetJsonBatch()
 	if jb == nil {
@@ -95,7 +88,7 @@ func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 
 // Empty JSON payloads are valid and must be preserved end-to-end.
 func TestJSONEncoderAcceptsEmptyRecord(t *testing.T) {
-	msg, err := (jsonEncoder{}).encode(1, nil)
+	msg, err := (jsonEncoder{}).encode(nil)
 	if err != nil {
 		t.Fatalf("encode empty json record: %v", err)
 	}
@@ -103,7 +96,7 @@ func TestJSONEncoderAcceptsEmptyRecord(t *testing.T) {
 		t.Fatalf("want empty json string, got %q", got)
 	}
 
-	msg, err = (jsonEncoder{}).encode(1, []byte{})
+	msg, err = (jsonEncoder{}).encode([]byte{})
 	if err != nil {
 		t.Fatalf("encode zero-length json record: %v", err)
 	}
@@ -115,7 +108,7 @@ func TestJSONEncoderAcceptsEmptyRecord(t *testing.T) {
 // Empty proto records are valid in single and batch requests.
 func TestProtoEncoderAcceptsEmptyRecord(t *testing.T) {
 	def := []byte{} // zero-length serialization of an all-default message
-	msg, err := protoEncoder{}.encode(1, def)
+	msg, err := protoEncoder{}.encode(def)
 	if err != nil {
 		t.Fatalf("encode empty proto record: %v", err)
 	}
@@ -123,7 +116,7 @@ func TestProtoEncoderAcceptsEmptyRecord(t *testing.T) {
 		t.Fatalf("want one empty record back, got %v", got)
 	}
 
-	batch, err := protoEncoder{}.encodeBatch(1, [][]byte{def, {0x01}})
+	batch, err := protoEncoder{}.encodeBatch([][]byte{def, {0x01}})
 	if err != nil {
 		t.Fatalf("encodeBatch with empty proto record: %v", err)
 	}
@@ -134,12 +127,12 @@ func TestProtoEncoderAcceptsEmptyRecord(t *testing.T) {
 
 func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
 	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
-		if _, err := enc.encodeBatch(1, nil); err == nil {
+		if _, err := enc.encodeBatch(nil); err == nil {
 			t.Errorf("%T: want error for empty batch, got nil", enc)
 		}
 	}
 	// Empty JSON records inside a non-empty batch are valid.
-	msg, err := (jsonEncoder{}).encodeBatch(1, [][]byte{[]byte("ok"), {}})
+	msg, err := (jsonEncoder{}).encodeBatch([][]byte{[]byte("ok"), {}})
 	if err != nil {
 		t.Fatalf("jsonEncoder: empty record in batch should be accepted: %v", err)
 	}
@@ -152,7 +145,7 @@ func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
 func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
 	// A batch message must yield every record, not just the first, so GetUnacked
 	// doesn't silently drop the tail of an unacked batch.
-	protoMsg, err := protoEncoder{}.encodeBatch(1, [][]byte{{0x01}, {0x02}, {0x03}})
+	protoMsg, err := protoEncoder{}.encodeBatch([][]byte{{0x01}, {0x02}, {0x03}})
 	if err != nil {
 		t.Fatalf("encodeBatch: %v", err)
 	}
@@ -160,7 +153,7 @@ func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
 		t.Fatalf("proto batch: want 3 records extracted, got %d", len(got))
 	}
 
-	jsonMsg, err := jsonEncoder{}.encodeBatch(1, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	jsonMsg, err := jsonEncoder{}.encodeBatch([][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
 	if err != nil {
 		t.Fatalf("encodeBatch: %v", err)
 	}
@@ -170,7 +163,7 @@ func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
 	}
 
 	// A single-record message still yields exactly one entry.
-	single, err := jsonEncoder{}.encode(1, []byte(`{"x":1}`))
+	single, err := jsonEncoder{}.encode([]byte(`{"x":1}`))
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -183,7 +176,7 @@ func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
 // buffer after Ingest returns must not be able to mutate the queued payload.
 func TestProtoEncoderClonesRecord(t *testing.T) {
 	rec := []byte{0x01, 0x02, 0x03}
-	msg, err := protoEncoder{}.encode(1, rec)
+	msg, err := protoEncoder{}.encode(rec)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -196,7 +189,7 @@ func TestProtoEncoderClonesRecord(t *testing.T) {
 
 func TestProtoBatchEncoderClonesRecords(t *testing.T) {
 	recs := [][]byte{{0x01}, {0x02}}
-	msg, err := protoEncoder{}.encodeBatch(1, recs)
+	msg, err := protoEncoder{}.encodeBatch(recs)
 	if err != nil {
 		t.Fatalf("encodeBatch: %v", err)
 	}
@@ -207,17 +200,56 @@ func TestProtoBatchEncoderClonesRecords(t *testing.T) {
 	}
 }
 
-// wireSize reports the serialized size including proto framing, so it exceeds
-// the raw record length.
+// maxWireSize includes proto framing and the worst-case offset.
 func TestWireSizeIncludesFraming(t *testing.T) {
 	rec := []byte("hello")
 	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
-		msg, err := enc.encode(1, rec)
+		msg, err := enc.encode(rec)
 		if err != nil {
 			t.Fatalf("%T encode: %v", enc, err)
 		}
-		if got := enc.wireSize(msg); got <= len(rec) {
-			t.Errorf("%T: wireSize %d should exceed raw len %d", enc, got, len(rec))
+		if got := enc.maxWireSize(msg); got <= len(rec) {
+			t.Errorf("%T: maxWireSize %d should exceed raw len %d", enc, got, len(rec))
 		}
+	}
+}
+
+func TestEncoderMaxWireSizeCoversEveryOffset(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		single, err := enc.encode([]byte("hello"))
+		if err != nil {
+			t.Fatalf("%T encode: %v", enc, err)
+		}
+		batch, err := enc.encodeBatch([][]byte{[]byte("hello"), []byte("world")})
+		if err != nil {
+			t.Fatalf("%T encodeBatch: %v", enc, err)
+		}
+		for _, msg := range []encodedMsg{single, batch} {
+			maxSize := enc.maxWireSize(msg)
+			for _, offset := range []int64{0, 127, 128, 16_384, math.MaxInt64} {
+				enc.stampOffset(msg, offset)
+				if got := proto.Size(msg); got > maxSize {
+					t.Fatalf("%T offset %d size = %d, maxWireSize = %d",
+						enc, offset, got, maxSize)
+				}
+			}
+		}
+	}
+}
+
+func TestEncoderReusesOffsetPointer(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encode([]byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	offsetPtr := msg.GetIngestRecord().OffsetId
+	enc.stampOffset(msg, 1)
+	enc.stampOffset(msg, 2)
+	if msg.GetIngestRecord().OffsetId != offsetPtr {
+		t.Fatal("stampOffset replaced the offset pointer")
+	}
+	if got := *offsetPtr; got != 2 {
+		t.Fatalf("offset = %d, want 2", got)
 	}
 }

--- a/purego/internal/stream/errors.go
+++ b/purego/internal/stream/errors.go
@@ -23,6 +23,9 @@ var ErrPayloadTooLarge = errors.New("stream: ingest payload too large")
 // reaches a terminal/closed state.
 var ErrStreamStillActive = errors.New("stream: cannot get unacked records from an active stream")
 
+// ErrOffsetExhausted marks a stream that assigned every logical offset.
+var ErrOffsetExhausted = errors.New("stream: logical offset space exhausted")
+
 // errUnsupportedRecordType is returned when no encoder/ackModel exists for a
 // record type (e.g. RECORD_TYPE_UNSPECIFIED).
 func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
@@ -33,15 +36,17 @@ func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
 type pauseSignal struct {
 	// duration is the server-requested pause window; zero if unspecified.
 	duration time.Duration
+	// resumeAt is the effective client-capped reconnect deadline.
+	resumeAt time.Time
 }
 
 func (pauseSignal) Error() string { return "stream: server requested pause (close-stream signal)" }
 
-// openFailure marks an error already handled by the transport Open path.
+// openFailure distinguishes failures before a transport stream is established
+// from failures on a live or recovering stream.
 type openFailure struct{ cause error }
 
 func (e *openFailure) Error() string { return e.cause.Error() }
-
 func (e *openFailure) Unwrap() error { return e.cause }
 
 // openBudgetExceeded marks a timed-out Open as retryable. Because isRetryable

--- a/purego/internal/stream/export_test.go
+++ b/purego/internal/stream/export_test.go
@@ -11,8 +11,20 @@ func (b *buffer[Req]) len() int {
 
 // enqueue combines reserve and append for tests.
 func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
-	if err := b.reserve(ctx); err != nil {
+	if err := b.reserve(ctx, 1); err != nil {
 		return err
 	}
-	return b.append(offset, msg)
+	return b.append(offset, msg, 1)
+}
+
+func (b *buffer[Req]) usage() (int, int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.usedItems, b.usedBytes
+}
+
+func (b *buffer[Req]) waiterCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.waiters.Len()
 }

--- a/purego/internal/stream/helpers_test.go
+++ b/purego/internal/stream/helpers_test.go
@@ -362,45 +362,43 @@ func (o *blockedSendOpener) Open(_ context.Context, _ transport.StreamParams) (w
 }
 
 type countingHeadersProvider struct {
-	invalidations atomic.Int64
+	invalidations  atomic.Int64
+	getErr         error
+	lastGet        atomic.Value
+	lastInvalidate atomic.Value
 }
 
-func (*countingHeadersProvider) GetHeaders(context.Context, string) (map[string]string, error) {
-	return nil, nil
+func (p *countingHeadersProvider) GetHeaders(_ context.Context, tableName string) (map[string]string, error) {
+	p.lastGet.Store(tableName)
+	return nil, p.getErr
 }
 
-func (p *countingHeadersProvider) Invalidate(context.Context, string) {
+func (p *countingHeadersProvider) Invalidate(_ context.Context, tableName string) {
 	p.invalidations.Add(1)
+	p.lastInvalidate.Store(tableName)
 }
 
-// authRejectingOpener models transport Open, which owns invalidation for
-// handshake failures before returning the rejection to the supervisor.
-type authRejectingOpener struct {
-	provider *countingHeadersProvider
-}
+type authRejectingOpener struct{}
 
-func (o *authRejectingOpener) Open(ctx context.Context, params transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
-	o.provider.Invalidate(ctx, params.TableName)
+func (*authRejectingOpener) Open(context.Context, transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
 	return nil, status.Error(codes.Unauthenticated, "stale credentials")
 }
 
 // authRefreshOpener rejects a configured number of initial Open attempts,
-// modelling transport-owned credential invalidation, then succeeds.
+// then succeeds. The supervisor owns credential invalidation.
 type authRefreshOpener struct {
 	mu         sync.Mutex
-	provider   *countingHeadersProvider
 	rpc        *fakeRPC
 	rejections int
 	attempts   int
 	code       codes.Code
 }
 
-func (o *authRefreshOpener) Open(ctx context.Context, params transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+func (o *authRefreshOpener) Open(context.Context, transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.attempts++
 	if o.attempts <= o.rejections {
-		o.provider.Invalidate(ctx, params.TableName)
 		code := o.code
 		if code == codes.OK {
 			code = codes.Unauthenticated
@@ -416,21 +414,27 @@ func (o *authRefreshOpener) openCount() int {
 	return o.attempts
 }
 
+type headersResolvingOpener struct{}
+
+func (*headersResolvingOpener) Open(ctx context.Context, params transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	_, err := params.HeadersProvider.GetHeaders(ctx, params.TableName)
+	return nil, err
+}
+
 type openStep struct {
 	rpc *fakeRPC
 	err error
 }
 
-// scriptedOpenOpener returns one result per Open. It models transport-owned
-// invalidation when a handshake result rejects authentication.
+// scriptedOpenOpener returns one result per Open. Credential invalidation is the
+// supervisor's job, so a rejecting step only returns the status.
 type scriptedOpenOpener struct {
 	mu       sync.Mutex
-	provider *countingHeadersProvider
 	steps    []openStep
 	attempts int
 }
 
-func (o *scriptedOpenOpener) Open(ctx context.Context, params transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+func (o *scriptedOpenOpener) Open(context.Context, transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.attempts++
@@ -439,9 +443,6 @@ func (o *scriptedOpenOpener) Open(ctx context.Context, params transport.StreamPa
 	}
 	step := o.steps[o.attempts-1]
 	if step.err != nil {
-		if o.provider != nil && transport.IsAuthRejection(step.err) {
-			o.provider.Invalidate(ctx, params.TableName)
-		}
 		return nil, step.err
 	}
 	return transport.NewFakeStreamForTesting(step.rpc), nil
@@ -529,6 +530,118 @@ func (o *eofSendOpener) Open(_ context.Context, _ transport.StreamParams) (wireS
 
 func durationPtr(d time.Duration) *time.Duration { return &d }
 
+type recvStep struct {
+	resp *zerobuspb.EphemeralStreamResponse
+	err  error
+}
+
+type scriptedRPC struct {
+	*fakeRPC
+	steps       chan recvStep
+	recvStarted chan int64
+	recvCalls   atomic.Int64
+	aborted     chan struct{}
+	abortOnce   sync.Once
+}
+
+func newScriptedRPC() *scriptedRPC {
+	return &scriptedRPC{
+		fakeRPC:     newFakeRPC(),
+		steps:       make(chan recvStep, 16),
+		recvStarted: make(chan int64, 16),
+		aborted:     make(chan struct{}),
+	}
+}
+
+func (f *scriptedRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	f.recvStarted <- f.recvCalls.Add(1)
+	select {
+	case step := <-f.steps:
+		return step.resp, step.err
+	case <-f.aborted:
+		return nil, io.ErrClosedPipe
+	}
+}
+
+type blockingAckModel struct {
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (m *blockingAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
+	m.once.Do(func() { close(m.entered) })
+	<-m.release
+	return (offsetAckModel{}).classify(resp)
+}
+
+func (f *scriptedRPC) Abort() {
+	f.abortOnce.Do(func() {
+		close(f.aborted)
+		f.fakeRPC.close()
+	})
+}
+
+func (f *scriptedRPC) pause(d time.Duration) {
+	f.steps <- recvStep{resp: &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{Duration: durationpb.New(d)},
+		},
+	}}
+}
+
+func (f *scriptedRPC) malformed() {
+	f.steps <- recvStep{resp: &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{},
+		},
+	}}
+}
+
+func (f *scriptedRPC) ack(offset int64) {
+	f.steps <- recvStep{resp: &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(offset),
+			},
+		},
+	}}
+}
+
+func (f *scriptedRPC) fail(err error) {
+	f.steps <- recvStep{err: err}
+}
+
+type scriptedOpener struct{ rpc *scriptedRPC }
+
+func (o *scriptedOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return transport.NewFakeStreamForTesting(o.rpc), nil
+}
+
+type streamSequenceOpener struct {
+	mu       sync.Mutex
+	streams  []wireStream[encodedMsg, ephemeralResp]
+	attempts int
+}
+
+func (o *streamSequenceOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.attempts++
+	if len(o.streams) == 0 {
+		return nil, fmt.Errorf("streamSequenceOpener: no more streams")
+	}
+	stream := o.streams[0]
+	o.streams = o.streams[1:]
+	return stream, nil
+}
+
+func (o *streamSequenceOpener) openCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.attempts
+}
+
 type classifiedError struct {
 	retryable bool
 }
@@ -551,10 +664,23 @@ type concurrentEncoder struct {
 	release <-chan struct{}
 }
 
-func (e *concurrentEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+func (e *concurrentEncoder) encode(record []byte) (encodedMsg, error) {
 	e.entered <- struct{}{}
 	<-e.release
-	return e.jsonEncoder.encode(offset, record)
+	return e.jsonEncoder.encode(record)
+}
+
+type failingEncoder struct {
+	jsonEncoder
+	err error
+}
+
+func (e failingEncoder) encode(record []byte) (encodedMsg, error) {
+	return nil, e.err
+}
+
+func (e failingEncoder) encodeBatch(records [][]byte) (encodedMsg, error) {
+	return nil, e.err
 }
 
 type blockingNthEncoder struct {
@@ -565,12 +691,12 @@ type blockingNthEncoder struct {
 	release <-chan struct{}
 }
 
-func (e *blockingNthEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+func (e *blockingNthEncoder) encode(record []byte) (encodedMsg, error) {
 	if e.calls.Add(1) == e.blockAt {
 		close(e.entered)
 		<-e.release
 	}
-	return e.jsonEncoder.encode(offset, record)
+	return e.jsonEncoder.encode(record)
 }
 
 type timeoutOpener struct {

--- a/purego/internal/stream/helpers_test.go
+++ b/purego/internal/stream/helpers_test.go
@@ -91,16 +91,18 @@ type controlledSendRPC struct {
 	started   chan struct{}
 	result    chan error
 	aborted   chan struct{}
+	pauseRead chan struct{}
 	startOnce sync.Once
 	abortOnce sync.Once
 }
 
 func newControlledSendRPC() *controlledSendRPC {
 	return &controlledSendRPC{
-		fakeRPC: newFakeRPC(),
-		started: make(chan struct{}),
-		result:  make(chan error, 1),
-		aborted: make(chan struct{}),
+		fakeRPC:   newFakeRPC(),
+		started:   make(chan struct{}),
+		result:    make(chan error, 1),
+		aborted:   make(chan struct{}),
+		pauseRead: make(chan struct{}, 1),
 	}
 }
 
@@ -115,6 +117,17 @@ func (f *controlledSendRPC) Send(req *zerobuspb.EphemeralStreamRequest) error {
 	case <-f.aborted:
 		return io.ErrClosedPipe
 	}
+}
+
+func (f *controlledSendRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	resp, err := f.fakeRPC.Recv()
+	if resp != nil && resp.GetCloseStreamSignal() != nil {
+		select {
+		case f.pauseRead <- struct{}{}:
+		default:
+		}
+	}
+	return resp, err
 }
 
 func (f *controlledSendRPC) Abort() {

--- a/purego/internal/stream/helpers_test.go
+++ b/purego/internal/stream/helpers_test.go
@@ -130,6 +130,78 @@ func (o *controlledSendOpener) Open(_ context.Context, _ transport.StreamParams)
 	return transport.NewFakeStreamForTesting(o.rpc), nil
 }
 
+// blockedSendTerminalRPC keeps Send blocked until Abort while allowing Recv to
+// report an authoritative server failure first.
+type blockedSendTerminalRPC struct {
+	*controlledSendRPC
+	recvErr chan error
+}
+
+func newBlockedSendTerminalRPC() *blockedSendTerminalRPC {
+	return &blockedSendTerminalRPC{
+		controlledSendRPC: newControlledSendRPC(),
+		recvErr:           make(chan error, 1),
+	}
+}
+
+func (f *blockedSendTerminalRPC) Recv() (*zerobuspb.EphemeralStreamResponse, error) {
+	select {
+	case resp, ok := <-f.recvs:
+		if !ok {
+			return nil, io.EOF
+		}
+		return resp, nil
+	case err := <-f.recvErr:
+		return nil, err
+	case <-f.aborted:
+		return nil, io.ErrClosedPipe
+	}
+}
+
+type blockedSendTerminalOpener struct{ rpc *blockedSendTerminalRPC }
+
+func (o *blockedSendTerminalOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return transport.NewFakeStreamForTesting(o.rpc), nil
+}
+
+// authOnCloseStream models a live Recv whose authentication rejection becomes
+// observable while Close is tearing the connection down.
+type authOnCloseStream struct {
+	recvStarted chan struct{}
+	closed      chan struct{}
+	startOnce   sync.Once
+	closeOnce   sync.Once
+}
+
+func newAuthOnCloseStream() *authOnCloseStream {
+	return &authOnCloseStream{
+		recvStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (*authOnCloseStream) ServerID() string { return "auth-on-close" }
+
+func (*authOnCloseStream) Send(encodedMsg) error { return nil }
+
+func (s *authOnCloseStream) Recv() (ephemeralResp, error) {
+	s.startOnce.Do(func() { close(s.recvStarted) })
+	<-s.closed
+	return nil, status.Error(codes.Unauthenticated, "expired credentials")
+}
+
+func (*authOnCloseStream) CloseSend() error { return io.ErrClosedPipe }
+
+func (s *authOnCloseStream) Close() {
+	s.closeOnce.Do(func() { close(s.closed) })
+}
+
+type authOnCloseOpener struct{ stream *authOnCloseStream }
+
+func (o *authOnCloseOpener) Open(_ context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return o.stream, nil
+}
+
 type reconnectControlledOpener struct {
 	mu     sync.Mutex
 	first  *fakeRPC
@@ -381,6 +453,17 @@ func (p *countingHeadersProvider) Invalidate(_ context.Context, tableName string
 type authRejectingOpener struct{}
 
 func (*authRejectingOpener) Open(context.Context, transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	return nil, status.Error(codes.Unauthenticated, "stale credentials")
+}
+
+type cancelThenAuthOpener struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (o *cancelThenAuthOpener) Open(ctx context.Context, _ transport.StreamParams) (wireStream[encodedMsg, ephemeralResp], error) {
+	o.once.Do(func() { close(o.started) })
+	<-ctx.Done()
 	return nil, status.Error(codes.Unauthenticated, "stale credentials")
 }
 

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -81,7 +81,9 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 				)
 				break
 			}
-			// The receiver already drained the pause window.
+			if !cs.pauseWait(ctx, ps.resumeAt) {
+				return
+			}
 			continue
 		}
 
@@ -106,8 +108,7 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 		if !isOpenFailure {
 			openedOnce = true
 		}
-		if !isOpenFailure &&
-			transport.IsAuthRejection(runErr) &&
+		if transport.IsAuthRejection(runErr) &&
 			cs.params.HeadersProvider != nil {
 			cs.params.HeadersProvider.Invalidate(ctx, cs.params.TableName)
 		}

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -10,7 +10,8 @@ import (
 )
 
 // supervise runs the connect, stream, and recovery lifecycle.
-// Successful connections reset the retry budget.
+// Durable progress or a connection that survives RecoveryResetAfter resets the
+// retry budget.
 func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 	defer func() {
 		if ctx.Err() != nil {
@@ -59,10 +60,19 @@ func (cs *CoreStream[Req, Resp]) supervise(ctx context.Context) {
 
 		// ctx cancelled = clean exit via Close. Don't treat server-side EOF as clean.
 		if ctx.Err() != nil {
+			// A definitive rejection still invalidates the credential that
+			// caused it, even when Close raced the completed Open/Recv. The
+			// provider contract requires Invalidate to be non-blocking.
+			if transport.IsAuthRejection(runErr) &&
+				cs.params.HeadersProvider != nil {
+				cs.params.HeadersProvider.Invalidate(
+					context.WithoutCancel(ctx), cs.params.TableName,
+				)
+			}
 			return
 		}
 
-		// Reset the retry budget after a successful Open.
+		// Reset after durable progress or sufficient connection uptime.
 		if resetRecoveryBudget {
 			failedAttempts = 0
 		}

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -108,9 +108,6 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 
 	stream, err := c.open(handshakeCtx, streamCtx, cancelStream, p)
 	if err != nil {
-		if p.HeadersProvider != nil && isAuthRejection(err) {
-			p.HeadersProvider.Invalidate(ctx, p.TableName)
-		}
 		// Deregister the bridge before returning so its AfterFunc doesn't linger
 		// until handshakeCtx ends (which, on the default-budget path, is bounded,
 		// but on a caller-supplied long-lived ctx would otherwise stay pinned).

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -155,10 +155,6 @@ func isUsableAsHeaderValue(value string) bool {
 	return true
 }
 
-// isAuthRejection reports whether err is a gRPC auth rejection
-// (Unauthenticated or PermissionDenied), unwrapping wrapped errors.
-func isAuthRejection(err error) bool { return IsAuthRejection(err) }
-
 // IsAuthRejection reports whether err rejects authentication.
 func IsAuthRejection(err error) bool {
 	code := status.Code(err)

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -36,11 +36,10 @@ type HeadersProvider interface {
 	GetHeaders(ctx context.Context, tableName string) (map[string]string, error)
 
 	// Invalidate drops any cached credentials so the next GetHeaders re-derives
-	// them. Open calls this when the server rejects the supplied credentials
-	// with Unauthenticated or PermissionDenied during stream creation.
+	// them. The stream lifecycle calls this when an Open or live stream rejects
+	// credentials with Unauthenticated or PermissionDenied.
 	//
-	// It must not block: Open calls it synchronously on the failure path, and
-	// the ctx it receives may already be cancelled.
+	// It must not block: recovery calls it synchronously on the failure path.
 	Invalidate(ctx context.Context, tableName string)
 }
 

--- a/purego/internal/transport/raw_stream_test.go
+++ b/purego/internal/transport/raw_stream_test.go
@@ -66,7 +66,7 @@ func TestRawStreamHandshakeSendEOFFallsThroughToRecv(t *testing.T) {
 	if err == nil {
 		t.Fatal("handshake with Send io.EOF: got nil error, want the recv status")
 	}
-	if !isAuthRejection(err) {
+	if !IsAuthRejection(err) {
 		t.Fatalf("handshake error = %v, want an auth rejection recovered from recv", err)
 	}
 }

--- a/purego/internal/transport/transport_test.go
+++ b/purego/internal/transport/transport_test.go
@@ -188,12 +188,17 @@ func dialFake(t *testing.T, srv *fakeServer) *transport.Conn {
 	lis := bufconn.Listen(1 << 20)
 	gsrv := grpc.NewServer()
 	zerobuspb.RegisterZerobusServer(gsrv, srv)
+	serveDone := make(chan struct{})
 	go func() {
-		if err := gsrv.Serve(lis); err != nil {
+		defer close(serveDone)
+		if err := gsrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			t.Errorf("fake server stopped: %v", err)
 		}
 	}()
-	t.Cleanup(gsrv.Stop)
+	t.Cleanup(func() {
+		gsrv.Stop()
+		<-serveDone
+	})
 
 	dialer := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 		return lis.DialContext(ctx)
@@ -526,7 +531,7 @@ func TestOpenHeadersProviderNoAuthSendsNoAuthHeader(t *testing.T) {
 	}
 }
 
-func TestOpenAuthRejectionInvalidatesHeadersProvider(t *testing.T) {
+func TestOpenAuthRejectionPreservesStatusForLifecycle(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		code codes.Code
@@ -549,11 +554,11 @@ func TestOpenAuthRejectionInvalidatesHeadersProvider(t *testing.T) {
 			if err == nil {
 				t.Fatal("Open with server auth rejection: got nil error")
 			}
-			if p.invalidateCalls.Load() != 1 {
-				t.Fatalf("Invalidate calls = %d, want 1", p.invalidateCalls.Load())
+			if got := status.Code(err); got != tc.code {
+				t.Fatalf("status code = %v, want %v", got, tc.code)
 			}
-			if last, _ := p.lastTable.Load().(string); last != "c.s.t" {
-				t.Fatalf("Invalidate saw table %q, want %q", last, "c.s.t")
+			if p.invalidateCalls.Load() != 0 {
+				t.Fatalf("transport invalidated credentials %d time(s)", p.invalidateCalls.Load())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

**4 of 4** — completes the generic proto/JSON ingestion core with lifecycle, recovery, callback, transport, and bounded-memory hardening on top of #577.

## Changes

- Preserves pause deadlines while ensuring protocol, authentication, and transport failures remain authoritative.
- Prioritizes receiver terminal causes over sender errors induced by teardown, preventing retries or credential reuse after definitive server rejection.
- Centralizes credential invalidation in the supervisor, including Open/live-stream rejections that race `Close`, and normalizes table-name cache keys.
- Adds FIFO count-and-byte backpressure across queued and in-flight work.
- Charges conservative encoded retained size—including framing, per-record containers, and request overhead—so tiny or empty batches cannot bypass the memory budget.
- Makes buffer reservation rollback idempotent across `close`/`drain` races and removes obsolete timer-drain handling for Go 1.25.
- Guards logical and physical offset exhaustion.
- Makes encoding offset-independent with conservative wire-size validation and connection-local physical-to-logical ACK translation.
- Reuses per-connection send synchronization and a persistent receive pump with deterministic worker teardown.
- Strengthens callback ordering, bounded shutdown, recovery, backpressure, authentication-race, and concurrency coverage.
- Adds ACK-path and recovery-requeue benchmarks and deterministically reaps fake gRPC servers in transport tests.
- Cleans up internal test hooks, dead aliases, and stale lifecycle/backpressure documentation.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- Focused lifecycle, buffer-accounting, pause-arbitration, and authentication-race tests repeated under the race detector.

## Size

16 files changed, **1,640 additions**, 297 deletions.

## Stack

- 1/4 — primitives — #575
- 2/4 — basic core stream — #576
- 3/4 — durability and callbacks — #577
- 4/4 — lifecycle and performance hardening — this PR