### PR TITLE
[Rust] Enforce per-batch Arrow Flight acknowledgement deadlines

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -21,7 +21,8 @@
 
 ### Bug Fixes
 
-- **Arrow Flight — invalid acknowledgment watermarks are rejected** (Beta): ack progress is now monotonic, so delayed or duplicate responses cannot move the durable watermark backward. A response claiming more records than were actually submitted on the active connection is rejected without making buffered, unsent records appear durable.
+- **Arrow Flight — acknowledgment deadlines now start when work becomes pending** (Beta): no timer runs while the stream is idle. The timeout is an absolute deadline for the oldest pending batch: acknowledgments that leave that batch pending do not refresh it, replayed batches receive a fresh deadline on their recovered connection, and malformed or non-progressing responses cannot indefinitely postpone recovery. A valid acknowledgment already ready at expiry is applied before recovery is considered.
+- **Arrow Flight — acknowledgment watermarks are handled monotonically** (Beta): delayed, duplicate, or backward watermarks are absorbed without moving durable progress backward. A forward watermark that claims more records than were submitted on the active connection is rejected without making buffered, unsent records appear durable.
 
 ### Documentation
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -800,6 +800,15 @@ Also accepts `0` or `no`.
 | `ack_callback` | `Option<Arc<dyn AckCallback>>` | `None` | Optional callback for acknowledgment notifications |
 | `callback_max_wait_time_ms` | `Option<u64>` | `None` | Maximum time to wait for callback processing to complete after closing the stream (`None` = wait indefinitely, `Some(x)` = wait up to `x` ms) |
 
+For Arrow Flight streams *(Beta)*, `server_lack_of_ack_timeout_ms` is an
+absolute limit on how long a batch may remain pending, not an inactivity
+timeout. No timer runs while the stream is idle. Each batch's timer starts when
+it becomes pending and is not refreshed when earlier batches are acknowledged.
+Partial acknowledgments do not extend it. If recovery replays pending batches
+on a new connection, their deadlines restart relative to that connection.
+Configure the timeout together with `max_inflight_batches` so the server can
+acknowledge a full allowed backlog within the timeout.
+
 
 **Example:**
 

--- a/rust/sdk/src/arrow_configuration.rs
+++ b/rust/sdk/src/arrow_configuration.rs
@@ -65,10 +65,16 @@ pub struct ArrowStreamConfigurationOptions {
     /// Default: 4
     pub recovery_retries: u32,
 
-    /// Timeout in milliseconds for waiting for server acknowledgements.
+    /// Maximum time in milliseconds that a batch may remain pending without being fully
+    /// acknowledged on the active connection.
     ///
-    /// If no acknowledgement is received within this time (and there are pending batches),
-    /// the stream will be considered failed and recovery will be triggered (if enabled).
+    /// No timer runs while there are no pending batches. Each batch's timer starts when it
+    /// becomes pending and is not refreshed when earlier batches are acknowledged. Partial
+    /// acknowledgments do not extend it. Configure this timeout and `max_inflight_batches`
+    /// so the server can acknowledge a full allowed backlog within the timeout.
+    /// After recovery, replayed batches receive a fresh deadline relative to the recovered
+    /// connection. If a batch remains pending when its deadline expires, the stream is
+    /// considered failed and recovery is triggered (if enabled).
     ///
     /// Default: 60,000 (60 seconds)
     pub server_lack_of_ack_timeout_ms: u64,

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -19,10 +19,8 @@ use arrow_flight::{FlightClient, PutResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-#[cfg(feature = "test-hooks")]
-use tokio::sync::Notify;
-use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
-use tokio::time::{sleep, Duration};
+use tokio::sync::{mpsc, watch, Mutex, Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::time::{sleep, Duration, Instant};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
 use tonic::metadata::MetadataValue;
@@ -45,6 +43,9 @@ use crate::ZerobusResult;
 /// Type alias for the batch sender channel, wrapped for thread-safe sharing.
 type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
 
+/// Stream of Arrow Flight responses carrying acknowledgments from the server.
+type FlightResponseStream = Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>;
+
 /// Test-only barrier used to pause `reconnect` at a precise point — the new connection
 /// is established but pending ranges are not yet rebuilt — so a test can schedule a
 /// concurrent ingest or `close()`.
@@ -65,6 +66,11 @@ struct ReconnectRebuildBarrier {
 /// partial ack has landed before it proceeds.
 #[cfg(feature = "test-hooks")]
 type AckAppliedGate = Arc<Mutex<Option<Arc<Notify>>>>;
+
+/// Test-only gate: when armed, `process_acks` fires after observing an empty pending
+/// set and immediately before parking without an ack deadline.
+#[cfg(feature = "test-hooks")]
+type AckIdleGate = Arc<Mutex<Option<Arc<Notify>>>>;
 
 /// Test-only barrier that parks `close()` after the supervisor and sender are gone but
 /// before pending batches are finalized, allowing cancellation-safe teardown tests.
@@ -102,8 +108,51 @@ struct PendingBatch {
     /// Cumulative record count after this batch.
     /// Batch is fully acked when `acked_records >= end_record`.
     end_record: u64,
+    /// Time this batch most recently became pending on the active connection.
+    enqueued_at: Instant,
     /// Backpressure permit; dropping it frees one `max_inflight_batches` slot.
     _permit: OwnedSemaphorePermit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PendingBatchIdentity {
+    offset_id: OffsetId,
+    start_record: u64,
+    end_record: u64,
+}
+
+impl From<&PendingBatch> for PendingBatchIdentity {
+    fn from(batch: &PendingBatch) -> Self {
+        Self {
+            offset_id: batch.offset_id,
+            start_record: batch.start_record,
+            end_record: batch.end_record,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DeadlineTieGrant {
+    head_identity: PendingBatchIdentity,
+    acknowledged_records: u64,
+}
+
+enum AckEvent {
+    Response(Option<Result<PutResult, FlightError>>),
+    PendingBatchAvailable,
+    AckDeadline,
+}
+
+fn oldest_pending_ack_deadline(
+    pending: &[PendingBatch],
+    ack_timeout: Duration,
+) -> Option<(PendingBatchIdentity, Instant)> {
+    pending.first().map(|batch| {
+        (
+            PendingBatchIdentity::from(batch),
+            batch.enqueued_at + ack_timeout,
+        )
+    })
 }
 
 /// Returns the batch portion not durably acknowledged, avoiding duplicate retry of an
@@ -267,6 +316,8 @@ pub struct ZerobusArrowStream {
     receiver_task: Arc<Mutex<Option<tokio::task::JoinHandle<ZerobusResult<()>>>>>,
     /// Accepted batches not yet fully acknowledged; retained for replay or retrieval.
     pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
+    /// Wakes the ack processor when the pending set transitions from empty to non-empty.
+    pending_notify: Arc<Notify>,
     /// Unacknowledged batch suffixes finalized after terminal failure or failed close.
     failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
     /// Count of recovery attempts.
@@ -307,6 +358,9 @@ pub struct ZerobusArrowStream {
     /// Test seam (see [`AckAppliedGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     ack_applied_gate: AckAppliedGate,
+    /// Test seam (see [`AckIdleGate`]); compiled only under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    ack_idle_gate: AckIdleGate,
     /// Test seam (see [`CloseFinalizeGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     close_finalize_gate: CloseFinalizeGate,
@@ -339,6 +393,7 @@ impl ZerobusArrowStream {
         let (last_ack_tx, _last_ack_rx) = tokio::sync::watch::channel(None);
         let is_closed = Arc::new(AtomicBool::new(false));
         let pending_batches = Arc::new(Mutex::new(Vec::new()));
+        let pending_notify = Arc::new(Notify::new());
         let failed_batches = Arc::new(Mutex::new(Vec::new()));
         let recovery_attempts = Arc::new(AtomicU32::new(0));
         let batch_tx = Arc::new(Mutex::new(None));
@@ -364,6 +419,7 @@ impl ZerobusArrowStream {
             close_flush_error: Mutex::new(None),
             receiver_task,
             pending_batches,
+            pending_notify,
             failed_batches,
             recovery_attempts,
             endpoint: endpoint.to_string(),
@@ -383,6 +439,8 @@ impl ZerobusArrowStream {
             reconnect_rebuild_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            ack_idle_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             close_finalize_gate: Arc::new(Mutex::new(None)),
         };
@@ -453,6 +511,7 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.is_closed),
             stream.last_ack_tx.clone(),
             Arc::clone(&stream.pending_batches),
+            Arc::clone(&stream.pending_notify),
             Arc::clone(&stream.failed_batches),
             Arc::clone(&stream.recovery_attempts),
             stream.server_error_tx.clone(),
@@ -467,6 +526,8 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.reconnect_rebuild_gate),
             #[cfg(feature = "test-hooks")]
             Arc::clone(&stream.ack_applied_gate),
+            #[cfg(feature = "test-hooks")]
+            Arc::clone(&stream.ack_idle_gate),
         );
 
         {
@@ -752,6 +813,7 @@ impl ZerobusArrowStream {
         is_closed: Arc<AtomicBool>,
         last_ack_tx: tokio::sync::watch::Sender<Option<OffsetId>>,
         pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
+        pending_notify: Arc<Notify>,
         failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
         recovery_attempts: Arc<AtomicU32>,
         server_error_tx: watch::Sender<Option<ZerobusError>>,
@@ -764,6 +826,7 @@ impl ZerobusArrowStream {
         sdk_identifier: Arc<str>,
         #[cfg(feature = "test-hooks")] reconnect_rebuild_gate: ReconnectRebuildGate,
         #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
+        #[cfg(feature = "test-hooks")] ack_idle_gate: AckIdleGate,
     ) -> tokio::task::JoinHandle<ZerobusResult<()>> {
         tokio::spawn(async move {
             let ack_timeout = Duration::from_millis(options.server_lack_of_ack_timeout_ms);
@@ -796,6 +859,7 @@ impl ZerobusArrowStream {
                         Arc::clone(&is_closed),
                         last_ack_tx.clone(),
                         Arc::clone(&pending_batches),
+                        Arc::clone(&pending_notify),
                         ack_timeout,
                         server_error_tx.clone(),
                         Arc::clone(&submitted_records),
@@ -804,6 +868,8 @@ impl ZerobusArrowStream {
                         &options,
                         #[cfg(feature = "test-hooks")]
                         Arc::clone(&ack_applied_gate),
+                        #[cfg(feature = "test-hooks")]
+                        Arc::clone(&ack_idle_gate),
                     )
                     .await
                 };
@@ -1187,6 +1253,7 @@ impl ZerobusArrowStream {
             let mut new_pending = Vec::with_capacity(pending.len());
             let mut replay = Vec::with_capacity(pending.len());
             let mut new_cumulative: u64 = 0;
+            let replay_enqueued_at = Instant::now();
 
             if !pending.is_empty() {
                 info!(
@@ -1212,6 +1279,7 @@ impl ZerobusArrowStream {
                         offset_id: pb.offset_id,
                         start_record,
                         end_record,
+                        enqueued_at: replay_enqueued_at,
                         // Carry the permit across recovery; skipped batches drop theirs.
                         _permit: pb._permit,
                     });
@@ -1302,6 +1370,58 @@ impl ZerobusArrowStream {
         Self::move_pending_to_failed(pending_batches, failed_batches, last_acked_records).await;
     }
 
+    /// Waits for a server response or newly pending work while no ack deadline is armed.
+    async fn wait_while_idle(
+        response_stream: &mut FlightResponseStream,
+        pending_notify: &Notify,
+        #[cfg(feature = "test-hooks")] ack_idle_gate: &AckIdleGate,
+    ) -> AckEvent {
+        #[cfg(feature = "test-hooks")]
+        if let Some(notify) = ack_idle_gate.lock().await.take() {
+            notify.notify_one();
+        }
+
+        tokio::select! {
+            biased;
+            res = response_stream.next() => AckEvent::Response(res),
+            _ = pending_notify.notified() => AckEvent::PendingBatchAvailable,
+        }
+    }
+
+    /// Waits for a server response while enforcing the oldest pending ack deadline.
+    /// A ready progressive response wins one expiry tie; non-progressing traffic cannot
+    /// repeatedly postpone recovery after the deadline.
+    async fn wait_with_pending_deadline(
+        response_stream: &mut FlightResponseStream,
+        head_identity: PendingBatchIdentity,
+        acknowledged_records: u64,
+        ack_deadline: Instant,
+        ack_deadline_tie_grant: &mut Option<DeadlineTieGrant>,
+    ) -> AckEvent {
+        let now = Instant::now();
+        let current_state = DeadlineTieGrant {
+            head_identity,
+            acknowledged_records,
+        };
+        if *ack_deadline_tie_grant == Some(current_state) && now >= ack_deadline {
+            return AckEvent::AckDeadline;
+        }
+
+        let event = tokio::select! {
+            biased;
+            res = response_stream.next() => AckEvent::Response(res),
+            _ = tokio::time::sleep_until(ack_deadline) => AckEvent::AckDeadline,
+        };
+
+        let response_won = matches!(&event, AckEvent::Response(_));
+        *ack_deadline_tie_grant = if response_won && Instant::now() >= ack_deadline {
+            Some(current_state)
+        } else {
+            None
+        };
+        event
+    }
+
     /// Advances the monotonic record watermark and removes fully acknowledged batches.
     async fn apply_acknowledgment(
         ack: &FlightAckMetadata,
@@ -1373,10 +1493,11 @@ impl ZerobusArrowStream {
     /// by `FlightDataEncoderBuilder`.
     #[allow(clippy::too_many_arguments)]
     async fn process_acks(
-        mut response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
+        mut response_stream: FlightResponseStream,
         is_closed: Arc<AtomicBool>,
         last_ack_tx: tokio::sync::watch::Sender<Option<OffsetId>>,
         pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
+        pending_notify: Arc<Notify>,
         ack_timeout: Duration,
         server_error_tx: watch::Sender<Option<ZerobusError>>,
         submitted_records: Arc<AtomicU64>,
@@ -1384,8 +1505,10 @@ impl ZerobusArrowStream {
         is_paused: Arc<AtomicBool>,
         options: &ArrowStreamConfigurationOptions,
         #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
+        #[cfg(feature = "test-hooks")] ack_idle_gate: AckIdleGate,
     ) -> ZerobusResult<()> {
-        let mut pause_deadline: Option<tokio::time::Instant> = None;
+        let mut pause_deadline: Option<Instant> = None;
+        let mut ack_deadline_tie_grant: Option<DeadlineTieGrant> = None;
 
         loop {
             if is_closed.load(Ordering::Relaxed) {
@@ -1412,25 +1535,52 @@ impl ZerobusArrowStream {
                 }
             }
 
-            // TODO: Anchor this timeout to the oldest pending batch. The current
-            // per-response timeout can spend most of its window while idle and restarts
-            // whenever any response arrives, even if it makes no ack progress.
-            let result = if let Some(deadline) = pause_deadline {
+            let event = if let Some(deadline) = pause_deadline {
                 // TODO: Race graceful close against the active ack deadline and
                 // preserve the earliest close deadline when repeated signals arrive.
-                tokio::select! {
+                // Graceful close retains its existing behavior in this change: while
+                // paused, a lack of acknowledgements is tolerated until the close deadline.
+                let result = tokio::select! {
                     biased;
-                    _ = tokio::time::sleep_until(deadline) => {
-                        continue;
-                    }
+                    _ = tokio::time::sleep_until(deadline) => continue,
                     res = tokio::time::timeout(ack_timeout, response_stream.next()) => res,
+                };
+                match result {
+                    Ok(response) => AckEvent::Response(response),
+                    Err(_) => continue,
                 }
             } else {
-                tokio::time::timeout(ack_timeout, response_stream.next()).await
+                let oldest_pending = {
+                    let pending = pending_batches.lock().await;
+                    oldest_pending_ack_deadline(&pending, ack_timeout)
+                };
+                match oldest_pending {
+                    Some((head_identity, ack_deadline)) => {
+                        let acknowledged_records = last_acked_records.load(Ordering::Acquire);
+                        Self::wait_with_pending_deadline(
+                            &mut response_stream,
+                            head_identity,
+                            acknowledged_records,
+                            ack_deadline,
+                            &mut ack_deadline_tie_grant,
+                        )
+                        .await
+                    }
+                    None => {
+                        Self::wait_while_idle(
+                            &mut response_stream,
+                            &pending_notify,
+                            #[cfg(feature = "test-hooks")]
+                            &ack_idle_gate,
+                        )
+                        .await
+                    }
+                }
             };
 
-            match result {
-                Ok(Some(Ok(put_result))) => {
+            match event {
+                AckEvent::PendingBatchAvailable => continue,
+                AckEvent::Response(Some(Ok(put_result))) => {
                     match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
                         Ok(ack) => {
                             // Handle close stream signal.
@@ -1502,7 +1652,7 @@ impl ZerobusArrowStream {
                         }
                     }
                 }
-                Ok(Some(Err(e))) => {
+                AckEvent::Response(Some(Err(e))) => {
                     // A stream error while paused ends the graceful-close wait and
                     // triggers recovery.
                     if pause_deadline.is_some() {
@@ -1520,7 +1670,7 @@ impl ZerobusArrowStream {
                     let _ = server_error_tx.send(Some(error.clone()));
                     return Err(error);
                 }
-                Ok(None) => {
+                AckEvent::Response(None) => {
                     // During graceful close, stream end is expected.
                     // Return retriable error to trigger recovery.
                     if pause_deadline.is_some() {
@@ -1537,25 +1687,24 @@ impl ZerobusArrowStream {
                     // finalization) in its terminal branch.
                     return Err(error);
                 }
-                Err(_timeout) => {
-                    // During graceful close, ack timeout is not an error.
-                    if pause_deadline.is_some() {
+                AckEvent::AckDeadline => {
+                    // Confirm the currently oldest batch is still expired; a ready ack
+                    // may have removed the head immediately before this event.
+                    let pending = pending_batches.lock().await;
+                    let deadline_expired = oldest_pending_ack_deadline(&pending, ack_timeout)
+                        .map(|(_, deadline)| Instant::now() >= deadline)
+                        .unwrap_or(false);
+                    if !deadline_expired {
                         continue;
                     }
-                    // Check if there are pending acks that should have been received.
-                    let pending = pending_batches.lock().await;
-                    if !pending.is_empty() {
-                        error!(
-                            pending_count = pending.len(),
-                            "Server ack timeout with pending batches"
-                        );
-                        let error = ZerobusError::StreamClosedError(
-                            tonic::Status::deadline_exceeded("Server ack timeout"),
-                        );
-                        // Returned to the supervisor, which publishes it (before + after
-                        // finalization) in its terminal branch.
-                        return Err(error);
-                    }
+
+                    error!(
+                        pending_count = pending.len(),
+                        "Server ack timeout with pending batches"
+                    );
+                    return Err(ZerobusError::StreamClosedError(
+                        tonic::Status::deadline_exceeded("Server ack timeout"),
+                    ));
                 }
             }
         }
@@ -1654,15 +1803,21 @@ impl ZerobusArrowStream {
             .fetch_add(record_count, Ordering::Relaxed);
         let end_record = start_record + record_count;
 
-        {
+        let became_pending = {
             let mut pending = self.pending_batches.lock().await;
+            let became_pending = pending.is_empty();
             pending.push(PendingBatch {
                 batch: batch.clone(),
                 offset_id,
                 start_record,
                 end_record,
+                enqueued_at: Instant::now(),
                 _permit: permit,
             });
+            became_pending
+        };
+        if became_pending {
+            self.pending_notify.notify_one();
         }
 
         // While paused for a close signal or recovery handoff, retain the batch as
@@ -2169,6 +2324,15 @@ impl ZerobusArrowStream {
         notify
     }
 
+    /// Test-only: arms a one-shot notification for the next no-pending ack wait.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_ack_idle_notify(&self) -> Arc<Notify> {
+        let notify = Arc::new(Notify::new());
+        *self.ack_idle_gate.lock().await = Some(Arc::clone(&notify));
+        notify
+    }
+
     /// Test-only: parks the next `close()` after supervisor/sender teardown but before
     /// finalization. Dropping the close future at that point simulates cancellation.
     #[cfg(feature = "test-hooks")]
@@ -2223,6 +2387,8 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicUsize;
+    use std::task::Poll;
 
     struct PassthroughTlsConfig;
 
@@ -2288,8 +2454,162 @@ mod tests {
             offset_id,
             start_record,
             end_record,
+            enqueued_at: Instant::now(),
             _permit: Arc::clone(sem).try_acquire_owned().unwrap(),
         }
+    }
+
+    /// A valid acknowledgement already ready at expiry is applied before timeout handling.
+    #[tokio::test]
+    async fn ready_valid_ack_wins_expired_deadline_tie() {
+        const ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_millis(10);
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let mut pending = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
+        pending.enqueued_at = Instant::now() - ACKNOWLEDGEMENT_TIMEOUT;
+        let pending_batches = Arc::new(Mutex::new(vec![pending]));
+        let mut ack = Some(PutResult {
+            app_metadata: serde_json::to_vec(&FlightAckMetadata {
+                ack_up_to_offset: 0,
+                ack_up_to_records: 1,
+                close_stream_duration_ms: None,
+            })
+            .unwrap()
+            .into(),
+        });
+        let response_stream = futures::stream::poll_fn(move |_| match ack.take() {
+            Some(ack) => Poll::Ready(Some(Ok(ack))),
+            None => Poll::Pending,
+        });
+        let (last_ack_tx, last_ack_rx) = watch::channel(None);
+        let (server_error_tx, _server_error_rx) = watch::channel(None);
+        let last_acked_records = Arc::new(AtomicU64::new(0));
+        let options = ArrowStreamConfigurationOptions::default();
+        let process_acks = ZerobusArrowStream::process_acks(
+            Box::pin(response_stream),
+            Arc::new(AtomicBool::new(false)),
+            last_ack_tx,
+            Arc::clone(&pending_batches),
+            Arc::new(Notify::new()),
+            ACKNOWLEDGEMENT_TIMEOUT,
+            server_error_tx,
+            Arc::new(AtomicU64::new(1)),
+            Arc::clone(&last_acked_records),
+            Arc::new(AtomicBool::new(false)),
+            &options,
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+        );
+        tokio::pin!(process_acks);
+
+        assert!(futures::poll!(process_acks.as_mut()).is_pending());
+        assert!(pending_batches.lock().await.is_empty());
+        assert_eq!(*last_ack_rx.borrow(), Some(0));
+        assert_eq!(last_acked_records.load(Ordering::Acquire), 1);
+    }
+
+    /// Partial progress does not refresh the oldest batch's original deadline.
+    #[tokio::test]
+    async fn partial_ack_does_not_refresh_ack_deadline() {
+        const ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_millis(10);
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let mut pending = pending_batch(&sem, batch_with_rows(&schema, 10), 0, 0, 10);
+        pending.enqueued_at = Instant::now() - ACKNOWLEDGEMENT_TIMEOUT;
+        let pending_batches = Arc::new(Mutex::new(vec![pending]));
+        let mut ready_acks = [5, 5].into_iter().map(|records| PutResult {
+            app_metadata: serde_json::to_vec(&FlightAckMetadata {
+                ack_up_to_offset: 0,
+                ack_up_to_records: records,
+                close_stream_duration_ms: None,
+            })
+            .unwrap()
+            .into(),
+        });
+        let response_stream = futures::stream::poll_fn(move |_| match ready_acks.next() {
+            Some(ack) => Poll::Ready(Some(Ok(ack))),
+            None => Poll::Pending,
+        });
+        let (last_ack_tx, _last_ack_rx) = watch::channel(None);
+        let (server_error_tx, _server_error_rx) = watch::channel(None);
+        let last_acked_records = Arc::new(AtomicU64::new(0));
+        let error = ZerobusArrowStream::process_acks(
+            Box::pin(response_stream),
+            Arc::new(AtomicBool::new(false)),
+            last_ack_tx,
+            Arc::clone(&pending_batches),
+            Arc::new(Notify::new()),
+            ACKNOWLEDGEMENT_TIMEOUT,
+            server_error_tx,
+            Arc::new(AtomicU64::new(10)),
+            Arc::clone(&last_acked_records),
+            Arc::new(AtomicBool::new(false)),
+            &ArrowStreamConfigurationOptions::default(),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+        )
+        .await
+        .expect_err("the original ack deadline must expire");
+
+        assert!(matches!(
+            error,
+            ZerobusError::StreamClosedError(ref status)
+                if status.code() == tonic::Code::DeadlineExceeded
+        ));
+        assert_eq!(last_acked_records.load(Ordering::Acquire), 5);
+        assert_eq!(pending_batches.lock().await.len(), 1);
+    }
+
+    /// Ready malformed or non-progressing responses cannot starve an expired deadline.
+    #[tokio::test]
+    async fn ready_non_progressing_responses_cannot_starve_expired_deadline() {
+        const ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_millis(10);
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let mut pending = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
+        pending.enqueued_at = Instant::now() - ACKNOWLEDGEMENT_TIMEOUT;
+        let pending_batches = Arc::new(Mutex::new(vec![pending]));
+        let polls = Arc::new(AtomicUsize::new(0));
+        let observed_polls = Arc::clone(&polls);
+        let response_stream = futures::stream::poll_fn(move |_| {
+            let poll = observed_polls.fetch_add(1, Ordering::Relaxed);
+            assert!(poll < 2, "responses starved the expired ack deadline");
+            Poll::Ready(Some(Ok(PutResult {
+                app_metadata: Bytes::from_static(b"malformed ack metadata"),
+            })))
+        });
+        let (last_ack_tx, _last_ack_rx) = watch::channel(None);
+        let (server_error_tx, _server_error_rx) = watch::channel(None);
+        let error = ZerobusArrowStream::process_acks(
+            Box::pin(response_stream),
+            Arc::new(AtomicBool::new(false)),
+            last_ack_tx,
+            pending_batches,
+            Arc::new(Notify::new()),
+            ACKNOWLEDGEMENT_TIMEOUT,
+            server_error_tx,
+            Arc::new(AtomicU64::new(1)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicBool::new(false)),
+            &ArrowStreamConfigurationOptions::default(),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
+        )
+        .await
+        .expect_err("the expired ack deadline must be enforced");
+
+        assert!(matches!(
+            error,
+            ZerobusError::StreamClosedError(ref status)
+                if status.code() == tonic::Code::DeadlineExceeded
+        ));
+        assert_eq!(polls.load(Ordering::Relaxed), 1);
     }
 
     /// An acknowledgement beyond the connection-local submitted-record count is a protocol
@@ -2324,12 +2644,15 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
+            Arc::new(Notify::new()),
             Duration::from_secs(60),
             server_error_tx,
             Arc::clone(&submitted_records),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(false)),
             &ArrowStreamConfigurationOptions::default(),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),
         )
@@ -2384,12 +2707,15 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
+            Arc::new(Notify::new()),
             Duration::from_secs(60),
             server_error_tx,
             Arc::clone(&submitted_records),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(true)),
             &ArrowStreamConfigurationOptions::default(),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),
         )
@@ -2448,12 +2774,15 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
+            Arc::new(Notify::new()),
             Duration::from_secs(60),
             server_error_tx,
             Arc::new(AtomicU64::new(10)),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(false)),
             &ArrowStreamConfigurationOptions::default(),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),
         )

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -2133,6 +2133,90 @@ mod arrow_flight_tests {
     mod timeout_tests {
         use super::*;
 
+        /// Idle time before ingestion must not consume a future batch's ack deadline.
+        #[tokio::test]
+        async fn test_ack_timeout_starts_when_batch_becomes_pending(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            const ACKNOWLEDGEMENT_TIMEOUT_MS: u64 = 1_000;
+            const IDLE_MS: u64 = 800;
+            const TARGET_ACKNOWLEDGEMENT_DELAY_MS: u64 = 400;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: TARGET_ACKNOWLEDGEMENT_DELAY_MS,
+                        ack_up_to_records: 1,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .server_lack_of_ack_timeout_ms(ACKNOWLEDGEMENT_TIMEOUT_MS)
+                .flush_timeout_ms(ACKNOWLEDGEMENT_TIMEOUT_MS * 2)
+                .recovery(false)
+                .build_arrow()
+                .await?;
+
+            let ack_idle = stream.arm_ack_idle_notify().await;
+            tokio::time::timeout(std::time::Duration::from_secs(5), ack_idle.notified())
+                .await
+                .expect("ack processor should enter its no-pending wait");
+
+            tokio::time::pause();
+            tokio::time::advance(std::time::Duration::from_millis(IDLE_MS)).await;
+
+            let delayed_ack_armed = mock_server.delayed_ack_armed();
+            let batch = create_test_record_batch(schema, vec![2], vec![Some("target")]);
+            let offset = stream.ingest_batch(batch).await?;
+
+            // Keep the current-thread runtime runnable while the batch crosses the real
+            // loopback socket, so paused time cannot auto-advance first.
+            let delayed_ack_armed = delayed_ack_armed.notified();
+            tokio::pin!(delayed_ack_armed);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while futures::poll!(delayed_ack_armed.as_mut()).is_pending() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "mock server did not arm the delayed ack"
+                );
+                tokio::task::yield_now().await;
+            }
+
+            tokio::time::advance(std::time::Duration::from_millis(
+                ACKNOWLEDGEMENT_TIMEOUT_MS - IDLE_MS + 1,
+            ))
+            .await;
+            tokio::task::yield_now().await;
+            assert!(
+                !stream.is_closed(),
+                "idle time must not consume the target batch's ack deadline"
+            );
+
+            tokio::time::advance(std::time::Duration::from_millis(
+                TARGET_ACKNOWLEDGEMENT_DELAY_MS,
+            ))
+            .await;
+            tokio::task::yield_now().await;
+            stream.wait_for_offset(offset).await?;
+            assert_eq!(mock_server.get_batch_count().await, 1);
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_ack_timeout() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
@@ -2184,6 +2268,64 @@ mod arrow_flight_tests {
                 err
             );
 
+            Ok(())
+        }
+
+        /// Recovery must give a replayed batch a fresh full ack deadline.
+        #[tokio::test]
+        async fn test_ack_timeout_recovery_refreshes_replay_deadline(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            const ACKNOWLEDGEMENT_TIMEOUT_MS: u64 = 500;
+            const REPLAY_ACKNOWLEDGEMENT_DELAY_MS: u64 = 100;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::WithholdAck,
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: REPLAY_ACKNOWLEDGEMENT_DELAY_MS,
+                            ack_up_to_records: 1,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .server_lack_of_ack_timeout_ms(ACKNOWLEDGEMENT_TIMEOUT_MS)
+                .flush_timeout_ms(5_000)
+                .recovery(true)
+                .recovery_timeout_ms(5_000)
+                .recovery_backoff_ms(100)
+                .recovery_retries(3)
+                .build_arrow()
+                .await?;
+
+            let batch = create_test_record_batch(schema, vec![1], vec![Some("test")]);
+            let offset = stream.ingest_batch(batch).await?;
+            tokio::time::timeout(
+                std::time::Duration::from_secs(3),
+                stream.wait_for_offset(offset),
+            )
+            .await
+            .expect("timeout-triggered recovery should complete")?;
+
+            assert_eq!(mock_server.get_batch_count().await, 2);
+            assert_eq!(mock_server.get_total_records_received().await, 2);
             Ok(())
         }
 
@@ -2444,7 +2586,7 @@ mod arrow_flight_tests {
     mod backpressure_tests {
         use super::*;
 
-        /// `max_inflight_batches` bounds batches awaiting ACK, not just batches
+        /// `max_inflight_batches` bounds batches awaiting acknowledgement, not just batches
         /// buffered before the encoder drains. With capacity 1 the second ingest must
         /// block until the first is acked.
         #[tokio::test]

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -13,7 +13,7 @@ use arrow_flight::{
 use futures::Stream;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time::sleep;
 use tonic::transport::{Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
@@ -58,6 +58,9 @@ pub enum MockFlightResponse {
         /// Cumulative records acknowledged.
         ack_up_to_records: u64,
     },
+    /// Consume this scripted response when a batch arrives without sending anything.
+    /// This leaves the connection open so the client can exercise its ack deadline.
+    WithholdAck,
     /// Error response - sent immediately when a batch arrives.
     Error { status: Status, delay_ms: u64 },
     /// Reject a connection's setup: send this error instead of the ready signal on the
@@ -98,6 +101,8 @@ pub struct MockFlightServer {
     /// Observation of every `ack_up_to_records` value emitted on the auto-ack path,
     /// in emission order. Used by tests to assert acks are connection-relative.
     auto_ack_records: Arc<Mutex<Vec<u64>>>,
+    /// Signals immediately before a scripted delayed ack registers its timer.
+    delayed_ack_armed: Arc<Notify>,
 }
 
 impl MockFlightServer {
@@ -109,7 +114,13 @@ impl MockFlightServer {
             row_count: Arc::new(Mutex::new(0)),
             response_indices: Arc::new(Mutex::new(HashMap::new())),
             auto_ack_records: Arc::new(Mutex::new(Vec::new())),
+            delayed_ack_armed: Arc::new(Notify::new()),
         }
+    }
+
+    /// Returns a notification fired immediately before a delayed ack starts waiting.
+    pub fn delayed_ack_armed(&self) -> Arc<Notify> {
+        Arc::clone(&self.delayed_ack_armed)
     }
 
     /// Inject responses for a specific table
@@ -233,6 +244,7 @@ impl FlightService for MockFlightServer {
         let row_count = Arc::clone(&self.row_count);
         let response_indices = Arc::clone(&self.response_indices);
         let auto_ack_records = Arc::clone(&self.auto_ack_records);
+        let delayed_ack_armed = Arc::clone(&self.delayed_ack_armed);
 
         tokio::spawn(async move {
             let mut stream_responses: Vec<MockFlightResponse> = Vec::new();
@@ -380,6 +392,7 @@ impl FlightService for MockFlightServer {
                                 .unwrap_or(false)
                             {
                                 if *delay_ms > 0 {
+                                    delayed_ack_armed.notify_one();
                                     sleep(Duration::from_millis(*delay_ms)).await;
                                 }
 
@@ -409,6 +422,12 @@ impl FlightService for MockFlightServer {
                                     indices.insert(table_name.clone(), response_index);
                                 }
                             }
+                        }
+                        MockFlightResponse::WithholdAck => {
+                            info!("Withholding acknowledgment as configured");
+                            response_index += 1;
+                            let mut indices = response_indices.lock().await;
+                            indices.insert(table_name.clone(), response_index);
                         }
                         MockFlightResponse::Error { status, delay_ms } => {
                             // Error responses trigger immediately on first batch
@@ -595,6 +614,7 @@ async fn start_mock_flight_server_inner(
         row_count: Arc::clone(&mock_server.row_count),
         response_indices: Arc::clone(&mock_server.response_indices),
         auto_ack_records: Arc::clone(&mock_server.auto_ack_records),
+        delayed_ack_armed: Arc::clone(&mock_server.delayed_ack_armed),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

### High-level behavior

For Arrow Flight streams, this PR changes `server_lack_of_ack_timeout_ms` from a timeout around each wait for a server response into a deadline derived from the oldest pending batch.

The old response timeout could be mostly consumed while the stream was idle because accepting the first batch did not restart the wait. Response traffic could also start a new timeout window even when it made no durable progress. As a result, recovery timing depended on when responses arrived instead of how long pending work had been waiting.

With this change, no acknowledgement timer runs while the pending set is empty. Once a batch becomes pending, the acknowledgement processor uses that batch's timestamp to calculate the deadline. Receiving a response does not replace that timestamp with a new timeout window.

### Implementation details

- Store an `enqueued_at` timestamp on every pending batch and derive the active acknowledgement deadline from the oldest pending batch.
- Notify the acknowledgement processor when the pending set changes from empty to non-empty, so a newly accepted batch gets a full timeout window after an idle period.
- Separate the idle wait from the pending-work wait. The idle path waits only for a response or newly pending work; the pending path races responses against the oldest batch's deadline.
- Let one ready response win an exact deadline tie for the same pending head and acknowledged-record state, then re-check that the current oldest batch is still expired before triggering recovery.
- Assign replayed batches a new timestamp while rebuilding them for the recovered connection.
- Document the Arrow Flight timeout behavior and its relationship with `max_inflight_batches` in the configuration docs and README.
- Clarify the acknowledgement-watermark changelog entry: delayed, duplicate, and backward watermarks are absorbed, while a forward watermark beyond the submitted-record count is rejected.

TODO: Graceful-close handling keeps its existing pause-deadline behavior in this change. Follow-up work will keep the oldest pending acknowledgement deadline active during graceful close.

## How is this tested?

- Unit test: a partial acknowledgement followed by a duplicate response does not replace the oldest batch's original deadline.
- Unit test: a valid acknowledgement already ready at expiry is applied before timeout recovery.
- Unit test: ready malformed or otherwise non-progressing responses cannot repeatedly win an expired-deadline tie.
- Arrow Flight E2E test: idle before ingestion, then verify the newly pending batch receives its full acknowledgement window.
- Arrow Flight E2E test: trigger timeout recovery, replay the pending batch, and verify the replay receives a fresh deadline and completes.