### PR TITLE
[PureGo] Add stable stream IDs

### DIFF
--- a/purego/README.md
+++ b/purego/README.md
@@ -26,8 +26,11 @@ Implemented packages:
   tokens (client-credentials flow) via `OAuthTokenProvider`, with per-table
   token caching and proactive refresh; `StaticHeadersProvider` returns a fixed
   header set for tests or externally managed credentials.
+- `internal/stream` — buffers records, tracks acknowledgements, and reconnects
+  interrupted streams. Each logical stream has a stable client ID, while
+  `ServerID` identifies its most recently opened server stream.
 
-Planned layers: ingest/ack state management, recovery, and the public API.
+Planned layer: the public API.
 
 ## Regenerating the protobuf bindings
 

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -2,10 +2,14 @@ package stream
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/transport"
@@ -152,6 +156,9 @@ type CoreStream[Req, Resp any] struct {
 	wm       *watermark
 	callback AckCallback
 
+	clientID string
+	serverID atomic.Pointer[string]
+
 	// ingestMu serializes offset assignment and enqueue.
 	ingestMu sync.Mutex
 	// nextOffset is protected by ingestMu.
@@ -168,6 +175,21 @@ type CoreStream[Req, Resp any] struct {
 	closeOnce sync.Once
 	// cancelSupervisor cancels the supervisor's context so Close unblocks it.
 	cancelSupervisor context.CancelFunc
+}
+
+var fallbackStreamIDCounter atomic.Uint64
+
+func newClientStreamID() string {
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err == nil {
+		return "client-stream-" + hex.EncodeToString(id[:])
+	}
+	return fmt.Sprintf(
+		"client-stream-%d-%d-%d",
+		os.Getpid(),
+		time.Now().UnixNano(),
+		fallbackStreamIDCounter.Add(1),
+	)
 }
 
 // NewCoreStream constructs a stream and starts its supervisor.
@@ -189,12 +211,31 @@ func NewCoreStream[Req, Resp any](
 		buf:              newBuffer[Req](cfg.MaxInflight),
 		wm:               newWatermark(),
 		callback:         callback,
+		clientID:         newClientStreamID(),
 		lastEnqueued:     -1,
 		done:             make(chan struct{}),
 		cancelSupervisor: cancel,
 	}
 	go cs.supervise(ctx)
 	return cs
+}
+
+// ID returns the stable client-generated logical stream ID.
+func (cs *CoreStream[Req, Resp]) ID() string {
+	return cs.clientID
+}
+
+// ServerID returns the most recently opened server-assigned stream ID.
+func (cs *CoreStream[Req, Resp]) ServerID() string {
+	id := cs.serverID.Load()
+	if id == nil {
+		return ""
+	}
+	return *id
+}
+
+func (cs *CoreStream[Req, Resp]) setServerID(id string) {
+	cs.serverID.Store(&id)
 }
 
 // Ingest queues one record and returns its durability offset.
@@ -330,6 +371,7 @@ func (cs *CoreStream[Req, Resp]) runOnce(ctx context.Context) (cause error, rese
 		}
 		return fmt.Errorf("stream: open: %w", err), false
 	}
+	cs.setServerID(stream.ServerID())
 	openedAt := time.Now()
 	startAck := cs.wm.current()
 

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -10,6 +10,93 @@ import (
 )
 
 // ---- tests -----------------------------------------------------------------
+func TestCoreStreamIDsAcrossRecovery(t *testing.T) {
+	first := newFakeRPC()
+	second := newFakeRPC()
+	opener := newFakeOpener(first, second)
+	opener.serverIDs = []string{"server-1", "server-2"}
+	cs := newTestStream(t, opener)
+
+	logicalID := cs.ID()
+	if logicalID == "" {
+		t.Fatal("ID returned an empty logical stream ID")
+	}
+	waitCondition(t, func() bool {
+		return cs.ServerID() == "server-1"
+	}, time.Second)
+
+	stopReads := make(chan struct{})
+	readErr := make(chan string, 1)
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stopReads:
+				return
+			default:
+				if got := cs.ID(); got != logicalID {
+					select {
+					case readErr <- got:
+					default:
+					}
+					return
+				}
+				_ = cs.ServerID()
+			}
+		}
+	}()
+
+	first.close()
+	waitCondition(t, func() bool {
+		return cs.ServerID() == "server-2"
+	}, time.Second)
+	close(stopReads)
+	readers.Wait()
+
+	select {
+	case got := <-readErr:
+		t.Fatalf("ID changed during recovery: got %q, want %q", got, logicalID)
+	default:
+	}
+	if got := cs.ID(); got != logicalID {
+		t.Fatalf("ID after recovery = %q, want %q", got, logicalID)
+	}
+}
+
+func TestCoreStreamIDsAreUnique(t *testing.T) {
+	cfg := testConfig()
+	cfg.Recovery = RecoveryDisabled
+	first := newCoreForTest(testParams(), cfg, &fakeOpener{openErr: errors.New("open failed")}, nil)
+	second := newCoreForTest(testParams(), cfg, &fakeOpener{openErr: errors.New("open failed")}, nil)
+	t.Cleanup(first.Close)
+	t.Cleanup(second.Close)
+
+	if first.ID() == second.ID() {
+		t.Fatalf("two streams received the same ID %q", first.ID())
+	}
+}
+
+func TestCoreStreamFailedRecoveryPreservesServerID(t *testing.T) {
+	rpc := newFakeRPC()
+	opener := newFakeOpener(rpc)
+	opener.serverIDs = []string{"server-1"}
+	cs := newTestStream(t, opener)
+
+	waitCondition(t, func() bool {
+		return cs.ServerID() == "server-1"
+	}, time.Second)
+	rpc.close()
+	waitCondition(t, func() bool {
+		return opener.openCount() >= 2
+	}, time.Second)
+
+	if got := cs.ServerID(); got != "server-1" {
+		t.Fatalf("ServerID after failed recovery = %q, want %q", got, "server-1")
+	}
+}
+
 func TestCoreStreamIngestAndFlush(t *testing.T) {
 	rpc := newFakeRPC()
 	cs := newTestStream(t, newFakeOpener(rpc))

--- a/purego/internal/stream/helpers_test.go
+++ b/purego/internal/stream/helpers_test.go
@@ -138,11 +138,12 @@ func (o *reconnectControlledOpener) Open(_ context.Context, _ transport.StreamPa
 }
 
 type fakeOpener struct {
-	mu       sync.Mutex
-	rpcs     []*fakeRPC
-	idx      int
-	openErr  error // if non-nil, all opens fail with this error
-	attempts int   // number of Open calls, for asserting retry behavior
+	mu        sync.Mutex
+	rpcs      []*fakeRPC
+	serverIDs []string
+	idx       int
+	openErr   error // if non-nil, all opens fail with this error
+	attempts  int   // number of Open calls, for asserting retry behavior
 }
 
 func newFakeOpener(rpcs ...*fakeRPC) *fakeOpener {
@@ -160,8 +161,24 @@ func (fo *fakeOpener) Open(_ context.Context, _ transport.StreamParams) (wireStr
 		return nil, fmt.Errorf("fakeOpener: no more RPCs")
 	}
 	rpc := fo.rpcs[fo.idx]
+	serverID := "fake-stream"
+	if fo.idx < len(fo.serverIDs) {
+		serverID = fo.serverIDs[fo.idx]
+	}
 	fo.idx++
-	return transport.NewFakeStreamForTesting(rpc), nil
+	return &serverIDStream{
+		wireStream: transport.NewFakeStreamForTesting(rpc),
+		serverID:   serverID,
+	}, nil
+}
+
+type serverIDStream struct {
+	wireStream[encodedMsg, ephemeralResp]
+	serverID string
+}
+
+func (s *serverIDStream) ServerID() string {
+	return s.serverID
 }
 
 func (fo *fakeOpener) openCount() int {

--- a/purego/internal/stream/wirestream.go
+++ b/purego/internal/stream/wirestream.go
@@ -9,6 +9,8 @@ import (
 // wireStream abstracts an open bidirectional transport stream.
 // The core uses one sender goroutine.
 type wireStream[Req, Resp any] interface {
+	// ServerID returns the identifier assigned when this connection opened.
+	ServerID() string
 	// Send writes one request to the server.
 	Send(req Req) error
 	// Recv returns io.EOF when the server ends the stream.

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -215,8 +215,12 @@ func NewFakeStreamForTesting(rpc FakeStreamRPC) *Stream {
 	return s
 }
 
+// ServerID returns the server-assigned stream identifier from the handshake.
+func (s *Stream) ServerID() string { return s.name() }
+
 // ID returns the server-assigned stream identifier from the handshake.
-func (s *Stream) ID() string { return s.name() }
+// Deprecated: use ServerID.
+func (s *Stream) ID() string { return s.ServerID() }
 
 // Send writes one request to the server. It is not safe for concurrent use.
 func (s *Stream) Send(req *zerobuspb.EphemeralStreamRequest) error { return s.send(req) }

--- a/purego/internal/transport/transport_test.go
+++ b/purego/internal/transport/transport_test.go
@@ -225,8 +225,11 @@ func TestOpenHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if got, want := stream.ID(), "stream-123"; got != want {
-		t.Errorf("stream ID = %q, want %q", got, want)
+	if got, want := stream.ServerID(), "stream-123"; got != want {
+		t.Errorf("server stream ID = %q, want %q", got, want)
+	}
+	if got, want := stream.ID(), stream.ServerID(); got != want {
+		t.Errorf("deprecated ID = %q, want %q", got, want)
 	}
 
 	got := <-srv.seen


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add separate identifiers for a logical PureGo ingestion stream and its current server connection:

- `CoreStream.ID()` returns a client-generated ID that remains stable across recovery.
- `CoreStream.ServerID()` returns the most recently opened server-assigned ID.
- `transport.Stream.ServerID()` makes the connection-scoped meaning explicit.
- `transport.Stream.ID()` remains as a deprecated compatibility alias.
- The internal wire-stream seam now provides the server ID to the recovery layer.

Recovery replaces the underlying transport stream and receives a new server ID. Keeping that value as the only identifier makes one logical stream difficult to correlate across reconnects. The new logical ID is generated before the supervisor starts, while the server ID is updated only after a successful open.

The public PureGo API is still planned; this change establishes the internal semantics it can expose without conflating logical and connection identifiers.

Closes #488.

## How is this tested?

- Added tests for logical ID stability across recovery.
- Added tests for ID uniqueness and concurrent reads.
- Added coverage for server ID rotation and preservation after a failed reconnect.
- Ran `go test -race ./...` from `purego/`.
- Ran `go vet ./...` from `purego/`.