### PR TITLE
[.NET] Make release workflow build-only, consistent with other SDKs

### DIFF
--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -151,9 +151,11 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Download all native libraries
+        # download-artifact paths are relative to the workspace root, not the
+        # job working-directory, so download under dotnet/ explicitly.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          path: native
+          path: dotnet/native
           pattern: ffi-*
           merge-multiple: false
 

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -1,20 +1,15 @@
-name: Build & Release .NET SDK
-run-name: "Release .NET SDK ${{ github.ref_name }}"
+name: Build .NET SDK
+run-name: "Build .NET SDK ${{ github.ref_name }}"
+
+# Build-only: packs the NuGet package with all native runtimes and uploads it
+# as an artifact. Publishing and the GitHub Release happen downstream.
 
 on:
-  push:
-    tags:
-      - 'dotnet/v*'
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: write
-  id-token: write # Required for attestation
-  attestations: write # Required for attestation
 
 jobs:
   build-ffi:
@@ -55,6 +50,9 @@ jobs:
 
     name: Build FFI - ${{ matrix.artifact_dir }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
 
     defaults:
       run:
@@ -63,8 +61,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Get JFrog OIDC token
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"
+
+      - name: Configure cargo for JFrog
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
+
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cross-compilation toolchain (Linux ARM64)
         if: matrix.cross
@@ -95,12 +103,16 @@ jobs:
         with:
           name: ffi-${{ matrix.artifact_dir }}
           path: rust/artifacts/${{ matrix.artifact_dir }}
+          if-no-files-found: error
 
-  publish:
+  package:
+    name: Pack NuGet package
     needs: build-ffi
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: dotnet
@@ -129,10 +141,6 @@ jobs:
           cp -r native/ffi-osx-arm64/osx-arm64 src/Zerobus/runtimes/
           cp -r native/ffi-win-x64/win-x64 src/Zerobus/runtimes/
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/dotnet/v}" >> "$GITHUB_OUTPUT"
-
       - name: Package NuGet
         env:
           CI: true
@@ -141,54 +149,11 @@ jobs:
             --configuration Release \
             --output ./packages \
             -p:SkipNativeBuild=true \
-            -p:Version=${{ steps.version.outputs.version }} \
-            -p:PackageVersion=${{ steps.version.outputs.version }} \
-            -p:AssemblyVersion=${{ steps.version.outputs.version }} \
-            -p:FileVersion=${{ steps.version.outputs.version }} \
-            -p:InformationalVersion=${{ steps.version.outputs.version }} \
             -p:CI=true
 
-      - name: Generate attestation
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+      - name: Upload NuGet package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          subject-path: "packages/*.nupkg"
-
-      - name: NuGet login (OIDC → temp API key)
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
-        id: login
-        with:
-          user: ${{ secrets.NUGET_USERNAME }}
-
-      - name: Publish to Nuget Packages
-        env:
-          NUGET_AUTH_TOKEN: ${{ steps.login.outputs.NUGET_API_KEY }}
-        run: |
-          dotnet nuget push packages/*.nupkg \
-            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
-            --skip-duplicate  \
-            --source https://api.nuget.org/v3/index.json
-
-  release:
-    name: Create GitHub Release
-    runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
-    needs: publish
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/dotnet/v}" >> "$GITHUB_OUTPUT"
-
-      - name: Extract release notes from changelog
-        run: |
-          version="v${{ steps.version.outputs.version }}"
-          awk "/^## Release ${version}/{found=1; next} /^## /{if(found) exit} found{print}" dotnet/CHANGELOG.md > /tmp/release-notes.md
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          name: .NET SDK v${{ steps.version.outputs.version }}
-          body_path: /tmp/release-notes.md
+          name: dotnet-package
+          path: dotnet/packages/*.nupkg
+          if-no-files-found: error

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -35,20 +35,9 @@ jobs:
             dynamic_lib: zerobus_ffi.dll
             artifact_dir: win-x64
             cross: false
-          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
-            target: aarch64-apple-darwin
-            static_lib: libzerobus_ffi.a
-            dynamic_lib: libzerobus_ffi.dylib
-            artifact_dir: osx-arm64
-            cross: false
-            zigbuild: true
-          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
-            target: x86_64-apple-darwin
-            static_lib: libzerobus_ffi.a
-            dynamic_lib: libzerobus_ffi.dylib
-            artifact_dir: osx-x64
-            cross: false
-            zigbuild: true
+          # macOS is omitted: the runtime .dylib must be linked against Apple's
+          # Security/CoreFoundation frameworks, which are unavailable when
+          # cross-compiling from Linux. Add macOS once a Mac build host exists.
 
     name: Build FFI - ${{ matrix.artifact_dir }}
     runs-on: ${{ matrix.runner }}
@@ -90,24 +79,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install Zig (zigbuild targets)
-        if: matrix.zigbuild
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.13.0
-
-      - name: Install cargo-zigbuild (zigbuild targets)
-        if: matrix.zigbuild
-        run: cargo install cargo-zigbuild --locked --version 0.19.8
-
       - name: Build FFI library
-        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
-
-      # macOS libraries are cross-compiled from Linux via zigbuild.
-      - name: Build FFI library (zigbuild)
-        if: matrix.zigbuild
-        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Prepare artifacts
         shell: bash
@@ -155,8 +128,6 @@ jobs:
           mkdir -p src/Zerobus/runtimes
           cp -r native/ffi-linux-x64/linux-x64 src/Zerobus/runtimes/
           cp -r native/ffi-linux-arm64/linux-arm64 src/Zerobus/runtimes/
-          cp -r native/ffi-osx-x64/osx-x64 src/Zerobus/runtimes/
-          cp -r native/ffi-osx-arm64/osx-arm64 src/Zerobus/runtimes/
           cp -r native/ffi-win-x64/win-x64 src/Zerobus/runtimes/
 
       - name: Package NuGet

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -29,6 +29,22 @@ jobs:
             dynamic_lib: libzerobus_ffi.so
             artifact_dir: linux-arm64
             cross: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: x86_64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            dynamic_lib: libzerobus_ffi.so
+            artifact_dir: linux-musl-x64
+            cross: false
+            zigbuild: true
+            rustflags: "-C target-feature=-crt-static"
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
+            target: aarch64-unknown-linux-musl
+            static_lib: libzerobus_ffi.a
+            dynamic_lib: libzerobus_ffi.so
+            artifact_dir: linux-musl-arm64
+            cross: false
+            zigbuild: true
+            rustflags: "-C target-feature=-crt-static"
           - runner: { group: databricks-protected-runner-group, labels: windows-server-latest }
             target: x86_64-pc-windows-msvc
             static_lib: zerobus_ffi.lib
@@ -79,8 +95,26 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (zigbuild targets)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (zigbuild targets)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build FFI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      # musl (Alpine) libraries are cross-compiled from glibc Linux via zigbuild.
+      - name: Build FFI library (zigbuild)
+        if: matrix.zigbuild
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Prepare artifacts
         shell: bash
@@ -128,6 +162,8 @@ jobs:
           mkdir -p src/Zerobus/runtimes
           cp -r native/ffi-linux-x64/linux-x64 src/Zerobus/runtimes/
           cp -r native/ffi-linux-arm64/linux-arm64 src/Zerobus/runtimes/
+          cp -r native/ffi-linux-musl-x64/linux-musl-x64 src/Zerobus/runtimes/
+          cp -r native/ffi-linux-musl-arm64/linux-musl-arm64 src/Zerobus/runtimes/
           cp -r native/ffi-win-x64/win-x64 src/Zerobus/runtimes/
 
       - name: Package NuGet

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -35,18 +35,20 @@ jobs:
             dynamic_lib: zerobus_ffi.dll
             artifact_dir: win-x64
             cross: false
-          - runner: [self-hosted, macOS, ARM64, zerobus-sdk]
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: aarch64-apple-darwin
             static_lib: libzerobus_ffi.a
             dynamic_lib: libzerobus_ffi.dylib
             artifact_dir: osx-arm64
             cross: false
-          - runner: [self-hosted, macOS, ARM64, zerobus-sdk]
+            zigbuild: true
+          - runner: { group: databricks-protected-runner-group, labels: linux-ubuntu-latest }
             target: x86_64-apple-darwin
             static_lib: libzerobus_ffi.a
             dynamic_lib: libzerobus_ffi.dylib
             artifact_dir: osx-x64
             cross: false
+            zigbuild: true
 
     name: Build FFI - ${{ matrix.artifact_dir }}
     runs-on: ${{ matrix.runner }}
@@ -88,8 +90,24 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Zig (zigbuild targets)
+        if: matrix.zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild (zigbuild targets)
+        if: matrix.zigbuild
+        run: cargo install cargo-zigbuild --locked --version 0.19.8
+
       - name: Build FFI library
+        if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}
+
+      # macOS libraries are cross-compiled from Linux via zigbuild.
+      - name: Build FFI library (zigbuild)
+        if: matrix.zigbuild
+        run: cargo zigbuild --release -p zerobus-ffi --target ${{ matrix.target }}
 
       - name: Prepare artifacts
         shell: bash

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -158,13 +158,15 @@ jobs:
           merge-multiple: false
 
       - name: Consolidate native libraries
+        # Each ffi-<rid> artifact holds native/<libs>; place it at runtimes/<rid>/native.
         run: |
-          mkdir -p src/Zerobus/runtimes
-          cp -r native/ffi-linux-x64/linux-x64 src/Zerobus/runtimes/
-          cp -r native/ffi-linux-arm64/linux-arm64 src/Zerobus/runtimes/
-          cp -r native/ffi-linux-musl-x64/linux-musl-x64 src/Zerobus/runtimes/
-          cp -r native/ffi-linux-musl-arm64/linux-musl-arm64 src/Zerobus/runtimes/
-          cp -r native/ffi-win-x64/win-x64 src/Zerobus/runtimes/
+          for dir in native/ffi-*/; do
+            rid=$(basename "$dir" | sed 's/^ffi-//')
+            mkdir -p "src/Zerobus/runtimes/$rid"
+            cp -r "$dir/native" "src/Zerobus/runtimes/$rid/"
+          done
+          echo "Consolidated runtimes:"
+          find src/Zerobus/runtimes -type f | sort
 
       - name: Package NuGet
         env:

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -170,6 +170,27 @@ jobs:
           echo "Consolidated runtimes:"
           find src/Zerobus/runtimes -type f | sort
 
+      - name: Assert expected native RID payloads are present
+        run: |
+          expected=(
+            "src/Zerobus/runtimes/linux-x64/native/libzerobus_ffi.so"
+            "src/Zerobus/runtimes/linux-arm64/native/libzerobus_ffi.so"
+            "src/Zerobus/runtimes/linux-musl-x64/native/libzerobus_ffi.so"
+            "src/Zerobus/runtimes/linux-musl-arm64/native/libzerobus_ffi.so"
+            "src/Zerobus/runtimes/win-x64/native/zerobus_ffi.dll"
+          )
+          missing=0
+          for f in "${expected[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "Missing expected native artifact: $f"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "RID payload assertion failed; refusing to pack incomplete nupkg."
+            exit 1
+          fi
+
       - name: Package NuGet
         env:
           CI: true

--- a/dotnet/NEXT_CHANGELOG.md
+++ b/dotnet/NEXT_CHANGELOG.md
@@ -12,4 +12,6 @@
 
 ### Internal Changes
 
+- Made the .NET release workflow build-only, consistent with the other SDKs. It now packs the NuGet package and uploads it as an artifact; publishing and the GitHub Release happen downstream.
+
 ### API Changes

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -341,13 +341,19 @@ cd dotnet
 
 The native library is placed in the standard .NET runtime identifier layout:
 
-| Platform    | Path                                             |
-| ----------- | ------------------------------------------------ |
-| Linux x64   | `runtimes/linux-x64/native/libzerobus_ffi.so`    |
-| Linux arm64 | `runtimes/linux-arm64/native/libzerobus_ffi.so`  |
-| macOS x64   | `runtimes/osx-x64/native/libzerobus_ffi.dylib`   |
-| macOS arm64 | `runtimes/osx-arm64/native/libzerobus_ffi.dylib` |
-| Windows x64 | `runtimes/win-x64/native/zerobus_ffi.dll`        |
+| Platform               | RID                 | Path                                                | NuGet package payload today |
+| ---------------------- | ------------------- | --------------------------------------------------- | --------------------------- |
+| Linux x64 (glibc)      | `linux-x64`         | `runtimes/linux-x64/native/libzerobus_ffi.so`       | Included                    |
+| Linux arm64 (glibc)    | `linux-arm64`       | `runtimes/linux-arm64/native/libzerobus_ffi.so`     | Included                    |
+| Linux x64 (musl/Alpine) | `linux-musl-x64`    | `runtimes/linux-musl-x64/native/libzerobus_ffi.so`  | Included                    |
+| Linux arm64 (musl)      | `linux-musl-arm64`  | `runtimes/linux-musl-arm64/native/libzerobus_ffi.so` | Included                    |
+| Windows x64            | `win-x64`           | `runtimes/win-x64/native/zerobus_ffi.dll`           | Included                    |
+| macOS x64              | `osx-x64`           | `runtimes/osx-x64/native/libzerobus_ffi.dylib`      | Source build only           |
+| macOS arm64            | `osx-arm64`         | `runtimes/osx-arm64/native/libzerobus_ffi.dylib`    | Source build only           |
+
+Published packages currently omit macOS native binaries. Source builds via
+`build_native.sh` still produce and place the macOS `.dylib` in the runtime
+layout above.
 
 ## Testing
 

--- a/dotnet/src/Zerobus/Zerobus.csproj
+++ b/dotnet/src/Zerobus/Zerobus.csproj
@@ -85,6 +85,22 @@
       PackagePath="runtimes/linux-arm64/native"
       Condition="Exists('runtimes/linux-arm64/native/libzerobus_ffi.so')" />
 
+    <!-- Linux musl x64 (Alpine) -->
+    <None Include="runtimes/linux-musl-x64/native/libzerobus_ffi.so"
+      CopyToOutputDirectory="PreserveNewest"
+      Link="runtimes/linux-musl-x64/native/libzerobus_ffi.so"
+      Pack="true"
+      PackagePath="runtimes/linux-musl-x64/native"
+      Condition="Exists('runtimes/linux-musl-x64/native/libzerobus_ffi.so')" />
+
+    <!-- Linux musl arm64 (Alpine) -->
+    <None Include="runtimes/linux-musl-arm64/native/libzerobus_ffi.so"
+      CopyToOutputDirectory="PreserveNewest"
+      Link="runtimes/linux-musl-arm64/native/libzerobus_ffi.so"
+      Pack="true"
+      PackagePath="runtimes/linux-musl-arm64/native"
+      Condition="Exists('runtimes/linux-musl-arm64/native/libzerobus_ffi.so')" />
+
     <!-- macOS x64 -->
     <None Include="runtimes/osx-x64/native/libzerobus_ffi.dylib"
       CopyToOutputDirectory="PreserveNewest"


### PR DESCRIPTION
## What

Makes the .NET release workflow build-only, consistent with every other SDK's release workflow.

- `release-dotnet.yml` is now `workflow_dispatch`-only (removed the `dotnet/v*` tag trigger).
- Dropped the registry-publish step and the GitHub Release job; the workflow now packs the NuGet package and uploads it as the `dotnet-package` artifact.
- Added the JFrog OIDC + cargo config steps the FFI build needs on protected runners (the build was previously missing them and would fail reaching crates.io).
- Version is taken from `Zerobus.csproj` rather than injected via tag-derived flags.
- Removed the self-hosted macOS runner legs and added Linux musl (Alpine) targets. The release now builds Linux glibc (x64, arm64), Linux musl (x64, arm64), and Windows (x64).
- Fixed the native-library consolidation: map each `ffi-<rid>` artifact's `native/` folder to `runtimes/<rid>/native` via a loop, and download the artifacts under `dotnet/` so the step (which runs from the `dotnet` working-directory) can find them. These were latent bugs never reached before, since earlier runs failed at the FFI build stage.

## Why

The .NET workflow was the only SDK release workflow that published directly to a public registry on tag push. Publishing is handled downstream, so the in-repo workflow should build and upload artifacts only — matching Python, TypeScript, Java, Go, etc.

### Linux musl (Alpine) targets

Added `linux-musl-x64` and `linux-musl-arm64`, cross-compiled from glibc Linux via `cargo-zigbuild` (`-C target-feature=-crt-static`), reusing the pattern `release-ffi.yml` and `release-jni.yml` already use for musl. Alpine-based containers are common in .NET deployments and map to the first-class `linux-musl-*` RIDs. Unlike macOS, musl links against Zig-provided libc (no Apple frameworks), so the dynamic `.so` links cleanly on CI. No loader change was needed — `NativeBindings.ResolveLibrary` resolves the native library from `RuntimeInformation.RuntimeIdentifier`, which returns the musl RID on Alpine.

### Why macOS is dropped for now

The .NET package loads its native library at runtime via P/Invoke, so it needs the dynamic `libzerobus_ffi.dylib` — not just the static `.a`. Linking that dylib requires Apple's `Security`/`CoreFoundation` frameworks, which are unavailable when cross-compiling from Linux. An attempt to cross-compile via `cargo-zigbuild` failed at link time with `unable to find framework 'Security'` — the same limitation `release-ffi.yml`/`release-go.yml`/`release-cpp.yml` avoid by building macOS as `static_only` (they ship a `.a`, which is never linked on CI). That trick doesn't work here because .NET needs a linked dylib. The only CI path that can produce a macOS dylib is a real Mac build host.

This also puts .NET in line with most SDKs: Java, Python, and TypeScript ship no macOS binary from their release workflows either. macOS can be added back once a Mac build host is available; the `.csproj` already conditions each runtime on `Exists(...)`, so a missing osx runtime doesn't break packing, and macOS users can build from source in the meantime.

## Validation

Dispatched the workflow on this branch. All five FFI legs (linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, win-x64) build green, and the Pack job produces a valid `.nupkg` bundling every runtime at the expected path:

```
runtimes/linux-x64/native/libzerobus_ffi.so
runtimes/linux-arm64/native/libzerobus_ffi.so
runtimes/linux-musl-x64/native/libzerobus_ffi.so
runtimes/linux-musl-arm64/native/libzerobus_ffi.so
runtimes/win-x64/native/zerobus_ffi.dll
```

## Notes

- The downstream publish workflow (in the secure public registry releases repo) still needs to be added before releases can go out, along with a NuGet API key secret for publishing.