### PR TITLE
[C++] Fix batch-ingest offset docs: one offset per batch, not last record

### DIFF
--- a/cpp/NEXT_CHANGELOG.md
+++ b/cpp/NEXT_CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Documentation
 
+- Correct the batch-ingest offset docs. `ingest_json_records()` /
+  `ingest_proto_records()` return the single logical offset assigned to the
+  whole batch, not "the offset of the last record" — a 3-record batch on a fresh
+  stream returns offset 0, not 2. Fixed the API docstrings, example comments,
+  and expected-output samples.
+
 ### Internal Changes
 
 ### Breaking Changes

--- a/cpp/examples/README.md
+++ b/cpp/examples/README.md
@@ -240,7 +240,7 @@ destructor swallows it.
 | **Method** | `ingest_json_record()` / `ingest_proto_record()` | `ingest_json_records()` / `ingest_proto_records()` |
 | **Use case** | Records arrive one at a time | Multiple records ready at once |
 | **Semantics** | Each record independent | All-or-nothing (atomic) |
-| **Acknowledgment** | Per record | Per batch (offset of last record) |
+| **Acknowledgment** | Per record | Per batch (one offset for the batch) |
 | **Throughput** | Lower | Higher (amortizes the FFI crossing) |
 
 **Single-record:**
@@ -253,9 +253,9 @@ stream.flush();
 
 **Batch:**
 ```cpp
-std::int64_t last = stream.ingest_json_records(records);
-if (last >= 0) {
-  stream.wait_for_offset(last);   // one wait confirms the whole batch
+std::int64_t batch_offset = stream.ingest_json_records(records);
+if (batch_offset >= 0) {
+  stream.wait_for_offset(batch_offset);   // one wait confirms the whole batch
 }
 ```
 

--- a/cpp/examples/json/README.md
+++ b/cpp/examples/json/README.md
@@ -128,29 +128,29 @@ Each `UnackedRecord` exposes `is_json()`, the raw `data()` bytes, and
 
 **Expected output:**
 ```
-Batch of 3 records queued; last offset ID: 2
-Batch acknowledged through offset ID: 2
+Batch of 3 records queued; batch offset ID: 0
+Batch acknowledged at offset ID: 0
 Stream closed successfully. Callback observed 3 acknowledgements.
 ```
 
 ### Code Highlights
 
 `ingest_json_records()` hands a whole vector of records to the SDK in a single
-FFI crossing and returns the offset of the **last** record. Waiting on that one
-offset confirms the whole batch, because acks are monotonic:
+FFI crossing and returns the single logical offset assigned to the batch.
+Waiting on that one offset confirms the whole batch:
 
 ```cpp
 const std::vector<std::string> batch = { record1, record2, record3 };
 
-const std::int64_t last_offset = stream.ingest_json_records(batch);
-if (last_offset >= 0) {
-  stream.wait_for_offset(last_offset);   // one wait confirms the batch
+const std::int64_t batch_offset = stream.ingest_json_records(batch);
+if (batch_offset >= 0) {
+  stream.wait_for_offset(batch_offset);   // one wait confirms the batch
 }
 ```
 
 **Batch semantics:**
 - **All-or-nothing** — the entire batch succeeds or fails as a unit.
-- **Single acknowledgment** — one offset (the last record's) for the whole batch.
+- **Single acknowledgment** — one logical offset for the whole batch.
 - **Empty batches** — a no-op; `ingest_json_records()` returns `-1`.
 
 In a hot path you would queue **many** batches and `flush()` once, rather than

--- a/cpp/examples/json/batch.cpp
+++ b/cpp/examples/json/batch.cpp
@@ -6,8 +6,8 @@
 // crossing has a fixed cost that batching amortizes, and a batch is
 // acknowledged all-or-nothing as a unit.
 //
-// The batch call returns the offset of the LAST record in the batch. Because
-// acks are monotonic, waiting on that single offset confirms the whole batch.
+// The batch call returns a single logical offset assigned to the whole batch.
+// Waiting on that one offset confirms the entire batch.
 //
 // It also demonstrates two optional features:
 //   - An async ack callback (StreamOptions::ack_callback) that observes
@@ -154,7 +154,8 @@ int main() {
     const std::int64_t now = now_micros();
 
     // 3. Build a batch and hand it over in one call. ingest_json_records()
-    //    queues the whole vector and returns the offset of the LAST record.
+    //    queues the whole vector and returns the single offset assigned to the
+    //    batch.
     const std::vector<std::string> batch = {
         make_order_json(1, "Alice Smith", "Wireless Mouse", 2, 25.99, "pending",
                         now),
@@ -164,18 +165,16 @@ int main() {
                         now),
     };
 
-    const std::int64_t last_offset = stream.ingest_json_records(batch);
+    const std::int64_t batch_offset = stream.ingest_json_records(batch);
     std::cout << "Batch of " << batch.size()
-              << " records queued; last offset ID: " << last_offset << "\n";
+              << " records queued; batch offset ID: " << batch_offset << "\n";
 
-    // 4. Confirm the batch. Waiting on the last offset is enough — acks are
-    //    monotonic, so offset N acked implies every offset <= N is acked. In a
-    //    hot path you would queue many batches and flush() once instead of
-    //    waiting after each.
-    if (last_offset >= 0) {
-      stream.wait_for_offset(last_offset);
-      std::cout << "Batch acknowledged through offset ID: " << last_offset
-                << "\n";
+    // 4. Confirm the batch. Waiting on the batch's single offset confirms every
+    //    record in it. In a hot path you would queue many batches and flush()
+    //    once instead of waiting after each.
+    if (batch_offset >= 0) {
+      stream.wait_for_offset(batch_offset);
+      std::cout << "Batch acknowledged at offset ID: " << batch_offset << "\n";
     }
 
     // 5. flush() drains anything still pending, then close at a controlled

--- a/cpp/examples/proto/README.md
+++ b/cpp/examples/proto/README.md
@@ -135,16 +135,16 @@ zerobus::Stream stream =
 
 **Expected output:**
 ```
-Batch of 3 records queued; last offset ID: 2
-Batch acknowledged through offset ID: 2
+Batch of 3 records queued; batch offset ID: 0
+Batch acknowledged at offset ID: 0
 Stream closed successfully.
 ```
 
 ### Code Highlights
 
 Encode each record, collect the bytes into a batch, and hand the whole batch to
-`ingest_proto_records()` in one call. It returns the offset of the **last**
-record; waiting on that one offset confirms the batch:
+`ingest_proto_records()` in one call. It returns the single logical offset
+assigned to the batch; waiting on that one offset confirms the batch:
 
 ```cpp
 const std::vector<std::vector<std::uint8_t>> batch = {
@@ -153,15 +153,15 @@ const std::vector<std::vector<std::uint8_t>> batch = {
     schema.encode_json(record3),
 };
 
-const std::int64_t last_offset = stream.ingest_proto_records(batch);
-if (last_offset >= 0) {
-  stream.wait_for_offset(last_offset);   // one wait confirms the batch
+const std::int64_t batch_offset = stream.ingest_proto_records(batch);
+if (batch_offset >= 0) {
+  stream.wait_for_offset(batch_offset);   // one wait confirms the batch
 }
 ```
 
 **Batch semantics:**
 - **All-or-nothing** — the entire batch succeeds or fails as a unit.
-- **Single acknowledgment** — one offset (the last record's) for the whole batch.
+- **Single acknowledgment** — one logical offset for the whole batch.
 - **Empty batches** — a no-op; `ingest_proto_records()` returns `-1`.
 
 In a hot path you would queue **many** batches and `flush()` once, rather than

--- a/cpp/examples/proto/batch.cpp
+++ b/cpp/examples/proto/batch.cpp
@@ -8,8 +8,8 @@
 //
 // Batching is the right choice in hot paths: each FFI crossing has a fixed cost
 // that batching amortizes, and a batch is acknowledged all-or-nothing as a
-// unit. The call returns the offset of the LAST record; because acks are
-// monotonic, waiting on that single offset confirms the whole batch.
+// unit. The call returns a single logical offset assigned to the whole batch;
+// waiting on that one offset confirms the entire batch.
 //
 // Configuration — every connection setting, plus the Unity Catalog table
 // metadata JSON, is read from the environment. Export these before running (see
@@ -110,17 +110,16 @@ int main() {
                                            45.00, "delivered", now)),
     };
 
-    const std::int64_t last_offset = stream.ingest_proto_records(batch);
+    const std::int64_t batch_offset = stream.ingest_proto_records(batch);
     std::cout << "Batch of " << batch.size()
-              << " records queued; last offset ID: " << last_offset << "\n";
+              << " records queued; batch offset ID: " << batch_offset << "\n";
 
-    // 5. Confirm the batch. Waiting on the last offset is enough — acks are
-    //    monotonic. In a hot path you would queue many batches and flush() once
-    //    instead of waiting after each.
-    if (last_offset >= 0) {
-      stream.wait_for_offset(last_offset);
-      std::cout << "Batch acknowledged through offset ID: " << last_offset
-                << "\n";
+    // 5. Confirm the batch. Waiting on the batch's single offset confirms every
+    //    record in it. In a hot path you would queue many batches and flush()
+    //    once instead of waiting after each.
+    if (batch_offset >= 0) {
+      stream.wait_for_offset(batch_offset);
+      std::cout << "Batch acknowledged at offset ID: " << batch_offset << "\n";
     }
 
     // 6. flush() drains anything still pending, then close at a controlled

--- a/cpp/include/zerobus/stream.hpp
+++ b/cpp/include/zerobus/stream.hpp
@@ -71,8 +71,9 @@ class Stream {
   /// crossing has a fixed cost that batching amortizes.
   ///
   /// @param records The protobuf-encoded records to ingest.
-  /// @return The logical offset of the last record in the batch, or -1 if
-  ///         @p records is empty (a no-op).
+  /// @return The single logical offset assigned to the whole batch, or -1 if
+  ///         @p records is empty (a no-op). Waiting on this one offset confirms
+  ///         the entire batch.
   /// @throws ZerobusException if the stream is closed or ingestion fails.
   std::int64_t ingest_proto_records(
       const std::vector<std::vector<std::uint8_t>>& records);
@@ -80,14 +81,16 @@ class Stream {
   /// Ingest a batch of JSON records, blocking until they are queued.
   ///
   /// @param records The records, each a UTF-8 JSON string.
-  /// @return The logical offset of the last record in the batch, or -1 if
-  ///         @p records is empty (a no-op).
+  /// @return The single logical offset assigned to the whole batch, or -1 if
+  ///         @p records is empty (a no-op). Waiting on this one offset confirms
+  ///         the entire batch.
   /// @throws ZerobusException if the stream is closed or ingestion fails.
   std::int64_t ingest_json_records(const std::vector<std::string>& records);
 
   /// Block until the record at @p offset has been acknowledged by the server.
   ///
-  /// @param offset A logical offset returned by an ingest call. Must be
+  /// @param offset A logical offset returned by an ingest call (for a batch,
+  ///        the single offset assigned to the whole batch). Must be
   ///        non-negative; the -1 returned by an empty ingest_*_records() batch
   ///        is rejected rather than forwarded to the server.
   /// @throws ZerobusException if @p offset is negative, the stream is closed,


### PR DESCRIPTION
## What

Corrects the C++ batch-ingest offset documentation. `ingest_json_records()` and `ingest_proto_records()` return the **single logical offset assigned to the whole batch**, not "the offset of the last record."

## Why

The Rust core generates one logical offset per batch call (`rust/sdk/src/stream/grpc/ingest.rs` — `logical_offset_id_generator.next()` is called once per batch, independent of record count). So a 3-record batch on a fresh stream returns offset `0`, not `2`.

The old C++ docs claimed the return value was "the offset of the LAST record" and showed sample output of `last offset ID: 2` for a 3-record batch — both wrong. This made C++ the outlier: Go ("one offset for the whole batch"), Rust, TypeScript, and Java all describe it as a single batch offset.

The contrast is visible in the examples themselves: the single-record example ingests 3 records in 3 calls and correctly shows offsets `0, 1, 2`; the batch example ingests the same 3 records in one call and now correctly shows `0`.

## Changes (docs/comments only — no behavior change)

- `include/zerobus/stream.hpp` — both batch `@return` docstrings and the `wait_for_offset` note.
- `examples/json/batch.cpp`, `examples/proto/batch.cpp` — comments, renamed `last_offset` → `batch_offset`, corrected printed labels.
- `examples/json/README.md`, `examples/proto/README.md` — Code Highlights text, "Single acknowledgment" bullet, and the Expected output samples (`2` → `0`).
- `examples/README.md` — comparison-table row and batch snippet.
- `NEXT_CHANGELOG.md` — Documentation entry.

The Arrow example and the multi-call `wait_for_offset` note are intentionally left unchanged — those track the last offset *across multiple ingest calls*, which is correct.