### PR TITLE
[C++] Ship Cargo.lock in release bundle for SBOM scan

### DIFF
--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -168,6 +168,10 @@ jobs:
           cp "target/${{ matrix.target }}/release/${{ matrix.static_lib }}" "$out/lib/"
           cp "ffi/zerobus.h" "$out/lib/"
 
+          # Lockfile for the prebuilt FFI archive; gives the release scan a
+          # manifest to build an SBOM from (an empty SBOM fails the scan).
+          cp "Cargo.lock" "$out/lib/"
+
           # A short pointer so the bundle is self-explanatory.
           cat > "$out/README.md" <<EOF
           # Zerobus C++ SDK — prebuilt bundle


### PR DESCRIPTION
## What

Copy \`rust/Cargo.lock\` into the C++ release bundle's \`lib/\` directory during the "Assemble C++ SDK bundle" step.

## Why

The C++ release ran `databricks/gh-action-scan` (which runs `trivy fs` over the bundle) and failed with exit code 2:

```
WARN  SBOM is empty — could not detect any components. This has been reported.
INFO  Metrics emitted (0 components, status=error)
##[error]Process completed with exit code 2.
```

This was not a vulnerability finding — the scan errors out when it cannot detect any components. The bundle shipped only C++ source, a prebuilt static FFI archive (`libzerobus_ffi.a`), and a header — none of which Trivy can enumerate. Trivy builds an SBOM from dependency manifests/lockfiles, so with no manifest present the SBOM is empty and the scan fails.

Shipping `Cargo.lock` (which describes exactly the dependency graph the prebuilt FFI archive was built from) gives Trivy a manifest to parse, producing a non-empty SBOM so the scan passes. The scanner in `secure-public-registry-releases-eng` downloads the `cpp-*` artifacts verbatim and runs `trivy fs` over them with no repackaging, so this change is sufficient on its own.

## Notes

- No version bump: `cpp/v0.1.0` was never actually released (the scan gate blocked the GitHub Release job, so no assets were published). The tag will be moved to the fixed commit and the release re-dispatched.
- Side effect: `Cargo.lock` now appears in the released tarball, documenting what the prebuilt archive was built from.