### PR TITLE
[Rust] Harden OAuth token caching

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4052,6 +4052,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerobus-token-cache-staging-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "databricks-zerobus-ingest-sdk",
+ "reqwest",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bug Fixes
 
+- OAuth token caching now tolerates common token-endpoint responses and refresh failures: `expires_in` may be returned as either a JSON number or a quoted integer without silently disabling the cache. When proactive refresh fails or times out, the SDK continues serving the cached access token until its reported expiry regardless of the mint error's retry classification, and briefly backs off before another refresh attempt so concurrent callers do not stampede the token endpoint. HTTP 429 responses remain retryable when no valid cached token can be used. An authentication rejection from Zerobus invalidates only the cache generation that supplied the rejected token.
 - **Arrow Flight — `close()` now propagates flush errors and survives cancellation** (Beta): `ZerobusArrowStream::close()` previously swallowed a failed final `flush()` and always returned `Ok(())`, contradicting its documentation and diverging from the proto stream's `close()`. It now returns the flush error after still tearing down the stream and moving pending batches to the failed set (retrievable via `get_unacked_batches()`). If the close future is cancelled after teardown starts, the stream enters a non-ingestable `Closing` state and a later `close()` resumes teardown without waiting for another flush.
 - **Arrow Flight — `max_inflight_batches` now bounds batches awaiting acknowledgment** (Beta): it previously limited only the pre-encode channel, so pending batches could grow unbounded under a slow-acking server. `ingest_batch` now holds a permit until the batch is acked, applying backpressure (it blocks) at the configured limit. `max_inflight_batches = 0` is now rejected with `InvalidArgument` instead of panicking.
 - **Arrow Flight — recovery replay is now failure-safe** (Beta): if a batch send failed while replaying after a reconnect, the pending set was drained and lost (unrecoverable via automatic replay or `get_unacked_batches()`). Pending batches (and their in-flight accounting) are now retained so the next recovery attempt replays them.
@@ -37,6 +38,7 @@
 
 ### Internal Changes
 
+- Added an opt-in staging harness that opens three real streams through a loopback OAuth proxy to verify quoted `expires_in` caching and fallback after an injected refresh failure.
 - Added a test-only `test-hooks` Cargo feature that exposes deterministic synchronization seams in the Arrow stream for recovery-race tests. It has zero footprint in default and FFI builds.
 
 ### Breaking Changes

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -20,6 +20,7 @@
 
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::callbacks::AckCallback;
 use crate::databricks::zerobus::RecordType;
@@ -44,6 +45,8 @@ enum AuthConfig {
     #[cfg(feature = "testing")]
     NoAuth,
 }
+
+const TOKEN_REFRESH_TIMEOUT_MARGIN: Duration = Duration::from_millis(100);
 
 /// Which record format was selected.
 enum FormatConfig {
@@ -365,7 +368,15 @@ impl<'a> StreamBuilder<'a> {
     }
 
     /// Resolve the headers provider from the stored auth config.
+    #[cfg(test)]
     fn resolve_headers_provider(&self) -> ZerobusResult<Arc<dyn HeadersProvider>> {
+        self.resolve_headers_provider_with_refresh_timeout(None)
+    }
+
+    fn resolve_headers_provider_with_refresh_timeout(
+        &self,
+        refresh_timeout: Option<Duration>,
+    ) -> ZerobusResult<Arc<dyn HeadersProvider>> {
         match self.auth.as_ref() {
             Some(AuthConfig::OAuth {
                 client_id,
@@ -377,6 +388,7 @@ impl<'a> StreamBuilder<'a> {
                 self.sdk.workspace_id.clone(),
                 self.sdk.unity_catalog_url.clone(),
                 Arc::clone(&self.sdk.token_cache),
+                refresh_timeout,
             ))),
             Some(AuthConfig::HeadersProvider(p)) => Ok(Arc::clone(p)),
             #[cfg(feature = "testing")]
@@ -391,7 +403,10 @@ impl<'a> StreamBuilder<'a> {
     /// or if an Arrow format was selected (use `build_arrow()` instead).
     pub async fn build(mut self) -> ZerobusResult<ZerobusStream> {
         self.validate()?;
-        let headers_provider = self.resolve_headers_provider()?;
+        let refresh_timeout = Duration::from_millis(self.grpc_config.recovery_timeout_ms)
+            .saturating_sub(TOKEN_REFRESH_TIMEOUT_MARGIN);
+        let headers_provider =
+            self.resolve_headers_provider_with_refresh_timeout(Some(refresh_timeout))?;
 
         let (record_type, descriptor_proto) = match self.format {
             Some(FormatConfig::Json) => (RecordType::Json, None),
@@ -452,7 +467,10 @@ impl<'a> StreamBuilder<'a> {
             crate::client_warnings::warn_payload_limit_ignored_for_arrow();
         }
 
-        let headers_provider = self.resolve_headers_provider()?;
+        let refresh_timeout = Duration::from_millis(self.arrow_config.recovery_timeout_ms)
+            .saturating_sub(TOKEN_REFRESH_TIMEOUT_MARGIN);
+        let headers_provider =
+            self.resolve_headers_provider_with_refresh_timeout(Some(refresh_timeout))?;
 
         let schema = match self.format {
             Some(FormatConfig::Arrow(schema)) => schema,

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -26,7 +26,9 @@ use crate::callbacks::AckCallback;
 use crate::databricks::zerobus::RecordType;
 #[cfg(feature = "testing")]
 use crate::headers_provider::NoAuthHeadersProvider;
-use crate::headers_provider::{HeadersProvider, OAuthHeadersProvider};
+use crate::headers_provider::{
+    HeadersProvider, OAuthHeadersProvider, MAX_PROACTIVE_REFRESH_TIMEOUT,
+};
 use crate::stream_configuration::StreamConfigurationOptions;
 use crate::{TableProperties, ZerobusError, ZerobusResult, ZerobusSdk, ZerobusStream};
 
@@ -46,7 +48,12 @@ enum AuthConfig {
     NoAuth,
 }
 
-const TOKEN_REFRESH_TIMEOUT_MARGIN: Duration = Duration::from_millis(100);
+/// Leaves at least half of a stream-creation attempt for transport setup while
+/// preventing a healthy-sized recovery budget from spending more than five
+/// seconds on a proactive refresh that already has a valid fallback token.
+fn proactive_refresh_timeout(recovery_timeout_ms: u64) -> Duration {
+    Duration::from_millis(recovery_timeout_ms / 2).min(MAX_PROACTIVE_REFRESH_TIMEOUT)
+}
 
 /// Which record format was selected.
 enum FormatConfig {
@@ -403,8 +410,7 @@ impl<'a> StreamBuilder<'a> {
     /// or if an Arrow format was selected (use `build_arrow()` instead).
     pub async fn build(mut self) -> ZerobusResult<ZerobusStream> {
         self.validate()?;
-        let refresh_timeout = Duration::from_millis(self.grpc_config.recovery_timeout_ms)
-            .saturating_sub(TOKEN_REFRESH_TIMEOUT_MARGIN);
+        let refresh_timeout = proactive_refresh_timeout(self.grpc_config.recovery_timeout_ms);
         let headers_provider =
             self.resolve_headers_provider_with_refresh_timeout(Some(refresh_timeout))?;
 
@@ -467,8 +473,7 @@ impl<'a> StreamBuilder<'a> {
             crate::client_warnings::warn_payload_limit_ignored_for_arrow();
         }
 
-        let refresh_timeout = Duration::from_millis(self.arrow_config.recovery_timeout_ms)
-            .saturating_sub(TOKEN_REFRESH_TIMEOUT_MARGIN);
+        let refresh_timeout = proactive_refresh_timeout(self.arrow_config.recovery_timeout_ms);
         let headers_provider =
             self.resolve_headers_provider_with_refresh_timeout(Some(refresh_timeout))?;
 
@@ -607,6 +612,19 @@ mod tests {
             crate::stream_options::defaults::MAX_INGEST_PAYLOAD_BYTES
         );
         assert!(builder.grpc_config.max_ingest_payload_bytes < 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn proactive_refresh_reserves_connection_budget() {
+        assert_eq!(
+            proactive_refresh_timeout(15_000),
+            MAX_PROACTIVE_REFRESH_TIMEOUT
+        );
+        assert_eq!(
+            proactive_refresh_timeout(4_000),
+            Duration::from_millis(2_000)
+        );
+        assert_eq!(proactive_refresh_timeout(99), Duration::from_millis(49));
     }
 
     #[test]

--- a/rust/sdk/src/default_token_factory.rs
+++ b/rust/sdk/src/default_token_factory.rs
@@ -242,10 +242,16 @@ impl DefaultTokenFactory {
     /// `Duration`. It is optional in the OAuth spec; if it is missing or not a
     /// positive integer the token has no known TTL and must not be cached.
     fn parse_expires_in(body: &serde_json::Value) -> Option<Duration> {
-        body["expires_in"]
-            .as_u64()
-            .filter(|secs| *secs > 0)
-            .map(Duration::from_secs)
+        let seconds = match &body["expires_in"] {
+            serde_json::Value::Number(value) => value.as_u64(),
+            // OAuth servers in the wild also encode this integer as a JSON
+            // string. Accept the same positive base-10 values as the numeric
+            // representation so that formatting does not disable caching.
+            serde_json::Value::String(value) => value.parse::<u64>().ok(),
+            _ => None,
+        };
+
+        seconds.filter(|secs| *secs > 0).map(Duration::from_secs)
     }
 
     /// Classifies HTTP status codes as retryable or non-retryable errors.
@@ -257,10 +263,10 @@ impl DefaultTokenFactory {
     ///
     /// # Returns
     ///
-    /// * `TokenFetchError` for 5xx server errors (retryable)
-    /// * `InvalidUCTokenError` for 4xx client errors (non-retryable)
+    /// * `TokenFetchError` for HTTP 429 and 5xx server errors (retryable)
+    /// * `InvalidUCTokenError` for other 4xx client errors (non-retryable)
     fn classify_status_code(status_code: u16, message: String) -> ZerobusError {
-        if status_code >= 500 {
+        if status_code == 429 || status_code >= 500 {
             ZerobusError::TokenFetchError(format!(
                 "Unity catalog server error ({}): {}",
                 status_code, message
@@ -367,9 +373,32 @@ mod tests {
         let zero = serde_json::json!({ "expires_in": 0 });
         assert_eq!(DefaultTokenFactory::parse_expires_in(&zero), None);
 
-        // A string value (non-integer) is not usable and yields no TTL.
-        let non_numeric = serde_json::json!({ "expires_in": "3600" });
-        assert_eq!(DefaultTokenFactory::parse_expires_in(&non_numeric), None);
+        let string_ttl = serde_json::json!({ "expires_in": "3600" });
+        assert_eq!(
+            DefaultTokenFactory::parse_expires_in(&string_ttl),
+            Some(Duration::from_secs(3600))
+        );
+
+        for invalid in [
+            serde_json::json!({ "expires_in": "0" }),
+            serde_json::json!({ "expires_in": "not-a-number" }),
+            serde_json::json!({ "expires_in": -1 }),
+            serde_json::json!({ "expires_in": 1.5 }),
+        ] {
+            assert_eq!(DefaultTokenFactory::parse_expires_in(&invalid), None);
+        }
+    }
+
+    #[test]
+    fn test_classify_status_code_treats_rate_limit_as_retryable() {
+        let rate_limited =
+            DefaultTokenFactory::classify_status_code(429, "rate limited".to_string());
+        assert!(matches!(rate_limited, ZerobusError::TokenFetchError(_)));
+        assert!(rate_limited.is_retryable());
+
+        let bad_request = DefaultTokenFactory::classify_status_code(400, "bad request".to_string());
+        assert!(matches!(bad_request, ZerobusError::InvalidUCTokenError(_)));
+        assert!(!bad_request.is_retryable());
     }
 
     #[test]

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -7,6 +7,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
+/// Upper bound for a proactive refresh. A cold miss remains governed by the
+/// enclosing stream-creation deadline because it has no cached fallback.
+pub(crate) const MAX_PROACTIVE_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// A trait for providing custom headers for gRPC requests.
 ///
 /// This trait allows you to implement custom logic for generating authentication headers,
@@ -63,6 +67,11 @@ pub trait HeadersProvider: Send + Sync {
 ///
 /// This provider implements the OAuth 2.0 client credentials flow to obtain
 /// access tokens for authenticating with the Zerobus service.
+///
+/// One provider instance tracks the token generation used by one stream. Do
+/// not share an `OAuthHeadersProvider` across concurrent stream builders;
+/// construct one provider per stream instead. The `.oauth(...)` stream-builder
+/// path does this automatically while still sharing the underlying token cache.
 pub struct OAuthHeadersProvider {
     client_id: String,
     client_secret: String,
@@ -96,7 +105,7 @@ impl OAuthHeadersProvider {
             workspace_id,
             unity_catalog_url,
             Arc::new(TokenCache::new(true, DEFAULT_REFRESH_BUFFER)),
-            None,
+            Some(MAX_PROACTIVE_REFRESH_TIMEOUT),
         )
     }
 

--- a/rust/sdk/src/headers_provider.rs
+++ b/rust/sdk/src/headers_provider.rs
@@ -1,9 +1,11 @@
 use crate::default_token_factory::DefaultTokenFactory;
-use crate::token_cache::{TokenCache, DEFAULT_REFRESH_BUFFER};
+use crate::token_cache::{TokenCache, TokenGeneration, DEFAULT_REFRESH_BUFFER};
 use crate::ZerobusResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
 
 /// A trait for providing custom headers for gRPC requests.
 ///
@@ -68,6 +70,8 @@ pub struct OAuthHeadersProvider {
     workspace_id: String,
     unity_catalog_url: String,
     token_cache: Arc<TokenCache>,
+    refresh_timeout: Option<Duration>,
+    token_generation: Mutex<Option<TokenGeneration>>,
 }
 
 impl OAuthHeadersProvider {
@@ -92,6 +96,7 @@ impl OAuthHeadersProvider {
             workspace_id,
             unity_catalog_url,
             Arc::new(TokenCache::new(true, DEFAULT_REFRESH_BUFFER)),
+            None,
         )
     }
 
@@ -106,6 +111,7 @@ impl OAuthHeadersProvider {
         workspace_id: String,
         unity_catalog_url: String,
         token_cache: Arc<TokenCache>,
+        refresh_timeout: Option<Duration>,
     ) -> Self {
         Self {
             client_id,
@@ -114,6 +120,8 @@ impl OAuthHeadersProvider {
             workspace_id,
             unity_catalog_url,
             token_cache,
+            refresh_timeout,
+            token_generation: Mutex::new(None),
         }
     }
 }
@@ -121,12 +129,13 @@ impl OAuthHeadersProvider {
 #[async_trait]
 impl HeadersProvider for OAuthHeadersProvider {
     async fn get_headers(&self) -> ZerobusResult<HashMap<&'static str, String>> {
-        let token = self
+        let result = self
             .token_cache
-            .get_or_fetch(
+            .get_or_fetch_with_timeout(
                 &self.client_id,
                 &self.client_secret,
                 &self.table_name,
+                self.refresh_timeout,
                 |reason| {
                     DefaultTokenFactory::fetch_token(
                         &self.unity_catalog_url,
@@ -139,16 +148,24 @@ impl HeadersProvider for OAuthHeadersProvider {
                 },
             )
             .await?;
+        *self.token_generation.lock().await = result.generation;
         let mut headers = HashMap::new();
-        headers.insert("authorization", format!("Bearer {}", token));
+        headers.insert("authorization", format!("Bearer {}", result.value));
         headers.insert("x-databricks-zerobus-table-name", self.table_name.clone());
         Ok(headers)
     }
 
     async fn invalidate(&self) {
-        self.token_cache
-            .invalidate(&self.client_id, &self.client_secret, &self.table_name)
-            .await;
+        if let Some(generation) = self.token_generation.lock().await.take() {
+            self.token_cache
+                .invalidate_generation(
+                    &self.client_id,
+                    &self.client_secret,
+                    &self.table_name,
+                    &generation,
+                )
+                .await;
+        }
     }
 }
 

--- a/rust/sdk/src/token_cache.rs
+++ b/rust/sdk/src/token_cache.rs
@@ -206,7 +206,24 @@ impl TokenCache {
             // Hold the per-entry lock across the fetch so concurrent callers for
             // the same key reuse a single mint instead of stampeding the endpoint.
             let mut guard = slot.token.lock().await;
-            if slot.invalidated.load(AtomicOrdering::Acquire) {
+            // The slot may have been pruned after it was cloned but before its
+            // token lock was acquired. Revalidate its map identity while holding
+            // the token lock; pruning cannot detach it after this point because
+            // `prune_expired` uses `try_lock`. Also clean up any tombstone left by
+            // a cancelled older implementation of invalidation.
+            let slot_is_current = {
+                let mut entries = self.entries.lock().await;
+                let is_current = entries
+                    .get(&key)
+                    .is_some_and(|current| Arc::ptr_eq(current, &slot));
+                if is_current && slot.invalidated.load(AtomicOrdering::Acquire) {
+                    entries.remove(&key);
+                    false
+                } else {
+                    is_current
+                }
+            };
+            if !slot_is_current {
                 continue;
             }
 
@@ -226,12 +243,12 @@ impl TokenCache {
                 }
             }
 
-            // A present-but-stale token means we are refreshing; an empty slot is
-            // a cold miss. The reason is surfaced on the mint log.
-            let reason = if guard.is_some() {
-                MintReason::Refresh
-            } else {
-                MintReason::ColdMiss
+            // Only an unexpired token can make this a proactive refresh. An
+            // expired entry has no fallback and must retain cold-miss timeout
+            // semantics.
+            let reason = match guard.as_ref() {
+                Some(cached) if !cached.is_expired() => MintReason::Refresh,
+                _ => MintReason::ColdMiss,
             };
 
             // `expires_in` starts at token issuance, not after a slow response has
@@ -335,13 +352,43 @@ impl TokenCache {
                         id: generation,
                     })
                 }
-                Some(_) | None => {
+                Some(_) => {
+                    // The response took longer than the token's entire reported
+                    // lifetime. Never send a token that is already expired by the
+                    // cache's conservative clock. A still-valid prior generation
+                    // remains the safest fallback; otherwise surface a retryable
+                    // mint error.
+                    if let Some(cached) = guard.as_mut() {
+                        if !cached.is_expired()
+                            && slot.current_generation.load(AtomicOrdering::Acquire)
+                                == cached.generation
+                        {
+                            cached.defer_refresh(self.refresh_failure_backoff);
+                            warn!(
+                                table = %table_name,
+                                "fetched token expired before arrival; serving still-valid cached token"
+                            );
+                            return Ok(TokenResult {
+                                value: cached.value.clone(),
+                                generation: Some(TokenGeneration {
+                                    slot: Arc::clone(&slot),
+                                    id: cached.generation,
+                                }),
+                            });
+                        }
+                    }
+                    Self::clear_cached_token(&slot, &mut guard, prior_generation)?;
+                    return Err(crate::ZerobusError::TokenFetchError(
+                        "Fetched OAuth token expired before the response completed".to_string(),
+                    ));
+                }
+                None => {
                     // No usable TTL: keep an existing still-valid token rather
                     // than discarding it. The newly returned token is not tied
                     // to that older cache generation.
                     let keep_existing = guard.as_ref().is_some_and(|cached| !cached.is_expired());
                     if !keep_existing {
-                        *guard = None;
+                        Self::clear_cached_token(&slot, &mut guard, prior_generation)?;
                     }
                     None
                 }
@@ -385,6 +432,16 @@ impl TokenCache {
         }
 
         let key = TokenKey::new(client_id, client_secret, table_name);
+        // Acquire the only awaited lock before mutating the slot. Once the CAS
+        // succeeds there is no cancellation point between tombstoning and map
+        // removal, so a timed-out invalidation cannot poison this key.
+        let mut entries = self.entries.lock().await;
+        let is_current = entries
+            .get(&key)
+            .is_some_and(|slot| Arc::ptr_eq(slot, &generation.slot));
+        if !is_current {
+            return;
+        }
         if generation
             .slot
             .current_generation
@@ -403,14 +460,31 @@ impl TokenCache {
             .slot
             .invalidated
             .store(true, AtomicOrdering::Release);
-        let mut entries = self.entries.lock().await;
-        let is_current = entries
-            .get(&key)
-            .is_some_and(|slot| Arc::ptr_eq(slot, &generation.slot));
-        if is_current {
-            entries.remove(&key);
-            debug!(table = %table_name, "token cache entry invalidated after auth rejection");
+        entries.remove(&key);
+        debug!(table = %table_name, "token cache entry invalidated after auth rejection");
+    }
+
+    /// Clears the token while keeping its mutex held and atomically returns the
+    /// slot to the cold-miss generation. A concurrent exact-generation
+    /// invalidation wins the CAS and is surfaced to the caller instead of
+    /// leaving detached state behind.
+    fn clear_cached_token(
+        slot: &Slot,
+        guard: &mut Option<CachedToken>,
+        prior_generation: Option<u64>,
+    ) -> ZerobusResult<()> {
+        let expected = prior_generation.unwrap_or(0);
+        if slot
+            .current_generation
+            .compare_exchange(expected, 0, AtomicOrdering::AcqRel, AtomicOrdering::Acquire)
+            .is_err()
+        {
+            return Err(crate::ZerobusError::TokenFetchError(
+                "Token cache generation changed while clearing an uncacheable token".to_string(),
+            ));
         }
+        *guard = None;
+        Ok(())
     }
 
     fn needs_refresh(&self, cached: &CachedToken) -> bool {
@@ -433,14 +507,14 @@ impl TokenCache {
         }
     }
 
-    /// Drops entries whose token has fully expired. Locked (in-flight) entries,
-    /// still-valid tokens, and empty slots are kept — keeping empty slots is
-    /// what preserves single-flight for a key being minted concurrently.
+    /// Drops idle entries whose token has fully expired or is absent. Locked
+    /// entries are retained, and lookups revalidate map identity after taking
+    /// the per-slot lock, so pruning cannot detach active single-flight work.
     fn prune_expired(entries: &mut HashMap<TokenKey, Slot>) {
         entries.retain(|_, slot| match slot.token.try_lock() {
             Ok(guard) => match guard.as_ref() {
                 Some(cached) => !cached.is_expired(),
-                None => true,
+                None => false,
             },
             Err(_) => true,
         });
@@ -1012,9 +1086,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slow_fetch_does_not_extend_reported_token_lifetime() {
+    async fn expired_entry_uses_cold_miss_timeout_semantics() {
         let cache = TokenCache::new(true, Duration::ZERO);
-        let first = cache
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("old", Some(3600)))
+            })
+            .await
+            .unwrap();
+        let slot = initial.generation.unwrap().slot;
+        slot.token.lock().await.as_mut().unwrap().expires_at = Instant::now();
+
+        // A zero proactive-refresh timeout must not affect replacement of an
+        // expired token because there is no cached fallback left to serve.
+        let replacement = cache
+            .get_or_fetch_with_timeout(
+                "id",
+                "secret",
+                "c.s.t",
+                Some(Duration::ZERO),
+                |reason| async move {
+                    assert!(matches!(reason, MintReason::ColdMiss));
+                    Ok(fetched("fresh", Some(3600)))
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(replacement.value, "fresh");
+    }
+
+    #[tokio::test]
+    async fn non_cacheable_refresh_resets_generation() {
+        let cache = TokenCache::new(true, Duration::ZERO);
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("old", Some(3600)))
+            })
+            .await
+            .unwrap();
+        let slot = initial.generation.unwrap().slot;
+        slot.token.lock().await.as_mut().unwrap().expires_at = Instant::now();
+
+        let uncached = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("no-ttl", None))
+            })
+            .await
+            .unwrap();
+        assert_eq!(uncached, "no-ttl");
+        assert_eq!(slot.current_generation.load(AtomicOrdering::Acquire), 0);
+
+        let cached_again = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("recovered", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(cached_again, "recovered");
+    }
+
+    #[tokio::test]
+    async fn expired_on_arrival_falls_back_to_valid_cached_token() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        let served = cache
             .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 Ok(FetchedToken {
@@ -1024,7 +1165,25 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(first, "already-expired");
+        assert_eq!(served, "valid");
+    }
+
+    #[tokio::test]
+    async fn expired_on_arrival_is_not_returned_on_cold_miss() {
+        let cache = TokenCache::new(true, Duration::ZERO);
+        let first = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                Ok(FetchedToken {
+                    token: "already-expired".to_string(),
+                    expires_in: Some(Duration::from_millis(10)),
+                })
+            })
+            .await;
+        assert!(matches!(
+            first,
+            Err(crate::ZerobusError::TokenFetchError(_))
+        ));
 
         let second = cache
             .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
@@ -1033,6 +1192,104 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(second, "fresh");
+    }
+
+    #[tokio::test]
+    async fn invalidation_cancelled_on_map_lock_leaves_slot_usable() {
+        let cache = Arc::new(TokenCache::new(true, Duration::ZERO));
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("cached", Some(3600)))
+            })
+            .await
+            .unwrap();
+        let generation = initial.generation.unwrap();
+
+        let entries_guard = cache.entries.lock().await;
+        let started = Arc::new(tokio::sync::Notify::new());
+        let invalidation = {
+            let cache = Arc::clone(&cache);
+            let started = Arc::clone(&started);
+            let generation = generation.clone();
+            tokio::spawn(async move {
+                started.notify_one();
+                cache
+                    .invalidate_generation("id", "secret", "c.s.t", &generation)
+                    .await;
+            })
+        };
+        started.notified().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(!generation.slot.invalidated.load(AtomicOrdering::Acquire));
+        assert_eq!(
+            generation
+                .slot
+                .current_generation
+                .load(AtomicOrdering::Acquire),
+            generation.id
+        );
+        invalidation.abort();
+        assert!(invalidation.await.unwrap_err().is_cancelled());
+        drop(entries_guard);
+
+        let still_cached = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                panic!("cancelled invalidation damaged the cached slot")
+            })
+            .await
+            .unwrap();
+        assert_eq!(still_cached, "cached");
+    }
+
+    #[tokio::test]
+    async fn lookup_self_heals_invalidated_mapped_slot() {
+        let cache = TokenCache::new(true, Duration::ZERO);
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("old", Some(3600)))
+            })
+            .await
+            .unwrap();
+        initial
+            .generation
+            .unwrap()
+            .slot
+            .invalidated
+            .store(true, AtomicOrdering::Release);
+
+        let replacement = tokio::time::timeout(
+            Duration::from_secs(1),
+            cache.get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("replacement", Some(3600)))
+            }),
+        )
+        .await
+        .expect("invalidated slot lookup must not spin")
+        .unwrap();
+        assert_eq!(replacement, "replacement");
+    }
+
+    #[tokio::test]
+    async fn miss_prunes_idle_empty_slots() {
+        let cache = TokenCache::new(true, Duration::ZERO);
+        let failed = cache
+            .get_or_fetch("id", "secret", "c.s.failed", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("boom".to_string()))
+            })
+            .await;
+        assert!(failed.is_err());
+        assert_eq!(cache.entries.lock().await.len(), 1);
+
+        cache
+            .get_or_fetch("id", "secret", "c.s.healthy", |_reason| async {
+                Ok(fetched("healthy", Some(3600)))
+            })
+            .await
+            .unwrap();
+        let entries = cache.entries.lock().await;
+        assert_eq!(entries.len(), 1);
+        assert!(entries.contains_key(&TokenKey::new("id", "secret", "c.s.healthy")));
     }
 
     #[tokio::test]

--- a/rust/sdk/src/token_cache.rs
+++ b/rust/sdk/src/token_cache.rs
@@ -14,6 +14,7 @@
 //! name is part of the cache key.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,15 +29,29 @@ use crate::ZerobusResult;
 /// Default lead time before expiry at which a cached token is refreshed.
 pub(crate) const DEFAULT_REFRESH_BUFFER: Duration = Duration::from_secs(300);
 
+/// Delay before retrying a failed proactive refresh. This suppresses a burst of
+/// waiting cache users from each repeating the same failed token request.
+const DEFAULT_REFRESH_FAILURE_BACKOFF: Duration = Duration::from_secs(5);
+
 /// A cached token and the instant at which it expires.
 struct CachedToken {
     value: String,
     expires_at: Instant,
+    refresh_retry_at: Option<Instant>,
+    generation: u64,
 }
 
 impl CachedToken {
     fn is_expired(&self) -> bool {
         Instant::now() >= self.expires_at
+    }
+
+    fn defer_refresh(&mut self, backoff: Duration) {
+        let retry_at = Instant::now()
+            .checked_add(backoff)
+            .unwrap_or(self.expires_at)
+            .min(self.expires_at);
+        self.refresh_retry_at = Some(retry_at);
     }
 }
 
@@ -65,7 +80,39 @@ impl TokenKey {
 /// Per-entry slot. Each key has its own mutex so that a cold-cache burst of
 /// concurrent stream creations for the same table mints a single token
 /// (single-flight) while creations for different tables never block each other.
-type Slot = Arc<Mutex<Option<CachedToken>>>;
+struct CacheSlot {
+    token: Mutex<Option<CachedToken>>,
+    invalidated: AtomicBool,
+    current_generation: AtomicU64,
+    next_generation: AtomicU64,
+}
+
+impl Default for CacheSlot {
+    fn default() -> Self {
+        Self {
+            token: Mutex::new(None),
+            invalidated: AtomicBool::new(false),
+            current_generation: AtomicU64::new(0),
+            next_generation: AtomicU64::new(1),
+        }
+    }
+}
+
+type Slot = Arc<CacheSlot>;
+
+/// Identifies the exact cache generation that supplied a token.
+#[derive(Clone)]
+pub(crate) struct TokenGeneration {
+    slot: Slot,
+    id: u64,
+}
+
+/// A token returned to the built-in headers provider, with the cache generation
+/// to invalidate if Zerobus rejects it.
+pub(crate) struct TokenResult {
+    pub(crate) value: String,
+    pub(crate) generation: Option<TokenGeneration>,
+}
 
 /// Caches OAuth tokens per table for the lifetime of a [`ZerobusSdk`].
 ///
@@ -73,24 +120,35 @@ type Slot = Arc<Mutex<Option<CachedToken>>>;
 pub(crate) struct TokenCache {
     entries: Mutex<HashMap<TokenKey, Slot>>,
     refresh_buffer: Duration,
+    refresh_failure_backoff: Duration,
     enabled: bool,
 }
 
 impl TokenCache {
     pub(crate) fn new(enabled: bool, refresh_buffer: Duration) -> Self {
+        Self::with_refresh_failure_backoff(enabled, refresh_buffer, DEFAULT_REFRESH_FAILURE_BACKOFF)
+    }
+
+    fn with_refresh_failure_backoff(
+        enabled: bool,
+        refresh_buffer: Duration,
+        refresh_failure_backoff: Duration,
+    ) -> Self {
         Self {
             entries: Mutex::new(HashMap::new()),
             refresh_buffer,
+            refresh_failure_backoff,
             enabled,
         }
     }
 
     /// Returns a valid token for the given credentials and table, fetching a new
-    /// one only if the cache is empty, the token has entered the refresh window,
-    /// or caching is disabled.
+    /// one only if the cache is empty, the token has entered the refresh window
+    /// without an active failure backoff, or caching is disabled.
     ///
     /// `fetch` is invoked to mint a fresh token. It is only ever called once per
     /// key at a time thanks to the per-entry lock.
+    #[cfg(test)]
     pub(crate) async fn get_or_fetch<F, Fut>(
         &self,
         client_id: &str,
@@ -102,104 +160,274 @@ impl TokenCache {
         F: FnOnce(MintReason) -> Fut,
         Fut: std::future::Future<Output = ZerobusResult<FetchedToken>>,
     {
+        self.get_or_fetch_with_timeout(client_id, client_secret, table_name, None, fetch)
+            .await
+            .map(|result| result.value)
+    }
+
+    /// Caching-aware token lookup used by the built-in OAuth headers provider.
+    /// A proactive refresh can be bounded independently of the enclosing stream
+    /// connection timeout so a stalled token endpoint still falls back to the
+    /// unexpired cached token.
+    pub(crate) async fn get_or_fetch_with_timeout<F, Fut>(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        table_name: &str,
+        refresh_timeout: Option<Duration>,
+        fetch: F,
+    ) -> ZerobusResult<TokenResult>
+    where
+        F: FnOnce(MintReason) -> Fut,
+        Fut: std::future::Future<Output = ZerobusResult<FetchedToken>>,
+    {
         if !self.enabled {
             return fetch(MintReason::CacheDisabled)
                 .await
-                .map(|fetched| fetched.token);
+                .map(|fetched| TokenResult {
+                    value: fetched.token,
+                    generation: None,
+                });
         }
 
         let key = TokenKey::new(client_id, client_secret, table_name);
+        let mut fetch = Some(fetch);
 
-        let slot = {
-            let mut entries = self.entries.lock().await;
-            // Sweep only on a miss, keeping the cost off the hot lookup path.
-            if !entries.contains_key(&key) {
-                Self::prune_expired(&mut entries);
+        loop {
+            let slot = {
+                let mut entries = self.entries.lock().await;
+                // Sweep only on a miss, keeping the cost off the hot lookup path.
+                if !entries.contains_key(&key) {
+                    Self::prune_expired(&mut entries);
+                }
+                Arc::clone(entries.entry(key.clone()).or_default())
+            };
+
+            // Hold the per-entry lock across the fetch so concurrent callers for
+            // the same key reuse a single mint instead of stampeding the endpoint.
+            let mut guard = slot.token.lock().await;
+            if slot.invalidated.load(AtomicOrdering::Acquire) {
+                continue;
             }
-            Arc::clone(entries.entry(key).or_default())
-        };
 
-        // Hold the per-entry lock across the fetch so concurrent callers for the
-        // same key reuse a single mint instead of stampeding the token endpoint.
-        let mut guard = slot.lock().await;
-
-        if let Some(cached) = guard.as_ref() {
-            if !self.needs_refresh(cached) {
-                debug!(table = %table_name, "token cache hit, reusing cached token");
-                return Ok(cached.value.clone());
+            if let Some(cached) = guard.as_ref() {
+                if slot.current_generation.load(AtomicOrdering::Acquire) != cached.generation {
+                    continue;
+                }
+                if !self.needs_refresh(cached) {
+                    debug!(table = %table_name, "token cache hit, reusing cached token");
+                    return Ok(TokenResult {
+                        value: cached.value.clone(),
+                        generation: Some(TokenGeneration {
+                            slot: Arc::clone(&slot),
+                            id: cached.generation,
+                        }),
+                    });
+                }
             }
-        }
 
-        // A present-but-stale token means we are refreshing; an empty slot is a
-        // cold miss. The reason is surfaced on the mint log.
-        let reason = if guard.is_some() {
-            MintReason::Refresh
-        } else {
-            MintReason::ColdMiss
-        };
+            // A present-but-stale token means we are refreshing; an empty slot is
+            // a cold miss. The reason is surfaced on the mint log.
+            let reason = if guard.is_some() {
+                MintReason::Refresh
+            } else {
+                MintReason::ColdMiss
+            };
 
-        let fetched = match fetch(reason).await {
-            Ok(fetched) => fetched,
-            Err(err) => {
-                // On a retryable failure, serve the still-valid cached token;
-                // let non-retryable errors (bad/revoked creds) surface.
-                if err.is_retryable() {
-                    if let Some(cached) = guard.as_ref() {
-                        if !cached.is_expired() {
-                            warn!(table = %table_name, "token refresh failed (retryable); serving still-valid cached token");
-                            return Ok(cached.value.clone());
-                        }
+            // `expires_in` starts at token issuance, not after a slow response has
+            // reached the client. Starting the local TTL before the fetch avoids
+            // extending the issuer's hard-expiry boundary by request latency.
+            let fetch_started_at = Instant::now();
+            let fetch_future = fetch.take().expect("fetch closure used once")(reason);
+            let fetch_result = match (reason, refresh_timeout) {
+                (MintReason::Refresh, Some(timeout)) => {
+                    match tokio::time::timeout(timeout, fetch_future).await {
+                        Ok(result) => result,
+                        Err(_) => Err(crate::ZerobusError::TokenFetchError(format!(
+                            "Proactive token refresh timed out after {}ms",
+                            timeout.as_millis()
+                        ))),
                     }
                 }
-                return Err(err);
-            }
-        };
+                _ => fetch_future.await,
+            };
 
-        let token = fetched.token.clone();
-
-        // Cache only tokens with a usable TTL. `checked_add` also drops an absurd
-        // `expires_in` that would overflow the clock instead of panicking.
-        let expires_at = fetched
-            .expires_in
-            .and_then(|ttl| Instant::now().checked_add(ttl));
-        match expires_at {
-            Some(expires_at) => {
-                *guard = Some(CachedToken {
-                    value: fetched.token,
-                    expires_at,
-                });
-            }
-            None => {
-                // No usable TTL: keep an existing still-valid token rather than
-                // discarding it.
-                let keep_existing = guard.as_ref().is_some_and(|cached| !cached.is_expired());
-                if !keep_existing {
-                    *guard = None;
+            let fetched = match fetch_result {
+                Ok(fetched) => fetched,
+                Err(err) => {
+                    // A proactive refresh failure says nothing about the validity
+                    // of the cached access token. Keep serving it until its actual
+                    // expiry regardless of how the mint error was classified. An
+                    // authentication rejection from Zerobus invalidates the exact
+                    // generation that supplied the rejected token.
+                    if !slot.invalidated.load(AtomicOrdering::Acquire) {
+                        if let Some(cached) = guard.as_mut() {
+                            if !cached.is_expired()
+                                && slot.current_generation.load(AtomicOrdering::Acquire)
+                                    == cached.generation
+                            {
+                                cached.defer_refresh(self.refresh_failure_backoff);
+                                warn!(
+                                    table = %table_name,
+                                    retryable = err.is_retryable(),
+                                    "token refresh failed; serving still-valid cached token"
+                                );
+                                return Ok(TokenResult {
+                                    value: cached.value.clone(),
+                                    generation: Some(TokenGeneration {
+                                        slot: Arc::clone(&slot),
+                                        id: cached.generation,
+                                    }),
+                                });
+                            }
+                        }
+                    }
+                    return Err(err);
                 }
-            }
-        }
+            };
 
-        Ok(token)
+            // If an auth rejection invalidated this generation while its fetch
+            // was in flight, neither return nor store that detached result. A
+            // retry will use the replacement map generation instead.
+            let prior_generation = guard.as_ref().map(|cached| cached.generation);
+            let prior_generation_invalidated = prior_generation.is_some_and(|generation| {
+                slot.current_generation.load(AtomicOrdering::Acquire) != generation
+            });
+            if slot.invalidated.load(AtomicOrdering::Acquire) || prior_generation_invalidated {
+                return Err(crate::ZerobusError::TokenFetchError(
+                    "Token cache generation was invalidated during refresh".to_string(),
+                ));
+            }
+
+            let token = fetched.token.clone();
+
+            // Cache only tokens with a usable TTL. `checked_add` also drops an
+            // absurd `expires_in` that would overflow the clock instead of panicking.
+            let expires_at = fetched
+                .expires_in
+                .and_then(|ttl| fetch_started_at.checked_add(ttl));
+            let generation = match expires_at {
+                Some(expires_at) if expires_at > Instant::now() => {
+                    let generation = slot.next_generation.fetch_add(1, AtomicOrdering::Relaxed);
+                    let expected = prior_generation.unwrap_or(0);
+                    if slot
+                        .current_generation
+                        .compare_exchange(
+                            expected,
+                            generation,
+                            AtomicOrdering::AcqRel,
+                            AtomicOrdering::Acquire,
+                        )
+                        .is_err()
+                    {
+                        return Err(crate::ZerobusError::TokenFetchError(
+                            "Token cache generation changed during refresh".to_string(),
+                        ));
+                    }
+                    *guard = Some(CachedToken {
+                        value: fetched.token,
+                        expires_at,
+                        refresh_retry_at: None,
+                        generation,
+                    });
+                    Some(TokenGeneration {
+                        slot: Arc::clone(&slot),
+                        id: generation,
+                    })
+                }
+                Some(_) | None => {
+                    // No usable TTL: keep an existing still-valid token rather
+                    // than discarding it. The newly returned token is not tied
+                    // to that older cache generation.
+                    let keep_existing = guard.as_ref().is_some_and(|cached| !cached.is_expired());
+                    if !keep_existing {
+                        *guard = None;
+                    }
+                    None
+                }
+            };
+
+            return Ok(TokenResult {
+                value: token,
+                generation,
+            });
+        }
     }
 
     /// Drops any cached token for the given credentials and table so the next
     /// `get_or_fetch` re-mints. Called when the server rejects the token (e.g.
     /// it was revoked at the IdP), so the re-mint re-checks grants at UC. No-op
     /// when caching is disabled or no entry exists.
+    #[cfg(test)]
     pub(crate) async fn invalidate(&self, client_id: &str, client_secret: &str, table_name: &str) {
         if !self.enabled {
             return;
         }
         let key = TokenKey::new(client_id, client_secret, table_name);
-        if self.entries.lock().await.remove(&key).is_some() {
+        if let Some(slot) = self.entries.lock().await.remove(&key) {
+            slot.invalidated.store(true, AtomicOrdering::Release);
+            slot.current_generation.store(0, AtomicOrdering::Release);
+            debug!(table = %table_name, "token cache entry invalidated after auth rejection");
+        }
+    }
+
+    /// Invalidates the exact cache generation that supplied rejected headers.
+    /// A late rejection from an older stream cannot remove a replacement token.
+    pub(crate) async fn invalidate_generation(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        table_name: &str,
+        generation: &TokenGeneration,
+    ) {
+        if !self.enabled {
+            return;
+        }
+
+        let key = TokenKey::new(client_id, client_secret, table_name);
+        if generation
+            .slot
+            .current_generation
+            .compare_exchange(
+                generation.id,
+                0,
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        generation
+            .slot
+            .invalidated
+            .store(true, AtomicOrdering::Release);
+        let mut entries = self.entries.lock().await;
+        let is_current = entries
+            .get(&key)
+            .is_some_and(|slot| Arc::ptr_eq(slot, &generation.slot));
+        if is_current {
+            entries.remove(&key);
             debug!(table = %table_name, "token cache entry invalidated after auth rejection");
         }
     }
 
     fn needs_refresh(&self, cached: &CachedToken) -> bool {
+        let now = Instant::now();
+        if now >= cached.expires_at {
+            return true;
+        }
+        if cached
+            .refresh_retry_at
+            .is_some_and(|retry_at| now < retry_at)
+        {
+            return false;
+        }
+
         // `checked_add` avoids a panic on an absurd refresh buffer (e.g.
         // `Duration::MAX`); an overflowing deadline means "always refresh".
-        match Instant::now().checked_add(self.refresh_buffer) {
+        match now.checked_add(self.refresh_buffer) {
             Some(deadline) => deadline >= cached.expires_at,
             None => true,
         }
@@ -209,7 +437,7 @@ impl TokenCache {
     /// still-valid tokens, and empty slots are kept — keeping empty slots is
     /// what preserves single-flight for a key being minted concurrently.
     fn prune_expired(entries: &mut HashMap<TokenKey, Slot>) {
-        entries.retain(|_, slot| match slot.try_lock() {
+        entries.retain(|_, slot| match slot.token.try_lock() {
             Ok(guard) => match guard.as_ref() {
                 Some(cached) => !cached.is_expired(),
                 None => true,
@@ -446,7 +674,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_failure_propagates_non_retryable_error() {
+    async fn non_retryable_refresh_failure_serves_still_valid_token() {
         let cache = TokenCache::new(true, Duration::from_secs(60));
 
         // Seed a token that is within the refresh buffer but not yet expired.
@@ -457,8 +685,371 @@ mod tests {
             .await
             .unwrap();
 
-        // A non-retryable refresh error (e.g. revoked or invalid credentials)
-        // must surface rather than being masked by the still-valid cached token.
+        // Even a non-retryable mint error does not invalidate the access token
+        // already in hand. Continue serving it until its actual expiry.
+        let served = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::InvalidUCTokenError(
+                    "revoked".to_string(),
+                ))
+            })
+            .await
+            .unwrap();
+        assert_eq!(served, "valid");
+    }
+
+    #[tokio::test]
+    async fn concurrent_callers_share_refresh_failure_backoff() {
+        let cache = Arc::new(TokenCache::with_refresh_failure_backoff(
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(3600),
+        ));
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let cache = Arc::clone(&cache);
+            let calls = Arc::clone(&calls);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        Err(crate::ZerobusError::InvalidUCTokenError(
+                            "rate limited".to_string(),
+                        ))
+                    })
+                    .await
+                    .unwrap()
+            }));
+        }
+
+        for handle in handles {
+            assert_eq!(handle.await.unwrap(), "valid");
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "waiting callers must not repeat the failed refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_is_retried_after_failure_backoff() {
+        let cache = TokenCache::with_refresh_failure_backoff(
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(3600),
+        );
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        let calls = AtomicUsize::new(0);
+        let served = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(crate::ZerobusError::TokenFetchError("blip".to_string()))
+            })
+            .await
+            .unwrap();
+        assert_eq!(served, "valid");
+
+        let during_backoff = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(fetched("too-early", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(during_backoff, "valid");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let key = TokenKey::new("id", "secret", "c.s.t");
+        let slot = {
+            let entries = cache.entries.lock().await;
+            Arc::clone(entries.get(&key).unwrap())
+        };
+        slot.token.lock().await.as_mut().unwrap().refresh_retry_at = Some(Instant::now());
+
+        let refreshed = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(fetched("fresh", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(refreshed, "fresh");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_backoff_never_extends_token_expiry() {
+        let cache = TokenCache::with_refresh_failure_backoff(
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(3600),
+        );
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("short-lived", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        let served = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("blip".to_string()))
+            })
+            .await
+            .unwrap();
+        assert_eq!(served, "short-lived");
+
+        let key = TokenKey::new("id", "secret", "c.s.t");
+        let slot = {
+            let entries = cache.entries.lock().await;
+            Arc::clone(entries.get(&key).unwrap())
+        };
+        {
+            let mut guard = slot.token.lock().await;
+            let cached = guard.as_mut().unwrap();
+            assert_eq!(cached.refresh_retry_at, Some(cached.expires_at));
+            cached.expires_at = Instant::now();
+        }
+
+        let result = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::InvalidUCTokenError(
+                    "still unavailable".to_string(),
+                ))
+            })
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::ZerobusError::InvalidUCTokenError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalidation_bypasses_refresh_failure_backoff() {
+        let cache = TokenCache::with_refresh_failure_backoff(
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(3600),
+        );
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("rejected", Some(30)))
+            })
+            .await
+            .unwrap();
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Err(crate::ZerobusError::TokenFetchError("blip".to_string()))
+            })
+            .await
+            .unwrap();
+
+        cache.invalidate("id", "secret", "c.s.t").await;
+        let reminted = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("fresh", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(reminted, "fresh");
+    }
+
+    #[tokio::test]
+    async fn invalidated_in_flight_generation_cannot_replace_or_remove_successor() {
+        let cache = Arc::new(TokenCache::new(true, Duration::from_secs(60)));
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("rejected", Some(30)))
+            })
+            .await
+            .unwrap();
+        let initial_generation = initial.generation.unwrap();
+
+        let refresh_started = Arc::new(tokio::sync::Notify::new());
+        let release_refresh = Arc::new(tokio::sync::Notify::new());
+        let refresh = {
+            let cache = Arc::clone(&cache);
+            let refresh_started = Arc::clone(&refresh_started);
+            let release_refresh = Arc::clone(&release_refresh);
+            tokio::spawn(async move {
+                cache
+                    .get_or_fetch_with_timeout(
+                        "id",
+                        "secret",
+                        "c.s.t",
+                        None,
+                        move |_reason| async move {
+                            refresh_started.notify_one();
+                            release_refresh.notified().await;
+                            Err(crate::ZerobusError::InvalidUCTokenError(
+                                "rate limited".to_string(),
+                            ))
+                        },
+                    )
+                    .await
+            })
+        };
+
+        refresh_started.notified().await;
+        cache
+            .invalidate_generation("id", "secret", "c.s.t", &initial_generation)
+            .await;
+        let replacement = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("replacement", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(replacement, "replacement");
+
+        release_refresh.notify_one();
+        assert!(matches!(
+            refresh.await.unwrap(),
+            Err(crate::ZerobusError::InvalidUCTokenError(_))
+        ));
+
+        // A late rejection from the old stream must not evict the replacement.
+        cache
+            .invalidate_generation("id", "secret", "c.s.t", &initial_generation)
+            .await;
+        let still_cached = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                panic!("old generation invalidation removed the replacement token")
+            })
+            .await
+            .unwrap();
+        assert_eq!(still_cached, "replacement");
+    }
+
+    #[tokio::test]
+    async fn late_rejection_cannot_invalidate_refresh_in_same_slot() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+        let initial = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("old", Some(30)))
+            })
+            .await
+            .unwrap();
+        let initial_generation = initial.generation.unwrap();
+
+        let refreshed = cache
+            .get_or_fetch_with_timeout("id", "secret", "c.s.t", None, |_reason| async {
+                Ok(fetched("new", Some(3600)))
+            })
+            .await
+            .unwrap();
+        let refreshed_generation = refreshed.generation.unwrap();
+        assert!(Arc::ptr_eq(
+            &initial_generation.slot,
+            &refreshed_generation.slot
+        ));
+        assert_ne!(initial_generation.id, refreshed_generation.id);
+
+        cache
+            .invalidate_generation("id", "secret", "c.s.t", &initial_generation)
+            .await;
+        let still_cached = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                panic!("late rejection removed a newer token in the same slot")
+            })
+            .await
+            .unwrap();
+        assert_eq!(still_cached, "new");
+    }
+
+    #[tokio::test]
+    async fn proactive_refresh_timeout_serves_still_valid_token() {
+        let cache = TokenCache::with_refresh_failure_backoff(
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(3600),
+        );
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("valid", Some(30)))
+            })
+            .await
+            .unwrap();
+
+        let served = cache
+            .get_or_fetch_with_timeout(
+                "id",
+                "secret",
+                "c.s.t",
+                Some(Duration::from_millis(20)),
+                |_reason| async {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    Ok(fetched("too-late", Some(3600)))
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(served.value, "valid");
+
+        let during_backoff = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                panic!("timed-out refresh did not arm failure backoff")
+            })
+            .await
+            .unwrap();
+        assert_eq!(during_backoff, "valid");
+    }
+
+    #[tokio::test]
+    async fn slow_fetch_does_not_extend_reported_token_lifetime() {
+        let cache = TokenCache::new(true, Duration::ZERO);
+        let first = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                Ok(FetchedToken {
+                    token: "already-expired".to_string(),
+                    expires_in: Some(Duration::from_millis(10)),
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(first, "already-expired");
+
+        let second = cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(fetched("fresh", Some(3600)))
+            })
+            .await
+            .unwrap();
+        assert_eq!(second, "fresh");
+    }
+
+    #[tokio::test]
+    async fn refresh_failure_surfaces_after_cached_token_expires() {
+        let cache = TokenCache::new(true, Duration::from_secs(60));
+
+        cache
+            .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
+                Ok(FetchedToken {
+                    token: "expired".to_string(),
+                    expires_in: Some(Duration::from_millis(1)),
+                })
+            })
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
         let result = cache
             .get_or_fetch("id", "secret", "c.s.t", |_reason| async {
                 Err(crate::ZerobusError::InvalidUCTokenError(

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/multiplexed_stream_tests.rs"
 name = "arrow_tests"
 path = "src/arrow_tests.rs"
 
+[[test]]
+name = "token_cache_tests"
+path = "src/token_cache_tests.rs"
+
 [dependencies]
 async-trait.workspace = true
 prost.workspace = true

--- a/rust/tests/src/token_cache_tests.rs
+++ b/rust/tests/src/token_cache_tests.rs
@@ -1,0 +1,157 @@
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use databricks_zerobus_ingest_sdk::{HeadersProvider, OAuthHeadersProvider};
+
+struct MockResponse {
+    status: &'static str,
+    body: &'static str,
+}
+
+fn read_request(stream: &mut TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let mut request = Vec::new();
+    let mut buffer = [0u8; 4096];
+    let (header_end, content_length) = loop {
+        let read = stream.read(&mut buffer).unwrap();
+        assert!(read > 0, "client closed before sending complete headers");
+        request.extend_from_slice(&buffer[..read]);
+
+        if let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            let header_end = header_end + 4;
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            break (header_end, content_length);
+        }
+    };
+
+    while request.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).unwrap();
+        assert!(read > 0, "client closed before sending complete body");
+        request.extend_from_slice(&buffer[..read]);
+    }
+}
+
+fn start_token_server(responses: Vec<MockResponse>) -> (String, JoinHandle<usize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let handle = thread::spawn(move || {
+        let mut served = 0;
+        for response in &responses {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break Some(stream),
+                    Err(error)
+                        if error.kind() == ErrorKind::WouldBlock && Instant::now() < deadline =>
+                    {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => break None,
+                    Err(error) => panic!("token server accept failed: {error}"),
+                }
+            };
+            let Some(mut stream) = stream.take() else {
+                break;
+            };
+            stream.set_nonblocking(false).unwrap();
+            read_request(&mut stream);
+            write!(
+                stream,
+                "HTTP/1.1 {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response.status,
+                response.body.len(),
+                response.body
+            )
+            .unwrap();
+            stream.flush().unwrap();
+            served += 1;
+        }
+        served
+    });
+    (url, handle)
+}
+
+fn provider(unity_catalog_url: String) -> OAuthHeadersProvider {
+    OAuthHeadersProvider::new(
+        "client-id".to_string(),
+        "client-secret".to_string(),
+        "catalog.schema.table".to_string(),
+        "workspace-id".to_string(),
+        unity_catalog_url,
+    )
+}
+
+#[tokio::test]
+async fn string_expires_in_is_cached_across_header_requests() {
+    let (url, server) = start_token_server(vec![MockResponse {
+        status: "200 OK",
+        body: r#"{"access_token":"cached-token","expires_in":"3600"}"#,
+    }]);
+    let provider = provider(url);
+
+    let first = provider.get_headers().await.unwrap();
+    let second = provider.get_headers().await.unwrap();
+
+    assert_eq!(first["authorization"], "Bearer cached-token");
+    assert_eq!(second["authorization"], "Bearer cached-token");
+    assert_eq!(
+        server.join().unwrap(),
+        1,
+        "second request must hit the cache"
+    );
+}
+
+#[tokio::test]
+async fn non_retryable_refresh_failure_uses_still_valid_token() {
+    let (url, server) = start_token_server(vec![
+        MockResponse {
+            status: "200 OK",
+            // The default five-minute refresh buffer makes this token due for
+            // proactive refresh immediately, while it remains valid for 30s.
+            body: r#"{"access_token":"still-valid","expires_in":"30"}"#,
+        },
+        MockResponse {
+            status: "400 Bad Request",
+            body: r#"{"error":"invalid_request"}"#,
+        },
+    ]);
+    let provider = provider(url);
+
+    let first = provider.get_headers().await.unwrap();
+    let second = provider.get_headers().await.unwrap();
+
+    assert_eq!(first["authorization"], "Bearer still-valid");
+    assert_eq!(second["authorization"], "Bearer still-valid");
+    assert_eq!(
+        server.join().unwrap(),
+        2,
+        "second request must attempt refresh"
+    );
+}
+
+#[tokio::test]
+async fn rate_limit_on_cold_cache_is_retryable() {
+    let (url, server) = start_token_server(vec![MockResponse {
+        status: "429 Too Many Requests",
+        body: r#"{"error":"rate_limited"}"#,
+    }]);
+    let provider = provider(url);
+
+    let error = provider.get_headers().await.unwrap_err();
+    assert!(error.is_retryable());
+    assert_eq!(server.join().unwrap(), 1);
+}

--- a/rust/tools/token_cache_staging/Cargo.toml
+++ b/rust/tools/token_cache_staging/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zerobus-token-cache-staging-harness"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+databricks-zerobus-ingest-sdk = { path = "../../sdk" }
+reqwest.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/rust/tools/token_cache_staging/README.md
+++ b/rust/tools/token_cache_staging/README.md
@@ -1,0 +1,28 @@
+# Token-cache staging harness
+
+This opt-in harness verifies both token-cache regressions against a real
+staging Zerobus endpoint without ingesting records. It opens and closes three
+JSON streams against the same table and SDK instance.
+
+A loopback-only OAuth proxy forwards the first token request to the configured
+staging workspace over HTTPS, rewrites its `expires_in` value as a JSON string,
+then returns HTTP 429 for the proactive refresh request. The second and third
+streams are opened concurrently: both must use the cached, unexpired token, and
+the caller waiting behind the failed refresh must not make another token request.
+The proxy never logs credentials or tokens.
+
+Use a staging service principal and a disposable staging table:
+
+```bash
+export DATABRICKS_CLIENT_ID='<staging-service-principal-id>'
+export DATABRICKS_CLIENT_SECRET='<staging-service-principal-secret>'
+export DATABRICKS_WORKSPACE_URL='https://<staging-workspace>'
+export ZEROBUS_ENDPOINT='https://<staging-zerobus-endpoint>'
+export DATABRICKS_TABLE_NAME='<catalog>.<schema>.<table>'
+
+cargo run -p zerobus-token-cache-staging-harness
+```
+
+Success means all three streams opened and the proxy observed exactly two token
+requests: the initial mint and one injected failed refresh. The concurrent
+caller must not repeat the failed refresh.

--- a/rust/tools/token_cache_staging/src/main.rs
+++ b/rust/tools/token_cache_staging/src/main.rs
@@ -1,0 +1,265 @@
+use std::env;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use databricks_zerobus_ingest_sdk::{ZerobusSdk, ZerobusStream};
+use reqwest::header::CONTENT_TYPE;
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+const MAX_REQUEST_BYTES: usize = 1024 * 1024;
+
+struct TokenProxy {
+    url: String,
+    request_count: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl TokenProxy {
+    async fn start(
+        workspace_url: String,
+        client_id: String,
+        client_secret: String,
+    ) -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind loopback OAuth proxy")?;
+        let url = format!("http://{}", listener.local_addr()?);
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = Arc::clone(&request_count);
+        let client = reqwest::Client::new();
+
+        let task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        eprintln!("OAuth proxy accept failed: {error}");
+                        return;
+                    }
+                };
+                let request_number = count.fetch_add(1, Ordering::SeqCst) + 1;
+                let workspace_url = workspace_url.clone();
+                let client_id = client_id.clone();
+                let client_secret = client_secret.clone();
+                let client = client.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_token_request(
+                        stream,
+                        request_number,
+                        &workspace_url,
+                        &client_id,
+                        &client_secret,
+                        &client,
+                    )
+                    .await
+                    {
+                        eprintln!("OAuth proxy request {request_number} failed: {error:#}");
+                    }
+                });
+            }
+        });
+
+        Ok(Self {
+            url,
+            request_count,
+            task,
+        })
+    }
+
+    fn requests(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for TokenProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn handle_token_request(
+    mut stream: TcpStream,
+    request_number: usize,
+    workspace_url: &str,
+    client_id: &str,
+    client_secret: &str,
+    client: &reqwest::Client,
+) -> Result<()> {
+    let request_body = read_request_body(&mut stream).await?;
+
+    if request_number == 1 {
+        let token_url = format!("{}/oidc/v1/token", workspace_url.trim_end_matches('/'));
+        let response = client
+            .post(token_url)
+            .basic_auth(client_id, Some(client_secret))
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(request_body)
+            .send()
+            .await
+            .context("forward token request to staging workspace")?;
+        let status = response.status();
+        let response_body = response
+            .bytes()
+            .await
+            .context("read staging token response")?;
+
+        if !status.is_success() {
+            let status_line = format!(
+                "{} {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("Upstream Error")
+            );
+            return write_response(&mut stream, &status_line, &response_body).await;
+        }
+
+        let mut body: Value =
+            serde_json::from_slice(&response_body).context("parse staging token response")?;
+        let expires_in = body
+            .get_mut("expires_in")
+            .context("staging token response did not contain expires_in")?;
+        let seconds = match expires_in {
+            Value::Number(value) => value.to_string(),
+            Value::String(value) => value.clone(),
+            value => bail!("staging expires_in was not an integer: {value}"),
+        };
+        *expires_in = Value::String(seconds);
+        let rewritten = serde_json::to_vec(&body)?;
+        write_response(&mut stream, "200 OK", &rewritten).await
+    } else {
+        write_response(
+            &mut stream,
+            "429 Too Many Requests",
+            br#"{"error":"injected_refresh_failure"}"#,
+        )
+        .await
+    }
+}
+
+async fn read_request_body(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    let mut request = Vec::new();
+    let mut buffer = [0u8; 4096];
+
+    let (header_end, content_length) = loop {
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            bail!("client closed before sending complete headers");
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.len() > MAX_REQUEST_BYTES {
+            bail!("token request exceeded {MAX_REQUEST_BYTES} bytes");
+        }
+
+        if let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            let header_end = header_end + 4;
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>())
+                })
+                .transpose()
+                .context("invalid content-length")?
+                .context("token request did not include content-length")?;
+            break (header_end, content_length);
+        }
+    };
+
+    if header_end + content_length > MAX_REQUEST_BYTES {
+        bail!("token request exceeded {MAX_REQUEST_BYTES} bytes");
+    }
+    while request.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            bail!("client closed before sending complete body");
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+
+    Ok(request[header_end..header_end + content_length].to_vec())
+}
+
+async fn write_response(stream: &mut TcpStream, status: &str, body: &[u8]) -> Result<()> {
+    let headers = format!(
+        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(headers.as_bytes()).await?;
+    stream.write_all(body).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+async fn open_and_close_stream(
+    sdk: &ZerobusSdk,
+    table_name: &str,
+    client_id: &str,
+    client_secret: &str,
+) -> Result<()> {
+    let mut stream: ZerobusStream = sdk
+        .stream_builder()
+        .table(table_name)
+        .oauth(client_id, client_secret)
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .context("open staging Zerobus stream")?;
+    stream.close().await.context("close staging Zerobus stream")
+}
+
+fn required_env(name: &str) -> Result<String> {
+    env::var(name).with_context(|| format!("required environment variable {name} is not set"))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client_id = required_env("DATABRICKS_CLIENT_ID")?;
+    let client_secret = required_env("DATABRICKS_CLIENT_SECRET")?;
+    let workspace_url = required_env("DATABRICKS_WORKSPACE_URL")?;
+    let zerobus_endpoint = required_env("ZEROBUS_ENDPOINT")?;
+    let table_name = required_env("DATABRICKS_TABLE_NAME")?;
+
+    let proxy = TokenProxy::start(workspace_url, client_id.clone(), client_secret.clone()).await?;
+    let sdk = ZerobusSdk::builder()
+        .endpoint(zerobus_endpoint)
+        .unity_catalog_url(&proxy.url)
+        // Force every cache hit into the proactive refresh path. The first
+        // token remains valid; only the lead-time calculation overflows.
+        .token_refresh_buffer(Duration::MAX)
+        .build()?;
+
+    println!("Opening first staging stream with a string-valued expires_in...");
+    open_and_close_stream(&sdk, &table_name, &client_id, &client_secret).await?;
+    if proxy.requests() != 1 {
+        bail!(
+            "expected one OAuth request after first stream, observed {}",
+            proxy.requests()
+        );
+    }
+
+    println!(
+        "Opening two more staging streams concurrently after an injected HTTP 429 refresh failure..."
+    );
+    tokio::try_join!(
+        open_and_close_stream(&sdk, &table_name, &client_id, &client_secret),
+        open_and_close_stream(&sdk, &table_name, &client_id, &client_secret),
+    )?;
+    if proxy.requests() != 2 {
+        bail!(
+            "expected concurrent refresh-failure backoff to keep OAuth requests at two, observed {}",
+            proxy.requests()
+        );
+    }
+
+    println!(
+        "PASS: quoted expires_in was cached, the valid token survived failed refresh, and the concurrent stream did not repeat the refresh"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- accept numeric and quoted integer `expires_in` values without disabling token caching
- serve an unexpired cached token when proactive refresh fails or times out, with single-flight failure backoff
- invalidate only the token generation rejected by Zerobus so late failures cannot evict a replacement
- treat token-endpoint HTTP 429 responses as retryable and derive expiry from the start of the mint
- add deterministic cache tests, loopback HTTP integration tests, and an opt-in non-ingesting staging harness

## Testing

- `cargo test -p databricks-zerobus-ingest-sdk token_cache`
- `cargo test -p tests --test token_cache_tests`