### PR TITLE
[PureGo] Ingestion primitives: buffer, encoder, ackmodel (1/4)

### DIFF
--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -49,7 +49,11 @@ func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal
 		if ack.DurabilityAckUpToOffset == nil {
 			return malformedResponse, 0, pauseSignal{}
 		}
-		return ackResponse, *ack.DurabilityAckUpToOffset, pauseSignal{}
+		off := *ack.DurabilityAckUpToOffset
+		if off < 0 {
+			return malformedResponse, 0, pauseSignal{}
+		}
+		return ackResponse, off, pauseSignal{}
 	}
 	return unknownResponse, 0, pauseSignal{}
 }

--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -12,18 +12,9 @@ import (
 // TODO(arrow): the Arrow wire path will supply its own ackModel over a Flight
 // response, mapping a cumulative record count back to an offset.
 type ackModel[Resp any] interface {
-	// classify inspects a server response and reports what it means to the core:
-	//   - kind == ackResponse: off is the highest fully-acked offset.
-	//   - kind == pauseResponse: the server asked the client to pause; pause
-	//     carries the requested duration. The core waits then reconnects.
-	//   - kind == unknownResponse: an unrecognized response type. The receiver
-	//     must fail the stream rather than ignore it, since silently dropping
-	//     unexpected messages hides a wire-contract mismatch.
-	//   - kind == malformedResponse: an ack whose offset field is absent.
-	//     Treating the zero default as a real ack would fake durability for
-	//     offset 0, so the receiver must fail the stream.
-	// Keeping close-signal detection here means the receiver never names a
-	// concrete proto message.
+	// classify reports what a server response means to the core: an ack offset,
+	// a pause request, or an unknown/malformed response the receiver must fail
+	// on. Detecting these here keeps the receiver blind to concrete proto types.
 	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
 }
 
@@ -54,9 +45,7 @@ func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal
 		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
 	}
 	if ack := resp.GetIngestRecordResponse(); ack != nil {
-		// DurabilityAckUpToOffset is an optional field; GetDurabilityAckUpToOffset
-		// would turn an absent value into 0 and fake an ack for offset 0. Preserve
-		// field presence and classify a missing offset as malformed.
+		// Absent offset must be malformed, not a fabricated ack for offset 0.
 		if ack.DurabilityAckUpToOffset == nil {
 			return malformedResponse, 0, pauseSignal{}
 		}

--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -1,0 +1,70 @@
+package stream
+
+import (
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// ackModel translates a raw server response into a logical "highest fully-acked
+// offset" that the core's watermark can compare against, and classifies
+// non-ack responses so the core stays blind to the concrete wire type. It is
+// edge #2 of the design and is generic over the response type Resp: proto/JSON
+// supply ackModel[ephemeralResp]; Arrow will supply its own over a Flight
+// response, mapping a cumulative record count back to an offset.
+//
+// This interface is intentionally the minimal offset-only subset. The
+// architecture note (§3a) sketches a wider Track/Resolve/Unacked shape for the
+// Arrow record-count model, where an ack can land mid-batch and recovery must
+// slice a straddling batch. That width is deferred until the Arrow wire path
+// lands; adding it now would be unused machinery. The core stays offset-only
+// and blind to the record-vs-batch distinction regardless.
+type ackModel[Resp any] interface {
+	// classify inspects a server response and reports what it means to the core:
+	//   - kind == ackResponse: off is the highest fully-acked offset.
+	//   - kind == pauseResponse: the server asked the client to pause; pause
+	//     carries the requested duration. The core waits then reconnects.
+	//   - kind == otherResponse: anything else (ignored by the receiver).
+	// Keeping close-signal detection here means the receiver never names a
+	// concrete proto message.
+	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
+}
+
+// respKind is the category the ackModel assigns to a server response.
+type respKind int
+
+const (
+	otherResponse respKind = iota // no ack, no pause — ignored
+	ackResponse                   // carries a durability ack offset
+	pauseResponse                 // server-requested pause (close-stream signal)
+)
+
+// ephemeralResp is the proto/JSON server response type. Aliased so the core's
+// Resp type parameter is named once here rather than spelled out at every use.
+type ephemeralResp = *zerobuspb.EphemeralStreamResponse
+
+// offsetAckModel is the proto/JSON ack model: the server sends
+// DurabilityAckUpToOffset directly as the logical offset, and a
+// CloseStreamSignal requests a pause.
+type offsetAckModel struct{}
+
+func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
+	if resp == nil {
+		return otherResponse, 0, pauseSignal{}
+	}
+	if sig := resp.GetCloseStreamSignal(); sig != nil {
+		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
+	}
+	if ack := resp.GetIngestRecordResponse(); ack != nil {
+		return ackResponse, ack.GetDurabilityAckUpToOffset(), pauseSignal{}
+	}
+	return otherResponse, 0, pauseSignal{}
+}
+
+// newAckModel returns the proto/JSON ack model for the given record type.
+func newAckModel(rt zerobuspb.RecordType) (ackModel[ephemeralResp], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO, zerobuspb.RecordType_JSON:
+		return offsetAckModel{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}

--- a/purego/internal/stream/ackmodel.go
+++ b/purego/internal/stream/ackmodel.go
@@ -7,22 +7,21 @@ import (
 // ackModel translates a raw server response into a logical "highest fully-acked
 // offset" that the core's watermark can compare against, and classifies
 // non-ack responses so the core stays blind to the concrete wire type. It is
-// edge #2 of the design and is generic over the response type Resp: proto/JSON
-// supply ackModel[ephemeralResp]; Arrow will supply its own over a Flight
-// response, mapping a cumulative record count back to an offset.
+// generic over the response type Resp: proto/JSON supply ackModel[ephemeralResp].
 //
-// This interface is intentionally the minimal offset-only subset. The
-// architecture note (§3a) sketches a wider Track/Resolve/Unacked shape for the
-// Arrow record-count model, where an ack can land mid-batch and recovery must
-// slice a straddling batch. That width is deferred until the Arrow wire path
-// lands; adding it now would be unused machinery. The core stays offset-only
-// and blind to the record-vs-batch distinction regardless.
+// TODO(arrow): the Arrow wire path will supply its own ackModel over a Flight
+// response, mapping a cumulative record count back to an offset.
 type ackModel[Resp any] interface {
 	// classify inspects a server response and reports what it means to the core:
 	//   - kind == ackResponse: off is the highest fully-acked offset.
 	//   - kind == pauseResponse: the server asked the client to pause; pause
 	//     carries the requested duration. The core waits then reconnects.
-	//   - kind == otherResponse: anything else (ignored by the receiver).
+	//   - kind == unknownResponse: an unrecognized response type. The receiver
+	//     must fail the stream rather than ignore it, since silently dropping
+	//     unexpected messages hides a wire-contract mismatch.
+	//   - kind == malformedResponse: an ack whose offset field is absent.
+	//     Treating the zero default as a real ack would fake durability for
+	//     offset 0, so the receiver must fail the stream.
 	// Keeping close-signal detection here means the receiver never names a
 	// concrete proto message.
 	classify(resp Resp) (kind respKind, off int64, pause pauseSignal)
@@ -32,9 +31,10 @@ type ackModel[Resp any] interface {
 type respKind int
 
 const (
-	otherResponse respKind = iota // no ack, no pause — ignored
-	ackResponse                   // carries a durability ack offset
-	pauseResponse                 // server-requested pause (close-stream signal)
+	ackResponse       respKind = iota // carries a durability ack offset
+	pauseResponse                     // server-requested pause (close-stream signal)
+	unknownResponse                   // unrecognized response type — receiver fails
+	malformedResponse                 // ack missing its offset field — receiver fails
 )
 
 // ephemeralResp is the proto/JSON server response type. Aliased so the core's
@@ -48,15 +48,21 @@ type offsetAckModel struct{}
 
 func (offsetAckModel) classify(resp ephemeralResp) (respKind, int64, pauseSignal) {
 	if resp == nil {
-		return otherResponse, 0, pauseSignal{}
+		return unknownResponse, 0, pauseSignal{}
 	}
 	if sig := resp.GetCloseStreamSignal(); sig != nil {
 		return pauseResponse, 0, pauseSignal{duration: sig.GetDuration().AsDuration()}
 	}
 	if ack := resp.GetIngestRecordResponse(); ack != nil {
-		return ackResponse, ack.GetDurabilityAckUpToOffset(), pauseSignal{}
+		// DurabilityAckUpToOffset is an optional field; GetDurabilityAckUpToOffset
+		// would turn an absent value into 0 and fake an ack for offset 0. Preserve
+		// field presence and classify a missing offset as malformed.
+		if ack.DurabilityAckUpToOffset == nil {
+			return malformedResponse, 0, pauseSignal{}
+		}
+		return ackResponse, *ack.DurabilityAckUpToOffset, pauseSignal{}
 	}
-	return otherResponse, 0, pauseSignal{}
+	return unknownResponse, 0, pauseSignal{}
 }
 
 // newAckModel returns the proto/JSON ack model for the given record type.

--- a/purego/internal/stream/ackmodel_test.go
+++ b/purego/internal/stream/ackmodel_test.go
@@ -77,6 +77,23 @@ func TestClassifyMalformedAckMissingOffset(t *testing.T) {
 	}
 }
 
+func TestClassifyMalformedAckNegativeOffset(t *testing.T) {
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(-1),
+			},
+		},
+	}
+	kind, off, _ := offsetAckModel{}.classify(resp)
+	if kind != malformedResponse {
+		t.Fatalf("want malformedResponse for negative offset, got %v", kind)
+	}
+	if off != 0 {
+		t.Fatalf("want offset 0 for malformed, got %d", off)
+	}
+}
+
 // Nil and payload-less responses are unknown, not ignorable, so the receiver
 // can fail the stream on a wire-contract mismatch.
 func TestClassifyUnknown(t *testing.T) {

--- a/purego/internal/stream/ackmodel_test.go
+++ b/purego/internal/stream/ackmodel_test.go
@@ -1,0 +1,89 @@
+package stream
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+func TestClassifyAck(t *testing.T) {
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(42),
+			},
+		},
+	}
+	kind, off, _ := offsetAckModel{}.classify(resp)
+	if kind != ackResponse {
+		t.Fatalf("want ackResponse, got %v", kind)
+	}
+	if off != 42 {
+		t.Fatalf("want offset 42, got %d", off)
+	}
+}
+
+// Offset 0 is a real ack (stream offsets start at 0), so it must be accepted as
+// long as the field is present.
+func TestClassifyAckOffsetZero(t *testing.T) {
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+				DurabilityAckUpToOffset: proto.Int64(0),
+			},
+		},
+	}
+	kind, off, _ := offsetAckModel{}.classify(resp)
+	if kind != ackResponse || off != 0 {
+		t.Fatalf("want ackResponse offset 0, got kind=%v off=%d", kind, off)
+	}
+}
+
+func TestClassifyPause(t *testing.T) {
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CloseStreamSignal{
+			CloseStreamSignal: &zerobuspb.CloseStreamSignal{
+				Duration: durationpb.New(3 * time.Second),
+			},
+		},
+	}
+	kind, _, pause := offsetAckModel{}.classify(resp)
+	if kind != pauseResponse {
+		t.Fatalf("want pauseResponse, got %v", kind)
+	}
+	if pause.duration != 3*time.Second {
+		t.Fatalf("want 3s pause, got %v", pause.duration)
+	}
+}
+
+// An IngestRecordResponse with an absent offset must be malformed, not an ack
+// fabricated at offset 0.
+func TestClassifyMalformedAckMissingOffset(t *testing.T) {
+	resp := &zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+			IngestRecordResponse: &zerobuspb.IngestRecordResponse{}, // offset absent
+		},
+	}
+	kind, off, _ := offsetAckModel{}.classify(resp)
+	if kind != malformedResponse {
+		t.Fatalf("want malformedResponse for absent offset, got %v", kind)
+	}
+	if off != 0 {
+		t.Fatalf("want offset 0 for malformed, got %d", off)
+	}
+}
+
+// Nil and payload-less responses are unknown, not ignorable, so the receiver
+// can fail the stream on a wire-contract mismatch.
+func TestClassifyUnknown(t *testing.T) {
+	for _, resp := range []ephemeralResp{nil, {}} {
+		kind, _, _ := offsetAckModel{}.classify(resp)
+		if kind != unknownResponse {
+			t.Fatalf("want unknownResponse, got %v", kind)
+		}
+	}
+}

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -1,0 +1,209 @@
+// Package stream is the generic ingestion core: offset assignment, send/recv
+// goroutines, ack watermark, Flush/WaitForOffset, and the recovery supervisor.
+// Protocol-specific behaviour (encoding, ack parsing, wire transport) is
+// injected through the encoder, ackModel, and wireStream interfaces, so the
+// core is written once and instantiated per wire protocol (proto/JSON today,
+// Arrow Flight later) without editing this package's core logic.
+package stream
+
+import (
+	"context"
+	"sync"
+)
+
+// item is one unit of work in the buffer: an already-encoded wire message
+// paired with the logical offset that identifies it for acknowledgment. Req is
+// the wire request type the core is instantiated with (encodedMsg for
+// proto/JSON; a Flight frame for Arrow).
+type item[Req any] struct {
+	offset  int64
+	payload Req
+}
+
+// buffer is the bounded, offset-assigning queue between the caller's Ingest
+// calls and the sender goroutine. Callers enqueue already-encoded messages;
+// the sender observes them (moves to in-flight); acks cause them to be
+// discarded. It is generic over the wire request type so the core holds no
+// concrete proto type.
+//
+// Concurrency model:
+//   - Many goroutines may call enqueue concurrently.
+//   - Exactly one sender goroutine calls next.
+//   - Exactly one receiver goroutine calls discardThrough as acks arrive.
+//   - The supervisor calls requeue and drain, but only while the sender is
+//     stopped — so next never runs concurrently with requeue or drain.
+//
+// All state (queue, flight, sem, cond) is private; the sender and receiver
+// interact only through these methods, never by touching the fields directly.
+//
+// The semaphore enforces the MaxInflight cap: enqueue blocks once the cap is
+// reached and unblocks as acks arrive and discardThrough releases permits.
+type buffer[Req any] struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	queue    []item[Req] // pending: enqueued but not yet observed by the sender
+	flight   []item[Req] // in-flight: observed by the sender, waiting for ack
+	closed   bool
+	sem      chan struct{} // capacity = maxInflight; held while item is in queue or flight
+	doneOnce sync.Once
+	doneCh   chan struct{} // closed when the buffer is closed/drained; unblocks sem waiters
+}
+
+func newBuffer[Req any](maxInflight int) *buffer[Req] {
+	// queue/flight grow on demand; don't preallocate to maxInflight, which with
+	// the default 1M cap would reserve tens of MB per stream before a single
+	// record is ingested. Only the semaphore is sized to the cap, since it is the
+	// backpressure gate and its capacity defines the bound.
+	b := &buffer[Req]{
+		sem:    make(chan struct{}, maxInflight),
+		doneCh: make(chan struct{}),
+	}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *buffer[Req]) closeDone() {
+	b.doneOnce.Do(func() { close(b.doneCh) })
+}
+
+// enqueue adds an already-encoded message to the pending queue, blocking until
+// a slot is available (backpressure) or ctx is cancelled. The offset must be
+// monotonically increasing; the caller (coreStream) is responsible for that.
+// Returns ctx.Err() if ctx fires before a slot opens.
+func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error {
+	// Honor an already-cancelled ctx first: select picks randomly among ready
+	// cases, so a free slot could otherwise mask cancellation.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Acquire a slot before touching the queue so callers block here rather than
+	// inside the mutex. ctx cancellation wakes up the select immediately.
+	select {
+	case b.sem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.doneCh:
+		return errClosed
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		<-b.sem // release the slot we just took
+		return errClosed
+	}
+	b.queue = append(b.queue, item[Req]{offset: offset, payload: msg})
+	b.mu.Unlock()
+	b.cond.Signal()
+	return nil
+}
+
+// next blocks until a pending item is available and moves it to the in-flight
+// list, returning the item. The sender must later call discard (on ack) or
+// requeue (on reconnect) for every item returned by next.
+//
+// Returns errClosed when the buffer has been closed and drained.
+// Returns ctx.Err() if ctx is cancelled while waiting.
+func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
+	b.mu.Lock()
+	for len(b.queue) == 0 && !b.closed {
+		// Wake up on ctx cancellation too.
+		stop := context.AfterFunc(ctx, func() { b.cond.Broadcast() })
+		b.cond.Wait()
+		stop()
+		if ctx.Err() != nil {
+			b.mu.Unlock()
+			return item[Req]{}, ctx.Err()
+		}
+	}
+	if len(b.queue) == 0 {
+		b.mu.Unlock()
+		return item[Req]{}, errClosed
+	}
+	it := b.queue[0]
+	b.queue = b.queue[1:]
+	b.flight = append(b.flight, it)
+	b.mu.Unlock()
+	return it, nil
+}
+
+// discardThrough removes every in-flight item whose offset is <= offset (all
+// now acknowledged by the server) and releases one semaphore slot per removed
+// item so blocked enqueue callers can proceed. It is the sender/receiver's only
+// hook for ack-driven eviction, keeping the buffer's internals (flight, sem,
+// cond) private. Returns the number of items discarded.
+func (b *buffer[Req]) discardThrough(offset int64) int {
+	b.mu.Lock()
+	n := 0
+	for len(b.flight) > 0 && b.flight[0].offset <= offset {
+		b.flight = b.flight[1:]
+		n++
+	}
+	b.mu.Unlock()
+	for range n {
+		<-b.sem
+	}
+	if n > 0 {
+		b.cond.Broadcast()
+	}
+	return n
+}
+
+// requeue moves all in-flight items back to the front of the pending queue so
+// they are re-sent after a reconnect. Called by the supervisor on stream failure.
+func (b *buffer[Req]) requeue() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Prepend in-flight items (in order) before any still-pending ones.
+	b.queue = append(b.flight, b.queue...)
+	b.flight = b.flight[:0]
+	b.cond.Broadcast()
+}
+
+// drain returns all items currently in the buffer (pending + in-flight) and
+// closes it. Subsequent enqueue calls return errClosed. Called once the
+// supervisor has given up and the caller wants unacked records.
+//
+// The sender must be stopped before drain is called: an item returned by next
+// but not yet discarded is still in flight, so draining it concurrently would
+// report a record as unacked while the sender is putting it on the wire.
+func (b *buffer[Req]) drain() []item[Req] {
+	b.mu.Lock()
+	all := make([]item[Req], 0, len(b.flight)+len(b.queue))
+	all = append(all, b.flight...)
+	all = append(all, b.queue...)
+	b.queue = nil
+	b.flight = nil
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+	return all
+}
+
+// close marks the buffer closed and wakes any blocked next or enqueue calls.
+// Pending items are not discarded — drain must be called to retrieve them.
+func (b *buffer[Req]) close() {
+	b.mu.Lock()
+	b.closed = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+	b.closeDone()
+}
+
+// len returns the total number of items in the buffer (pending + in-flight).
+func (b *buffer[Req]) len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.queue) + len(b.flight)
+}
+
+// inFlight returns the number of items observed by the sender but not yet
+// acknowledged. The receiver uses it to gate the lack-of-ack timeout: silence
+// is only a failure while records are actually awaiting an ack; an idle stream
+// (nothing in flight) legitimately receives no acks and must not be torn down.
+func (b *buffer[Req]) inFlight() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.flight)
+}

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -181,7 +181,15 @@ func (b *buffer[Req]) requeue() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// Prepend in-flight items (in order) before any still-pending ones.
-	b.queue = append(b.flight, b.queue...)
+	requeued := make([]item[Req], 0, len(b.flight)+len(b.queue))
+	requeued = append(requeued, b.flight...)
+	requeued = append(requeued, b.queue...)
+	b.queue = requeued
+	// Zero departed slots so payload references in the old backing array become
+	// GC-collectible after flight is reset.
+	for i := range b.flight {
+		b.flight[i] = item[Req]{}
+	}
 	b.flight = b.flight[:0]
 	b.cond.Broadcast()
 }

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -54,10 +54,8 @@ type buffer[Req any] struct {
 }
 
 func newBuffer[Req any](maxInflight int) *buffer[Req] {
-	// A non-positive cap would make an unbuffered (0) or panicking (<0) semaphore
-	// and deadlock every reservation, so normalize it to the default. Callers
-	// that sanitize config upstream never hit this; it guards the primitive from
-	// breaking liveness on a bad value.
+	// Normalize a non-positive cap, which would otherwise deadlock (0) or
+	// panic (<0) at the semaphore.
 	if maxInflight <= 0 {
 		maxInflight = defaultMaxInflight
 	}
@@ -116,18 +114,15 @@ func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error 
 // Returns errClosed when the buffer has been closed and drained.
 // Returns ctx.Err() if ctx is cancelled while waiting.
 func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
-	// Fail fast if the sender's ctx is already cancelled (teardown/Close): a
-	// non-empty queue would otherwise skip the wait loop and put one more record
-	// on a stream that is being torn down.
+	// Fail fast on an already-cancelled ctx so a stopping sender doesn't dequeue
+	// one more record from a non-empty queue.
 	if err := ctx.Err(); err != nil {
 		return item[Req]{}, err
 	}
 	b.mu.Lock()
 	for len(b.queue) == 0 && !b.closed {
-		// Take b.mu inside the callback so the Broadcast cannot run until Wait has
-		// registered the waiter and released the lock. Without it, a cancellation
-		// landing between the loop's queue check and Wait's park step would fire
-		// too early and leave next asleep on an already-cancelled ctx.
+		// Take b.mu in the callback so the Broadcast can't run before Wait
+		// registers the waiter; otherwise the wake-up is lost.
 		stop := context.AfterFunc(ctx, func() {
 			b.mu.Lock()
 			b.cond.Broadcast()
@@ -144,16 +139,13 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 		b.mu.Unlock()
 		return item[Req]{}, errClosed
 	}
-	// Re-check after waking: teardown may have started while a queued item was
-	// available, and we must not hand it to a sender that is stopping.
+	// Re-check after waking: teardown may have started while an item was queued.
 	if err := ctx.Err(); err != nil {
 		b.mu.Unlock()
 		return item[Req]{}, err
 	}
 	it := b.queue[0]
-	// Zero the departed slot so its payload isn't pinned in the backing array
-	// after the item moves to flight.
-	b.queue[0] = item[Req]{}
+	b.queue[0] = item[Req]{} // release the departed slot's payload for GC
 	b.queue = b.queue[1:]
 	b.flight = append(b.flight, it)
 	b.mu.Unlock()
@@ -169,9 +161,7 @@ func (b *buffer[Req]) discardThrough(offset int64) int {
 	b.mu.Lock()
 	n := 0
 	for len(b.flight) > 0 && b.flight[0].offset <= offset {
-		// Zero the departed slot so the acknowledged payload isn't pinned in the
-		// backing array by later still-live entries.
-		b.flight[0] = item[Req]{}
+		b.flight[0] = item[Req]{} // release the acked payload for GC
 		b.flight = b.flight[1:]
 		n++
 	}

--- a/purego/internal/stream/buffer.go
+++ b/purego/internal/stream/buffer.go
@@ -11,6 +11,10 @@ import (
 	"sync"
 )
 
+// defaultMaxInflight is the fallback backpressure cap used when a non-positive
+// value reaches newBuffer.
+const defaultMaxInflight = 1_000_000
+
 // item is one unit of work in the buffer: an already-encoded wire message
 // paired with the logical offset that identifies it for acknowledgment. Req is
 // the wire request type the core is instantiated with (encodedMsg for
@@ -50,6 +54,13 @@ type buffer[Req any] struct {
 }
 
 func newBuffer[Req any](maxInflight int) *buffer[Req] {
+	// A non-positive cap would make an unbuffered (0) or panicking (<0) semaphore
+	// and deadlock every reservation, so normalize it to the default. Callers
+	// that sanitize config upstream never hit this; it guards the primitive from
+	// breaking liveness on a bad value.
+	if maxInflight <= 0 {
+		maxInflight = defaultMaxInflight
+	}
 	// queue/flight grow on demand; don't preallocate to maxInflight, which with
 	// the default 1M cap would reserve tens of MB per stream before a single
 	// record is ingested. Only the semaphore is sized to the cap, since it is the
@@ -105,10 +116,23 @@ func (b *buffer[Req]) enqueue(ctx context.Context, offset int64, msg Req) error 
 // Returns errClosed when the buffer has been closed and drained.
 // Returns ctx.Err() if ctx is cancelled while waiting.
 func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
+	// Fail fast if the sender's ctx is already cancelled (teardown/Close): a
+	// non-empty queue would otherwise skip the wait loop and put one more record
+	// on a stream that is being torn down.
+	if err := ctx.Err(); err != nil {
+		return item[Req]{}, err
+	}
 	b.mu.Lock()
 	for len(b.queue) == 0 && !b.closed {
-		// Wake up on ctx cancellation too.
-		stop := context.AfterFunc(ctx, func() { b.cond.Broadcast() })
+		// Take b.mu inside the callback so the Broadcast cannot run until Wait has
+		// registered the waiter and released the lock. Without it, a cancellation
+		// landing between the loop's queue check and Wait's park step would fire
+		// too early and leave next asleep on an already-cancelled ctx.
+		stop := context.AfterFunc(ctx, func() {
+			b.mu.Lock()
+			b.cond.Broadcast()
+			b.mu.Unlock()
+		})
 		b.cond.Wait()
 		stop()
 		if ctx.Err() != nil {
@@ -120,7 +144,16 @@ func (b *buffer[Req]) next(ctx context.Context) (item[Req], error) {
 		b.mu.Unlock()
 		return item[Req]{}, errClosed
 	}
+	// Re-check after waking: teardown may have started while a queued item was
+	// available, and we must not hand it to a sender that is stopping.
+	if err := ctx.Err(); err != nil {
+		b.mu.Unlock()
+		return item[Req]{}, err
+	}
 	it := b.queue[0]
+	// Zero the departed slot so its payload isn't pinned in the backing array
+	// after the item moves to flight.
+	b.queue[0] = item[Req]{}
 	b.queue = b.queue[1:]
 	b.flight = append(b.flight, it)
 	b.mu.Unlock()
@@ -136,6 +169,9 @@ func (b *buffer[Req]) discardThrough(offset int64) int {
 	b.mu.Lock()
 	n := 0
 	for len(b.flight) > 0 && b.flight[0].offset <= offset {
+		// Zero the departed slot so the acknowledged payload isn't pinned in the
+		// backing array by later still-live entries.
+		b.flight[0] = item[Req]{}
 		b.flight = b.flight[1:]
 		n++
 	}

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -1,0 +1,216 @@
+package stream
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dummyMsg returns a non-nil encodedMsg for use in buffer tests.
+func dummyMsg(offset int64) encodedMsg {
+	msg, _ := protoEncoder{}.encode(offset, []byte("x"))
+	return msg
+}
+
+func TestBufferEnqueueNext(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if it.offset != 1 {
+		t.Fatalf("want offset 1, got %d", it.offset)
+	}
+}
+
+func TestBufferFIFOOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 5; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	for i := int64(1); i <= 5; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferBackpressure(t *testing.T) {
+	const cap = 2
+	b := newBuffer[encodedMsg](cap)
+
+	// Fill the buffer to capacity.
+	for i := int64(1); i <= cap; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// A third enqueue should block until a slot is freed.
+	var enqueued atomic.Bool
+	go func() {
+		_ = b.enqueue(context.Background(), 3, dummyMsg(3))
+		enqueued.Store(true)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if enqueued.Load() {
+		t.Fatal("enqueue should be blocked at capacity")
+	}
+
+	// Observe and discard one item to free a slot.
+	it, err := b.next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	b.discardThrough(it.offset)
+
+	// Now the blocked enqueue should complete.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for !enqueued.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !enqueued.Load() {
+		t.Fatal("enqueue did not unblock after discard")
+	}
+}
+
+func TestBufferContextCancelUnblocksEnqueue(t *testing.T) {
+	b := newBuffer[encodedMsg](1)
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.enqueue(ctx, 2, dummyMsg(2))
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("enqueue did not unblock on context cancel")
+	}
+}
+
+func TestBufferRequeueResendsInOrder(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	for i := int64(1); i <= 3; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// Observe all three (move to in-flight).
+	for range 3 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	// Requeue moves them back to the front of the queue.
+	b.requeue()
+
+	for i := int64(1); i <= 3; i++ {
+		it, err := b.next(context.Background())
+		if err != nil {
+			t.Fatalf("next after requeue %d: %v", i, err)
+		}
+		if it.offset != i {
+			t.Fatalf("want offset %d after requeue, got %d", i, it.offset)
+		}
+	}
+}
+
+func TestBufferDrainReturnsAll(t *testing.T) {
+	b := newBuffer[encodedMsg](8)
+	for i := int64(1); i <= 4; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	// Observe two to put them in-flight.
+	for range 2 {
+		if _, err := b.next(context.Background()); err != nil {
+			t.Fatalf("next: %v", err)
+		}
+	}
+
+	items := b.drain()
+	if len(items) != 4 {
+		t.Fatalf("want 4 items from drain, got %d", len(items))
+	}
+	// Verify in-flight items come first (offsets 1,2), then pending (3,4).
+	for i, want := range []int64{1, 2, 3, 4} {
+		if items[i].offset != want {
+			t.Fatalf("drain[%d]: want offset %d, got %d", i, want, items[i].offset)
+		}
+	}
+}
+
+func TestBufferEnqueueAfterCloseErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.close()
+	err := b.enqueue(context.Background(), 1, dummyMsg(1))
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferNextAfterCloseAndDrainErrors(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	b.drain()
+	_, err := b.next(context.Background())
+	if err != errClosed {
+		t.Fatalf("want errClosed, got %v", err)
+	}
+}
+
+func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
+	const n = 100
+	b := newBuffer[encodedMsg](16)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			it, err := b.next(context.Background())
+			if err != nil {
+				return
+			}
+			b.discardThrough(it.offset)
+		}
+	}()
+
+	for i := int64(1); i <= n; i++ {
+		if err := b.enqueue(context.Background(), i, dummyMsg(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	wg.Wait()
+
+	if got := b.len(); got != 0 {
+		t.Fatalf("want buffer empty after all discards, got len=%d", got)
+	}
+}

--- a/purego/internal/stream/buffer_test.go
+++ b/purego/internal/stream/buffer_test.go
@@ -214,3 +214,57 @@ func TestBufferConcurrentEnqueueDiscard(t *testing.T) {
 		t.Fatalf("want buffer empty after all discards, got len=%d", got)
 	}
 }
+
+// next must unblock when its ctx is cancelled while parked on an empty buffer.
+// The AfterFunc broadcast has to be ordered under b.mu against cond.Wait, or
+// the wake-up can be lost and next sleeps forever on a cancelled ctx.
+func TestBufferNextContextCancelUnblocks(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := b.next(ctx)
+		errCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let it park in cond.Wait
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("next did not unblock on context cancel")
+	}
+}
+
+// next must return immediately on an already-cancelled ctx and leave a queued
+// item untouched, so a stopping sender never drains one more record.
+func TestBufferNextAlreadyCancelledCtx(t *testing.T) {
+	b := newBuffer[encodedMsg](4)
+	if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := b.next(ctx); err != context.Canceled {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if got := b.len(); got != 1 {
+		t.Fatalf("want item left in buffer, got len=%d", got)
+	}
+}
+
+// A non-positive cap is normalized to the default rather than deadlocking (0)
+// or panicking (<0), so the primitive stays live on a bad value.
+func TestNewBufferNormalizesNonPositiveCap(t *testing.T) {
+	for _, cap := range []int{0, -1} {
+		b := newBuffer[encodedMsg](cap)
+		if err := b.enqueue(context.Background(), 1, dummyMsg(1)); err != nil {
+			t.Fatalf("cap %d: enqueue should not block/fail, got %v", cap, err)
+		}
+	}
+}

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -36,9 +36,8 @@ type encoder[Req any] interface {
 	// return original content. A single-record message yields one entry; a batch
 	// yields all of its records so no unacked record is silently dropped.
 	decode(msg Req) [][]byte
-	// wireSize reports the exact serialized size of the message, including
-	// protobuf framing, so the caller can enforce a payload cap against what the
-	// server will actually receive rather than the raw input length.
+	// wireSize reports the serialized message size (incl. proto framing) so a
+	// payload cap can be enforced against what the server actually receives.
 	wireSize(msg Req) int
 }
 
@@ -47,10 +46,8 @@ type encoder[Req any] interface {
 type protoEncoder struct{}
 
 func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
-	// An empty slice is a valid proto encoding (an all-default message), so it is
-	// accepted. Clone the caller's bytes: Ingest returns before the sender
-	// serializes the request, so a reused scratch buffer must not alias the
-	// queued (or replayed) payload.
+	// Empty is a valid proto encoding (all-default message). Clone so a reused
+	// caller buffer can't mutate the queued payload before it's serialized.
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
 			IngestRecord: &zerobuspb.IngestRecordRequest{
@@ -65,8 +62,8 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 	if len(records) == 0 {
 		return nil, fmt.Errorf("stream: proto batch must not be empty")
 	}
-	// Empty proto records are valid; clone each so a reused source buffer can't
-	// mutate a queued or replayed payload, and copy the outer slice too.
+	// Clone each record (empty is valid) so a reused caller buffer can't mutate
+	// a queued payload.
 	copied := make([][]byte, len(records))
 	for i, r := range records {
 		copied[i] = bytes.Clone(r)
@@ -162,8 +159,8 @@ func extractEphemeralRecords(msg encodedMsg) [][]byte {
 		return nil
 	}
 	if ir := msg.GetIngestRecord(); ir != nil {
-		// Discriminate by oneof type, not by nil: an empty proto record is a
-		// valid non-nil case that must not be mistaken for a JSON record.
+		// Switch on oneof type, not nil: an empty proto record must not be read
+		// as JSON.
 		switch r := ir.GetRecord().(type) {
 		case *zerobuspb.IngestRecordRequest_ProtoEncodedRecord:
 			return [][]byte{r.ProtoEncodedRecord}

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -1,0 +1,163 @@
+package stream
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// encodedMsg is a wire-ready EphemeralStream ingest request, built once at
+// Ingest time and held in the buffer until the sender transmits it. It is the
+// Req type the proto/JSON core is instantiated with; the Arrow path will use a
+// Flight frame instead. Encoding is eager so the buffer never retains live user
+// objects.
+type encodedMsg = *zerobuspb.EphemeralStreamRequest
+
+// encoder turns user records into wire messages for a given offset and recovers
+// them again for GetUnacked. It is the send-side per-encoding
+// seam. The core is generic over the wire message type Req and
+// never names a concrete proto type — proto/JSON supply encoder[encodedMsg];
+// Arrow will supply encoder[flightFrame].
+//
+// The offset is stamped into the message here so re-sends after recovery reuse
+// the same logical offset the server already saw.
+type encoder[Req any] interface {
+	// encode turns a single user record into one wire message.
+	encode(offset int64, record []byte) (Req, error)
+	// encodeBatch turns many already-encoded records into one wire message. All
+	// records share a single offset and are atomic to the server (it acks the
+	// whole batch or none of it), so the batch occupies exactly one logical
+	// offset in the core's buffer.
+	encodeBatch(offset int64, records [][]byte) (Req, error)
+	// decode recovers the raw record bytes from a wire message so GetUnacked can
+	// return original content. A single-record message yields one entry; a batch
+	// yields all of its records so no unacked record is silently dropped.
+	decode(msg Req) [][]byte
+}
+
+// protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
+// serialized protobuf bytes), single and batched.
+type protoEncoder struct{}
+
+func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: proto record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: record},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: proto batch must not be empty")
+	}
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: proto batch record %d must not be empty", i)
+		}
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_ProtoEncodedBatch{
+					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: records},
+				},
+			},
+		},
+	}, nil
+}
+
+func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
+// and batched.
+type jsonEncoder struct{}
+
+func (jsonEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
+	if len(record) == 0 {
+		return nil, fmt.Errorf("stream: json record must not be empty")
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
+			IngestRecord: &zerobuspb.IngestRecordRequest{
+				OffsetId: proto.Int64(offset),
+				Record:   &zerobuspb.IngestRecordRequest_JsonRecord{JsonRecord: string(record)},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("stream: json batch must not be empty")
+	}
+	jsonRecords := make([]string, len(records))
+	for i, r := range records {
+		if len(r) == 0 {
+			return nil, fmt.Errorf("stream: json batch record %d must not be empty", i)
+		}
+		jsonRecords[i] = string(r)
+	}
+	return &zerobuspb.EphemeralStreamRequest{
+		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
+			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
+				OffsetId: proto.Int64(offset),
+				Batch: &zerobuspb.IngestRecordBatchRequest_JsonBatch{
+					JsonBatch: &zerobuspb.JsonRecordBatch{Records: jsonRecords},
+				},
+			},
+		},
+	}, nil
+}
+
+func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+// newEncoder returns the proto/JSON encoder for the given record type.
+func newEncoder(rt zerobuspb.RecordType) (encoder[encodedMsg], error) {
+	switch rt {
+	case zerobuspb.RecordType_PROTO:
+		return protoEncoder{}, nil
+	case zerobuspb.RecordType_JSON:
+		return jsonEncoder{}, nil
+	default:
+		return nil, errUnsupportedRecordType(rt)
+	}
+}
+
+// extractEphemeralRecords recovers the raw record bytes from an EphemeralStream
+// wire message. A single-record message yields one entry; a batch yields all of
+// its records. Shared by the proto and JSON encoders' decode.
+func extractEphemeralRecords(msg encodedMsg) [][]byte {
+	if msg == nil {
+		return nil
+	}
+	if ir := msg.GetIngestRecord(); ir != nil {
+		if b := ir.GetProtoEncodedRecord(); b != nil {
+			return [][]byte{b}
+		}
+		return [][]byte{[]byte(ir.GetJsonRecord())}
+	}
+	if ib := msg.GetIngestRecordBatch(); ib != nil {
+		if pb := ib.GetProtoEncodedBatch(); pb != nil {
+			return pb.GetRecords()
+		}
+		if jb := ib.GetJsonBatch(); jb != nil {
+			recs := jb.GetRecords()
+			out := make([][]byte, len(recs))
+			for i, r := range recs {
+				out[i] = []byte(r)
+			}
+			return out
+		}
+	}
+	return nil
+}

--- a/purego/internal/stream/encoder.go
+++ b/purego/internal/stream/encoder.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"bytes"
 	"fmt"
 
 	"google.golang.org/protobuf/proto"
@@ -35,6 +36,10 @@ type encoder[Req any] interface {
 	// return original content. A single-record message yields one entry; a batch
 	// yields all of its records so no unacked record is silently dropped.
 	decode(msg Req) [][]byte
+	// wireSize reports the exact serialized size of the message, including
+	// protobuf framing, so the caller can enforce a payload cap against what the
+	// server will actually receive rather than the raw input length.
+	wireSize(msg Req) int
 }
 
 // protoEncoder builds EphemeralStream payloads for proto-encoded records (raw
@@ -42,14 +47,15 @@ type encoder[Req any] interface {
 type protoEncoder struct{}
 
 func (protoEncoder) encode(offset int64, record []byte) (encodedMsg, error) {
-	if len(record) == 0 {
-		return nil, fmt.Errorf("stream: proto record must not be empty")
-	}
+	// An empty slice is a valid proto encoding (an all-default message), so it is
+	// accepted. Clone the caller's bytes: Ingest returns before the sender
+	// serializes the request, so a reused scratch buffer must not alias the
+	// queued (or replayed) payload.
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecord{
 			IngestRecord: &zerobuspb.IngestRecordRequest{
 				OffsetId: proto.Int64(offset),
-				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: record},
+				Record:   &zerobuspb.IngestRecordRequest_ProtoEncodedRecord{ProtoEncodedRecord: bytes.Clone(record)},
 			},
 		},
 	}, nil
@@ -59,17 +65,18 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 	if len(records) == 0 {
 		return nil, fmt.Errorf("stream: proto batch must not be empty")
 	}
+	// Empty proto records are valid; clone each so a reused source buffer can't
+	// mutate a queued or replayed payload, and copy the outer slice too.
+	copied := make([][]byte, len(records))
 	for i, r := range records {
-		if len(r) == 0 {
-			return nil, fmt.Errorf("stream: proto batch record %d must not be empty", i)
-		}
+		copied[i] = bytes.Clone(r)
 	}
 	return &zerobuspb.EphemeralStreamRequest{
 		Payload: &zerobuspb.EphemeralStreamRequest_IngestRecordBatch{
 			IngestRecordBatch: &zerobuspb.IngestRecordBatchRequest{
 				OffsetId: proto.Int64(offset),
 				Batch: &zerobuspb.IngestRecordBatchRequest_ProtoEncodedBatch{
-					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: records},
+					ProtoEncodedBatch: &zerobuspb.ProtoEncodedRecordBatch{Records: copied},
 				},
 			},
 		},
@@ -77,6 +84,13 @@ func (protoEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, err
 }
 
 func (protoEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
+
+func (protoEncoder) wireSize(msg encodedMsg) int {
+	if msg == nil {
+		return 0
+	}
+	return proto.Size(msg)
+}
 
 // jsonEncoder builds EphemeralStream payloads for JSON-encoded records, single
 // and batched.
@@ -121,6 +135,13 @@ func (jsonEncoder) encodeBatch(offset int64, records [][]byte) (encodedMsg, erro
 
 func (jsonEncoder) decode(msg encodedMsg) [][]byte { return extractEphemeralRecords(msg) }
 
+func (jsonEncoder) wireSize(msg encodedMsg) int {
+	if msg == nil {
+		return 0
+	}
+	return proto.Size(msg)
+}
+
 // newEncoder returns the proto/JSON encoder for the given record type.
 func newEncoder(rt zerobuspb.RecordType) (encoder[encodedMsg], error) {
 	switch rt {
@@ -141,10 +162,15 @@ func extractEphemeralRecords(msg encodedMsg) [][]byte {
 		return nil
 	}
 	if ir := msg.GetIngestRecord(); ir != nil {
-		if b := ir.GetProtoEncodedRecord(); b != nil {
-			return [][]byte{b}
+		// Discriminate by oneof type, not by nil: an empty proto record is a
+		// valid non-nil case that must not be mistaken for a JSON record.
+		switch r := ir.GetRecord().(type) {
+		case *zerobuspb.IngestRecordRequest_ProtoEncodedRecord:
+			return [][]byte{r.ProtoEncodedRecord}
+		case *zerobuspb.IngestRecordRequest_JsonRecord:
+			return [][]byte{[]byte(r.JsonRecord)}
 		}
-		return [][]byte{[]byte(ir.GetJsonRecord())}
+		return nil
 	}
 	if ib := msg.GetIngestRecordBatch(); ib != nil {
 		if pb := ib.GetProtoEncodedBatch(); pb != nil {

--- a/purego/internal/stream/encoder_test.go
+++ b/purego/internal/stream/encoder_test.go
@@ -1,0 +1,139 @@
+package stream
+
+import (
+	"testing"
+)
+
+func TestProtoEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encode(42, []byte{0x0a, 0x01, 0x78})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 42 {
+		t.Fatalf("want offset 42, got %d", ir.GetOffsetId())
+	}
+	if len(ir.GetProtoEncodedRecord()) == 0 {
+		t.Fatal("want non-empty proto record")
+	}
+}
+
+func TestJSONEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encode(7, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	ir := msg.GetIngestRecord()
+	if ir == nil {
+		t.Fatal("want IngestRecord payload, got nil")
+	}
+	if ir.GetOffsetId() != 7 {
+		t.Fatalf("want offset 7, got %d", ir.GetOffsetId())
+	}
+	if ir.GetJsonRecord() != `{"x":1}` {
+		t.Fatalf("want json record, got %q", ir.GetJsonRecord())
+	}
+}
+
+func TestProtoBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := protoEncoder{}
+	msg, err := enc.encodeBatch(3, [][]byte{{0x01, 0x02}, {0x03, 0x04}, {0x05}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 3 {
+		t.Fatalf("want offset 3, got %d", ib.GetOffsetId())
+	}
+	pb := ib.GetProtoEncodedBatch()
+	if pb == nil {
+		t.Fatal("want ProtoEncodedBatch, got nil")
+	}
+	// The batch must carry all three records, not one concatenated blob.
+	if got := len(pb.GetRecords()); got != 3 {
+		t.Fatalf("want 3 records in batch, got %d", got)
+	}
+}
+
+func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
+	enc := jsonEncoder{}
+	msg, err := enc.encodeBatch(5, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	ib := msg.GetIngestRecordBatch()
+	if ib == nil {
+		t.Fatal("want IngestRecordBatch payload, got nil")
+	}
+	if ib.GetOffsetId() != 5 {
+		t.Fatalf("want offset 5, got %d", ib.GetOffsetId())
+	}
+	jb := ib.GetJsonBatch()
+	if jb == nil {
+		t.Fatal("want JsonBatch, got nil")
+	}
+	if got := jb.GetRecords(); len(got) != 2 || got[0] != `{"a":1}` || got[1] != `{"b":2}` {
+		t.Fatalf("want 2 json records preserved, got %v", got)
+	}
+}
+
+func TestEncodersRejectEmptyRecord(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encode(1, nil); err == nil {
+			t.Errorf("%T: want error for empty record, got nil", enc)
+		}
+		if _, err := enc.encode(1, []byte{}); err == nil {
+			t.Errorf("%T: want error for zero-length record, got nil", enc)
+		}
+	}
+}
+
+func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		if _, err := enc.encodeBatch(1, nil); err == nil {
+			t.Errorf("%T: want error for empty batch, got nil", enc)
+		}
+		// A batch containing an empty record is rejected too.
+		if _, err := enc.encodeBatch(1, [][]byte{[]byte("ok"), {}}); err == nil {
+			t.Errorf("%T: want error for empty record within batch, got nil", enc)
+		}
+	}
+}
+
+func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
+	// A batch message must yield every record, not just the first, so GetUnacked
+	// doesn't silently drop the tail of an unacked batch.
+	protoMsg, err := protoEncoder{}.encodeBatch(1, [][]byte{{0x01}, {0x02}, {0x03}})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	if got := (protoEncoder{}).decode(protoMsg); len(got) != 3 {
+		t.Fatalf("proto batch: want 3 records extracted, got %d", len(got))
+	}
+
+	jsonMsg, err := jsonEncoder{}.encodeBatch(1, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	got := (jsonEncoder{}).decode(jsonMsg)
+	if len(got) != 2 || string(got[0]) != `{"a":1}` || string(got[1]) != `{"b":2}` {
+		t.Fatalf("json batch: want both records extracted, got %v", got)
+	}
+
+	// A single-record message still yields exactly one entry.
+	single, err := jsonEncoder{}.encode(1, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if got := (jsonEncoder{}).decode(single); len(got) != 1 || string(got[0]) != `{"x":1}` {
+		t.Fatalf("single record: want 1 entry, got %v", got)
+	}
+}

--- a/purego/internal/stream/encoder_test.go
+++ b/purego/internal/stream/encoder_test.go
@@ -85,14 +85,35 @@ func TestJSONBatchEncoderSetsOffsetAndPayload(t *testing.T) {
 	}
 }
 
-func TestEncodersRejectEmptyRecord(t *testing.T) {
-	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
-		if _, err := enc.encode(1, nil); err == nil {
-			t.Errorf("%T: want error for empty record, got nil", enc)
-		}
-		if _, err := enc.encode(1, []byte{}); err == nil {
-			t.Errorf("%T: want error for zero-length record, got nil", enc)
-		}
+// JSON records are text and must be non-empty; proto records may legitimately
+// be empty (an all-default message), so only JSON rejects empty input.
+func TestJSONEncoderRejectsEmptyRecord(t *testing.T) {
+	if _, err := (jsonEncoder{}).encode(1, nil); err == nil {
+		t.Error("want error for empty json record, got nil")
+	}
+	if _, err := (jsonEncoder{}).encode(1, []byte{}); err == nil {
+		t.Error("want error for zero-length json record, got nil")
+	}
+}
+
+// An empty proto record is a valid encoding and must be accepted, both as a
+// single record and within a batch, matching the Rust SDK.
+func TestProtoEncoderAcceptsEmptyRecord(t *testing.T) {
+	def := []byte{} // zero-length serialization of an all-default message
+	msg, err := protoEncoder{}.encode(1, def)
+	if err != nil {
+		t.Fatalf("encode empty proto record: %v", err)
+	}
+	if got := (protoEncoder{}).decode(msg); len(got) != 1 || len(got[0]) != 0 {
+		t.Fatalf("want one empty record back, got %v", got)
+	}
+
+	batch, err := protoEncoder{}.encodeBatch(1, [][]byte{def, {0x01}})
+	if err != nil {
+		t.Fatalf("encodeBatch with empty proto record: %v", err)
+	}
+	if got := (protoEncoder{}).decode(batch); len(got) != 2 || len(got[0]) != 0 {
+		t.Fatalf("want empty record preserved in batch, got %v", got)
 	}
 }
 
@@ -101,10 +122,10 @@ func TestBatchEncodersRejectEmptyBatch(t *testing.T) {
 		if _, err := enc.encodeBatch(1, nil); err == nil {
 			t.Errorf("%T: want error for empty batch, got nil", enc)
 		}
-		// A batch containing an empty record is rejected too.
-		if _, err := enc.encodeBatch(1, [][]byte{[]byte("ok"), {}}); err == nil {
-			t.Errorf("%T: want error for empty record within batch, got nil", enc)
-		}
+	}
+	// A JSON batch containing an empty record is still rejected.
+	if _, err := (jsonEncoder{}).encodeBatch(1, [][]byte{[]byte("ok"), {}}); err == nil {
+		t.Error("jsonEncoder: want error for empty record within batch, got nil")
 	}
 }
 
@@ -135,5 +156,48 @@ func TestExtractRecordsReturnsAllBatchRecords(t *testing.T) {
 	}
 	if got := (jsonEncoder{}).decode(single); len(got) != 1 || string(got[0]) != `{"x":1}` {
 		t.Fatalf("single record: want 1 entry, got %v", got)
+	}
+}
+
+// The proto encoder must snapshot caller bytes: a caller reusing a scratch
+// buffer after Ingest returns must not be able to mutate the queued payload.
+func TestProtoEncoderClonesRecord(t *testing.T) {
+	rec := []byte{0x01, 0x02, 0x03}
+	msg, err := protoEncoder{}.encode(1, rec)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	rec[0] = 0xff // mutate caller buffer post-encode
+	got := msg.GetIngestRecord().GetProtoEncodedRecord()
+	if len(got) != 3 || got[0] != 0x01 {
+		t.Fatalf("queued payload aliased caller buffer: got %v", got)
+	}
+}
+
+func TestProtoBatchEncoderClonesRecords(t *testing.T) {
+	recs := [][]byte{{0x01}, {0x02}}
+	msg, err := protoEncoder{}.encodeBatch(1, recs)
+	if err != nil {
+		t.Fatalf("encodeBatch: %v", err)
+	}
+	recs[0][0] = 0xff // mutate caller buffer post-encode
+	got := msg.GetIngestRecordBatch().GetProtoEncodedBatch().GetRecords()
+	if len(got) != 2 || got[0][0] != 0x01 {
+		t.Fatalf("queued batch payload aliased caller buffer: got %v", got)
+	}
+}
+
+// wireSize reports the serialized size including proto framing, so it exceeds
+// the raw record length.
+func TestWireSizeIncludesFraming(t *testing.T) {
+	rec := []byte("hello")
+	for _, enc := range []encoder[encodedMsg]{protoEncoder{}, jsonEncoder{}} {
+		msg, err := enc.encode(1, rec)
+		if err != nil {
+			t.Fatalf("%T encode: %v", enc, err)
+		}
+		if got := enc.wireSize(msg); got <= len(rec) {
+			t.Errorf("%T: wireSize %d should exceed raw len %d", enc, got, len(rec))
+		}
 	}
 }

--- a/purego/internal/stream/errors.go
+++ b/purego/internal/stream/errors.go
@@ -1,0 +1,34 @@
+package stream
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// errClosed is returned by buffer operations when the buffer has been closed.
+var errClosed = errors.New("stream: buffer closed")
+
+// errUnsupportedRecordType is returned when no encoder/ackModel exists for a
+// record type (e.g. RECORD_TYPE_UNSPECIFIED).
+func errUnsupportedRecordType(rt zerobuspb.RecordType) error {
+	return fmt.Errorf("stream: unsupported record type %v", rt)
+}
+
+// pauseSignal is what the ackModel returns when the server sent a
+// CloseStreamSignal: the server is about to close this stream and the client
+// should pause (stop sending, keep buffering and draining acks) then
+// reconnect, rather than treat it as a failure counted against the
+// recovery budget. It carries the server-requested pause duration.
+//
+// Consumers of pauseSignal (runOnce, supervisor) land in later PRs; the
+// type itself lives here because the ackModel decodes it out of the wire
+// CloseStreamSignal.
+type pauseSignal struct {
+	// duration is the server-requested pause window; zero if unspecified.
+	duration time.Duration
+}
+
+func (pauseSignal) Error() string { return "stream: server requested pause (close-stream signal)" }


### PR DESCRIPTION
## Summary

**1 of 4** — splits the ingestion core work in [#531](https://github.com/databricks/zerobus-sdk/pull/531).

Adds `internal/stream` primitives: three independent building blocks the ingestion core is composed of. Each is standalone-correct with its own tests; a subsequent PR wires them into a working stream.

## Contents

- **`buffer.go`** — bounded, offset-assigning queue with semaphore backpressure. `enqueue`/`next`/`requeue`/`discardThrough`/`drain`/`close`/`inFlight`/`len`. Ctx-cancellable at both `enqueue` and `next` so goroutines stop cleanly per stream. `doneCh` unblocks callers parked on the semaphore when the buffer closes.
- **`encoder.go`** — proto and JSON encoders build `EphemeralStream` payloads eagerly at `Ingest` time so the buffer holds `[]byte`, never live user objects. Generic `encoder[Req]` interface so the future Arrow path can slot in.
- **`ackmodel.go`** — `offsetAckModel` for proto/JSON. Distinguishes `ackResponse`, `pauseResponse`, and `otherResponse` (ignored). Generic `ackModel[Resp]` interface.
- **`errors.go`** — `errClosed` sentinel + `errUnsupportedRecordType` helper + `pauseSignal` type.

## Stack

- 1/4 (this) — primitives
- 2/4 — core + supervisor + wirestream
- 3/4 — durability + callbacks + retry classification
- 4/4 — pause & lifecycle robustness

Replaces the earlier three-way split ([#571](https://github.com/databricks/zerobus-sdk/pull/571) / [#572](https://github.com/databricks/zerobus-sdk/pull/572) / [#573](https://github.com/databricks/zerobus-sdk/pull/573)) which each exceeded 1500 lines.

## Test plan

`go test ./internal/stream/ -race` passes. Tests cover: buffer FIFO, backpressure, ctx-cancel unblock, requeue ordering, drain, closed-buffer errors, concurrent enqueue/discard; encoder single + batch for proto and JSON, empty-record rejection, batch-record extraction; ack-model classification (ack / pause / other).
