### PR TITLE
[Rust] Introduce arrow_schema_from_uc_columns_with_options to allow clients to have variant fields with an extension

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,14 +6,18 @@
 
 ### New Features and Improvements
 
-- Arrow Flight: `arrow_schema_from_uc_columns` / `arrow_schema_from_uc_schema`
-  now annotate `VARIANT` fields (top-level and nested inside structs, arrays, and
-  maps) with the canonical `arrow.parquet.variant` Arrow extension marker
-  (`ARROW:extension:name` + empty `ARROW:extension:metadata`), so downstream
-  consumers can recover which fields are variants — previously lost when a UC
-  schema was converted to Arrow. The physical `Struct<metadata, value>` shape is
-  unchanged, and the Databricks Arrow Flight server ignores and strips the marker
-  on the write path, so ingestion behavior is unaffected.
+- Arrow Flight: new `arrow_schema_from_uc_columns_with_options` /
+  `arrow_schema_from_uc_schema_with_options` accept an `ArrowSchemaOptions`. When
+  `annotate_variant_extension` is set, `VARIANT` fields (top-level and nested
+  inside structs, arrays, and maps) are annotated with the canonical
+  `arrow.parquet.variant` Arrow extension marker (`ARROW:extension:name` + empty
+  `ARROW:extension:metadata`), so downstream consumers can recover which fields
+  are variants — previously lost when a UC schema was converted to Arrow. The
+  physical `Struct<metadata, value>` shape is unchanged. The option defaults to
+  off (and `arrow_schema_from_uc_columns` / `arrow_schema_from_uc_schema` are
+  unchanged) because the Arrow Flight server's target schema is unmarked, so a
+  marked schema forces a per-batch server-side cast; enable it only when a
+  consumer needs the annotation and that cost is acceptable.
 
 ### Bug Fixes
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Documentation
 
+- README: document the opt-in variant extension annotation
+  (`ArrowSchemaOptions`) for the Arrow Flight UC→Arrow schema conversion.
+
 ### Internal Changes
 
 ### Breaking Changes

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ### New Features and Improvements
 
+- Arrow Flight: `arrow_schema_from_uc_columns` / `arrow_schema_from_uc_schema`
+  now annotate `VARIANT` fields (top-level and nested inside structs, arrays, and
+  maps) with the canonical `arrow.parquet.variant` Arrow extension marker
+  (`ARROW:extension:name` + empty `ARROW:extension:metadata`), so downstream
+  consumers can recover which fields are variants — previously lost when a UC
+  schema was converted to Arrow. The physical `Struct<metadata, value>` shape is
+  unchanged, and the Databricks Arrow Flight server ignores and strips the marker
+  on the write path, so ingestion behavior is unaffected.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/README.md
+++ b/rust/README.md
@@ -905,6 +905,25 @@ match stream.wait_for_offset(offset).await {
 
 `SchemaValidationCause` is `#[non_exhaustive]` and includes an `Unknown(String)` variant, so a newer server cause the SDK doesn't recognize is still surfaced rather than dropped.
 
+### Variant Extension Annotation (Arrow Flight)
+
+*(Beta; requires `features = ["arrow-flight"]`.)*
+
+`arrow_schema_from_uc_columns` / `arrow_schema_from_uc_schema` build an Arrow schema from Unity Catalog columns. By default `VARIANT` columns become a plain `Struct<metadata, value>` with no marker. Pass `ArrowSchemaOptions { annotate_variant_extension: true }` to also tag every variant field (top-level and nested) with the canonical `arrow.parquet.variant` Arrow extension, so downstream consumers can tell which fields are variants:
+
+```rust
+use databricks_zerobus_ingest_sdk::schema::{
+    arrow_schema_from_uc_columns_with_options, ArrowSchemaOptions, UcColumn,
+};
+
+let mut options = ArrowSchemaOptions::default();
+options.annotate_variant_extension = true;
+let schema = arrow_schema_from_uc_columns_with_options(&uc_columns, &options)?;
+# Ok::<(), databricks_zerobus_ingest_sdk::schema::SchemaError>(())
+```
+
+The physical `Struct<metadata, value>` shape is unchanged. Leave it off (the default) unless a consumer needs the marker: the Arrow Flight server's target schema is unmarked, so a marked schema forces a per-batch server-side cast. If you enable it, build your `RecordBatch` from the same marked schema — `ingest_batch` compares schemas including field metadata and rejects a marked-stream/unmarked-batch mismatch locally.
+
 ### Payload Size Limit
 
 The Zerobus server applies a **10 MiB limit** to the raw record bytes of an ingest call, and *additionally* enforces a transport-layer limit on the full serialized request (record bytes plus protobuf framing and stream metadata). The SDK enforces a limit client-side so you get an immediate `InvalidArgument` error rather than a server rejection:

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -685,7 +685,9 @@ fn sanitize_message_name(name: &str) -> String {
 ///
 /// Notable Arrow choices, all dictated by the Databricks Arrow Flight server:
 /// `STRING` / `DECIMAL` → `LargeUtf8`, `VARIANT` →
-/// `Struct<metadata: LargeBinary not null, value: LargeBinary not null>`,
+/// `Struct<metadata: LargeBinary not null, value: LargeBinary not null>`
+/// annotated with the canonical `arrow.parquet.variant` extension marker so
+/// downstream consumers can recover which fields are variants,
 /// `BINARY` → `LargeBinary`,
 /// `DATE` → `Date32`, `TIMESTAMP` → `Timestamp(Microsecond, Some("UTC"))`,
 /// `TIMESTAMP_NTZ` → `Timestamp(Microsecond, None)`, `ARRAY<T>` → `List` with
@@ -733,11 +735,7 @@ fn uc_column_to_arrow_field(column: &UcColumn) -> Result<arrow_schema::Field, Sc
         complex_type_to_arrow_field(&column.name, &complex, column.nullable)
     } else {
         let p = parse_uc_top_level_type(&column.type_name)?;
-        Ok(arrow_schema::Field::new(
-            &column.name,
-            map_primitive_to_arrow(p),
-            column.nullable,
-        ))
+        Ok(primitive_arrow_field(&column.name, p, column.nullable))
     }
 }
 
@@ -764,6 +762,40 @@ fn map_primitive_to_arrow(p: PrimitiveType) -> arrow_schema::DataType {
         PrimitiveType::Decimal => DataType::LargeUtf8,
         PrimitiveType::Variant => variant_arrow_data_type(),
     }
+}
+
+/// Canonical Arrow extension name for the Parquet Variant type (Arrow's
+/// `VariantType::NAME`). Stamped via raw metadata to avoid a `parquet-variant`
+/// dependency; the result is byte-identical.
+#[cfg(feature = "arrow-flight")]
+const VARIANT_EXTENSION_NAME: &str = "arrow.parquet.variant";
+
+/// Build an Arrow field for a UC primitive, marking `VARIANT` fields so
+/// downstream consumers can recover variant-ness. The Arrow Flight server
+/// strips the marker on the write path.
+#[cfg(feature = "arrow-flight")]
+fn primitive_arrow_field(name: &str, p: PrimitiveType, nullable: bool) -> arrow_schema::Field {
+    let field = arrow_schema::Field::new(name, map_primitive_to_arrow(p), nullable);
+    if matches!(p, PrimitiveType::Variant) {
+        variant_marked_field(field)
+    } else {
+        field
+    }
+}
+
+/// Stamp the canonical variant extension marker onto `field`: extension name
+/// plus empty metadata, matching `Field::with_extension_type(VariantType)`.
+#[cfg(feature = "arrow-flight")]
+fn variant_marked_field(field: arrow_schema::Field) -> arrow_schema::Field {
+    use arrow_schema::extension::{EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY};
+
+    let mut metadata = field.metadata().clone();
+    metadata.insert(
+        EXTENSION_TYPE_NAME_KEY.to_string(),
+        VARIANT_EXTENSION_NAME.to_string(),
+    );
+    metadata.insert(EXTENSION_TYPE_METADATA_KEY.to_string(), String::new());
+    field.with_metadata(metadata)
 }
 
 #[cfg(feature = "arrow-flight")]
@@ -799,7 +831,7 @@ fn complex_type_to_arrow_field(
     use std::sync::Arc;
 
     match ct {
-        ComplexType::Primitive(p) => Ok(Field::new(name, map_primitive_to_arrow(*p), nullable)),
+        ComplexType::Primitive(p) => Ok(primitive_arrow_field(name, *p, nullable)),
         ComplexType::Struct(st) => {
             let mut child_fields = Vec::with_capacity(st.fields.len());
             for f in &st.fields {
@@ -821,7 +853,7 @@ fn complex_type_to_arrow_field(
             // nullable elements (Spark/Delta semantics for an unspecified
             // value).
             let item_field = match element.as_ref() {
-                ComplexType::Primitive(p) => Field::new("item", map_primitive_to_arrow(*p), true),
+                ComplexType::Primitive(p) => primitive_arrow_field("item", *p, true),
                 ComplexType::Struct(_) => complex_type_to_arrow_field("item", element, true)?,
                 ComplexType::Array(_) => return Err(shape_unsupported("nested arrays", name)),
                 ComplexType::Map { .. } => return Err(shape_unsupported("arrays of maps", name)),
@@ -835,7 +867,7 @@ fn complex_type_to_arrow_field(
         ComplexType::Map { key, value } => {
             let key_primitive = validate_arrow_map_key(key, name)?;
             let value_field = match value.as_ref() {
-                ComplexType::Primitive(p) => Field::new("values", map_primitive_to_arrow(*p), true),
+                ComplexType::Primitive(p) => primitive_arrow_field("values", *p, true),
                 ComplexType::Struct(_) => complex_type_to_arrow_field("values", value, true)?,
                 ComplexType::Array(_) | ComplexType::Map { .. } => {
                     return Err(shape_unsupported("maps with complex value types", name));
@@ -1278,6 +1310,30 @@ mod tests {
             }
         }
 
+        /// Asserts `field` is a VARIANT struct carrying the canonical
+        /// `arrow.parquet.variant` extension marker.
+        fn assert_variant_marked(field: &arrow_schema::Field) {
+            use arrow_schema::extension::{EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY};
+
+            assert_variant_data_type(field.data_type());
+            assert_eq!(
+                field
+                    .metadata()
+                    .get(EXTENSION_TYPE_NAME_KEY)
+                    .map(String::as_str),
+                Some("arrow.parquet.variant"),
+                "variant field must carry the extension name marker"
+            );
+            assert_eq!(
+                field
+                    .metadata()
+                    .get(EXTENSION_TYPE_METADATA_KEY)
+                    .map(String::as_str),
+                Some(""),
+                "variant field must carry empty extension metadata"
+            );
+        }
+
         #[test]
         fn scalars_use_proper_arrow_types() {
             let cols = vec![
@@ -1312,8 +1368,11 @@ mod tests {
             // DECIMAL renders as LargeUtf8 (text encoding contract preserved).
             assert_eq!(arrow_field(&s, "price").data_type(), &DataType::LargeUtf8);
             let attributes = arrow_field(&s, "attributes");
-            assert_variant_data_type(attributes.data_type());
+            assert_variant_marked(attributes);
             assert!(!attributes.is_nullable());
+            // Non-variant fields carry no extension marker.
+            assert!(arrow_field(&s, "id").metadata().is_empty());
+            assert!(arrow_field(&s, "data").metadata().is_empty());
         }
 
         #[test]
@@ -1536,16 +1595,18 @@ mod tests {
             let s = arrow_schema_from_uc_columns(&cols).unwrap();
             match arrow_field(&s, "payload").data_type() {
                 DataType::Struct(fs) => {
-                    assert_variant_data_type(fs[0].data_type());
+                    // Nested variants, in a struct child / array item / map value,
+                    // all carry the extension marker.
+                    assert_variant_marked(&fs[0]);
                     match fs[1].data_type() {
-                        DataType::List(item) => assert_variant_data_type(item.data_type()),
+                        DataType::List(item) => assert_variant_marked(item),
                         other => panic!("expected List, got {:?}", other),
                     }
                     match fs[2].data_type() {
                         DataType::Map(entries, _) => match entries.data_type() {
                             DataType::Struct(kv) => {
                                 assert_eq!(kv[0].data_type(), &DataType::LargeUtf8);
-                                assert_variant_data_type(kv[1].data_type());
+                                assert_variant_marked(&kv[1]);
                             }
                             other => panic!("expected Struct inside Map, got {:?}", other),
                         },

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -1748,11 +1748,11 @@ mod tests {
             assert_nested_variants(&s, assert_variant_marked);
         }
 
-        /// Covers the case where a client does not simply reuse the marked
-        /// schema for its batches but rebuilds an equivalent one from scratch:
-        /// the batch must still compare equal so the client-side ingest gate
-        /// (`ingest_batch`, which rejects on a metadata-inclusive
-        /// `batch.schema() != stream_schema`) accepts it.
+        /// Two separate annotated conversions of the same columns produce equal
+        /// schemas (marker metadata included), so a client that rebuilds the
+        /// schema for its batch rather than reusing the stream's still satisfies
+        /// the metadata-inclusive ingest-gate comparison. (The gate itself is
+        /// exercised end-to-end in `arrow_tests`.)
         #[test]
         fn variant_batch_matches_marked_stream_schema() {
             use std::sync::Arc;

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -1748,50 +1748,6 @@ mod tests {
             assert_nested_variants(&s, assert_variant_marked);
         }
 
-        /// Two separate annotated conversions of the same columns produce equal
-        /// schemas (marker metadata included), so a client that rebuilds the
-        /// schema for its batch rather than reusing the stream's still satisfies
-        /// the metadata-inclusive ingest-gate comparison. (The gate itself is
-        /// exercised end-to-end in `arrow_tests`.)
-        #[test]
-        fn variant_batch_matches_marked_stream_schema() {
-            use std::sync::Arc;
-
-            use arrow_array::{LargeBinaryArray, RecordBatch, StructArray};
-
-            let cols = vec![col("attrs", "VARIANT", false, 0)];
-            // The stream schema and the batch's schema are converted separately
-            // (both annotated), so they are distinct instances rather than a
-            // shared `Arc`.
-            let stream_schema =
-                Arc::new(arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap());
-            let batch_schema =
-                Arc::new(arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap());
-            assert_variant_marked(arrow_field(&batch_schema, "attrs"));
-
-            // Physical arrays carry no marker (it lives on the field), matching
-            // how a client encodes variant data.
-            let DataType::Struct(child_fields) = arrow_field(&batch_schema, "attrs").data_type()
-            else {
-                panic!("expected VARIANT Struct");
-            };
-            let attrs = StructArray::new(
-                child_fields.clone(),
-                vec![
-                    Arc::new(LargeBinaryArray::from(vec![b"m".as_slice()])),
-                    Arc::new(LargeBinaryArray::from(vec![b"v".as_slice()])),
-                ],
-                None,
-            );
-            let batch = RecordBatch::try_new(batch_schema, vec![Arc::new(attrs)]).unwrap();
-
-            assert_eq!(
-                batch.schema(),
-                stream_schema,
-                "batch built from a separately converted schema must satisfy the ingest gate"
-            );
-        }
-
         #[test]
         fn rejects_excessively_deep_nesting() {
             let mut type_json = String::from("\"integer\"");

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -676,7 +676,44 @@ fn sanitize_message_name(name: &str) -> String {
 // Arrow schema conversion (feature = "arrow-flight")
 // ---------------------------------------------------------------------------
 
+/// Options controlling the UC → Arrow schema conversion.
+///
+/// Construct with [`Default`] and set the fields you need; the struct is
+/// `#[non_exhaustive]` so future options can be added without breaking callers.
+///
+/// ```
+/// # use databricks_zerobus_ingest_sdk::schema::ArrowSchemaOptions;
+/// let mut options = ArrowSchemaOptions::default();
+/// options.annotate_variant_extension = true;
+/// ```
+#[cfg(feature = "arrow-flight")]
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct ArrowSchemaOptions {
+    /// Annotate `VARIANT` fields with the canonical `arrow.parquet.variant`
+    /// Arrow extension marker so downstream consumers can identify which fields
+    /// are variants (the physical `Struct<metadata, value>` shape is unchanged).
+    ///
+    /// Defaults to `false`. The Databricks Arrow Flight server builds its target
+    /// schema from Delta *without* the marker, so a marked schema differs from
+    /// the target and forces a per-batch server-side cast. Enable this only when
+    /// a downstream consumer needs the annotation and that cost is acceptable.
+    pub annotate_variant_extension: bool,
+}
+
 /// Build an [`arrow_schema::Schema`] from a Unity Catalog table's columns.
+///
+/// Equivalent to [`arrow_schema_from_uc_columns_with_options`] with the default
+/// options (no variant annotation). See it for the full type mapping.
+#[cfg(feature = "arrow-flight")]
+pub fn arrow_schema_from_uc_columns(
+    columns: &[UcColumn],
+) -> Result<arrow_schema::Schema, SchemaError> {
+    arrow_schema_from_uc_columns_with_options(columns, &ArrowSchemaOptions::default())
+}
+
+/// Build an [`arrow_schema::Schema`] from a Unity Catalog table's columns,
+/// controlled by `options`.
 ///
 /// Parallels [`descriptor_from_uc_columns`] but targets Arrow Flight callers.
 /// Accepts the same set of UC types and applies the same structural rules
@@ -686,8 +723,8 @@ fn sanitize_message_name(name: &str) -> String {
 /// Notable Arrow choices, all dictated by the Databricks Arrow Flight server:
 /// `STRING` / `DECIMAL` → `LargeUtf8`, `VARIANT` →
 /// `Struct<metadata: LargeBinary not null, value: LargeBinary not null>`
-/// annotated with the canonical `arrow.parquet.variant` extension marker so
-/// downstream consumers can recover which fields are variants,
+/// (optionally annotated with the canonical `arrow.parquet.variant` extension
+/// marker — see [`ArrowSchemaOptions::annotate_variant_extension`]),
 /// `BINARY` → `LargeBinary`,
 /// `DATE` → `Date32`, `TIMESTAMP` → `Timestamp(Microsecond, Some("UTC"))`,
 /// `TIMESTAMP_NTZ` → `Timestamp(Microsecond, None)`, `ARRAY<T>` → `List` with
@@ -695,8 +732,9 @@ fn sanitize_message_name(name: &str) -> String {
 /// containing `"keys"` and `"values"` (the canonical schema the Databricks
 /// Arrow Flight server builds from Delta).
 #[cfg(feature = "arrow-flight")]
-pub fn arrow_schema_from_uc_columns(
+pub fn arrow_schema_from_uc_columns_with_options(
     columns: &[UcColumn],
+    options: &ArrowSchemaOptions,
 ) -> Result<arrow_schema::Schema, SchemaError> {
     let mut sorted: Vec<&UcColumn> = columns.iter().filter(|c| c.position >= 0).collect();
     sorted.sort_by_key(|c| c.position);
@@ -704,7 +742,7 @@ pub fn arrow_schema_from_uc_columns(
     let mut fields = Vec::with_capacity(sorted.len());
     for column in sorted.iter() {
         validate_field_name(&column.name)?;
-        fields.push(uc_column_to_arrow_field(column)?);
+        fields.push(uc_column_to_arrow_field(column, options)?);
     }
     Ok(arrow_schema::Schema::new(fields))
 }
@@ -721,8 +759,23 @@ pub fn arrow_schema_from_uc_schema(
     arrow_schema_from_uc_columns(&schema.columns)
 }
 
+/// Build an [`arrow_schema::Schema`] from a full [`UcTableSchema`], controlled
+/// by `options`.
+///
+/// See [`arrow_schema_from_uc_columns_with_options`] for the type mapping.
 #[cfg(feature = "arrow-flight")]
-fn uc_column_to_arrow_field(column: &UcColumn) -> Result<arrow_schema::Field, SchemaError> {
+pub fn arrow_schema_from_uc_schema_with_options(
+    schema: &UcTableSchema,
+    options: &ArrowSchemaOptions,
+) -> Result<arrow_schema::Schema, SchemaError> {
+    arrow_schema_from_uc_columns_with_options(&schema.columns, options)
+}
+
+#[cfg(feature = "arrow-flight")]
+fn uc_column_to_arrow_field(
+    column: &UcColumn,
+    options: &ArrowSchemaOptions,
+) -> Result<arrow_schema::Field, SchemaError> {
     if is_complex(&column.type_name) {
         if column.type_json.is_empty() {
             return Err(SchemaError::MissingTypeJson(column.name.clone()));
@@ -732,10 +785,15 @@ fn uc_column_to_arrow_field(column: &UcColumn) -> Result<arrow_schema::Field, Sc
                 column: column.name.clone(),
                 reason,
             })?;
-        complex_type_to_arrow_field(&column.name, &complex, column.nullable)
+        complex_type_to_arrow_field(&column.name, &complex, column.nullable, options)
     } else {
         let p = parse_uc_top_level_type(&column.type_name)?;
-        Ok(primitive_arrow_field(&column.name, p, column.nullable))
+        Ok(primitive_arrow_field(
+            &column.name,
+            p,
+            column.nullable,
+            options,
+        ))
     }
 }
 
@@ -770,13 +828,18 @@ fn map_primitive_to_arrow(p: PrimitiveType) -> arrow_schema::DataType {
 #[cfg(feature = "arrow-flight")]
 const VARIANT_EXTENSION_NAME: &str = "arrow.parquet.variant";
 
-/// Build an Arrow field for a UC primitive, marking `VARIANT` fields so
-/// downstream consumers can recover variant-ness. The Arrow Flight server
-/// strips the marker on the write path.
+/// Build an Arrow field for a UC primitive. When
+/// [`ArrowSchemaOptions::annotate_variant_extension`] is set, `VARIANT` fields
+/// are marked so downstream consumers can recover variant-ness.
 #[cfg(feature = "arrow-flight")]
-fn primitive_arrow_field(name: &str, p: PrimitiveType, nullable: bool) -> arrow_schema::Field {
+fn primitive_arrow_field(
+    name: &str,
+    p: PrimitiveType,
+    nullable: bool,
+    options: &ArrowSchemaOptions,
+) -> arrow_schema::Field {
     let field = arrow_schema::Field::new(name, map_primitive_to_arrow(p), nullable);
-    if matches!(p, PrimitiveType::Variant) {
+    if options.annotate_variant_extension && matches!(p, PrimitiveType::Variant) {
         variant_marked_field(field)
     } else {
         field
@@ -826,12 +889,13 @@ fn complex_type_to_arrow_field(
     name: &str,
     ct: &ComplexType,
     nullable: bool,
+    options: &ArrowSchemaOptions,
 ) -> Result<arrow_schema::Field, SchemaError> {
     use arrow_schema::{DataType, Field, Fields};
     use std::sync::Arc;
 
     match ct {
-        ComplexType::Primitive(p) => Ok(primitive_arrow_field(name, *p, nullable)),
+        ComplexType::Primitive(p) => Ok(primitive_arrow_field(name, *p, nullable, options)),
         ComplexType::Struct(st) => {
             let mut child_fields = Vec::with_capacity(st.fields.len());
             for f in &st.fields {
@@ -840,6 +904,7 @@ fn complex_type_to_arrow_field(
                     &f.name,
                     &f.field_type,
                     f.nullable,
+                    options,
                 )?);
             }
             Ok(Field::new(
@@ -853,8 +918,10 @@ fn complex_type_to_arrow_field(
             // nullable elements (Spark/Delta semantics for an unspecified
             // value).
             let item_field = match element.as_ref() {
-                ComplexType::Primitive(p) => primitive_arrow_field("item", *p, true),
-                ComplexType::Struct(_) => complex_type_to_arrow_field("item", element, true)?,
+                ComplexType::Primitive(p) => primitive_arrow_field("item", *p, true, options),
+                ComplexType::Struct(_) => {
+                    complex_type_to_arrow_field("item", element, true, options)?
+                }
                 ComplexType::Array(_) => return Err(shape_unsupported("nested arrays", name)),
                 ComplexType::Map { .. } => return Err(shape_unsupported("arrays of maps", name)),
             };
@@ -867,8 +934,10 @@ fn complex_type_to_arrow_field(
         ComplexType::Map { key, value } => {
             let key_primitive = validate_arrow_map_key(key, name)?;
             let value_field = match value.as_ref() {
-                ComplexType::Primitive(p) => primitive_arrow_field("values", *p, true),
-                ComplexType::Struct(_) => complex_type_to_arrow_field("values", value, true)?,
+                ComplexType::Primitive(p) => primitive_arrow_field("values", *p, true, options),
+                ComplexType::Struct(_) => {
+                    complex_type_to_arrow_field("values", value, true, options)?
+                }
                 ComplexType::Array(_) | ComplexType::Map { .. } => {
                     return Err(shape_unsupported("maps with complex value types", name));
                 }
@@ -1337,6 +1406,25 @@ mod tests {
             );
         }
 
+        /// Asserts `field` is a VARIANT struct with no extension marker (the
+        /// default when `annotate_variant_extension` is off).
+        fn assert_variant_unmarked(field: &arrow_schema::Field) {
+            assert_variant_data_type(field.data_type());
+            assert!(
+                field.metadata().is_empty(),
+                "variant field must carry no metadata by default, got {:?}",
+                field.metadata()
+            );
+        }
+
+        /// Options with variant annotation enabled.
+        fn annotate() -> ArrowSchemaOptions {
+            ArrowSchemaOptions {
+                annotate_variant_extension: true,
+                ..Default::default()
+            }
+        }
+
         #[test]
         fn scalars_use_proper_arrow_types() {
             let cols = vec![
@@ -1371,11 +1459,21 @@ mod tests {
             // DECIMAL renders as LargeUtf8 (text encoding contract preserved).
             assert_eq!(arrow_field(&s, "price").data_type(), &DataType::LargeUtf8);
             let attributes = arrow_field(&s, "attributes");
-            assert_variant_marked(attributes);
+            // Variant annotation is off by default, so no extension marker.
+            assert_variant_unmarked(attributes);
             assert!(!attributes.is_nullable());
-            // Non-variant fields carry no extension marker.
+        }
+
+        #[test]
+        fn variant_annotation_marks_top_level_field() {
+            let cols = vec![
+                col("id", "BIGINT", false, 0),
+                col("attributes", "VARIANT", false, 1),
+            ];
+            let s = arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap();
+            assert_variant_marked(arrow_field(&s, "attributes"));
+            // Non-variant fields are never marked.
             assert!(arrow_field(&s, "id").metadata().is_empty());
-            assert!(arrow_field(&s, "data").metadata().is_empty());
         }
 
         #[test]
@@ -1584,32 +1682,35 @@ mod tests {
             }
         }
 
-        #[test]
-        fn nested_variant_uses_binary_struct() {
-            let type_json = r#"{
+        /// A `payload` struct with a variant in a struct child, an array item,
+        /// and a map value. `assert_variant` is applied to each of the three.
+        fn payload_with_nested_variants_json() -> &'static str {
+            r#"{
                 "type":"struct",
                 "fields":[
                     {"name":"v","type":"variant","nullable":true,"metadata":{}},
                     {"name":"tags","type":{"type":"array","elementType":"variant","containsNull":true},"nullable":true,"metadata":{}},
                     {"name":"props","type":{"type":"map","keyType":"string","valueType":"variant","valueContainsNull":true},"nullable":true,"metadata":{}}
                 ]
-            }"#;
-            let cols = vec![complex_col("payload", "STRUCT", type_json, 0)];
-            let s = arrow_schema_from_uc_columns(&cols).unwrap();
-            match arrow_field(&s, "payload").data_type() {
+            }"#
+        }
+
+        fn assert_nested_variants(
+            s: &arrow_schema::Schema,
+            assert_variant: impl Fn(&arrow_schema::Field),
+        ) {
+            match arrow_field(s, "payload").data_type() {
                 DataType::Struct(fs) => {
-                    // Nested variants, in a struct child / array item / map value,
-                    // all carry the extension marker.
-                    assert_variant_marked(&fs[0]);
+                    assert_variant(&fs[0]);
                     match fs[1].data_type() {
-                        DataType::List(item) => assert_variant_marked(item),
+                        DataType::List(item) => assert_variant(item),
                         other => panic!("expected List, got {:?}", other),
                     }
                     match fs[2].data_type() {
                         DataType::Map(entries, _) => match entries.data_type() {
                             DataType::Struct(kv) => {
                                 assert_eq!(kv[0].data_type(), &DataType::LargeUtf8);
-                                assert_variant_marked(&kv[1]);
+                                assert_variant(&kv[1]);
                             }
                             other => panic!("expected Struct inside Map, got {:?}", other),
                         },
@@ -1618,6 +1719,33 @@ mod tests {
                 }
                 other => panic!("expected Struct, got {:?}", other),
             }
+        }
+
+        #[test]
+        fn nested_variant_uses_binary_struct() {
+            let cols = vec![complex_col(
+                "payload",
+                "STRUCT",
+                payload_with_nested_variants_json(),
+                0,
+            )];
+            let s = arrow_schema_from_uc_columns(&cols).unwrap();
+            // Off by default: variant structs are present but unmarked.
+            assert_nested_variants(&s, assert_variant_unmarked);
+        }
+
+        #[test]
+        fn variant_annotation_marks_nested_fields() {
+            let cols = vec![complex_col(
+                "payload",
+                "STRUCT",
+                payload_with_nested_variants_json(),
+                0,
+            )];
+            let s = arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap();
+            // With annotation, every nested variant (struct child / array item /
+            // map value) carries the marker.
+            assert_nested_variants(&s, assert_variant_marked);
         }
 
         /// Covers the case where a client does not simply reuse the marked
@@ -1632,10 +1760,13 @@ mod tests {
             use arrow_array::{LargeBinaryArray, RecordBatch, StructArray};
 
             let cols = vec![col("attrs", "VARIANT", false, 0)];
-            // The stream schema and the batch's schema are converted separately,
-            // so they are distinct instances rather than a shared `Arc`.
-            let stream_schema = Arc::new(arrow_schema_from_uc_columns(&cols).unwrap());
-            let batch_schema = Arc::new(arrow_schema_from_uc_columns(&cols).unwrap());
+            // The stream schema and the batch's schema are converted separately
+            // (both annotated), so they are distinct instances rather than a
+            // shared `Arc`.
+            let stream_schema =
+                Arc::new(arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap());
+            let batch_schema =
+                Arc::new(arrow_schema_from_uc_columns_with_options(&cols, &annotate()).unwrap());
             assert_variant_marked(arrow_field(&batch_schema, "attrs"));
 
             // Physical arrays carry no marker (it lives on the field), matching

--- a/rust/sdk/src/schema.rs
+++ b/rust/sdk/src/schema.rs
@@ -1305,6 +1305,9 @@ mod tests {
                     assert_eq!(fields[1].name(), "value");
                     assert_eq!(fields[1].data_type(), &DataType::LargeBinary);
                     assert!(!fields[1].is_nullable());
+                    // Marker belongs on the variant field, not its children.
+                    assert!(fields[0].metadata().is_empty());
+                    assert!(fields[1].metadata().is_empty());
                 }
                 other => panic!("expected VARIANT Struct, got {:?}", other),
             }
@@ -1615,6 +1618,47 @@ mod tests {
                 }
                 other => panic!("expected Struct, got {:?}", other),
             }
+        }
+
+        /// Covers the case where a client does not simply reuse the marked
+        /// schema for its batches but rebuilds an equivalent one from scratch:
+        /// the batch must still compare equal so the client-side ingest gate
+        /// (`ingest_batch`, which rejects on a metadata-inclusive
+        /// `batch.schema() != stream_schema`) accepts it.
+        #[test]
+        fn variant_batch_matches_marked_stream_schema() {
+            use std::sync::Arc;
+
+            use arrow_array::{LargeBinaryArray, RecordBatch, StructArray};
+
+            let cols = vec![col("attrs", "VARIANT", false, 0)];
+            // The stream schema and the batch's schema are converted separately,
+            // so they are distinct instances rather than a shared `Arc`.
+            let stream_schema = Arc::new(arrow_schema_from_uc_columns(&cols).unwrap());
+            let batch_schema = Arc::new(arrow_schema_from_uc_columns(&cols).unwrap());
+            assert_variant_marked(arrow_field(&batch_schema, "attrs"));
+
+            // Physical arrays carry no marker (it lives on the field), matching
+            // how a client encodes variant data.
+            let DataType::Struct(child_fields) = arrow_field(&batch_schema, "attrs").data_type()
+            else {
+                panic!("expected VARIANT Struct");
+            };
+            let attrs = StructArray::new(
+                child_fields.clone(),
+                vec![
+                    Arc::new(LargeBinaryArray::from(vec![b"m".as_slice()])),
+                    Arc::new(LargeBinaryArray::from(vec![b"v".as_slice()])),
+                ],
+                None,
+            );
+            let batch = RecordBatch::try_new(batch_schema, vec![Arc::new(attrs)]).unwrap();
+
+            assert_eq!(
+                batch.schema(),
+                stream_schema,
+                "batch built from a separately converted schema must satisfy the ingest gate"
+            );
         }
 
         #[test]

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -578,6 +578,100 @@ mod arrow_flight_tests {
             Ok(())
         }
 
+        /// The client-side ingest gate compares batch and stream schemas with
+        /// metadata included, so a stream created from a variant-annotated schema
+        /// rejects a batch whose (physically identical) schema lacks the
+        /// `arrow.parquet.variant` marker. This pins the marker as load-bearing:
+        /// a caller who annotates the stream schema must also annotate its
+        /// batches.
+        #[tokio::test]
+        async fn test_ingest_rejects_variant_marker_schema_mismatch(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            use std::sync::Arc;
+
+            use arrow_array::{LargeBinaryArray, RecordBatch, StructArray};
+            use arrow_schema::{DataType, Schema as ArrowSchema};
+            use databricks_zerobus_ingest_sdk::schema::{
+                arrow_schema_from_uc_columns, arrow_schema_from_uc_columns_with_options,
+                ArrowSchemaOptions, UcColumn,
+            };
+
+            setup_tracing();
+            info!("Starting test_ingest_rejects_variant_marker_schema_mismatch");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            mock_server.inject_responses(TABLE_NAME, vec![]).await;
+
+            let cols = vec![UcColumn {
+                name: "attrs".into(),
+                type_name: "VARIANT".into(),
+                type_text: "variant".into(),
+                type_json: String::new(),
+                nullable: false,
+                position: 0,
+            }];
+            // Stream schema is annotated; the batch schema is not (same physical
+            // shape). The marker is the only difference between them.
+            let mut annotate = ArrowSchemaOptions::default();
+            annotate.annotate_variant_extension = true;
+            let marked_schema =
+                Arc::new(arrow_schema_from_uc_columns_with_options(&cols, &annotate)?);
+            let unmarked_schema = Arc::new(arrow_schema_from_uc_columns(&cols)?);
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(Arc::clone(&marked_schema))
+                .build_arrow()
+                .await?;
+
+            // Build a variant batch against the unmarked schema.
+            let DataType::Struct(child_fields) = unmarked_schema.field(0).data_type() else {
+                panic!("expected VARIANT Struct");
+            };
+            let attrs = StructArray::new(
+                child_fields.clone(),
+                vec![
+                    Arc::new(LargeBinaryArray::from(vec![b"m".as_slice()])),
+                    Arc::new(LargeBinaryArray::from(vec![b"v".as_slice()])),
+                ],
+                None,
+            );
+            let batch = RecordBatch::try_new(Arc::clone(&unmarked_schema), vec![Arc::new(attrs)])?;
+            // Sanity: the two schemas differ only by the marker metadata.
+            assert_ne!(
+                batch.schema().as_ref(),
+                marked_schema.as_ref() as &ArrowSchema,
+                "test setup: marked and unmarked schemas must differ"
+            );
+
+            let err = stream
+                .ingest_batch(batch)
+                .await
+                .expect_err("a schema differing only by the variant marker must be rejected");
+            assert!(
+                err.to_string()
+                    .to_lowercase()
+                    .contains("schema does not match"),
+                "expected a schema-mismatch InvalidArgument, got: {}",
+                err
+            );
+            assert!(
+                !err.is_retryable(),
+                "schema-mismatch rejection is non-retryable, got: {}",
+                err
+            );
+
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_ingest_single_batch() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduces `arrow_schema_from_uc_columns_with_options` which has the option to annotate VARIANT fields with the canonical arrow.parquet.variant extension marker so that downstream consumers can recover which fields are variants.

The zerobus server will strip the marker so that ingestion can work with it.

## How is this tested?
Unit tests