### PR TITLE
[PureGo] Add public zerobus API package

### DIFF
--- a/.github/workflows/ci-purego.yml
+++ b/.github/workflows/ci-purego.yml
@@ -98,3 +98,10 @@ jobs:
       # covers data races regardless of target OS; no Windows entry needed.
       - name: Run tests (race detector)
         run: go test -race ./...
+
+      # The primary SDK claim is CGO-free usage. Keep an explicit non-race test
+      # run with CGO disabled so CI catches accidental CGO regressions.
+      - name: Run tests (CGO disabled)
+        env:
+          CGO_ENABLED: "0"
+        run: go test ./...

--- a/.github/workflows/ci-purego.yml
+++ b/.github/workflows/ci-purego.yml
@@ -99,8 +99,6 @@ jobs:
       - name: Run tests (race detector)
         run: go test -race ./...
 
-      # The primary SDK claim is CGO-free usage. Keep an explicit non-race test
-      # run with CGO disabled so CI catches accidental CGO regressions.
       - name: Run tests (CGO disabled)
         env:
           CGO_ENABLED: "0"

--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -16,6 +16,8 @@
 - Correctly normalize IPv6 Zerobus endpoints and reject plaintext HTTP
   endpoints because the SDK always uses TLS.
 - Validate application names before adding them to the gRPC user-agent.
+- Return offset `-1` (not `0`) from failed ingest calls, matching the
+  original Go SDK so callers can distinguish errors from the first real offset.
 
 ### Documentation
 

--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -1,0 +1,28 @@
+# NEXT CHANGELOG
+
+## Release v0.1.0
+
+### New Features and Improvements
+
+- Added context-aware single-record and batch ingestion methods so cancellation
+  can interrupt buffer backpressure.
+- Exposed recovery timeout/backoff, lack-of-ack timeout, maximum batch records,
+  and server-pause wait controls as stream options.
+
+### Deprecations
+
+### Bug Fixes
+
+- Correctly normalize IPv6 Zerobus endpoints and reject plaintext HTTP
+  endpoints because the SDK always uses TLS.
+- Validate application names before adding them to the gRPC user-agent.
+
+### Documentation
+
+- Clarified that callbacks may call stream methods, including `Close`.
+
+### Internal Changes
+
+### API Changes
+
+- Protocol Buffers are now the default record type, matching the other SDKs.

--- a/purego/README.md
+++ b/purego/README.md
@@ -1,36 +1,118 @@
 # Zerobus pure-Go SDK (work in progress)
 
 A native, pure-Go implementation of the Zerobus ingestion SDK that talks to the
-Zerobus gRPC service directly.
+Zerobus gRPC service directly — **no cgo, no FFI, no C toolchain**. It builds and
+cross-compiles as an ordinary Go module (`go get`, `CGO_ENABLED=0` friendly).
 
 It lives in its own top-level module (`github.com/databricks/zerobus-sdk/purego`)
 so it is fully isolated from the existing cgo-based SDK under `go/` while it is
 built out. The two do not share a `go.mod`: the cgo SDK keeps its lean
 dependency set, and this module owns the gRPC/protobuf dependencies.
 
-## Current scope
+## Quick start
 
-Implemented packages:
+```go
+import "github.com/databricks/zerobus-sdk/purego/zerobus"
 
-- `internal/zerobuspb` — protobuf message types and the gRPC `ZerobusClient`
-  (the bidirectional `EphemeralStream` RPC), generated from `zerobus_service.proto`.
-- `internal/transport` — dials the service (TLS by default), performs the
-  create-stream handshake, and exposes send/receive operations over the
-  bidirectional stream. It validates stream-open inputs (`TableName`,
-  `RecordType`, descriptor requirement for `PROTO`) and sets auth metadata from
-  the `StreamParams.HeadersProvider`. The authorization value is sent verbatim as
-  the provider formats it (e.g. `"Bearer <token>"`); the transport does not add a
-  scheme prefix.
-- `internal/auth` — the `HeadersProvider` seam that feeds transport open, with
-  two implementations. `OAuthHeadersProvider` mints Unity Catalog OAuth 2.0
-  tokens (client-credentials flow) via `OAuthTokenProvider`, with per-table
-  token caching and proactive refresh; `StaticHeadersProvider` returns a fixed
-  header set for tests or externally managed credentials.
-- `internal/stream` — buffers records, tracks acknowledgements, and reconnects
-  interrupted streams. Each logical stream has a stable client ID, while
-  `ServerID` identifies its most recently opened server stream.
+sdk, err := zerobus.New(
+    "https://your-workspace.zerobus.region.cloud.databricks.com",
+    "https://your-workspace.cloud.databricks.com",
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer sdk.Close()
 
-Planned layer: the public API.
+stream, err := sdk.CreateStream(ctx, "catalog.schema.table",
+    clientID, clientSecret, zerobus.WithJSON())
+if err != nil {
+    log.Fatal(err)
+}
+defer stream.Close()
+```
+
+## Ingesting data
+
+Ingestion is asynchronous and pipelined. `IngestRecordOffset` returns as soon as
+the record is queued and the offset is assigned; sending and acknowledgement
+happen in the background. **Queue records in a loop and confirm durability with a
+single `Flush`** — never wait for an acknowledgement after every record, which
+collapses throughput to one record per server round-trip.
+
+```go
+for _, rec := range records {
+    if _, err := stream.IngestRecordOffset(rec); err != nil { // queue only — do NOT wait here
+        log.Fatal(err)
+    }
+}
+if err := stream.Flush(); err != nil { // wait once for all pending acks
+    log.Fatal(err)
+}
+```
+
+For continuous, unbounded streams, call `Flush` periodically (every N records) to
+bound in-flight memory, or register an ack callback with `WithAckCallback` for
+async notification. Prefer the batch API `IngestRecordsOffset` in hot paths: one
+batch is one buffer entry and one atomic ack.
+
+Reserve per-record `WaitForOffset` for genuinely low-volume cases where each
+record must be confirmed durable before continuing. Because acks are ordered and
+the watermark is monotonic, waiting on the last offset of a group confirms all
+prior offsets too.
+
+## Authentication
+
+`CreateStream` uses the Unity Catalog OAuth 2.0 client-credentials flow. For
+custom authentication (externally managed credentials, a custom token source, or
+tests), implement `HeadersProvider` and use `CreateStreamWithProvider`:
+
+```go
+stream, err := sdk.CreateStreamWithProvider(ctx, "catalog.schema.table",
+    myProvider, zerobus.WithProto(descriptorProto))
+```
+
+`NewStaticHeadersProvider` returns a fixed-header provider for tests or
+externally managed credentials.
+
+## Record types
+
+- **JSON** (default) — `WithJSON()`; records are UTF-8 JSON bytes.
+- **Protocol Buffers** — `WithProto(descriptorProto)`; records are marshaled
+  protobuf bytes and the serialized message descriptor is supplied once.
+
+## Error handling
+
+Operations return an `*Error` that reports whether a retry could succeed. Use the
+package-level `Retryable` helper, which also classifies wrapped core errors:
+
+```go
+if _, err := stream.IngestRecordOffset(rec); err != nil {
+    if zerobus.Retryable(err) {
+        // transient — a retry or a fresh stream may succeed
+    } else {
+        // permanent — fix configuration or input before retrying
+    }
+}
+```
+
+## Recovery
+
+Streams reconnect automatically on recoverable failures (default 4 retries).
+Disable with `WithRecovery(zerobus.RecoveryDisabled)`. After a stream closes or
+fails, `GetUnackedRecords` / `GetUnackedBatches` return the records that were
+never acknowledged, for replay or persistence.
+
+## Package layout
+
+```
+purego/
+├── zerobus/              PUBLIC API — SDK, Stream, options, errors
+└── internal/
+    ├── stream/           generic ingestion core (buffer, watermark, supervisor)
+    ├── transport/        gRPC connection, TLS, EphemeralStream handshake
+    ├── auth/             HeadersProvider, token cache, UC OAuth
+    └── zerobuspb/        generated protobuf bindings
+```
 
 ## Regenerating the protobuf bindings
 

--- a/purego/README.md
+++ b/purego/README.md
@@ -60,6 +60,10 @@ record must be confirmed durable before continuing. Because acks are ordered and
 the watermark is monotonic, waiting on the last offset of a group confirms all
 prior offsets too.
 
+When buffer backpressure may block longer than the caller can wait, use
+`IngestRecordOffsetContext` or `IngestRecordsOffsetContext`. Cancellation only
+interrupts admission; once queued, a record remains owned by the stream.
+
 ## Authentication
 
 `CreateStream` uses the Unity Catalog OAuth 2.0 client-credentials flow. For
@@ -76,9 +80,10 @@ externally managed credentials.
 
 ## Record types
 
-- **JSON** (default) — `WithJSON()`; records are UTF-8 JSON bytes.
-- **Protocol Buffers** — `WithProto(descriptorProto)`; records are marshaled
-  protobuf bytes and the serialized message descriptor is supplied once.
+- **Protocol Buffers** (default record type) —
+  `WithProto(descriptorProto)`; records are marshaled protobuf bytes and the
+  required serialized message descriptor is supplied once.
+- **JSON** — `WithJSON()`; records are UTF-8 JSON bytes.
 
 ## Error handling
 
@@ -101,6 +106,11 @@ Streams reconnect automatically on recoverable failures (default 4 retries).
 Disable with `WithRecovery(zerobus.RecoveryDisabled)`. After a stream closes or
 fails, `GetUnackedRecords` / `GetUnackedBatches` return the records that were
 never acknowledged, for replay or persistence.
+
+Recovery and buffering can be tuned with `WithRecoveryRetries`,
+`WithRecoveryTimeout`, `WithRecoveryBackoff`, `WithLackOfAckTimeout`,
+`WithMaxInflight`, `WithMaxBufferedPayloadBytes`, `WithMaxBatchRecords`, and
+`WithStreamPausedMaxWait`.
 
 ## Package layout
 

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -517,7 +517,13 @@ func (cs *CoreStream[Req, Resp]) Flush(ctx context.Context) error {
 
 func (cs *CoreStream[Req, Resp]) flushThrough(ctx context.Context, target int64) error {
 	if target < 0 {
-		return nil // nothing successfully ingested yet
+		// Nothing was successfully ingested, so there is no watermark to wait
+		// for. A stream that already failed terminally — an unknown table or a
+		// rejected credential on the background open — must still report that
+		// failure here rather than a bare success, since Flush is where such a
+		// failure is documented to surface. A clean Close sets no terminal
+		// error, so it still reports nil.
+		return cs.terminalErr()
 	}
 	return cs.WaitForOffset(ctx, target)
 }
@@ -607,6 +613,29 @@ func (cs *CoreStream[Req, Resp]) Close() error {
 		cs.cancelSupervisor()
 		cs.buf.close()
 		<-cs.done // wait for the supervisor to exit
+	})
+	return cs.closeErr
+}
+
+// Terminate stops admission and tears the stream down immediately, without the
+// final flush Close performs: records queued but not yet acknowledged are
+// abandoned rather than waited on (still retrievable via GetUnacked, and
+// reported through the AckCallback's OnError). Use it when the underlying
+// connection is going away and waiting for acknowledgements cannot succeed.
+//
+// It is idempotent, blocks until lifecycle teardown completes, and shares its
+// once-guard with Close, so whichever call runs first decides the result both
+// report. It returns any terminal stream failure, nil otherwise.
+func (cs *CoreStream[Req, Resp]) Terminate() error {
+	cs.closeOnce.Do(func() {
+		cs.offsetMu.Lock()
+		cs.closing = true
+		cs.offsetMu.Unlock()
+
+		cs.cancelSupervisor()
+		cs.buf.close()
+		<-cs.done // wait for the supervisor to exit
+		cs.closeErr = cs.terminalErr()
 	})
 	return cs.closeErr
 }

--- a/purego/internal/stream/core.go
+++ b/purego/internal/stream/core.go
@@ -389,11 +389,12 @@ func waitUntil(ctx context.Context, deadline time.Time) bool {
 
 // Ingest encodes record and enqueues it in the buffer, blocking if the buffer
 // is at capacity (backpressure). Returns the logical offset assigned to this
-// record. For throughput, queue records in a loop and call Flush once; waiting
-// for every offset serializes ingestion on server round trips.
+// record, or -1 with an error when the record is not queued. For throughput,
+// queue records in a loop and call Flush once; waiting for every offset
+// serializes ingestion on server round trips.
 func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int64, error) {
 	if err := cs.checkRawSize(len(record)); err != nil {
-		return 0, err
+		return -1, err
 	}
 	weight := cs.enc.retainedSize(len(record), 1)
 	return cs.enqueueEncoded(ctx, weight, func() (Req, error) {
@@ -403,9 +404,9 @@ func (cs *CoreStream[Req, Resp]) Ingest(ctx context.Context, record []byte) (int
 
 // IngestBatch encodes records as a single atomic batch and enqueues it, blocking
 // if the buffer is at capacity. The whole batch occupies one logical offset and
-// the server acks it atomically. Returns that offset, or -1 for an empty batch,
-// which is a no-op. Prefer this over Ingest in hot paths: it amortizes
-// per-message overhead across the batch.
+// the server acks it atomically. Returns that offset, -1 for an empty batch
+// (a no-op), or -1 with an error when the batch is not queued. Prefer this over
+// Ingest in hot paths: it amortizes per-message overhead across the batch.
 func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]byte) (int64, error) {
 	if len(records) == 0 {
 		// Rust returns Ok(None) for empty batches; in Go we model that as a
@@ -413,19 +414,19 @@ func (cs *CoreStream[Req, Resp]) IngestBatch(ctx context.Context, records [][]by
 		return -1, nil
 	}
 	if len(records) > cs.cfg.MaxBatchRecords {
-		return 0, fmt.Errorf("%w: %d records exceeds MaxBatchRecords=%d",
+		return -1, fmt.Errorf("%w: %d records exceeds MaxBatchRecords=%d",
 			ErrPayloadTooLarge, len(records), cs.cfg.MaxBatchRecords)
 	}
 	total := 0
 	for _, record := range records {
 		if len(record) > cs.cfg.MaxPayloadBytes || total > cs.cfg.MaxPayloadBytes-len(record) {
-			return 0, fmt.Errorf("%w: raw batch exceeds MaxPayloadBytes=%d",
+			return -1, fmt.Errorf("%w: raw batch exceeds MaxPayloadBytes=%d",
 				ErrPayloadTooLarge, cs.cfg.MaxPayloadBytes)
 		}
 		total += len(record)
 	}
 	if err := cs.checkRawSize(total); err != nil {
-		return 0, err
+		return -1, err
 	}
 	weight := cs.enc.retainedSize(total, len(records))
 	return cs.enqueueEncoded(ctx, weight, func() (Req, error) {
@@ -442,6 +443,7 @@ func (cs *CoreStream[Req, Resp]) checkRawSize(size int) error {
 }
 
 // enqueueEncoded reserves capacity and encodes before assigning an offset.
+// Failed ingest returns -1 to match the original Go SDK (offsets start at 0).
 func (cs *CoreStream[Req, Resp]) enqueueEncoded(
 	ctx context.Context,
 	weight int64,
@@ -449,31 +451,31 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(
 ) (int64, error) {
 	if cs.isClosed() {
 		if err := cs.terminalErr(); err != nil {
-			return 0, err
+			return -1, err
 		}
-		return 0, errClosed
+		return -1, errClosed
 	}
 	cs.offsetMu.Lock()
 	closing := cs.closing
 	cs.offsetMu.Unlock()
 	if closing {
-		return 0, errClosed
+		return -1, errClosed
 	}
 	if cs.offsetExhausted.Load() {
-		return 0, ErrOffsetExhausted
+		return -1, ErrOffsetExhausted
 	}
 	if err := cs.buf.reserve(ctx, weight); err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	msg, err := encodeFn()
 	if err != nil {
 		cs.buf.release(weight)
-		return 0, err
+		return -1, err
 	}
 	if size := cs.enc.maxWireSize(msg); size > cs.cfg.MaxPayloadBytes {
 		cs.buf.release(weight)
-		return 0, fmt.Errorf("%w: encoded size %d exceeds MaxPayloadBytes=%d",
+		return -1, fmt.Errorf("%w: encoded size %d exceeds MaxPayloadBytes=%d",
 			ErrPayloadTooLarge, size, cs.cfg.MaxPayloadBytes)
 	}
 
@@ -481,18 +483,18 @@ func (cs *CoreStream[Req, Resp]) enqueueEncoded(
 	if cs.closing {
 		cs.offsetMu.Unlock()
 		cs.buf.release(weight)
-		return 0, errClosed
+		return -1, errClosed
 	}
 	if cs.offsetExhausted.Load() {
 		cs.offsetMu.Unlock()
 		cs.buf.release(weight)
-		return 0, ErrOffsetExhausted
+		return -1, ErrOffsetExhausted
 	}
 	offset := cs.nextOffset
 	cs.enc.stampOffset(msg, offset)
 	if err := cs.buf.append(offset, msg, weight); err != nil {
 		cs.offsetMu.Unlock()
-		return 0, err
+		return -1, err
 	}
 	if offset == math.MaxInt64 {
 		cs.offsetExhausted.Store(true)

--- a/purego/internal/stream/core_test.go
+++ b/purego/internal/stream/core_test.go
@@ -1013,15 +1013,18 @@ func TestCoreStreamMalformedAckTearsDownAndRecovers(t *testing.T) {
 }
 
 // TestCoreStreamIngestOnClosedStreamErrors verifies that Ingest on a cleanly
-// closed stream returns an error, not (0, nil).
+// closed stream returns (-1, err), matching the original Go SDK.
 func TestCoreStreamIngestOnClosedStreamErrors(t *testing.T) {
 	rpc := newFakeRPC()
 	cs := newTestStream(t, newFakeOpener(rpc))
 	cs.Close()
 
-	_, err := cs.Ingest(context.Background(), []byte(`{}`))
+	off, err := cs.Ingest(context.Background(), []byte(`{}`))
 	if err == nil {
 		t.Fatal("want error from Ingest on closed stream, got nil")
+	}
+	if off != -1 {
+		t.Fatalf("closed Ingest offset = %d, want -1", off)
 	}
 }
 
@@ -2578,20 +2581,26 @@ func TestCoreStreamRejectsOversizedPayloadWithoutConsumingOffset(t *testing.T) {
 	cs := newCoreForTest(testParams(), cfg, newFakeOpener(rpc), nil)
 	t.Cleanup(func() { cs.Close() })
 
-	if _, err := cs.Ingest(context.Background(), bytes.Repeat([]byte("x"), 65)); !errors.Is(err, ErrPayloadTooLarge) {
+	if off, err := cs.Ingest(context.Background(), bytes.Repeat([]byte("x"), 65)); !errors.Is(err, ErrPayloadTooLarge) {
 		t.Fatalf("want ErrPayloadTooLarge for record, got %v", err)
+	} else if off != -1 {
+		t.Fatalf("oversized Ingest offset = %d, want -1", off)
 	}
-	if _, err := cs.IngestBatch(context.Background(), [][]byte{
+	if off, err := cs.IngestBatch(context.Background(), [][]byte{
 		bytes.Repeat([]byte("x"), 40),
 		bytes.Repeat([]byte("y"), 30),
 	}); !errors.Is(err, ErrPayloadTooLarge) {
 		t.Fatalf("want ErrPayloadTooLarge for batch, got %v", err)
+	} else if off != -1 {
+		t.Fatalf("oversized IngestBatch offset = %d, want -1", off)
 	}
 	cs.cfg.MaxBatchRecords = 1
-	if _, err := cs.IngestBatch(context.Background(), [][]byte{
+	if off, err := cs.IngestBatch(context.Background(), [][]byte{
 		[]byte(`{}`), []byte(`{}`),
 	}); !errors.Is(err, ErrPayloadTooLarge) {
 		t.Fatalf("want ErrPayloadTooLarge for batch record count, got %v", err)
+	} else if off != -1 {
+		t.Fatalf("oversized batch count offset = %d, want -1", off)
 	}
 	cs.cfg.MaxBatchRecords = DefaultMaxBatchRecords
 	offset, err := cs.Ingest(context.Background(), []byte(`{}`))

--- a/purego/internal/stream/supervisor.go
+++ b/purego/internal/stream/supervisor.go
@@ -155,6 +155,12 @@ type retryableError interface {
 	IsRetryable() bool
 }
 
+// IsRetryable reports whether err represents a transient failure that a retry
+// or a fresh stream could recover from, using the same classification the
+// supervisor applies to reconnect decisions. It is exported for the public
+// zerobus package to derive the retryability of the errors it surfaces.
+func IsRetryable(err error) bool { return isRetryable(err) }
+
 // isRetryable reports whether reconnecting may succeed.
 func isRetryable(err error) bool {
 	if err == nil {

--- a/purego/zerobus/errors.go
+++ b/purego/zerobus/errors.go
@@ -1,0 +1,80 @@
+package zerobus
+
+import (
+	"errors"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/stream"
+)
+
+// Error is the error type returned by SDK and Stream operations. It wraps the
+// underlying cause and reports whether reconnecting or retrying the operation
+// could succeed.
+//
+// Not every error returned by the SDK is an *Error; wrapped standard-library
+// and context errors also flow through. Use errors.As to test for it, or the
+// package-level Retryable helper, which handles both cases:
+//
+//	if _, err := stream.IngestRecordOffset(rec); err != nil {
+//	    if zerobus.Retryable(err) {
+//	        // transient — a retry or fresh stream may succeed
+//	    } else {
+//	        // permanent — fix configuration or input before retrying
+//	    }
+//	}
+type Error struct {
+	// Op is the SDK operation that failed (e.g. "CreateStream", "Flush").
+	Op string
+	// cause is the underlying error.
+	cause error
+	// retryable records whether the failure is transient.
+	retryable bool
+}
+
+func (e *Error) Error() string {
+	if e.Op == "" {
+		return e.cause.Error()
+	}
+	return "zerobus: " + e.Op + ": " + e.cause.Error()
+}
+
+// Unwrap exposes the underlying cause for errors.Is / errors.As.
+func (e *Error) Unwrap() error { return e.cause }
+
+// Retryable reports whether the failure is transient and a retry (or a fresh
+// stream) may succeed. A non-retryable error indicates a permanent condition —
+// invalid configuration, bad input, or a rejected credential — that a retry
+// cannot fix.
+func (e *Error) Retryable() bool { return e.retryable }
+
+// wrapErr wraps a core/transport error as an *Error tagged with the operation
+// name, deriving retryability from the core's classification. A nil error
+// wraps to nil so call sites can wrap unconditionally.
+func wrapErr(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	// Preserve an already-classified *Error rather than double-wrapping; just
+	// attach the operation if it lacks one.
+	var e *Error
+	if errors.As(err, &e) {
+		if e.Op == "" {
+			e.Op = op
+		}
+		return err
+	}
+	return &Error{Op: op, cause: err, retryable: stream.IsRetryable(err)}
+}
+
+// Retryable reports whether err (or any error it wraps) is transient. It is the
+// package-level counterpart to (*Error).Retryable and also classifies raw
+// core/transport errors that were not wrapped as an *Error.
+func Retryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var e *Error
+	if errors.As(err, &e) {
+		return e.retryable
+	}
+	return stream.IsRetryable(err)
+}

--- a/purego/zerobus/example_test.go
+++ b/purego/zerobus/example_test.go
@@ -1,0 +1,114 @@
+package zerobus_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/databricks/zerobus-sdk/purego/zerobus"
+)
+
+// Ingest a batch of JSON records with the idiomatic loop-then-Flush pattern:
+// queue every record without waiting, then confirm durability once at the end.
+func ExampleStream_ingestThenFlush() {
+	sdk, err := zerobus.New(
+		"https://your-workspace.zerobus.region.cloud.databricks.com",
+		"https://your-workspace.cloud.databricks.com",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sdk.Close()
+
+	stream, err := sdk.CreateStream(context.Background(), "catalog.schema.table",
+		clientID(), clientSecret(), zerobus.WithJSON())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer stream.Close()
+
+	records := [][]byte{[]byte(`{"id":1}`), []byte(`{"id":2}`), []byte(`{"id":3}`)}
+	for _, rec := range records {
+		if _, err := stream.IngestRecordOffset(rec); err != nil { // queue only — do NOT wait here
+			log.Fatal(err)
+		}
+	}
+	if err := stream.Flush(); err != nil { // wait once for all pending acks
+		log.Fatal(err)
+	}
+}
+
+// For a continuous stream, register an ack callback instead of blocking on
+// Flush, and flush periodically to bound in-flight memory.
+func ExampleStream_ackCallback() {
+	sdk, err := zerobus.New(
+		"https://your-workspace.zerobus.region.cloud.databricks.com",
+		"https://your-workspace.cloud.databricks.com",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sdk.Close()
+
+	stream, err := sdk.CreateStream(context.Background(), "catalog.schema.table",
+		clientID(), clientSecret(),
+		zerobus.WithJSON(),
+		zerobus.WithAckCallback(logAckCallback{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer stream.Close()
+
+	for i := 0; ; i++ {
+		if _, err := stream.IngestRecordOffset([]byte(`{"event":"tick"}`)); err != nil {
+			log.Fatal(err)
+		}
+		if i%10_000 == 0 {
+			if err := stream.Flush(); err != nil { // bound in-flight memory periodically
+				log.Fatal(err)
+			}
+		}
+	}
+}
+
+// Ingest Protocol Buffer records: pass the serialized message descriptor to
+// WithProto and hand IngestRecordOffset the marshaled protobuf bytes.
+func ExampleStream_proto() {
+	sdk, err := zerobus.New(
+		"https://your-workspace.zerobus.region.cloud.databricks.com",
+		"https://your-workspace.cloud.databricks.com",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sdk.Close()
+
+	stream, err := sdk.CreateStream(context.Background(), "catalog.schema.table",
+		clientID(), clientSecret(), zerobus.WithProto(descriptorProto()))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer stream.Close()
+
+	// protoBytes is a marshaled protobuf message matching the descriptor.
+	if _, err := stream.IngestRecordOffset(protoBytes()); err != nil {
+		log.Fatal(err)
+	}
+	if err := stream.Flush(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// logAckCallback logs each acknowledged offset and any per-record error.
+type logAckCallback struct{}
+
+func (logAckCallback) OnAck(offset int64) { log.Printf("acked offset %d", offset) }
+func (logAckCallback) OnError(offset int64, err error) {
+	log.Printf("offset %d failed: %v", offset, err)
+}
+
+// Stand-ins so the examples compile without external configuration.
+func clientID() string        { return "" }
+func clientSecret() string    { return "" }
+func descriptorProto() []byte { return nil }
+func protoBytes() []byte      { return nil }

--- a/purego/zerobus/export_test.go
+++ b/purego/zerobus/export_test.go
@@ -1,0 +1,30 @@
+package zerobus
+
+import "github.com/databricks/zerobus-sdk/purego/internal/transport"
+
+// Test-only accessors for unexported helpers and injection points.
+
+// GRPCTarget exposes grpcTarget for endpoint-normalization tests.
+func GRPCTarget(endpoint string) (string, error) { return grpcTarget(endpoint) }
+
+// NewWithConn builds an SDK around an already-dialed transport connection,
+// bypassing New's dialing so tests can point the SDK at an in-memory server.
+func NewWithConn(conn *transport.Conn, zerobusEndpoint, ucEndpoint string) *SDK {
+	return &SDK{
+		zerobusEndpoint: zerobusEndpoint,
+		ucEndpoint:      ucEndpoint,
+		conn:            conn,
+	}
+}
+
+// ResolveStreamConfig applies the given options and returns the resolved record
+// type, descriptor, and a subset of the core config for assertion.
+func ResolveStreamConfig(opts ...StreamOption) (recordType int32, descriptor []byte, maxInflight int, recovery RecoverySetting) {
+	sc := defaultStreamConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&sc)
+		}
+	}
+	return int32(sc.recordType), sc.descriptor, sc.cfg.MaxInflight, sc.cfg.Recovery
+}

--- a/purego/zerobus/export_test.go
+++ b/purego/zerobus/export_test.go
@@ -1,6 +1,10 @@
 package zerobus
 
-import "github.com/databricks/zerobus-sdk/purego/internal/transport"
+import (
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
 
 // Test-only accessors for unexported helpers and injection points.
 
@@ -31,4 +35,21 @@ func ResolveStreamConfig(opts ...StreamOption) (recordType int32, descriptor []b
 		}
 	}
 	return int32(sc.recordType), sc.descriptor, sc.cfg.MaxInflight, sc.cfg.Recovery
+}
+
+// ResolveStreamTuning applies options and returns the public tuning values that
+// need wiring assertions.
+func ResolveStreamTuning(opts ...StreamOption) (
+	recoveryTimeout, recoveryBackoff, lackOfAckTimeout time.Duration,
+	maxBatchRecords int,
+	streamPausedMaxWait *time.Duration,
+) {
+	sc := defaultStreamConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&sc)
+		}
+	}
+	return sc.cfg.RecoveryTimeout, sc.cfg.RecoveryBackoff, sc.cfg.LackOfAckTimeout,
+		sc.cfg.MaxBatchRecords, sc.cfg.StreamPausedMaxWait
 }

--- a/purego/zerobus/export_test.go
+++ b/purego/zerobus/export_test.go
@@ -10,11 +10,15 @@ func GRPCTarget(endpoint string) (string, error) { return grpcTarget(endpoint) }
 // NewWithConn builds an SDK around an already-dialed transport connection,
 // bypassing New's dialing so tests can point the SDK at an in-memory server.
 func NewWithConn(conn *transport.Conn, zerobusEndpoint, ucEndpoint string) *SDK {
-	return &SDK{
-		zerobusEndpoint: zerobusEndpoint,
-		ucEndpoint:      ucEndpoint,
-		conn:            conn,
-	}
+	return newSDK(conn, zerobusEndpoint, ucEndpoint)
+}
+
+// OpenStreamCount reports how many streams the SDK still tracks for Close, so
+// tests can assert that Stream.Close deregisters itself.
+func (s *SDK) OpenStreamCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.streams)
 }
 
 // ResolveStreamConfig applies the given options and returns the resolved record

--- a/purego/zerobus/options.go
+++ b/purego/zerobus/options.go
@@ -18,8 +18,9 @@ type sdkConfig struct {
 
 // WithApplicationName appends a caller-supplied identifier such as "my-app/1.0"
 // to the gRPC user-agent header. Leading and trailing whitespace is trimmed and
-// blank names are ignored. The final value is "zerobus-sdk-go-purego/<version>
-// <name>".
+// blank names are ignored. Names must be valid ASCII user-agent values; invalid
+// UTF-8, control characters, and DEL cause New to fail. The final value is
+// "zerobus-sdk-go-purego/<version> <name>".
 func WithApplicationName(name string) Option {
 	return func(c *sdkConfig) { c.applicationName = name }
 }
@@ -45,7 +46,8 @@ const (
 // AckCallback receives asynchronous per-offset acknowledgement and error
 // notifications. Register one with WithAckCallback as an alternative to blocking
 // on Flush or WaitForOffset. Callbacks run on a dedicated worker, so
-// implementations must return promptly and must not call back into the stream.
+// implementations should return promptly to avoid delaying later notifications.
+// Stream methods, including Close, may be called from a callback.
 type AckCallback = stream.AckCallback
 
 // StreamOption configures a stream created with CreateStream or
@@ -63,15 +65,12 @@ type streamConfig struct {
 
 func defaultStreamConfig() streamConfig {
 	return streamConfig{
-		// JSON is the default so a record type is always valid without a
-		// descriptor; WithProto switches to proto and supplies the descriptor.
-		recordType: zerobuspb.RecordType_JSON,
+		recordType: zerobuspb.RecordType_PROTO,
 		cfg:        stream.DefaultConfig(),
 	}
 }
 
-// WithJSON selects JSON record encoding. It is the default when no encoding
-// option is given.
+// WithJSON selects JSON record encoding.
 func WithJSON() StreamOption {
 	return func(c *streamConfig) {
 		c.recordType = zerobuspb.RecordType_JSON
@@ -124,6 +123,25 @@ func WithRecoveryRetries(n int) StreamOption {
 	return func(c *streamConfig) { c.cfg.RecoveryRetries = n }
 }
 
+// WithRecoveryTimeout bounds each stream-open attempt during recovery. A
+// non-positive value keeps the default (15 seconds).
+func WithRecoveryTimeout(d time.Duration) StreamOption {
+	return func(c *streamConfig) { c.cfg.RecoveryTimeout = d }
+}
+
+// WithRecoveryBackoff sets the delay between consecutive recovery attempts. A
+// non-positive value keeps the default (2 seconds).
+func WithRecoveryBackoff(d time.Duration) StreamOption {
+	return func(c *streamConfig) { c.cfg.RecoveryBackoff = d }
+}
+
+// WithLackOfAckTimeout bounds how long records may remain in flight without an
+// acknowledgement before recovery starts. A non-positive value keeps the
+// default (60 seconds).
+func WithLackOfAckTimeout(d time.Duration) StreamOption {
+	return func(c *streamConfig) { c.cfg.LackOfAckTimeout = d }
+}
+
 // WithFlushTimeout sets the upper bound on how long Flush and WaitForOffset wait
 // for acknowledgement. A caller context may shorten this budget but cannot
 // extend it. A non-positive value keeps the default (5 minutes).
@@ -135,4 +153,20 @@ func WithFlushTimeout(d time.Duration) StreamOption {
 // non-positive value keeps the default (just under the 10 MiB service limit).
 func WithMaxPayloadBytes(n int) StreamOption {
 	return func(c *streamConfig) { c.cfg.MaxPayloadBytes = n }
+}
+
+// WithMaxBatchRecords caps the number of records accepted by one
+// IngestRecordsOffset call. A non-positive value keeps the default (100,000).
+func WithMaxBatchRecords(n int) StreamOption {
+	return func(c *streamConfig) { c.cfg.MaxBatchRecords = n }
+}
+
+// WithStreamPausedMaxWait caps how long the client honors a server-requested
+// pause before reconnecting. If omitted, the full server-requested duration is
+// honored. Passing zero reconnects immediately; a positive duration waits for
+// the shorter of that duration and the server request.
+func WithStreamPausedMaxWait(d time.Duration) StreamOption {
+	return func(c *streamConfig) {
+		c.cfg.StreamPausedMaxWait = &d
+	}
 }

--- a/purego/zerobus/options.go
+++ b/purego/zerobus/options.go
@@ -1,0 +1,138 @@
+package zerobus
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/stream"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// Option configures a SDK created with New.
+type Option func(*sdkConfig)
+
+type sdkConfig struct {
+	applicationName string
+	tlsConfig       *tls.Config
+}
+
+// WithApplicationName appends a caller-supplied identifier such as "my-app/1.0"
+// to the gRPC user-agent header. Leading and trailing whitespace is trimmed and
+// blank names are ignored. The final value is "zerobus-sdk-go-purego/<version>
+// <name>".
+func WithApplicationName(name string) Option {
+	return func(c *sdkConfig) { c.applicationName = name }
+}
+
+// WithTLSConfig secures the connection with a custom TLS configuration,
+// replacing the default of system root CAs. It is intended for pinning a custom
+// CA or for tests; production callers rarely need it.
+func WithTLSConfig(tc *tls.Config) Option {
+	return func(c *sdkConfig) { c.tlsConfig = tc }
+}
+
+// RecoverySetting controls whether a stream reconnects after a recoverable
+// failure. Its zero value enables recovery.
+type RecoverySetting = stream.RecoverySetting
+
+const (
+	// RecoveryEnabled reconnects on recoverable failures. It is the zero value.
+	RecoveryEnabled = stream.RecoveryEnabled
+	// RecoveryDisabled fails the stream on the first error without reconnecting.
+	RecoveryDisabled = stream.RecoveryDisabled
+)
+
+// AckCallback receives asynchronous per-offset acknowledgement and error
+// notifications. Register one with WithAckCallback as an alternative to blocking
+// on Flush or WaitForOffset. Callbacks run on a dedicated worker, so
+// implementations must return promptly and must not call back into the stream.
+type AckCallback = stream.AckCallback
+
+// StreamOption configures a stream created with CreateStream or
+// CreateStreamWithProvider. Record type, recovery behavior, buffering limits,
+// and the ack callback are all set through these options; unset options take
+// their defaults.
+type StreamOption func(*streamConfig)
+
+type streamConfig struct {
+	recordType zerobuspb.RecordType
+	descriptor []byte
+	callback   AckCallback
+	cfg        stream.Config
+}
+
+func defaultStreamConfig() streamConfig {
+	return streamConfig{
+		// JSON is the default so a record type is always valid without a
+		// descriptor; WithProto switches to proto and supplies the descriptor.
+		recordType: zerobuspb.RecordType_JSON,
+		cfg:        stream.DefaultConfig(),
+	}
+}
+
+// WithJSON selects JSON record encoding. It is the default when no encoding
+// option is given.
+func WithJSON() StreamOption {
+	return func(c *streamConfig) {
+		c.recordType = zerobuspb.RecordType_JSON
+		c.descriptor = nil
+	}
+}
+
+// WithProto selects Protocol Buffer record encoding. descriptorProto is the
+// serialized message descriptor (a FileDescriptorProto / DescriptorProto) the
+// service uses to interpret the raw protobuf record bytes; it is required for
+// proto streams.
+func WithProto(descriptorProto []byte) StreamOption {
+	return func(c *streamConfig) {
+		c.recordType = zerobuspb.RecordType_PROTO
+		c.descriptor = descriptorProto
+	}
+}
+
+// WithAckCallback registers a callback for asynchronous ack/error notification.
+// It is an alternative to blocking on Flush or WaitForOffset; both may be used
+// together.
+func WithAckCallback(cb AckCallback) StreamOption {
+	return func(c *streamConfig) { c.callback = cb }
+}
+
+// WithRecovery sets whether the stream reconnects after a recoverable failure.
+// Recovery is enabled by default.
+func WithRecovery(r RecoverySetting) StreamOption {
+	return func(c *streamConfig) { c.cfg.Recovery = r }
+}
+
+// WithMaxInflight caps the number of unacknowledged ingest calls buffered before
+// IngestRecordOffset / IngestRecordsOffset block for backpressure. One call
+// occupies one slot regardless of how many records it carries. A non-positive
+// value keeps the default.
+func WithMaxInflight(n int) StreamOption {
+	return func(c *streamConfig) { c.cfg.MaxInflight = n }
+}
+
+// WithMaxBufferedPayloadBytes caps the estimated encoded memory retained by
+// queued and in-flight payloads. Whichever of this and WithMaxInflight binds
+// first applies backpressure. A non-positive value keeps the default.
+func WithMaxBufferedPayloadBytes(n int64) StreamOption {
+	return func(c *streamConfig) { c.cfg.MaxBufferedPayloadBytes = n }
+}
+
+// WithRecoveryRetries limits consecutive reconnect failures before the stream
+// gives up. A non-positive value keeps the default (4).
+func WithRecoveryRetries(n int) StreamOption {
+	return func(c *streamConfig) { c.cfg.RecoveryRetries = n }
+}
+
+// WithFlushTimeout sets the upper bound on how long Flush and WaitForOffset wait
+// for acknowledgement. A caller context may shorten this budget but cannot
+// extend it. A non-positive value keeps the default (5 minutes).
+func WithFlushTimeout(d time.Duration) StreamOption {
+	return func(c *streamConfig) { c.cfg.FlushTimeout = d }
+}
+
+// WithMaxPayloadBytes caps the encoded size of a single ingest request. A
+// non-positive value keeps the default (just under the 10 MiB service limit).
+func WithMaxPayloadBytes(n int) StreamOption {
+	return func(c *streamConfig) { c.cfg.MaxPayloadBytes = n }
+}

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -52,15 +52,18 @@ package zerobus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	"google.golang.org/grpc"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/auth"
 	"github.com/databricks/zerobus-sdk/purego/internal/stream"
 	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
 
 // version identifies this SDK in the gRPC user-agent header.
@@ -95,6 +98,30 @@ type SDK struct {
 	zerobusEndpoint string
 	ucEndpoint      string
 	conn            *transport.Conn
+	// tokenCache backs every OAuth provider this SDK creates so a token minted
+	// for a table is reused by later streams on the same table instead of
+	// re-minting per stream.
+	tokenCache *auth.SharedTokenCache
+
+	// mu guards the open-stream set and the closed flag.
+	mu     sync.Mutex
+	closed bool
+	// streams holds the streams this SDK created and has not yet torn down, so
+	// Close can terminate them. Entries are removed by Stream.Close.
+	streams map[*Stream]struct{}
+}
+
+// newSDK builds an SDK around an already-dialed connection. It is the single
+// construction point shared by New and the test-only NewWithConn so both get
+// the shared token cache and stream registry.
+func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string) *SDK {
+	return &SDK{
+		zerobusEndpoint: strings.TrimSpace(zerobusEndpoint),
+		ucEndpoint:      strings.TrimSpace(ucEndpoint),
+		conn:            conn,
+		tokenCache:      auth.NewSharedTokenCache(),
+		streams:         make(map[*Stream]struct{}),
+	}
 }
 
 // New connects to the Zerobus service and returns an SDK.
@@ -136,17 +163,47 @@ func New(zerobusEndpoint, ucEndpoint string, opts ...Option) (*SDK, error) {
 	if err != nil {
 		return nil, &Error{Op: "New", cause: err, retryable: false}
 	}
-	return &SDK{
-		zerobusEndpoint: strings.TrimSpace(zerobusEndpoint),
-		ucEndpoint:      strings.TrimSpace(ucEndpoint),
-		conn:            conn,
-	}, nil
+	return newSDK(conn, zerobusEndpoint, ucEndpoint), nil
 }
 
-// Close releases the SDK's connection. Streams created from it are terminated;
-// close individual streams first for orderly shutdown and durability results.
+// Close terminates every stream still open from this SDK, then releases the
+// shared connection. It is idempotent, and further CreateStream calls fail.
+//
+// Termination is abrupt: records queued but not yet acknowledged are abandoned
+// rather than flushed, and are reported through each stream's ack callback (or
+// retrievable with GetUnackedRecords). Close individual streams first for an
+// orderly shutdown with durability results.
 func (s *SDK) Close() error {
-	return wrapErr("Close", s.conn.Close())
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	open := make([]*Stream, 0, len(s.streams))
+	for st := range s.streams {
+		open = append(open, st)
+	}
+	s.streams = nil
+	s.mu.Unlock()
+
+	// Each teardown waits on its own supervisor goroutine, so terminate
+	// concurrently rather than summing every stream's teardown on the shutdown
+	// path.
+	errs := make([]error, len(open)+1)
+	var wg sync.WaitGroup
+	for i, st := range open {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = st.terminate()
+		}()
+	}
+	wg.Wait()
+	// Close the connection only after the streams are down, so a supervisor
+	// cannot reconnect onto a connection that is going away.
+	errs[len(open)] = s.conn.Close()
+	return wrapErr("Close", errors.Join(errs...))
 }
 
 // CreateStream opens an ingestion stream for tableName authenticated with the
@@ -167,6 +224,7 @@ func (s *SDK) CreateStream(
 ) (*Stream, error) {
 	provider, err := auth.NewOAuthHeadersProvider(
 		clientID, clientSecret, s.zerobusEndpoint, s.ucEndpoint,
+		auth.WithSharedTokenCache(s.tokenCache),
 	)
 	if err != nil {
 		return nil, &Error{Op: "CreateStream", cause: err, retryable: false}
@@ -206,6 +264,9 @@ func (s *SDK) createStream(
 			opt(&sc)
 		}
 	}
+	if err := validateStreamArgs(tableName, sc); err != nil {
+		return nil, &Error{Op: op, cause: err, retryable: false}
+	}
 
 	params := stream.StreamParams{
 		TableName:       tableName,
@@ -222,7 +283,40 @@ func (s *SDK) createStream(
 	if err != nil {
 		return nil, wrapErr(op, err)
 	}
-	return &Stream{core: core}, nil
+	st := &Stream{core: core, sdk: s}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		// Terminate rather than leak the supervisor goroutine NewProtoJSONStream
+		// already started.
+		_ = core.Terminate()
+		return nil, &Error{Op: op, cause: fmt.Errorf("SDK is closed"), retryable: false}
+	}
+	s.streams[st] = struct{}{}
+	s.mu.Unlock()
+	return st, nil
+}
+
+// validateStreamArgs rejects stream arguments that transport open would reject
+// asynchronously, so a caller mistake fails at CreateStream instead of surfacing
+// much later on the first Flush. It deliberately mirrors the transport's checks
+// rather than adding stricter rules of its own.
+func validateStreamArgs(tableName string, sc streamConfig) error {
+	if strings.TrimSpace(tableName) == "" {
+		return fmt.Errorf("table name is required")
+	}
+	if sc.recordType == zerobuspb.RecordType_PROTO && len(sc.descriptor) == 0 {
+		return fmt.Errorf("WithProto requires a non-empty descriptor proto")
+	}
+	return nil
+}
+
+// forget drops st from the open-stream set once it has torn itself down, so a
+// long-lived SDK does not retain closed streams.
+func (s *SDK) forget(st *Stream) {
+	s.mu.Lock()
+	delete(s.streams, st)
+	s.mu.Unlock()
 }
 
 // grpcTarget converts a user-facing endpoint (an https URL, a bare host, or a

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -1,0 +1,278 @@
+// Package zerobus is a native, pure-Go client for streaming ingestion into
+// Databricks Delta tables through the Zerobus service. It talks gRPC to the
+// service directly — no cgo, no FFI, no C toolchain — so it builds and
+// cross-compiles as an ordinary Go module.
+//
+// # Quick start
+//
+//	sdk, err := zerobus.New(
+//	    "https://your-workspace.zerobus.region.cloud.databricks.com",
+//	    "https://your-workspace.cloud.databricks.com",
+//	)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer sdk.Close()
+//
+//	stream, err := sdk.CreateStream(ctx, "catalog.schema.table",
+//	    clientID, clientSecret, zerobus.WithJSON())
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer stream.Close()
+//
+// # Ingesting data
+//
+// Ingestion is asynchronous and pipelined: IngestRecordOffset returns as soon as
+// the record is queued and the offset is assigned; sending and acknowledgement
+// happen in the background. Queue records in a loop and confirm durability with
+// a single Flush — never wait for an acknowledgement after every record, which
+// collapses throughput to one record per round-trip.
+//
+//	for _, rec := range records {
+//	    if _, err := stream.IngestRecordOffset(rec); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
+//	if err := stream.Flush(); err != nil { // wait once for all pending acks
+//	    log.Fatal(err)
+//	}
+//
+// For continuous streams call Flush periodically (every N records) or register
+// an ack callback with WithAckCallback. Reserve per-record WaitForOffset for
+// genuinely low-volume cases where each record must be confirmed before
+// continuing.
+//
+// # Authentication
+//
+// CreateStream uses the Unity Catalog OAuth 2.0 client-credentials flow. For
+// custom authentication, implement HeadersProvider and use
+// CreateStreamWithProvider.
+package zerobus
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/auth"
+	"github.com/databricks/zerobus-sdk/purego/internal/stream"
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+)
+
+// version identifies this SDK in the gRPC user-agent header.
+const version = "0.1.0"
+
+// userAgentPrefix is the leading user-agent token sent on every request. An
+// application name supplied via WithApplicationName is appended after a space.
+const userAgentPrefix = "zerobus-sdk-go-purego/" + version
+
+// HeadersProvider supplies the gRPC authentication metadata for a stream.
+// Implement it to plug in custom authentication with CreateStreamWithProvider;
+// the built-in OAuth path (CreateStream) provides one for you.
+//
+// GetHeaders returns the metadata headers for tableName; it may block on a token
+// mint, bounded by ctx. Invalidate is called on a server auth rejection so
+// cached credentials can be dropped before the next attempt — it must not block
+// on network I/O.
+type HeadersProvider = transport.HeadersProvider
+
+// NewStaticHeadersProvider returns a HeadersProvider that returns the same fixed
+// headers on every call. It is intended for tests or externally managed
+// credentials; pair it with CreateStreamWithProvider.
+func NewStaticHeadersProvider(headers map[string]string) HeadersProvider {
+	return auth.NewStaticHeadersProvider(headers)
+}
+
+// SDK is the entry point for creating ingestion streams. It owns the shared gRPC
+// connection to the Zerobus service and, for the OAuth path, a per-table token
+// cache reused across every stream it creates. A single SDK is safe for
+// concurrent use; callers must Close it when done.
+type SDK struct {
+	zerobusEndpoint string
+	ucEndpoint      string
+	conn            *transport.Conn
+}
+
+// New connects to the Zerobus service and returns an SDK.
+//
+// zerobusEndpoint is the Zerobus gRPC endpoint (e.g.
+// "https://ws.zerobus.region.cloud.databricks.com"). ucEndpoint is the Unity
+// Catalog workspace URL used to mint OAuth tokens (e.g.
+// "https://ws.cloud.databricks.com").
+//
+// The connection is secured with TLS using the host's root CAs unless
+// WithTLSConfig overrides it. Dialing is lazy: the TCP/TLS handshake happens
+// when the first stream opens, so New does not fail on an unreachable service.
+func New(zerobusEndpoint, ucEndpoint string, opts ...Option) (*SDK, error) {
+	var cfg sdkConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	target, err := grpcTarget(zerobusEndpoint)
+	if err != nil {
+		return nil, &Error{Op: "New", cause: err, retryable: false}
+	}
+
+	ua := userAgentPrefix
+	if name := strings.TrimSpace(cfg.applicationName); name != "" {
+		ua = ua + " " + name
+	}
+
+	dialOpts := []transport.DialOption{
+		transport.WithGRPCDialOptions(grpc.WithUserAgent(ua)),
+	}
+	if cfg.tlsConfig != nil {
+		dialOpts = append(dialOpts, transport.WithTLSConfig(cfg.tlsConfig))
+	}
+
+	conn, err := transport.Dial(target, dialOpts...)
+	if err != nil {
+		return nil, &Error{Op: "New", cause: err, retryable: false}
+	}
+	return &SDK{
+		zerobusEndpoint: strings.TrimSpace(zerobusEndpoint),
+		ucEndpoint:      strings.TrimSpace(ucEndpoint),
+		conn:            conn,
+	}, nil
+}
+
+// Close releases the SDK's connection. Streams created from it are terminated;
+// close individual streams first for orderly shutdown and durability results.
+func (s *SDK) Close() error {
+	return wrapErr("Close", s.conn.Close())
+}
+
+// CreateStream opens an ingestion stream for tableName authenticated with the
+// Unity Catalog OAuth 2.0 client-credentials flow using clientID and
+// clientSecret. The record encoding defaults to JSON; pass WithProto to ingest
+// Protocol Buffer records, along with any tuning options.
+//
+// The stream opens asynchronously: CreateStream validates its arguments and
+// returns a ready stream immediately, while the first connection (token mint
+// plus handshake) proceeds in the background and recovers on failure. A
+// connection error that cannot be recovered — bad credentials, an unknown
+// table — therefore surfaces on the first Flush, WaitForOffset, or ack
+// callback, not from CreateStream. The caller must Close the returned stream.
+func (s *SDK) CreateStream(
+	ctx context.Context,
+	tableName, clientID, clientSecret string,
+	opts ...StreamOption,
+) (*Stream, error) {
+	provider, err := auth.NewOAuthHeadersProvider(
+		clientID, clientSecret, s.zerobusEndpoint, s.ucEndpoint,
+	)
+	if err != nil {
+		return nil, &Error{Op: "CreateStream", cause: err, retryable: false}
+	}
+	return s.createStream(ctx, "CreateStream", tableName, provider, opts...)
+}
+
+// CreateStreamWithProvider opens an ingestion stream for tableName using a custom
+// HeadersProvider for authentication. Use it when the OAuth client-credentials
+// flow of CreateStream does not fit — for externally managed credentials, a
+// custom token source, or tests. Options behave as in CreateStream.
+func (s *SDK) CreateStreamWithProvider(
+	ctx context.Context,
+	tableName string,
+	provider HeadersProvider,
+	opts ...StreamOption,
+) (*Stream, error) {
+	if provider == nil {
+		return nil, &Error{
+			Op:        "CreateStreamWithProvider",
+			cause:     fmt.Errorf("headers provider is required"),
+			retryable: false,
+		}
+	}
+	return s.createStream(ctx, "CreateStreamWithProvider", tableName, provider, opts...)
+}
+
+func (s *SDK) createStream(
+	_ context.Context,
+	op, tableName string,
+	provider HeadersProvider,
+	opts ...StreamOption,
+) (*Stream, error) {
+	sc := defaultStreamConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&sc)
+		}
+	}
+
+	params := stream.StreamParams{
+		TableName:       tableName,
+		RecordType:      sc.recordType,
+		DescriptorProto: sc.descriptor,
+		HeadersProvider: provider,
+	}
+	// NewProtoJSONStream validates the record type / descriptor and starts the
+	// supervisor, which opens the first transport stream in the background. Only
+	// construction-time validation errors surface here; connection failures
+	// surface on the first Flush/WaitForOffset (see CreateStream). The context is
+	// accepted for a uniform, forward-compatible signature.
+	core, err := stream.NewProtoJSONStream(s.conn, params, sc.cfg, sc.callback)
+	if err != nil {
+		return nil, wrapErr(op, err)
+	}
+	return &Stream{core: core}, nil
+}
+
+// grpcTarget converts a user-facing endpoint (an https URL, a bare host, or a
+// gRPC resolver target) into a target grpc.NewClient accepts. An https/http URL
+// is reduced to host[:port], defaulting to :443. Explicit resolver targets
+// (containing "://", e.g. "dns:///", "passthrough:///") pass through unchanged
+// so tests and advanced callers can inject their own.
+func grpcTarget(endpoint string) (string, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("zerobusEndpoint is required")
+	}
+	lower := strings.ToLower(endpoint)
+	if !strings.HasPrefix(lower, "https://") && !strings.HasPrefix(lower, "http://") {
+		// A gRPC resolver target (scheme://... other than http/https) is passed
+		// through; a bare host gets the default TLS port.
+		if strings.Contains(endpoint, "://") {
+			return endpoint, nil
+		}
+		if _, port, err := splitHostPort(endpoint); err == nil && port != "" {
+			return endpoint, nil
+		}
+		return endpoint + ":443", nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("zerobusEndpoint is not a valid URL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("zerobusEndpoint has no host: %q", endpoint)
+	}
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	return host + ":" + port, nil
+}
+
+// splitHostPort reports the host and port of a "host:port" string, returning an
+// empty port when none is present. It tolerates a bare host without erroring so
+// grpcTarget can decide whether to append the default port.
+func splitHostPort(s string) (host, port string, err error) {
+	i := strings.LastIndexByte(s, ':')
+	if i < 0 {
+		return s, "", nil
+	}
+	// A ':' inside brackets is part of an IPv6 literal, not a port separator.
+	if strings.HasSuffix(s[:i], "]") || !strings.Contains(s, "]") {
+		return s[:i], s[i+1:], nil
+	}
+	return s, "", nil
+}

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -218,7 +218,7 @@ func (s *SDK) Close() error {
 // WithProto with the required descriptor, or WithJSON for JSON records.
 //
 // The stream opens asynchronously: CreateStream validates its arguments and
-// returns a ready stream immediately, while the first connection (token mint
+// returns a stream immediately, while the first connection (token mint
 // plus handshake) proceeds in the background and recovers on failure. A
 // connection error that cannot be recovered — bad credentials, an unknown
 // table — therefore surfaces on the first Flush, WaitForOffset, or ack

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -54,9 +54,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"google.golang.org/grpc"
 
@@ -147,8 +149,12 @@ func New(zerobusEndpoint, ucEndpoint string, opts ...Option) (*SDK, error) {
 		return nil, &Error{Op: "New", cause: err, retryable: false}
 	}
 
+	name := strings.TrimSpace(cfg.applicationName)
+	if err := validateApplicationName(name); err != nil {
+		return nil, &Error{Op: "New", cause: err, retryable: false}
+	}
 	ua := userAgentPrefix
-	if name := strings.TrimSpace(cfg.applicationName); name != "" {
+	if name != "" {
 		ua = ua + " " + name
 	}
 
@@ -208,8 +214,8 @@ func (s *SDK) Close() error {
 
 // CreateStream opens an ingestion stream for tableName authenticated with the
 // Unity Catalog OAuth 2.0 client-credentials flow using clientID and
-// clientSecret. The record encoding defaults to JSON; pass WithProto to ingest
-// Protocol Buffer records, along with any tuning options.
+// clientSecret. The record encoding defaults to Protocol Buffers; pass
+// WithProto with the required descriptor, or WithJSON for JSON records.
 //
 // The stream opens asynchronously: CreateStream validates its arguments and
 // returns a ready stream immediately, while the first connection (token mint
@@ -311,6 +317,22 @@ func validateStreamArgs(tableName string, sc streamConfig) error {
 	return nil
 }
 
+// validateApplicationName applies gRPC metadata's ASCII-value constraints
+// before constructing the lazy connection, so malformed user-agent data fails
+// at New rather than later during the first stream open.
+func validateApplicationName(name string) error {
+	if !utf8.ValidString(name) {
+		return fmt.Errorf("application name must be valid UTF-8")
+	}
+	for i := 0; i < len(name); i++ {
+		b := name[i]
+		if b != '\t' && (b < 0x20 || b == 0x7f || b > 0x7e) {
+			return fmt.Errorf("application name contains invalid user-agent characters")
+		}
+	}
+	return nil
+}
+
 // forget drops st from the open-stream set once it has torn itself down, so a
 // long-lived SDK does not retain closed streams.
 func (s *SDK) forget(st *Stream) {
@@ -319,9 +341,9 @@ func (s *SDK) forget(st *Stream) {
 	s.mu.Unlock()
 }
 
-// grpcTarget converts a user-facing endpoint (an https URL, a bare host, or a
-// gRPC resolver target) into a target grpc.NewClient accepts. An https/http URL
-// is reduced to host[:port], defaulting to :443. Explicit resolver targets
+// grpcTarget converts a user-facing endpoint (an HTTPS URL, a bare host, or a
+// gRPC resolver target) into a target grpc.NewClient accepts. An HTTPS URL is
+// reduced to host[:port], defaulting to :443. Explicit resolver targets
 // (containing "://", e.g. "dns:///", "passthrough:///") pass through unchanged
 // so tests and advanced callers can inject their own.
 func grpcTarget(endpoint string) (string, error) {
@@ -330,16 +352,22 @@ func grpcTarget(endpoint string) (string, error) {
 		return "", fmt.Errorf("zerobusEndpoint is required")
 	}
 	lower := strings.ToLower(endpoint)
-	if !strings.HasPrefix(lower, "https://") && !strings.HasPrefix(lower, "http://") {
-		// A gRPC resolver target (scheme://... other than http/https) is passed
+	if strings.HasPrefix(lower, "http://") {
+		return "", fmt.Errorf("zerobusEndpoint must use HTTPS")
+	}
+	if !strings.HasPrefix(lower, "https://") {
+		// A gRPC resolver target (scheme://... other than HTTPS) is passed
 		// through; a bare host gets the default TLS port.
 		if strings.Contains(endpoint, "://") {
 			return endpoint, nil
 		}
-		if _, port, err := splitHostPort(endpoint); err == nil && port != "" {
-			return endpoint, nil
+		if ip := net.ParseIP(strings.Trim(endpoint, "[]")); ip != nil {
+			return net.JoinHostPort(ip.String(), "443"), nil
 		}
-		return endpoint + ":443", nil
+		if host, port, err := net.SplitHostPort(endpoint); err == nil {
+			return net.JoinHostPort(host, port), nil
+		}
+		return net.JoinHostPort(endpoint, "443"), nil
 	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
@@ -353,20 +381,5 @@ func grpcTarget(endpoint string) (string, error) {
 	if port == "" {
 		port = "443"
 	}
-	return host + ":" + port, nil
-}
-
-// splitHostPort reports the host and port of a "host:port" string, returning an
-// empty port when none is present. It tolerates a bare host without erroring so
-// grpcTarget can decide whether to append the default port.
-func splitHostPort(s string) (host, port string, err error) {
-	i := strings.LastIndexByte(s, ':')
-	if i < 0 {
-		return s, "", nil
-	}
-	// A ':' inside brackets is part of an IPv6 literal, not a port separator.
-	if strings.HasSuffix(s[:i], "]") || !strings.Contains(s, "]") {
-		return s[:i], s[i+1:], nil
-	}
-	return s, "", nil
+	return net.JoinHostPort(host, port), nil
 }

--- a/purego/zerobus/stream.go
+++ b/purego/zerobus/stream.go
@@ -1,0 +1,134 @@
+package zerobus
+
+import (
+	"context"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/stream"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+)
+
+// Stream is an open ingestion stream. Records are queued with IngestRecordOffset
+// / IngestRecordsOffset and confirmed durable with Flush or WaitForOffset.
+//
+// A Stream is safe for concurrent use by multiple goroutines. Ingestion is
+// asynchronous: the ingest methods return once the record is queued and never
+// wait for a server round-trip. The caller must Close the stream when done.
+type Stream struct {
+	core *stream.CoreStream[*zerobuspb.EphemeralStreamRequest, *zerobuspb.EphemeralStreamResponse]
+}
+
+// IngestRecordOffset queues one record and returns the logical offset assigned
+// to it. It returns as soon as the record is buffered; sending and
+// acknowledgement happen in the background. If the buffer is full it blocks for
+// backpressure until space frees up or the stream fails.
+//
+// record is the raw record payload: serialized protobuf bytes for a proto
+// stream, or UTF-8 JSON bytes for a JSON stream.
+//
+// The returned offset is a handle to wait on later with WaitForOffset — not a
+// signal to wait now. For throughput, queue records in a loop and call Flush
+// once; waiting after every record collapses throughput to one record per
+// round-trip.
+func (s *Stream) IngestRecordOffset(record []byte) (int64, error) {
+	off, err := s.core.Ingest(context.Background(), record)
+	return off, wrapErr("IngestRecordOffset", err)
+}
+
+// IngestRecordsOffset queues records as one atomic batch and returns the single
+// logical offset covering the whole batch. The server acknowledges the batch
+// atomically. An empty batch is a no-op that returns -1 with no error.
+//
+// Prefer this over IngestRecordOffset in hot paths: one batch is one buffer
+// entry and one ack, amortizing per-call overhead. Each element is a raw record
+// payload (proto bytes or JSON bytes) as for IngestRecordOffset.
+func (s *Stream) IngestRecordsOffset(records [][]byte) (int64, error) {
+	off, err := s.core.IngestBatch(context.Background(), records)
+	return off, wrapErr("IngestRecordsOffset", err)
+}
+
+// Flush blocks until every record queued so far has been acknowledged by the
+// server, returning nil once all are durable. This is the idiomatic way to
+// confirm durability for high-throughput ingestion: queue records in a loop,
+// then call Flush once.
+//
+// It returns an error if the stream fails or the flush timeout
+// (WithFlushTimeout) expires. The wait is bounded by that timeout.
+func (s *Stream) Flush() error {
+	return wrapErr("Flush", s.core.Flush(context.Background()))
+}
+
+// FlushContext is Flush with a caller-supplied context that can cancel or
+// shorten the wait. The effective deadline is the earlier of ctx's deadline and
+// the configured flush timeout.
+func (s *Stream) FlushContext(ctx context.Context) error {
+	return wrapErr("Flush", s.core.Flush(ctx))
+}
+
+// WaitForOffset blocks until the server has acknowledged every record up to and
+// including offset, or the stream fails. Because acks are ordered and the
+// watermark is monotonic, waiting on the last offset of a group confirms all
+// prior offsets too.
+//
+// Use it to confirm a specific record before continuing; prefer Flush for bulk
+// durability. offset must be one returned by a successful ingest call. The wait
+// is bounded by the configured flush timeout.
+func (s *Stream) WaitForOffset(offset int64) error {
+	return wrapErr("WaitForOffset", s.core.WaitForOffset(context.Background(), offset))
+}
+
+// WaitForOffsetContext is WaitForOffset with a caller-supplied context that can
+// cancel or shorten the wait, bounded by the configured flush timeout.
+func (s *Stream) WaitForOffsetContext(ctx context.Context, offset int64) error {
+	return wrapErr("WaitForOffset", s.core.WaitForOffset(ctx, offset))
+}
+
+// GetUnackedRecords returns the records that were queued but never acknowledged,
+// one entry per record, so a caller can persist or replay them after a failure.
+//
+// It must be called only after the stream has closed or failed terminally;
+// calling it on an active stream returns an error. The result is a fresh copy on
+// every call and never aliases internal buffers, so a diagnostic read is
+// repeatable and non-destructive.
+func (s *Stream) GetUnackedRecords() ([][]byte, error) {
+	recs, err := s.core.GetUnacked()
+	return recs, wrapErr("GetUnackedRecords", err)
+}
+
+// GetUnackedBatches is the batch-preserving form of GetUnackedRecords: it groups
+// unacknowledged records as they were submitted, one entry per ingest call, in
+// offset order. Prefer it when replaying, since each group can be resubmitted as
+// one batch to reproduce the original durability boundaries.
+func (s *Stream) GetUnackedBatches() ([][][]byte, error) {
+	batches, err := s.core.GetUnackedBatches()
+	return batches, wrapErr("GetUnackedBatches", err)
+}
+
+// Close flushes every record queued before the close boundary, then tears the
+// stream down and releases its resources. It is idempotent, blocks until
+// teardown completes, and returns the same durability result to every caller.
+//
+// If the flush cannot complete within the flush timeout, Close proceeds with
+// teardown and any remaining records are abandoned — retrievable via
+// GetUnackedRecords or reported through the ack callback's OnError.
+func (s *Stream) Close() error {
+	return wrapErr("Close", s.core.Close())
+}
+
+// IsClosed reports whether the stream has been closed or has failed terminally.
+func (s *Stream) IsClosed() bool {
+	return s.core.IsClosed()
+}
+
+// ID returns the stable client-generated stream identifier, minted once when the
+// stream is created and unchanged across recovery reconnects. Use it to correlate
+// log lines for a logical stream. See ServerID for the per-connection identifier.
+func (s *Stream) ID() string {
+	return s.core.ID()
+}
+
+// ServerID returns the identifier the server assigned to the most recently
+// opened connection. Unlike ID it changes on every reconnect, and it is empty
+// until the first connection is established.
+func (s *Stream) ServerID() string {
+	return s.core.ServerID()
+}

--- a/purego/zerobus/stream.go
+++ b/purego/zerobus/stream.go
@@ -23,7 +23,8 @@ type Stream struct {
 // IngestRecordOffset queues one record and returns the logical offset assigned
 // to it. It returns as soon as the record is buffered; sending and
 // acknowledgement happen in the background. If the buffer is full it blocks for
-// backpressure until space frees up or the stream fails.
+// backpressure until space frees up or the stream fails. On error it returns
+// offset -1, matching the original Go SDK.
 //
 // record is the raw record payload: serialized protobuf bytes for a proto
 // stream, or UTF-8 JSON bytes for a JSON stream.
@@ -46,7 +47,8 @@ func (s *Stream) IngestRecordOffsetContext(ctx context.Context, record []byte) (
 
 // IngestRecordsOffset queues records as one atomic batch and returns the single
 // logical offset covering the whole batch. The server acknowledges the batch
-// atomically. An empty batch is a no-op that returns -1 with no error.
+// atomically. An empty batch is a no-op that returns -1 with no error. On error
+// it returns offset -1, matching the original Go SDK.
 //
 // Prefer this over IngestRecordOffset in hot paths: one batch is one buffer
 // entry and one ack, amortizing per-call overhead. Each element is a raw record

--- a/purego/zerobus/stream.go
+++ b/purego/zerobus/stream.go
@@ -33,7 +33,14 @@ type Stream struct {
 // once; waiting after every record collapses throughput to one record per
 // round-trip.
 func (s *Stream) IngestRecordOffset(record []byte) (int64, error) {
-	off, err := s.core.Ingest(context.Background(), record)
+	return s.IngestRecordOffsetContext(context.Background(), record)
+}
+
+// IngestRecordOffsetContext is IngestRecordOffset with a caller-supplied
+// context. Cancellation only interrupts waiting for buffer capacity; once the
+// record is queued, its lifecycle is owned by the stream.
+func (s *Stream) IngestRecordOffsetContext(ctx context.Context, record []byte) (int64, error) {
+	off, err := s.core.Ingest(ctx, record)
 	return off, wrapErr("IngestRecordOffset", err)
 }
 
@@ -45,7 +52,14 @@ func (s *Stream) IngestRecordOffset(record []byte) (int64, error) {
 // entry and one ack, amortizing per-call overhead. Each element is a raw record
 // payload (proto bytes or JSON bytes) as for IngestRecordOffset.
 func (s *Stream) IngestRecordsOffset(records [][]byte) (int64, error) {
-	off, err := s.core.IngestBatch(context.Background(), records)
+	return s.IngestRecordsOffsetContext(context.Background(), records)
+}
+
+// IngestRecordsOffsetContext is IngestRecordsOffset with a caller-supplied
+// context. Cancellation only interrupts waiting for buffer capacity; once the
+// batch is queued, its lifecycle is owned by the stream.
+func (s *Stream) IngestRecordsOffsetContext(ctx context.Context, records [][]byte) (int64, error) {
+	off, err := s.core.IngestBatch(ctx, records)
 	return off, wrapErr("IngestRecordsOffset", err)
 }
 

--- a/purego/zerobus/stream.go
+++ b/purego/zerobus/stream.go
@@ -15,6 +15,9 @@ import (
 // wait for a server round-trip. The caller must Close the stream when done.
 type Stream struct {
 	core *stream.CoreStream[*zerobuspb.EphemeralStreamRequest, *zerobuspb.EphemeralStreamResponse]
+	// sdk is the SDK that created this stream. Close deregisters from it so a
+	// long-lived SDK does not retain streams the caller has already closed.
+	sdk *SDK
 }
 
 // IngestRecordOffset queues one record and returns the logical offset assigned
@@ -111,7 +114,19 @@ func (s *Stream) GetUnackedBatches() ([][][]byte, error) {
 // teardown and any remaining records are abandoned — retrievable via
 // GetUnackedRecords or reported through the ack callback's OnError.
 func (s *Stream) Close() error {
-	return wrapErr("Close", s.core.Close())
+	err := s.core.Close()
+	if s.sdk != nil {
+		s.sdk.forget(s)
+	}
+	return wrapErr("Close", err)
+}
+
+// terminate tears the stream down without the final flush Close performs. It is
+// the SDK.Close path: the shared connection is going away, so waiting for
+// acknowledgements would only stall shutdown. Close and terminate share one
+// once-guard, so whichever runs first decides the result both report.
+func (s *Stream) terminate() error {
+	return wrapErr("Close", s.core.Terminate())
 }
 
 // IsClosed reports whether the stream has been closed or has failed terminally.

--- a/purego/zerobus/zerobus_test.go
+++ b/purego/zerobus/zerobus_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -278,5 +281,177 @@ func TestStreamBatchIngest(t *testing.T) {
 	}
 	if err := stream.Flush(); err != nil {
 		t.Fatalf("Flush: %v", err)
+	}
+}
+
+// ucTokenServer is a stand-in for the Unity Catalog OIDC token endpoint that
+// counts how many client-credentials mints it served.
+type ucTokenServer struct {
+	mints atomic.Int64
+}
+
+func (s *ucTokenServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/oidc/v1/token" {
+		http.NotFound(w, r)
+		return
+	}
+	s.mints.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"access_token":"minted-token","expires_in":3600}`)
+}
+
+func TestCreateStreamSharesTokenCacheAcrossStreams(t *testing.T) {
+	uc := &ucTokenServer{}
+	ucSrv := httptest.NewServer(uc)
+	defer ucSrv.Close()
+
+	conn := dialEcho(t, &echoServer{streamID: "stream-oauth"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", ucSrv.URL)
+	defer sdk.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Two streams on the same table with the same credentials must reuse one
+	// minted token rather than each provider caching its own.
+	for i := 0; i < 2; i++ {
+		st, err := sdk.CreateStream(ctx, "main.sales.orders", "client-id", "client-secret")
+		if err != nil {
+			t.Fatalf("CreateStream[%d]: %v", i, err)
+		}
+		if _, err := st.IngestRecordOffset([]byte(`{"id":1}`)); err != nil {
+			t.Fatalf("IngestRecordOffset[%d]: %v", i, err)
+		}
+		// Flushing forces the background open — and therefore the token mint —
+		// to have completed before the next stream is created.
+		if err := st.Flush(); err != nil {
+			t.Fatalf("Flush[%d]: %v", i, err)
+		}
+		if err := st.Close(); err != nil {
+			t.Fatalf("Close[%d]: %v", i, err)
+		}
+	}
+	if got := uc.mints.Load(); got != 1 {
+		t.Errorf("token mints = %d, want 1 (cache shared across streams)", got)
+	}
+}
+
+func TestCreateStreamRejectsInvalidArguments(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-invalid"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+	defer sdk.Close()
+	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
+
+	tests := []struct {
+		name  string
+		table string
+		opts  []zerobus.StreamOption
+	}{
+		{name: "empty table name", table: ""},
+		{name: "blank table name", table: "   "},
+		{
+			name:  "proto without descriptor",
+			table: "main.sales.orders",
+			opts:  []zerobus.StreamOption{zerobus.WithProto(nil)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, err := sdk.CreateStreamWithProvider(context.Background(), tc.table, provider, tc.opts...)
+			if err == nil {
+				_ = st.Close()
+				t.Fatal("CreateStreamWithProvider succeeded, want a validation error")
+			}
+			if zerobus.Retryable(err) {
+				t.Errorf("error %v is retryable, want permanent", err)
+			}
+		})
+	}
+	if n := sdk.OpenStreamCount(); n != 0 {
+		t.Errorf("SDK tracks %d streams, want 0 after rejected creates", n)
+	}
+}
+
+func TestFlushReportsTerminalFailureWithNoRecords(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-terminal"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+	defer sdk.Close()
+
+	// An empty static provider fails every open, and disabling recovery makes the
+	// stream terminal after the first attempt instead of retrying.
+	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders",
+		zerobus.NewStaticHeadersProvider(nil), zerobus.WithRecovery(zerobus.RecoveryDisabled))
+	if err != nil {
+		t.Fatalf("CreateStreamWithProvider: %v", err)
+	}
+	defer st.Close()
+
+	waitFor(t, st.IsClosed, "stream to fail terminally")
+
+	// Nothing was ingested, so there is no watermark to wait for — but Flush is
+	// where a failed background open is documented to surface, so it must not
+	// report success.
+	if err := st.Flush(); err == nil {
+		t.Error("Flush on a terminally failed stream = nil, want the open failure")
+	}
+}
+
+func TestSDKCloseTerminatesOpenStreams(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-sdk-close"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
+
+	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider)
+	if err != nil {
+		t.Fatalf("CreateStreamWithProvider: %v", err)
+	}
+	if _, err := st.IngestRecordOffset([]byte(`{"id":1}`)); err != nil {
+		t.Fatalf("IngestRecordOffset: %v", err)
+	}
+
+	if err := sdk.Close(); err != nil {
+		t.Fatalf("SDK.Close: %v", err)
+	}
+	if !st.IsClosed() {
+		t.Error("stream still open after SDK.Close")
+	}
+	if err := sdk.Close(); err != nil {
+		t.Errorf("second SDK.Close: %v, want nil (idempotent)", err)
+	}
+	if _, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider); err == nil {
+		t.Error("CreateStreamWithProvider succeeded on a closed SDK")
+	}
+}
+
+func TestStreamCloseDeregistersFromSDK(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-deregister"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+	defer sdk.Close()
+	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
+
+	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider)
+	if err != nil {
+		t.Fatalf("CreateStreamWithProvider: %v", err)
+	}
+	if n := sdk.OpenStreamCount(); n != 1 {
+		t.Fatalf("SDK tracks %d streams, want 1 after CreateStream", n)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if n := sdk.OpenStreamCount(); n != 0 {
+		t.Errorf("SDK tracks %d streams, want 0 after Stream.Close", n)
+	}
+}
+
+// waitFor polls cond until it holds, failing the test if it never does.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/purego/zerobus/zerobus_test.go
+++ b/purego/zerobus/zerobus_test.go
@@ -1,0 +1,282 @@
+package zerobus_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
+	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+	"github.com/databricks/zerobus-sdk/purego/zerobus"
+)
+
+func TestGRPCTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+		wantErr  bool
+	}{
+		{name: "https URL", endpoint: "https://ws.zerobus.databricks.com", want: "ws.zerobus.databricks.com:443"},
+		{name: "https URL with port", endpoint: "https://ws.zerobus.databricks.com:8443", want: "ws.zerobus.databricks.com:8443"},
+		{name: "http URL", endpoint: "http://localhost:8080", want: "localhost:8080"},
+		{name: "bare host", endpoint: "ws.zerobus.databricks.com", want: "ws.zerobus.databricks.com:443"},
+		{name: "host:port", endpoint: "ws.zerobus.databricks.com:9000", want: "ws.zerobus.databricks.com:9000"},
+		{name: "resolver target passthrough", endpoint: "passthrough:///bufnet", want: "passthrough:///bufnet"},
+		{name: "dns target", endpoint: "dns:///ws.zerobus.databricks.com:443", want: "dns:///ws.zerobus.databricks.com:443"},
+		{name: "trims whitespace", endpoint: "  https://ws.databricks.com  ", want: "ws.databricks.com:443"},
+		{name: "empty", endpoint: "", wantErr: true},
+		{name: "empty host", endpoint: "https://", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := zerobus.GRPCTarget(tc.endpoint)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("GRPCTarget(%q) = %q, want error", tc.endpoint, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GRPCTarget(%q): %v", tc.endpoint, err)
+			}
+			if got != tc.want {
+				t.Errorf("GRPCTarget(%q) = %q, want %q", tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveStreamConfigDefaults(t *testing.T) {
+	rt, desc, maxInflight, recovery := zerobus.ResolveStreamConfig()
+	if rt != int32(zerobuspb.RecordType_JSON) {
+		t.Errorf("default record type = %d, want JSON(%d)", rt, zerobuspb.RecordType_JSON)
+	}
+	if desc != nil {
+		t.Errorf("default descriptor = %v, want nil", desc)
+	}
+	if maxInflight != stream_DefaultMaxInflight {
+		t.Errorf("default MaxInflight = %d, want %d", maxInflight, stream_DefaultMaxInflight)
+	}
+	if recovery != zerobus.RecoveryEnabled {
+		t.Errorf("default recovery = %v, want RecoveryEnabled", recovery)
+	}
+}
+
+// stream_DefaultMaxInflight mirrors internal/stream.DefaultMaxInflight so the
+// test asserts the wired-through default without importing the internal const.
+const stream_DefaultMaxInflight = 1_000_000
+
+func TestResolveStreamConfigOptions(t *testing.T) {
+	desc := []byte("descriptor-bytes")
+	rt, gotDesc, maxInflight, recovery := zerobus.ResolveStreamConfig(
+		zerobus.WithProto(desc),
+		zerobus.WithMaxInflight(42),
+		zerobus.WithRecovery(zerobus.RecoveryDisabled),
+	)
+	if rt != int32(zerobuspb.RecordType_PROTO) {
+		t.Errorf("record type = %d, want PROTO(%d)", rt, zerobuspb.RecordType_PROTO)
+	}
+	if string(gotDesc) != string(desc) {
+		t.Errorf("descriptor = %q, want %q", gotDesc, desc)
+	}
+	if maxInflight != 42 {
+		t.Errorf("MaxInflight = %d, want 42", maxInflight)
+	}
+	if recovery != zerobus.RecoveryDisabled {
+		t.Errorf("recovery = %v, want RecoveryDisabled", recovery)
+	}
+}
+
+func TestWithJSONClearsDescriptor(t *testing.T) {
+	// WithProto then WithJSON must drop the descriptor: a JSON stream carries none.
+	rt, desc, _, _ := zerobus.ResolveStreamConfig(zerobus.WithProto([]byte("d")), zerobus.WithJSON())
+	if rt != int32(zerobuspb.RecordType_JSON) {
+		t.Errorf("record type = %d, want JSON", rt)
+	}
+	if desc != nil {
+		t.Errorf("descriptor = %q, want nil after WithJSON", desc)
+	}
+}
+
+func TestErrorRetryable(t *testing.T) {
+	// A non-retryable underlying error stays non-retryable through the helper.
+	if zerobus.Retryable(context.Canceled) {
+		t.Error("context.Canceled classified retryable")
+	}
+	if zerobus.Retryable(nil) {
+		t.Error("nil classified retryable")
+	}
+}
+
+// --- integration test against an in-memory server ---
+
+// echoServer completes the create-stream handshake with a fixed ID, then echoes
+// each ingested record's offset back as a durability ack.
+type echoServer struct {
+	zerobuspb.UnimplementedZerobusServer
+	streamID string
+}
+
+func (s *echoServer) EphemeralStream(stream zerobuspb.Zerobus_EphemeralStreamServer) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if req.GetCreateStream() == nil {
+		return io.ErrUnexpectedEOF
+	}
+	if err := stream.Send(&zerobuspb.EphemeralStreamResponse{
+		Payload: &zerobuspb.EphemeralStreamResponse_CreateStreamResponse{
+			CreateStreamResponse: &zerobuspb.CreateIngestStreamResponse{
+				StreamId: proto.String(s.streamID),
+			},
+		},
+	}); err != nil {
+		return err
+	}
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// Ack single records and batches alike by echoing the wire offset the
+		// sender stamped on the request.
+		var offset *int64
+		if ingest := req.GetIngestRecord(); ingest != nil {
+			offset = ingest.OffsetId
+		} else if batch := req.GetIngestRecordBatch(); batch != nil {
+			offset = batch.OffsetId
+		} else {
+			continue
+		}
+		if err := stream.Send(&zerobuspb.EphemeralStreamResponse{
+			Payload: &zerobuspb.EphemeralStreamResponse_IngestRecordResponse{
+				IngestRecordResponse: &zerobuspb.IngestRecordResponse{
+					DurabilityAckUpToOffset: offset,
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+func dialEcho(t *testing.T, srv *echoServer) *transport.Conn {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	gsrv := grpc.NewServer()
+	zerobuspb.RegisterZerobusServer(gsrv, srv)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := gsrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("fake server stopped: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		gsrv.Stop()
+		<-done
+	})
+	dialer := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	})
+	// bufconn carries no TLS; auth rides plaintext metadata, which is fine for an
+	// in-memory test server. Insecure creds are injected via the pass-through gRPC
+	// dial options rather than the transport's test-only WithInsecure hook.
+	conn, err := transport.Dial("passthrough:///bufnet",
+		transport.WithGRPCDialOptions(dialer, grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func TestStreamIngestFlushClose(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-xyz"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+
+	provider := zerobus.NewStaticHeadersProvider(map[string]string{
+		"authorization": "Bearer test-token",
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stream, err := sdk.CreateStreamWithProvider(ctx, "main.sales.orders", provider, zerobus.WithJSON())
+	if err != nil {
+		t.Fatalf("CreateStreamWithProvider: %v", err)
+	}
+	defer stream.Close()
+
+	if stream.ID() == "" {
+		t.Error("stream ID is empty")
+	}
+
+	var last int64
+	for i := 0; i < 100; i++ {
+		off, err := stream.IngestRecordOffset([]byte(`{"id":1}`))
+		if err != nil {
+			t.Fatalf("IngestRecordOffset[%d]: %v", i, err)
+		}
+		last = off
+	}
+	if last != 99 {
+		t.Errorf("last offset = %d, want 99", last)
+	}
+
+	if err := stream.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := stream.WaitForOffset(last); err != nil {
+		t.Fatalf("WaitForOffset(%d): %v", last, err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !stream.IsClosed() {
+		t.Error("IsClosed = false after Close")
+	}
+}
+
+func TestStreamBatchIngest(t *testing.T) {
+	conn := dialEcho(t, &echoServer{streamID: "stream-batch"})
+	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := sdk.CreateStreamWithProvider(ctx, "main.sales.orders", provider)
+	if err != nil {
+		t.Fatalf("CreateStreamWithProvider: %v", err)
+	}
+	defer stream.Close()
+
+	// Empty batch is a no-op returning -1.
+	if off, err := stream.IngestRecordsOffset(nil); err != nil || off != -1 {
+		t.Fatalf("empty IngestRecordsOffset = (%d, %v), want (-1, nil)", off, err)
+	}
+
+	off, err := stream.IngestRecordsOffset([][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	if err != nil {
+		t.Fatalf("IngestRecordsOffset: %v", err)
+	}
+	if off != 0 {
+		t.Errorf("batch offset = %d, want 0", off)
+	}
+	if err := stream.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}

--- a/purego/zerobus/zerobus_test.go
+++ b/purego/zerobus/zerobus_test.go
@@ -30,9 +30,13 @@ func TestGRPCTarget(t *testing.T) {
 	}{
 		{name: "https URL", endpoint: "https://ws.zerobus.databricks.com", want: "ws.zerobus.databricks.com:443"},
 		{name: "https URL with port", endpoint: "https://ws.zerobus.databricks.com:8443", want: "ws.zerobus.databricks.com:8443"},
-		{name: "http URL", endpoint: "http://localhost:8080", want: "localhost:8080"},
+		{name: "http URL rejected", endpoint: "http://localhost:8080", wantErr: true},
 		{name: "bare host", endpoint: "ws.zerobus.databricks.com", want: "ws.zerobus.databricks.com:443"},
 		{name: "host:port", endpoint: "ws.zerobus.databricks.com:9000", want: "ws.zerobus.databricks.com:9000"},
+		{name: "IPv6 URL", endpoint: "https://[::1]", want: "[::1]:443"},
+		{name: "IPv6 URL with port", endpoint: "https://[::1]:8443", want: "[::1]:8443"},
+		{name: "bare IPv6", endpoint: "::1", want: "[::1]:443"},
+		{name: "bracketed IPv6 with port", endpoint: "[::1]:8443", want: "[::1]:8443"},
 		{name: "resolver target passthrough", endpoint: "passthrough:///bufnet", want: "passthrough:///bufnet"},
 		{name: "dns target", endpoint: "dns:///ws.zerobus.databricks.com:443", want: "dns:///ws.zerobus.databricks.com:443"},
 		{name: "trims whitespace", endpoint: "  https://ws.databricks.com  ", want: "ws.databricks.com:443"},
@@ -60,8 +64,8 @@ func TestGRPCTarget(t *testing.T) {
 
 func TestResolveStreamConfigDefaults(t *testing.T) {
 	rt, desc, maxInflight, recovery := zerobus.ResolveStreamConfig()
-	if rt != int32(zerobuspb.RecordType_JSON) {
-		t.Errorf("default record type = %d, want JSON(%d)", rt, zerobuspb.RecordType_JSON)
+	if rt != int32(zerobuspb.RecordType_PROTO) {
+		t.Errorf("default record type = %d, want PROTO(%d)", rt, zerobuspb.RecordType_PROTO)
 	}
 	if desc != nil {
 		t.Errorf("default descriptor = %v, want nil", desc)
@@ -110,6 +114,67 @@ func TestWithJSONClearsDescriptor(t *testing.T) {
 	}
 }
 
+func TestResolveStreamTuningOptions(t *testing.T) {
+	pauseWait := 3 * time.Second
+	recoveryTimeout, recoveryBackoff, lackOfAckTimeout, maxBatchRecords, gotPauseWait :=
+		zerobus.ResolveStreamTuning(
+			zerobus.WithRecoveryTimeout(11*time.Second),
+			zerobus.WithRecoveryBackoff(12*time.Second),
+			zerobus.WithLackOfAckTimeout(13*time.Second),
+			zerobus.WithMaxBatchRecords(14),
+			zerobus.WithStreamPausedMaxWait(pauseWait),
+		)
+	if recoveryTimeout != 11*time.Second {
+		t.Errorf("RecoveryTimeout = %v, want 11s", recoveryTimeout)
+	}
+	if recoveryBackoff != 12*time.Second {
+		t.Errorf("RecoveryBackoff = %v, want 12s", recoveryBackoff)
+	}
+	if lackOfAckTimeout != 13*time.Second {
+		t.Errorf("LackOfAckTimeout = %v, want 13s", lackOfAckTimeout)
+	}
+	if maxBatchRecords != 14 {
+		t.Errorf("MaxBatchRecords = %d, want 14", maxBatchRecords)
+	}
+	if gotPauseWait == nil || *gotPauseWait != pauseWait {
+		t.Errorf("StreamPausedMaxWait = %v, want %v", gotPauseWait, pauseWait)
+	}
+
+	_, _, _, _, zeroPauseWait := zerobus.ResolveStreamTuning(zerobus.WithStreamPausedMaxWait(0))
+	if zeroPauseWait == nil || *zeroPauseWait != 0 {
+		t.Errorf("explicit zero StreamPausedMaxWait = %v, want pointer to zero", zeroPauseWait)
+	}
+}
+
+func TestNewRejectsInvalidApplicationName(t *testing.T) {
+	tests := []struct {
+		name string
+		app  string
+	}{
+		{name: "invalid UTF-8", app: string([]byte{0xff})},
+		{name: "NUL", app: "my-app\x00suffix"},
+		{name: "newline", app: "my-app\nsuffix"},
+		{name: "DEL", app: "my-app\x7f"},
+		{name: "non-ASCII", app: "my-app-é"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sdk, err := zerobus.New(
+				"https://ws.zerobus.databricks.com",
+				"https://ws.databricks.com",
+				zerobus.WithApplicationName(tc.app),
+			)
+			if err == nil {
+				_ = sdk.Close()
+				t.Fatal("New succeeded, want invalid application-name error")
+			}
+			if zerobus.Retryable(err) {
+				t.Errorf("error %v is retryable, want permanent", err)
+			}
+		})
+	}
+}
+
 func TestErrorRetryable(t *testing.T) {
 	// A non-retryable underlying error stays non-retryable through the helper.
 	if zerobus.Retryable(context.Canceled) {
@@ -127,6 +192,7 @@ func TestErrorRetryable(t *testing.T) {
 type echoServer struct {
 	zerobuspb.UnimplementedZerobusServer
 	streamID string
+	noAcks   bool
 }
 
 func (s *echoServer) EphemeralStream(stream zerobuspb.Zerobus_EphemeralStreamServer) error {
@@ -153,6 +219,9 @@ func (s *echoServer) EphemeralStream(stream zerobuspb.Zerobus_EphemeralStreamSer
 		}
 		if err != nil {
 			return err
+		}
+		if s.noAcks {
+			continue
 		}
 		// Ack single records and batches alike by echoing the wire offset the
 		// sender stamped on the request.
@@ -261,7 +330,7 @@ func TestStreamBatchIngest(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	stream, err := sdk.CreateStreamWithProvider(ctx, "main.sales.orders", provider)
+	stream, err := sdk.CreateStreamWithProvider(ctx, "main.sales.orders", provider, zerobus.WithJSON())
 	if err != nil {
 		t.Fatalf("CreateStreamWithProvider: %v", err)
 	}
@@ -315,7 +384,7 @@ func TestCreateStreamSharesTokenCacheAcrossStreams(t *testing.T) {
 	// Two streams on the same table with the same credentials must reuse one
 	// minted token rather than each provider caching its own.
 	for i := 0; i < 2; i++ {
-		st, err := sdk.CreateStream(ctx, "main.sales.orders", "client-id", "client-secret")
+		st, err := sdk.CreateStream(ctx, "main.sales.orders", "client-id", "client-secret", zerobus.WithJSON())
 		if err != nil {
 			t.Fatalf("CreateStream[%d]: %v", i, err)
 		}
@@ -349,6 +418,7 @@ func TestCreateStreamRejectsInvalidArguments(t *testing.T) {
 	}{
 		{name: "empty table name", table: ""},
 		{name: "blank table name", table: "   "},
+		{name: "default proto without descriptor", table: "main.sales.orders"},
 		{
 			name:  "proto without descriptor",
 			table: "main.sales.orders",
@@ -380,7 +450,8 @@ func TestFlushReportsTerminalFailureWithNoRecords(t *testing.T) {
 	// An empty static provider fails every open, and disabling recovery makes the
 	// stream terminal after the first attempt instead of retrying.
 	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders",
-		zerobus.NewStaticHeadersProvider(nil), zerobus.WithRecovery(zerobus.RecoveryDisabled))
+		zerobus.NewStaticHeadersProvider(nil), zerobus.WithJSON(),
+		zerobus.WithRecovery(zerobus.RecoveryDisabled))
 	if err != nil {
 		t.Fatalf("CreateStreamWithProvider: %v", err)
 	}
@@ -401,7 +472,8 @@ func TestSDKCloseTerminatesOpenStreams(t *testing.T) {
 	sdk := zerobus.NewWithConn(conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
 	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
 
-	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider)
+	st, err := sdk.CreateStreamWithProvider(
+		context.Background(), "main.sales.orders", provider, zerobus.WithJSON())
 	if err != nil {
 		t.Fatalf("CreateStreamWithProvider: %v", err)
 	}
@@ -418,7 +490,8 @@ func TestSDKCloseTerminatesOpenStreams(t *testing.T) {
 	if err := sdk.Close(); err != nil {
 		t.Errorf("second SDK.Close: %v, want nil (idempotent)", err)
 	}
-	if _, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider); err == nil {
+	if _, err := sdk.CreateStreamWithProvider(
+		context.Background(), "main.sales.orders", provider, zerobus.WithJSON()); err == nil {
 		t.Error("CreateStreamWithProvider succeeded on a closed SDK")
 	}
 }
@@ -429,7 +502,8 @@ func TestStreamCloseDeregistersFromSDK(t *testing.T) {
 	defer sdk.Close()
 	provider := zerobus.NewStaticHeadersProvider(map[string]string{"authorization": "Bearer t"})
 
-	st, err := sdk.CreateStreamWithProvider(context.Background(), "main.sales.orders", provider)
+	st, err := sdk.CreateStreamWithProvider(
+		context.Background(), "main.sales.orders", provider, zerobus.WithJSON())
 	if err != nil {
 		t.Fatalf("CreateStreamWithProvider: %v", err)
 	}
@@ -441,6 +515,56 @@ func TestStreamCloseDeregistersFromSDK(t *testing.T) {
 	}
 	if n := sdk.OpenStreamCount(); n != 0 {
 		t.Errorf("SDK tracks %d streams, want 0 after Stream.Close", n)
+	}
+}
+
+func TestIngestContextCancelsBackpressure(t *testing.T) {
+	tests := []struct {
+		name   string
+		ingest func(*zerobus.Stream, context.Context) error
+	}{
+		{
+			name: "record",
+			ingest: func(st *zerobus.Stream, ctx context.Context) error {
+				_, err := st.IngestRecordOffsetContext(ctx, []byte(`{"id":2}`))
+				return err
+			},
+		},
+		{
+			name: "batch",
+			ingest: func(st *zerobus.Stream, ctx context.Context) error {
+				_, err := st.IngestRecordsOffsetContext(ctx, [][]byte{[]byte(`{"id":2}`)})
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := dialEcho(t, &echoServer{streamID: "stream-backpressure", noAcks: true})
+			sdk := zerobus.NewWithConn(
+				conn, "https://ws.zerobus.databricks.com", "https://ws.databricks.com")
+			t.Cleanup(func() { _ = sdk.Close() })
+			provider := zerobus.NewStaticHeadersProvider(
+				map[string]string{"authorization": "Bearer t"})
+
+			st, err := sdk.CreateStreamWithProvider(
+				context.Background(), "main.sales.orders", provider,
+				zerobus.WithJSON(), zerobus.WithMaxInflight(1),
+			)
+			if err != nil {
+				t.Fatalf("CreateStreamWithProvider: %v", err)
+			}
+			if _, err := st.IngestRecordOffset([]byte(`{"id":1}`)); err != nil {
+				t.Fatalf("first IngestRecordOffset: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+			defer cancel()
+			err = tc.ingest(st, ctx)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("context ingest error = %v, want DeadlineExceeded", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the public `purego/zerobus` package tracked in #467 on top of the merged stream, transport, and authentication layers.

- add the public `SDK` API: `New`, `CreateStream`, `CreateStreamWithProvider`, and `Close`
- add the public `Stream` API for single and batch ingestion, context-aware admission, flushing, offset waiting, unacknowledged-record recovery, IDs, and lifecycle management
- use Protocol Buffers as the default record type, with explicit `WithProto` and `WithJSON` options
- expose recovery timeout/backoff, lack-of-ack timeout, buffering, batching, server-pause, TLS, application-name, and ack-callback controls
- share the OAuth token cache across streams and make `SDK.Close` terminate tracked streams before closing the gRPC connection
- eagerly validate stream arguments and application names, reject plaintext HTTP endpoints, and correctly normalize HTTPS, bare-host, resolver, and IPv6 endpoints
- expose structured retryability through `Error`, `Retryable(err)`, and the internal stream classifier
- add public documentation and tests built around pipelined ingestion followed by one `Flush`
- verify that the module builds and tests with `CGO_ENABLED=0`

## Notes

- Stream open is asynchronous by default: `CreateStream` validates arguments and returns a stream immediately while token resolution and the first handshake run in the background. Terminal connection failures surface through `Flush`, `WaitForOffset`, or the ack callback.
- Opt-in wait-ready creation and full first-open context semantics are added in follow-up PR #646.
- Public API examples are added in stacked PR #645, and the build-only release workflow is added in stacked PR #647.

## Test plan

- [x] `cd purego && go build ./...`
- [x] `cd purego && go test ./...`
- [x] `cd purego && go test -race ./...`
- [x] `cd purego && go vet ./...`
- [x] `cd purego && CGO_ENABLED=0 go test ./...`
- [x] `gofmt` clean