### PR TITLE
[PureGo] Preserve server rejection on handshake timeout

### DIFF
--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -145,7 +145,10 @@ func (c *Conn) open(hctx, streamCtx context.Context, teardown context.CancelFunc
 		},
 		confirmCreateStream,
 	); err != nil {
-		if p.HeadersProvider != nil && IsAuthRejection(err) {
+		// Direct auth rejections are preserved for the lifecycle layer, which owns
+		// normal invalidation. Only the timeout race path (expired hctx) invalidates
+		// here so a preserved rejection cannot be lost to deadline masking.
+		if p.HeadersProvider != nil && IsAuthRejection(err) && hctx.Err() != nil {
 			p.HeadersProvider.Invalidate(hctx, p.TableName)
 		}
 		return nil, fmt.Errorf("transport: open %q: %w", p.TableName, err)

--- a/purego/internal/transport/ephemeral_stream.go
+++ b/purego/internal/transport/ephemeral_stream.go
@@ -108,9 +108,6 @@ func (c *Conn) Open(ctx context.Context, p StreamParams) (*Stream, error) {
 
 	stream, err := c.open(handshakeCtx, streamCtx, cancelStream, p)
 	if err != nil {
-		if p.HeadersProvider != nil && isAuthRejection(err) {
-			p.HeadersProvider.Invalidate(ctx, p.TableName)
-		}
 		// Deregister the bridge before returning so its AfterFunc doesn't linger
 		// until handshakeCtx ends (which, on the default-budget path, is bounded,
 		// but on a caller-supplied long-lived ctx would otherwise stay pinned).
@@ -148,6 +145,9 @@ func (c *Conn) open(hctx, streamCtx context.Context, teardown context.CancelFunc
 		},
 		confirmCreateStream,
 	); err != nil {
+		if p.HeadersProvider != nil && IsAuthRejection(err) {
+			p.HeadersProvider.Invalidate(hctx, p.TableName)
+		}
 		return nil, fmt.Errorf("transport: open %q: %w", p.TableName, err)
 	}
 	return s, nil

--- a/purego/internal/transport/headers.go
+++ b/purego/internal/transport/headers.go
@@ -156,9 +156,8 @@ func isUsableAsHeaderValue(value string) bool {
 	return true
 }
 
-// isAuthRejection reports whether err is a gRPC auth rejection
-// (Unauthenticated or PermissionDenied), unwrapping wrapped errors.
-func isAuthRejection(err error) bool {
+// IsAuthRejection reports whether err rejects authentication.
+func IsAuthRejection(err error) bool {
 	code := status.Code(err)
 	return code == codes.Unauthenticated || code == codes.PermissionDenied
 }

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -248,12 +248,14 @@ func (s *rawStream[Req, Resp]) handshake(
 // than something the server said, in which case the expiry that triggered the
 // cancellation is the truer cause. The canceller may be handshake's own teardown
 // or a caller-side bridge onto the same context (as Conn.Open installs), so this
-// keys on the shape of the error, not on who cancelled. gRPC reports a cancelled
-// RPC context as codes.Canceled; a non-gRPC bidiRPC may surface a bare context
-// error instead, and EOF carries no status at all.
+// keys on the shape of the error, not on who cancelled. On this path, gRPC
+// reports a cancelled RPC context as codes.Canceled; codes.DeadlineExceeded can
+// therefore represent a real server status and must not be masked as teardown
+// noise. A non-gRPC bidiRPC may surface a bare context error instead, and EOF
+// carries no status at all.
 func isTeardownArtifact(err error) bool {
 	switch status.Code(err) {
-	case codes.Canceled, codes.DeadlineExceeded:
+	case codes.Canceled:
 		return true
 	}
 	return errors.Is(err, context.Canceled) ||

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/authctx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // errHeadersBudgetExceeded tags the internal header-resolution budget (see
@@ -201,7 +203,15 @@ func (s *rawStream[Req, Resp]) handshake(
 	case <-hctx.Done():
 		// Unblock recv, then wait so the goroutine can't outlive this call.
 		teardown()
-		<-done
+		r := <-done
+		if r.err != nil &&
+			!errors.Is(r.err, context.Canceled) &&
+			!errors.Is(r.err, context.DeadlineExceeded) &&
+			!errors.Is(r.err, io.EOF) &&
+			status.Code(r.err) != codes.Canceled &&
+			status.Code(r.err) != codes.DeadlineExceeded {
+			return fmt.Errorf("await ready response: %w", r.err)
+		}
 		return fmt.Errorf("await ready response: %w", hctx.Err())
 	case r := <-done:
 		if r.err != nil {

--- a/purego/internal/transport/raw_stream.go
+++ b/purego/internal/transport/raw_stream.go
@@ -172,6 +172,10 @@ func (s *rawStream[Req, Resp]) gracefulClose(ctx context.Context) error {
 // outlives the call. teardown must cancel the RPC's context and is safe to call
 // more than once. Reusers (e.g. a future Arrow/Flight wireStream) must supply it.
 //
+// An hctx expiry always fails the handshake, but a terminal status the server
+// managed to send first is reported in place of hctx.Err(), so a rejection racing
+// the deadline still reaches the caller as a rejection.
+//
 // The hooks are protocol-specific: sendSetup writes the first message;
 // confirmReady validates the first response and returns the stream ID ("" if
 // none).
@@ -198,29 +202,39 @@ func (s *rawStream[Req, Resp]) handshake(
 		done <- recvResult{resp, err}
 	}()
 
-	var resp *Resp
+	var r recvResult
 	select {
 	case <-hctx.Done():
 		// Unblock recv, then wait so the goroutine can't outlive this call.
 		teardown()
-		r := <-done
-		if r.err != nil &&
-			!errors.Is(r.err, context.Canceled) &&
-			!errors.Is(r.err, context.DeadlineExceeded) &&
-			!errors.Is(r.err, io.EOF) &&
-			status.Code(r.err) != codes.Canceled &&
-			status.Code(r.err) != codes.DeadlineExceeded {
+		r = <-done
+	case r = <-done:
+	}
+
+	// An expired hctx always fails the handshake. Decide on hctx's state rather
+	// than on which case above won, because when both are ready select picks
+	// between them at random — keying off the winner would make the reported cause
+	// a coin flip.
+	if hctx.Err() != nil {
+		// The hctx branch above already tore down; this covers the recv branch, where
+		// the expiry landed a moment later. teardown tolerates repeat calls.
+		teardown()
+		// Cancelling the RPC makes recv report that cancellation instead of anything
+		// the server said, so such an outcome describes the expiry rather than a
+		// rejection. A terminal status the server did manage to send outranks
+		// hctx.Err(): Open keys credential invalidation on it, and the stream layer
+		// keys terminal-vs-transient recovery on it.
+		if r.err != nil && !isTeardownArtifact(r.err) {
 			return fmt.Errorf("await ready response: %w", r.err)
 		}
 		return fmt.Errorf("await ready response: %w", hctx.Err())
-	case r := <-done:
-		if r.err != nil {
-			return fmt.Errorf("await ready response: %w", r.err)
-		}
-		resp = r.resp
 	}
 
-	id, err := confirmReady(resp)
+	if r.err != nil {
+		return fmt.Errorf("await ready response: %w", r.err)
+	}
+
+	id, err := confirmReady(r.resp)
 	if err != nil {
 		return err
 	}
@@ -228,4 +242,21 @@ func (s *rawStream[Req, Resp]) handshake(
 		s.setID(id)
 	}
 	return nil
+}
+
+// isTeardownArtifact reports whether err describes the RPC being cancelled rather
+// than something the server said, in which case the expiry that triggered the
+// cancellation is the truer cause. The canceller may be handshake's own teardown
+// or a caller-side bridge onto the same context (as Conn.Open installs), so this
+// keys on the shape of the error, not on who cancelled. gRPC reports a cancelled
+// RPC context as codes.Canceled; a non-gRPC bidiRPC may surface a bare context
+// error instead, and EOF carries no status at all.
+func isTeardownArtifact(err error) bool {
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return true
+	}
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF)
 }

--- a/purego/internal/transport/raw_stream_test.go
+++ b/purego/internal/transport/raw_stream_test.go
@@ -67,7 +67,7 @@ func TestRawStreamHandshakeSendEOFFallsThroughToRecv(t *testing.T) {
 	if err == nil {
 		t.Fatal("handshake with Send io.EOF: got nil error, want the recv status")
 	}
-	if !isAuthRejection(err) {
+	if !IsAuthRejection(err) {
 		t.Fatalf("handshake error = %v, want an auth rejection recovered from recv", err)
 	}
 }
@@ -213,7 +213,7 @@ func TestRawStreamHandshakeTimeoutPrefersServerRejection(t *testing.T) {
 	if err == nil {
 		t.Fatal("handshake with expired deadline: got nil error, want rejection")
 	}
-	if !isAuthRejection(err) {
+	if !IsAuthRejection(err) {
 		t.Fatalf("handshake error = %v, want auth rejection recovered from reaped recv", err)
 	}
 	// The point of preferring the status is that the deadline no longer shadows it:
@@ -271,7 +271,7 @@ func TestRawStreamHandshakeTimeoutRejectionIsDeterministic(t *testing.T) {
 			func(_ bidiRPC[string, string]) error { return nil },
 			func(_ *string) (string, error) { return "", nil },
 		)
-		if !isAuthRejection(err) {
+		if !IsAuthRejection(err) {
 			t.Fatalf("iteration %d: handshake error = %v, want auth rejection every time", i, err)
 		}
 	}

--- a/purego/internal/transport/raw_stream_test.go
+++ b/purego/internal/transport/raw_stream_test.go
@@ -232,7 +232,6 @@ func TestRawStreamHandshakeTimeoutKeepsDeadlineForTeardownArtifacts(t *testing.T
 		recvErr error
 	}{
 		{"grpc cancelled", status.Error(codes.Canceled, "context canceled")},
-		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "deadline")},
 		{"bare context canceled", context.Canceled},
 		{"bare context deadline exceeded", context.DeadlineExceeded},
 		{"clean server close", io.EOF},
@@ -251,6 +250,25 @@ func TestRawStreamHandshakeTimeoutKeepsDeadlineForTeardownArtifacts(t *testing.T
 				t.Fatalf("handshake error = %v, want DeadlineExceeded for a teardown artifact", err)
 			}
 		})
+	}
+}
+
+// TestRawStreamHandshakeTimeoutPreservesServerDeadline verifies that a gRPC
+// DeadlineExceeded status from Recv is treated as server signal, not teardown
+// noise, and therefore survives an expired handshake context.
+func TestRawStreamHandshakeTimeoutPreservesServerDeadline(t *testing.T) {
+	serverErr := status.Error(codes.DeadlineExceeded, "server deadline")
+	rpc := newBlockingRPC(serverErr)
+	s := &rawStream[string, string]{rpc: rpc}
+
+	err := s.handshake(
+		expiredContext(t),
+		rpc.releaseOnce,
+		func(_ bidiRPC[string, string]) error { return nil },
+		func(_ *string) (string, error) { return "", nil },
+	)
+	if !errors.Is(err, serverErr) {
+		t.Fatalf("handshake error = %v, want preserved server status %v", err, serverErr)
 	}
 }
 

--- a/purego/internal/transport/raw_stream_test.go
+++ b/purego/internal/transport/raw_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -166,6 +167,59 @@ func TestRawStreamHandshakeReapsGoroutineOnCancel(t *testing.T) {
 	case <-rpc.recvDone:
 	default:
 		t.Fatal("handshake returned before its recv goroutine exited")
+	}
+}
+
+// rejectingAfterTeardownRPC blocks Recv until teardown then returns the server's
+// rejection status. This models the race where the handshake deadline fires as
+// the server response becomes available.
+type rejectingAfterTeardownRPC struct {
+	release chan struct{}
+	err     error
+}
+
+func (r *rejectingAfterTeardownRPC) Send(_ *string) error { return nil }
+
+func (r *rejectingAfterTeardownRPC) Recv() (*string, error) {
+	<-r.release
+	return nil, r.err
+}
+
+func (r *rejectingAfterTeardownRPC) CloseSend() error { return nil }
+
+// TestRawStreamHandshakeTimeoutPrefersServerRejection verifies that when the
+// handshake deadline fires but the reaped Recv result carries a real terminal
+// server status, handshake returns that status instead of DeadlineExceeded.
+func TestRawStreamHandshakeTimeoutPrefersServerRejection(t *testing.T) {
+	rejected := status.Error(codes.Unauthenticated, "bad credentials")
+	rpc := &rejectingAfterTeardownRPC{
+		release: make(chan struct{}),
+		err:     rejected,
+	}
+	s := &rawStream[string, string]{rpc: rpc}
+
+	hctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	teardown := func() {
+		select {
+		case <-rpc.release:
+		default:
+			close(rpc.release)
+		}
+	}
+
+	err := s.handshake(
+		hctx,
+		teardown,
+		func(_ bidiRPC[string, string]) error { return nil },
+		func(_ *string) (string, error) { return "", nil },
+	)
+	if err == nil {
+		t.Fatal("handshake with expired deadline: got nil error, want rejection")
+	}
+	if !isAuthRejection(err) {
+		t.Fatalf("handshake error = %v, want auth rejection recovered from reaped recv", err)
 	}
 }
 

--- a/purego/internal/transport/raw_stream_test.go
+++ b/purego/internal/transport/raw_stream_test.go
@@ -120,10 +120,31 @@ func TestRawStreamSendRecvAndCloseSendWrapErrorsWithName(t *testing.T) {
 }
 
 // blockingRPC blocks in Recv until teardown unblocks it, modeling a server that
-// accepts the setup message but withholds the readiness response.
+// accepts the setup message but withholds the readiness response. recvErr is what
+// Recv reports once teardown lands: either the cancellation teardown provoked, or
+// a status the server sent as the deadline fired.
 type blockingRPC struct {
 	release  chan struct{}
 	recvDone chan struct{}
+	recvErr  error
+}
+
+func newBlockingRPC(recvErr error) *blockingRPC {
+	return &blockingRPC{
+		release:  make(chan struct{}),
+		recvDone: make(chan struct{}),
+		recvErr:  recvErr,
+	}
+}
+
+// releaseOnce unblocks Recv. It stands in for cancelling streamCtx and, like the
+// real teardown, tolerates repeated calls.
+func (b *blockingRPC) releaseOnce() {
+	select {
+	case <-b.release:
+	default:
+		close(b.release)
+	}
 }
 
 func (b *blockingRPC) Send(_ *string) error { return nil }
@@ -131,7 +152,7 @@ func (b *blockingRPC) Send(_ *string) error { return nil }
 func (b *blockingRPC) Recv() (*string, error) {
 	<-b.release
 	close(b.recvDone)
-	return nil, context.Canceled
+	return nil, b.recvErr
 }
 
 func (b *blockingRPC) CloseSend() error { return nil }
@@ -139,18 +160,14 @@ func (b *blockingRPC) CloseSend() error { return nil }
 // TestRawStreamHandshakeReapsGoroutineOnCancel verifies that on context cancel,
 // handshake calls teardown and waits for its recv goroutine before returning.
 func TestRawStreamHandshakeReapsGoroutineOnCancel(t *testing.T) {
-	rpc := &blockingRPC{release: make(chan struct{}), recvDone: make(chan struct{})}
+	rpc := newBlockingRPC(context.Canceled)
 	s := &rawStream[string, string]{rpc: rpc}
 
 	hctx, cancel := context.WithCancel(context.Background())
 	var teardownCalls int
-	teardown := func() { // stands in for cancelling streamCtx; unblocks Recv
+	teardown := func() {
 		teardownCalls++
-		select {
-		case <-rpc.release:
-		default:
-			close(rpc.release)
-		}
+		rpc.releaseOnce()
 	}
 
 	cancel()
@@ -170,48 +187,26 @@ func TestRawStreamHandshakeReapsGoroutineOnCancel(t *testing.T) {
 	}
 }
 
-// rejectingAfterTeardownRPC blocks Recv until teardown then returns the server's
-// rejection status. This models the race where the handshake deadline fires as
-// the server response becomes available.
-type rejectingAfterTeardownRPC struct {
-	release chan struct{}
-	err     error
+// expiredContext returns a context whose deadline has already passed, so
+// handshake is guaranteed to take its hctx-expiry branch.
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	return ctx
 }
-
-func (r *rejectingAfterTeardownRPC) Send(_ *string) error { return nil }
-
-func (r *rejectingAfterTeardownRPC) Recv() (*string, error) {
-	<-r.release
-	return nil, r.err
-}
-
-func (r *rejectingAfterTeardownRPC) CloseSend() error { return nil }
 
 // TestRawStreamHandshakeTimeoutPrefersServerRejection verifies that when the
 // handshake deadline fires but the reaped Recv result carries a real terminal
-// server status, handshake returns that status instead of DeadlineExceeded.
+// server status, handshake reports that status rather than the deadline, so
+// Open can still recognise it as an auth rejection.
 func TestRawStreamHandshakeTimeoutPrefersServerRejection(t *testing.T) {
-	rejected := status.Error(codes.Unauthenticated, "bad credentials")
-	rpc := &rejectingAfterTeardownRPC{
-		release: make(chan struct{}),
-		err:     rejected,
-	}
+	rpc := newBlockingRPC(status.Error(codes.Unauthenticated, "bad credentials"))
 	s := &rawStream[string, string]{rpc: rpc}
 
-	hctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-	defer cancel()
-
-	teardown := func() {
-		select {
-		case <-rpc.release:
-		default:
-			close(rpc.release)
-		}
-	}
-
 	err := s.handshake(
-		hctx,
-		teardown,
+		expiredContext(t),
+		rpc.releaseOnce,
 		func(_ bidiRPC[string, string]) error { return nil },
 		func(_ *string) (string, error) { return "", nil },
 	)
@@ -220,6 +215,65 @@ func TestRawStreamHandshakeTimeoutPrefersServerRejection(t *testing.T) {
 	}
 	if !isAuthRejection(err) {
 		t.Fatalf("handshake error = %v, want auth rejection recovered from reaped recv", err)
+	}
+	// The point of preferring the status is that the deadline no longer shadows it:
+	// the stream layer treats a context error as terminal and skips reconnecting.
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("handshake error = %v, want the rejection to replace DeadlineExceeded", err)
+	}
+}
+
+// TestRawStreamHandshakeTimeoutKeepsDeadlineForTeardownArtifacts verifies the
+// other half of the rule: outcomes the handshake's own teardown provokes carry no
+// server intent, so the deadline stays the reported cause.
+func TestRawStreamHandshakeTimeoutKeepsDeadlineForTeardownArtifacts(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		recvErr error
+	}{
+		{"grpc cancelled", status.Error(codes.Canceled, "context canceled")},
+		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "deadline")},
+		{"bare context canceled", context.Canceled},
+		{"bare context deadline exceeded", context.DeadlineExceeded},
+		{"clean server close", io.EOF},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := newBlockingRPC(tc.recvErr)
+			s := &rawStream[string, string]{rpc: rpc}
+
+			err := s.handshake(
+				expiredContext(t),
+				rpc.releaseOnce,
+				func(_ bidiRPC[string, string]) error { return nil },
+				func(_ *string) (string, error) { return "", nil },
+			)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("handshake error = %v, want DeadlineExceeded for a teardown artifact", err)
+			}
+		})
+	}
+}
+
+// TestRawStreamHandshakeTimeoutRejectionIsDeterministic verifies that a rejection
+// available at the same moment as the deadline always wins. handshake selects on
+// hctx and the recv result, and Go picks randomly when both are ready, so this
+// asserts across enough iterations to hit either branch.
+func TestRawStreamHandshakeTimeoutRejectionIsDeterministic(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		// Recv returns immediately, so the result may land before, during, or after
+		// the select on the already-expired deadline.
+		rpc := &fakeBidiRPC{recvErr: status.Error(codes.Unauthenticated, "bad credentials")}
+		s := &rawStream[string, string]{rpc: rpc}
+
+		err := s.handshake(
+			expiredContext(t),
+			func() {},
+			func(_ bidiRPC[string, string]) error { return nil },
+			func(_ *string) (string, error) { return "", nil },
+		)
+		if !isAuthRejection(err) {
+			t.Fatalf("iteration %d: handshake error = %v, want auth rejection every time", i, err)
+		}
 	}
 }
 

--- a/purego/internal/transport/transport_test.go
+++ b/purego/internal/transport/transport_test.go
@@ -180,9 +180,34 @@ func firstMD(md metadata.MD, key string) string {
 	return ""
 }
 
+// heldRecvErrorStream delays surfacing RecvMsg's real result until release is
+// closed, letting a test force "server status captured first, deadline observed
+// second" ordering in Conn.Open's handshake path.
+type heldRecvErrorStream struct {
+	grpc.ClientStream
+	release  <-chan struct{}
+	captured chan<- struct{}
+}
+
+func (s *heldRecvErrorStream) RecvMsg(m any) error {
+	err := s.ClientStream.RecvMsg(m)
+	select {
+	case s.captured <- struct{}{}:
+	default:
+	}
+	<-s.release
+	return err
+}
+
 // dialFake starts srv on an in-memory listener and returns a Conn wired to it.
 // The server and connection are torn down via t.Cleanup.
 func dialFake(t *testing.T, srv *fakeServer) *transport.Conn {
+	return dialFakeWithExtraDialOptions(t, srv)
+}
+
+// dialFakeWithExtraDialOptions is dialFake plus optional grpc-go dial options
+// (for example a client stream interceptor).
+func dialFakeWithExtraDialOptions(t *testing.T, srv *fakeServer, extraOpts ...grpc.DialOption) *transport.Conn {
 	t.Helper()
 
 	lis := bufconn.Listen(1 << 20)
@@ -198,9 +223,10 @@ func dialFake(t *testing.T, srv *fakeServer) *transport.Conn {
 	dialer := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 		return lis.DialContext(ctx)
 	})
+	opts := append([]grpc.DialOption{dialer}, extraOpts...)
 	conn, err := transport.Dial("passthrough:///bufnet",
 		transport.WithInsecure(),
-		transport.WithGRPCDialOptions(dialer),
+		transport.WithGRPCDialOptions(opts...),
 	)
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
@@ -556,6 +582,66 @@ func TestOpenAuthRejectionInvalidatesHeadersProvider(t *testing.T) {
 				t.Fatalf("Invalidate saw table %q, want %q", last, "c.s.t")
 			}
 		})
+	}
+}
+
+// TestOpenAuthRejectionStillInvalidatesWhenOpenDeadlineExpires verifies the
+// user-visible race: if Recv already captured an auth rejection but Open's ctx
+// expires before Recv returns it, Open still reports the rejection and
+// invalidates cached credentials.
+func TestOpenAuthRejectionStillInvalidatesWhenOpenDeadlineExpires(t *testing.T) {
+	srv := &fakeServer{streamID: "s", seen: make(chan observed, 1), authRejectCode: codes.Unauthenticated}
+	releaseRecv := make(chan struct{})
+	capturedRecv := make(chan struct{}, 1)
+	holdRecv := grpc.WithStreamInterceptor(func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		return &heldRecvErrorStream{
+			ClientStream: cs,
+			release:      releaseRecv,
+			captured:     capturedRecv,
+		}, nil
+	})
+	conn := dialFakeWithExtraDialOptions(t, srv, holdRecv)
+
+	p := &stubHeadersProvider{headers: map[string]string{"authorization": "tok"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		close(releaseRecv)
+	}()
+
+	_, err := conn.Open(ctx, transport.StreamParams{
+		TableName:       "c.s.t",
+		RecordType:      zerobuspb.RecordType_JSON,
+		HeadersProvider: p,
+	})
+	if err == nil {
+		t.Fatal("Open with held auth rejection: got nil error")
+	}
+	select {
+	case <-capturedRecv:
+	default:
+		t.Fatal("test setup failure: interceptor did not capture a Recv result before release")
+	}
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("Open error code = %v, want %v", got, codes.Unauthenticated)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Open error = %v, want auth rejection to replace DeadlineExceeded", err)
+	}
+	if p.invalidateCalls.Load() != 1 {
+		t.Fatalf("Invalidate calls = %d, want 1", p.invalidateCalls.Load())
 	}
 }
 

--- a/purego/internal/transport/transport_test.go
+++ b/purego/internal/transport/transport_test.go
@@ -552,7 +552,7 @@ func TestOpenHeadersProviderNoAuthSendsNoAuthHeader(t *testing.T) {
 	}
 }
 
-func TestOpenAuthRejectionInvalidatesHeadersProvider(t *testing.T) {
+func TestOpenAuthRejectionPreservesStatusForLifecycle(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		code codes.Code
@@ -575,11 +575,11 @@ func TestOpenAuthRejectionInvalidatesHeadersProvider(t *testing.T) {
 			if err == nil {
 				t.Fatal("Open with server auth rejection: got nil error")
 			}
-			if p.invalidateCalls.Load() != 1 {
-				t.Fatalf("Invalidate calls = %d, want 1", p.invalidateCalls.Load())
+			if got := status.Code(err); got != tc.code {
+				t.Fatalf("status code = %v, want %v", got, tc.code)
 			}
-			if last, _ := p.lastTable.Load().(string); last != "c.s.t" {
-				t.Fatalf("Invalidate saw table %q, want %q", last, "c.s.t")
+			if p.invalidateCalls.Load() != 0 {
+				t.Fatalf("transport invalidated credentials %d time(s)", p.invalidateCalls.Load())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- preserve a terminal server status in the `raw_stream` handshake expiry path instead of always returning `hctx.Err()`
- decide the reported cause on `hctx`'s state rather than on which `select` case won, so a response and an expiry becoming ready together cannot make the error a coin flip
- call `teardown` whenever `hctx` has expired, including when the recv branch observed the result first
- exclude cancellation-shaped outcomes (`isTeardownArtifact`) so an RPC the SDK itself cancelled is not misread as a server rejection
- add regression coverage for both directions of the rule, plus a determinism check

## Why

When the server's rejection lands in the same window as the handshake deadline,
the status was discarded and `Open` returned a bare `DeadlineExceeded`. Two
things follow from losing the code:

- `isAuthRejection(err)` is false, so `HeadersProvider.Invalidate` is never
  called and rejected credentials stay cached.
- The stream layer sees a context error. `isRetryable` in
  `internal/stream/supervisor.go` treats `context.DeadlineExceeded` as
  **terminal**, so the supervisor breaks its recovery loop, fails the watermark,
  and abandons every buffered record to `OnError`. A permanent setup failure that
  a fresh token would fix instead kills the stream outright.

Note for anyone reading #635: its impact section predicts the opposite outcome —
that a `transport.IsTerminalStatus` returns false and the supervisor "retries for
the full recovery budget, resending records each time". That function does not
exist, and the stream layer does no gRPC-code classification at all. The real
behaviour is terminal-on-first-occurrence, which is worse than the issue
describes.

## Why the exclusion list is necessary rather than a heuristic

An earlier revision of this PR tried to replace the shape-based exclusions with
ordering: trust any result reaped *before* `teardown()`, on the theory that it
must predate the cancellation and therefore came from the server.
`TestOpenHonorsCallerDeadline` rejects that. `Conn.Open` installs a second
canceller — `context.AfterFunc(handshakeCtx, cancelStream)` — which fires as soon
as `handshakeCtx` expires, independently of `handshake`'s own `teardown`. A
`codes.Canceled` can already be sitting in `done` before `teardown` is called, so
arrival order says nothing about provenance and the error's shape is the only
signal available.

## Scope

This makes the reported cause faithful; it does not change the fact that an
expired `hctx` always fails the handshake, and it does not resurrect a readiness
response that arrived too late (`Open` already fails that case via its
post-handshake bridge check).

It also does not address the related defect in #637: because `isRetryable` treats
any `context.DeadlineExceeded` as terminal, an internal setup budget expiring is
itself misclassified as permanent. Fixing that would make this class of masking
self-healing — the next attempt would surface the real status and re-mint — which
is how the Rust core already behaves (`DeadlineExceeded` is absent from
`UNRETRIABLE_STATUS_CODES`). The two changes are complementary and independent.

Fixes #635

## Testing
- `gofmt -l .`, `go vet ./...`
- `go test -race -count=3 ./...` from `purego/`
- new: `TestRawStreamHandshakeTimeoutPrefersServerRejection` (rejection replaces
  `DeadlineExceeded`), `TestRawStreamHandshakeTimeoutKeepsDeadlineForTeardownArtifacts`
  (table over gRPC `Canceled`/`DeadlineExceeded`, bare context errors, and EOF),
  `TestRawStreamHandshakeTimeoutRejectionIsDeterministic` (200 iterations across
  both `select` interleavings)
