### PR TITLE
[Rust] Fix Arrow Flight rotation H2 resets

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug Fixes
 
 - **Arrow Flight — invalid acknowledgment watermarks are rejected** (Beta): ack progress is now monotonic, so delayed or duplicate responses cannot move the durable watermark backward. A response claiming more records than were actually submitted on the active connection is rejected without making buffered, unsent records appear durable.
+- Fixed server-initiated Arrow Flight rotation to wait only for records submitted on the active connection, half-close its request, and drain late acknowledgments or peer status before reconnecting. `stream_paused_max_wait_time_ms = Some(0)` skips the ACK wait but still performs bounded transport cleanup. Explicit close and teardown of incomplete replacement connections retain their existing best-effort behavior.
 
 ### Documentation
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -796,7 +796,7 @@ Also accepts `0` or `no`.
 | `server_lack_of_ack_timeout_ms` | `u64` | 60,000 | Timeout waiting for server acks (ms) |
 | `flush_timeout_ms` | `u64` | 300,000 | Timeout for flush operations (ms) |
 | `record_type` | `RecordType` | `RecordType::Proto` | Record serialization format (Proto or Json) |
-| `stream_paused_max_wait_time_ms` | `Option<u64>` | `None` | Max time to wait during graceful close (`None` = full server duration, `Some(0)` = immediate, `Some(x)` = min(x, server_duration)) |
+| `stream_paused_max_wait_time_ms` | `Option<u64>` | `None` | Max time to wait for outstanding acknowledgments during graceful close (`None` = server grace remaining after reserving transport cleanup time, `Some(0)` = skip the ACK wait, `Some(x)` = the smaller of `x` and that remaining grace). A bounded request/response drain still runs after the ACK wait. |
 | `ack_callback` | `Option<Arc<dyn AckCallback>>` | `None` | Optional callback for acknowledgment notifications |
 | `callback_max_wait_time_ms` | `Option<u64>` | `None` | Maximum time to wait for callback processing to complete after closing the stream (`None` = wait indefinitely, `Some(x)` = wait up to `x` ms) |
 

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -36,6 +36,8 @@
 
 ### Behavior Changes
 
+- Server-initiated Arrow Flight rotation now waits only for records submitted on the active connection, half-closes its request, and drains late responses before reconnecting. `stream_paused_max_wait_time_ms = 0` skips the ACK wait but still permits bounded transport cleanup.
+
 ### Breaking Changes
 
 - `zerobus_sdk_create_stream_with_headers_provider`,

--- a/rust/ffi/src/arrow.rs
+++ b/rust/ffi/src/arrow.rs
@@ -36,8 +36,10 @@ pub struct CArrowStreamConfigurationOptions {
     pub connection_timeout_ms: u64,
     /// -1 = None, 0 = LZ4_FRAME, 1 = ZSTD
     pub ipc_compression: i32,
-    /// Maximum time in milliseconds to wait during graceful stream close.
-    /// -1 = None (wait full server duration), 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+    /// Maximum acknowledgment wait in milliseconds during graceful stream close.
+    /// -1 = use the available server grace period, 0 = no ACK wait, >0 = capped ACK wait.
+    /// Bounded transport cleanup still runs with 0; very short server grace periods get a
+    /// best-effort local cleanup window even if the server may already have hard-closed.
     pub stream_paused_max_wait_time_ms: i64,
 }
 

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -65,8 +65,10 @@ typedef struct CArrowStreamConfigurationOptions {
    */
   int32_t ipc_compression;
   /**
-   * Maximum time in milliseconds to wait during graceful stream close.
-   * -1 = None (wait full server duration), 0 = immediate recovery, >0 = wait up to min(this, server_duration).
+   * Maximum acknowledgment wait in milliseconds during graceful stream close.
+   * -1 = use the available server grace period, 0 = no ACK wait, >0 = capped ACK wait.
+   * Bounded transport cleanup still runs with 0; very short server grace periods get a
+   * best-effort local cleanup window even if the server may already have hard-closed.
    */
   int64_t stream_paused_max_wait_time_ms;
 } CArrowStreamConfigurationOptions;

--- a/rust/sdk/src/arrow_configuration.rs
+++ b/rust/sdk/src/arrow_configuration.rs
@@ -97,21 +97,39 @@ pub struct ArrowStreamConfigurationOptions {
     /// Default: `None`
     pub ipc_compression: Option<CompressionType>,
 
-    /// Maximum time in milliseconds to wait during graceful stream close.
+    /// Maximum time in milliseconds to wait for acknowledgments during server-initiated
+    /// graceful stream rotation.
     ///
     /// When the server sends a close stream signal indicating it will close the stream,
     /// the SDK enters a "paused" state where it:
     /// - Continues accepting and buffering new `ingest_batch()` calls
     /// - Stops sending buffered batches to the server
     /// - Continues processing acknowledgments for in-flight batches
-    /// - Waits for either all in-flight batches to be acknowledged or the timeout to expire
+    /// - Waits for batches already sent at the time of the signal to be acknowledged,
+    ///   or for the configured grace period to expire
+    /// - Half-closes the request, then shares up to 500ms between observing request EOF
+    ///   and draining the response so the peer can send `END_STREAM` before recovery
     ///
     /// Configuration values:
-    /// - `None`: Wait for the full server-specified duration (most graceful)
-    /// - `Some(0)`: Immediate recovery, close stream right away
-    /// - `Some(x)`: Wait up to min(x, server_duration) milliseconds
+    /// - `None`: Use the available server grace period for acknowledgments
+    /// - `Some(0)`: Do not wait for acknowledgments
+    /// - `Some(x)`: Wait up to `x` milliseconds for acknowledgments, further capped by
+    ///   the server grace period after reserving transport-cleanup time
     ///
-    /// Default: `None` (wait for full server duration)
+    /// The SDK reserves time inside the server grace period for bounded request/response
+    /// transport cleanup. This cleanup still runs when the configured ACK wait is zero.
+    /// If the server advertises less than 500ms (including zero), the SDK skips the ACK
+    /// wait and makes a best-effort local cleanup attempt for up to 500ms; the server may
+    /// already have hard-closed, so clean peer shutdown cannot be guaranteed in that case.
+    /// Close signals are honored even when recovery is disabled: the SDK performs transport
+    /// cleanup and terminates without reconnecting. Batches accepted while paused remain
+    /// available through `get_unacked_batches()`.
+    ///
+    /// The clean half-close guarantee applies to the active connection during normal
+    /// server rotation. Explicit close during recovery remains best-effort and may abort
+    /// an incomplete replacement request.
+    ///
+    /// Default: `None` (use the available server grace period)
     pub stream_paused_max_wait_time_ms: Option<u64>,
 }
 

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -1723,41 +1723,27 @@ impl ZerobusArrowStream {
                         }
                     };
 
-                    if ack.is_close_signal() {
+                    if ack.is_close_signal() && matches!(&rotation, RotationState::Open) {
                         let server_duration_ms = ack.close_stream_duration_ms.unwrap_or(0);
-                        let (new_ack_deadline, new_drain_deadline) = Self::rotation_deadlines(
+                        let (ack_deadline, drain_deadline) = Self::rotation_deadlines(
                             server_duration_ms,
                             options.stream_paused_max_wait_time_ms,
                         );
-
-                        match &mut rotation {
-                            RotationState::Open => {
-                                let target_records = Self::pause_and_snapshot_submitted(
-                                    &ingest_mutex,
-                                    &is_paused,
-                                    &submitted_records,
-                                )
-                                .await;
-                                rotation = RotationState::WaitingForAcks {
-                                    target_records,
-                                    ack_deadline: new_ack_deadline,
-                                    drain_deadline: new_drain_deadline,
-                                };
-                                info!(
-                                    server_duration_ms,
-                                    target_records, "Server requested graceful stream rotation"
-                                );
-                            }
-                            RotationState::WaitingForAcks {
-                                ack_deadline,
-                                drain_deadline,
-                                ..
-                            } => {
-                                *ack_deadline = (*ack_deadline).min(new_ack_deadline);
-                                *drain_deadline = (*drain_deadline).min(new_drain_deadline);
-                            }
-                            RotationState::Draining(_) => unreachable!(),
-                        }
+                        let target_records = Self::pause_and_snapshot_submitted(
+                            &ingest_mutex,
+                            &is_paused,
+                            &submitted_records,
+                        )
+                        .await;
+                        rotation = RotationState::WaitingForAcks {
+                            target_records,
+                            ack_deadline,
+                            drain_deadline,
+                        };
+                        info!(
+                            server_duration_ms,
+                            target_records, "Server requested graceful stream rotation"
+                        );
                     }
 
                     if ack.ack_up_to_records > 0 {

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -86,6 +86,17 @@ struct FlightConnection {
     request_body: RequestBodyControl,
 }
 
+/// State captured when rotation stops waiting for acknowledgments and begins transport
+/// cleanup. The response may already have ended, but the request must still reach EOF.
+struct DrainState {
+    /// Hard cutoff shared by request EOF observation and response draining.
+    deadline: Instant,
+    /// Whether the response ended before the request entered the drain helper.
+    response_finished: bool,
+    /// Peer or protocol error to preserve while the remaining transport settles.
+    terminal_error: Option<ZerobusError>,
+}
+
 /// Server-initiated rotation has only three phases: normal traffic, waiting for the
 /// pre-signal acknowledgment snapshot, and transport drain.
 enum RotationState {
@@ -95,11 +106,7 @@ enum RotationState {
         ack_deadline: Instant,
         drain_deadline: Instant,
     },
-    Draining {
-        deadline: Instant,
-        response_finished: bool,
-        terminal_error: Option<ZerobusError>,
-    },
+    Draining(DrainState),
 }
 
 /// Test-only barrier used to pause `reconnect` at a precise point — the new connection
@@ -161,6 +168,103 @@ struct PendingBatch {
     end_record: u64,
     /// Backpressure permit; dropping it frees one `max_inflight_batches` slot.
     _permit: OwnedSemaphorePermit,
+}
+
+/// Borrowed view of the active connection's acknowledgment bookkeeping.
+///
+/// Keeping these values together makes every ACK path use the same connection-local
+/// submitted watermark, monotonic durable watermark, and pending-batch collection.
+struct AckProgress<'a> {
+    submitted_records: &'a AtomicU64,
+    last_acked_records: &'a AtomicU64,
+    pending_batches: &'a Mutex<Vec<PendingBatch>>,
+    last_ack_tx: &'a watch::Sender<Option<OffsetId>>,
+    #[cfg(feature = "test-hooks")]
+    ack_applied_gate: &'a AckAppliedGate,
+}
+
+impl AckProgress<'_> {
+    /// Validates an ACK against the active connection, advances the monotonic durable
+    /// watermark, removes fully acknowledged batches, and wakes completed offset waiters.
+    async fn apply(&self, ack: &FlightAckMetadata) -> ZerobusResult<()> {
+        let acked_records = ack.ack_up_to_records;
+        // `ack_up_to_records` is the durability boundary. Derive completed SDK offsets
+        // from local pending ranges so an inconsistent `ack_up_to_offset` cannot advance
+        // a waiter; keep the server-provided offset only for diagnostics.
+        let (effective_acked_records, max_acked_offset) = {
+            // Ingest publishes submitted_records and commits to the active sender while
+            // holding this same lock. Validation therefore cannot observe a submitted
+            // watermark before its handoff, or a handoff before its watermark.
+            let mut pending = self.pending_batches.lock().await;
+            let submitted_records = self.submitted_records.load(Ordering::Acquire);
+            if acked_records > submitted_records {
+                return Err(ZerobusError::InvalidStateError(format!(
+                    "Acknowledgement claims {acked_records} records, but only {submitted_records} records were submitted"
+                )));
+            }
+
+            let previous_acked_records = self
+                .last_acked_records
+                .fetch_max(acked_records, Ordering::AcqRel);
+            let effective_acked_records = previous_acked_records.max(acked_records);
+            let mut max_acked_offset: Option<OffsetId> = None;
+            pending.retain(|pb| {
+                if effective_acked_records >= pb.end_record {
+                    max_acked_offset =
+                        Some(max_acked_offset.map_or(pb.offset_id, |o| o.max(pb.offset_id)));
+                    false
+                } else {
+                    true
+                }
+            });
+            (effective_acked_records, max_acked_offset)
+        };
+
+        debug!(
+            ack_up_to_offset = ack.ack_up_to_offset,
+            ack_up_to_records = acked_records,
+            effective_acked_records,
+            "Received acknowledgment"
+        );
+
+        #[cfg(feature = "test-hooks")]
+        if acked_records > 0 {
+            if let Some(notify) = self.ack_applied_gate.lock().await.as_ref() {
+                notify.notify_one();
+            }
+        }
+
+        if let Some(offset) = max_acked_offset {
+            let _ = self.last_ack_tx.send(Some(offset));
+        }
+
+        Ok(())
+    }
+}
+
+/// Borrowed handles needed to stop sending and half-close the active Flight request.
+///
+/// The pause gate and sender are changed under `ingest_mutex`, ensuring a concurrent ingest
+/// either reaches the old connection first or remains buffered for replay.
+struct RequestControl<'a> {
+    request_body: &'a RequestBodyControl,
+    ingest_mutex: &'a Mutex<()>,
+    is_paused: &'a AtomicBool,
+    batch_tx: &'a BatchSender,
+}
+
+impl RequestControl<'_> {
+    /// Atomically stops new sends, detaches queued work, then asks tonic to poll the request
+    /// body to EOF. [`RequestBodyControl::wait_for_eof`] observes completion separately.
+    async fn half_close(&self) {
+        ZerobusArrowStream::pause_and_detach_sender(
+            self.ingest_mutex,
+            self.is_paused,
+            self.batch_tx,
+        )
+        .await;
+        self.request_body.shutdown();
+    }
 }
 
 /// Returns the batch portion not durably acknowledged, avoiding duplicate retry of an
@@ -1327,8 +1431,8 @@ impl ZerobusArrowStream {
     /// either finishes first, or observes `is_paused == true` and buffers — it never
     /// reads a detached (`None`) sender while `is_paused` is still false.
     async fn pause_and_detach_sender(
-        ingest_mutex: &Arc<Mutex<()>>,
-        is_paused: &Arc<AtomicBool>,
+        ingest_mutex: &Mutex<()>,
+        is_paused: &AtomicBool,
         batch_tx: &BatchSender,
     ) {
         let _guard = ingest_mutex.lock().await;
@@ -1390,68 +1494,6 @@ impl ZerobusArrowStream {
         Self::move_pending_to_failed(pending_batches, failed_batches, last_acked_records).await;
     }
 
-    /// Advances the monotonic record watermark and removes fully acknowledged batches.
-    async fn apply_acknowledgment(
-        ack: &FlightAckMetadata,
-        submitted_records: &AtomicU64,
-        last_acked_records: &AtomicU64,
-        pending_batches: &Mutex<Vec<PendingBatch>>,
-        last_ack_tx: &watch::Sender<Option<OffsetId>>,
-        #[cfg(feature = "test-hooks")] ack_applied_gate: &AckAppliedGate,
-    ) -> ZerobusResult<()> {
-        let acked_records = ack.ack_up_to_records;
-        // `ack_up_to_records` is the durability boundary. Derive completed SDK offsets
-        // from local pending ranges so an inconsistent `ack_up_to_offset` cannot advance
-        // a waiter; keep the server-provided offset only for diagnostics.
-        let (effective_acked_records, max_acked_offset) = {
-            // Ingest publishes submitted_records and commits to the active sender while
-            // holding this same lock. Validation therefore cannot observe a submitted
-            // watermark before its handoff, or a handoff before its watermark.
-            let mut pending = pending_batches.lock().await;
-            let submitted_records = submitted_records.load(Ordering::Acquire);
-            if acked_records > submitted_records {
-                return Err(ZerobusError::InvalidStateError(format!(
-                    "Acknowledgement claims {acked_records} records, but only {submitted_records} records were submitted"
-                )));
-            }
-
-            let previous_acked_records =
-                last_acked_records.fetch_max(acked_records, Ordering::AcqRel);
-            let effective_acked_records = previous_acked_records.max(acked_records);
-            let mut max_acked_offset: Option<OffsetId> = None;
-            pending.retain(|pb| {
-                if effective_acked_records >= pb.end_record {
-                    max_acked_offset =
-                        Some(max_acked_offset.map_or(pb.offset_id, |o| o.max(pb.offset_id)));
-                    false
-                } else {
-                    true
-                }
-            });
-            (effective_acked_records, max_acked_offset)
-        };
-
-        debug!(
-            ack_up_to_offset = ack.ack_up_to_offset,
-            ack_up_to_records = acked_records,
-            effective_acked_records,
-            "Received acknowledgment"
-        );
-
-        #[cfg(feature = "test-hooks")]
-        if acked_records > 0 {
-            if let Some(notify) = ack_applied_gate.lock().await.as_ref() {
-                notify.notify_one();
-            }
-        }
-
-        if let Some(offset) = max_acked_offset {
-            let _ = last_ack_tx.send(Some(offset));
-        }
-
-        Ok(())
-    }
-
     fn rotation_error() -> ZerobusError {
         ZerobusError::StreamClosedError(tonic::Status::unavailable(
             "Server requested graceful stream rotation",
@@ -1504,26 +1546,20 @@ impl ZerobusArrowStream {
     /// deadline. Late acknowledgments are applied while tonic settles request EOF.
     /// A real peer status or invalid acknowledgment outranks the synthetic retryable
     /// rotation result.
-    #[allow(clippy::too_many_arguments)]
     async fn close_request_and_drain_response(
         response_stream: &mut FlightResponseStream,
-        request_body: &RequestBodyControl,
-        deadline: Instant,
-        mut response_finished: bool,
-        mut terminal_error: Option<ZerobusError>,
-        ingest_mutex: &Arc<Mutex<()>>,
-        is_paused: &Arc<AtomicBool>,
-        batch_tx: &BatchSender,
-        submitted_records: &Arc<AtomicU64>,
-        last_acked_records: &Arc<AtomicU64>,
-        pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
-        last_ack_tx: &watch::Sender<Option<OffsetId>>,
-        #[cfg(feature = "test-hooks")] ack_applied_gate: &AckAppliedGate,
+        request: RequestControl<'_>,
+        acknowledgments: AckProgress<'_>,
+        state: DrainState,
     ) -> ZerobusResult<()> {
-        Self::pause_and_detach_sender(ingest_mutex, is_paused, batch_tx).await;
-        request_body.shutdown();
+        let DrainState {
+            deadline,
+            mut response_finished,
+            mut terminal_error,
+        } = state;
+        request.half_close().await;
 
-        let mut request_eof = Box::pin(request_body.wait_for_eof());
+        let mut request_eof = Box::pin(request.request_body.wait_for_eof());
         let mut request_finished = false;
 
         loop {
@@ -1547,17 +1583,7 @@ impl ZerobusArrowStream {
                         Some(Ok(put_result)) => {
                             match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
                                 Ok(ack) if ack.ack_up_to_records > 0 => {
-                                    if let Err(error) = Self::apply_acknowledgment(
-                                        &ack,
-                                        submitted_records,
-                                        last_acked_records,
-                                        pending_batches,
-                                        last_ack_tx,
-                                        #[cfg(feature = "test-hooks")]
-                                        ack_applied_gate,
-                                    )
-                                    .await
-                                    {
+                                    if let Err(error) = acknowledgments.apply(&ack).await {
                                         Self::update_rotation_error(&mut terminal_error, error);
                                     }
                                 }
@@ -1605,6 +1631,20 @@ impl ZerobusArrowStream {
         #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
     ) -> ZerobusResult<()> {
         let mut rotation = RotationState::Open;
+        let request = RequestControl {
+            request_body: &request_body,
+            ingest_mutex: ingest_mutex.as_ref(),
+            is_paused: is_paused.as_ref(),
+            batch_tx: &batch_tx,
+        };
+        let acknowledgments = AckProgress {
+            submitted_records: submitted_records.as_ref(),
+            last_acked_records: last_acked_records.as_ref(),
+            pending_batches: pending_batches.as_ref(),
+            last_ack_tx: &last_ack_tx,
+            #[cfg(feature = "test-hooks")]
+            ack_applied_gate: &ack_applied_gate,
+        };
 
         loop {
             if is_closed.load(Ordering::Relaxed) {
@@ -1621,39 +1661,26 @@ impl ZerobusArrowStream {
                 if last_acked_records.load(Ordering::Acquire) >= *target_records
                     || Instant::now() >= *ack_deadline
                 {
-                    rotation = RotationState::Draining {
+                    rotation = RotationState::Draining(DrainState {
                         deadline: Self::bounded_rotation_drain_deadline(*drain_deadline),
                         response_finished: false,
                         terminal_error: None,
-                    };
+                    });
                     continue;
                 }
             }
 
-            if matches!(rotation, RotationState::Draining { .. }) {
-                let RotationState::Draining {
-                    deadline,
-                    response_finished,
-                    terminal_error,
-                } = std::mem::replace(&mut rotation, RotationState::Open)
+            if matches!(rotation, RotationState::Draining(_)) {
+                let RotationState::Draining(state) =
+                    std::mem::replace(&mut rotation, RotationState::Open)
                 else {
                     unreachable!()
                 };
                 return Self::close_request_and_drain_response(
                     &mut response_stream,
-                    &request_body,
-                    deadline,
-                    response_finished,
-                    terminal_error,
-                    &ingest_mutex,
-                    &is_paused,
-                    &batch_tx,
-                    &submitted_records,
-                    &last_acked_records,
-                    &pending_batches,
-                    &last_ack_tx,
-                    #[cfg(feature = "test-hooks")]
-                    &ack_applied_gate,
+                    request,
+                    acknowledgments,
+                    state,
                 )
                 .await;
             }
@@ -1683,7 +1710,7 @@ impl ZerobusArrowStream {
                         response = response_stream.next() => response,
                     }
                 }
-                RotationState::Draining { .. } => unreachable!(),
+                RotationState::Draining(_) => unreachable!(),
             };
 
             match response {
@@ -1729,28 +1756,19 @@ impl ZerobusArrowStream {
                                 *ack_deadline = (*ack_deadline).min(new_ack_deadline);
                                 *drain_deadline = (*drain_deadline).min(new_drain_deadline);
                             }
-                            RotationState::Draining { .. } => unreachable!(),
+                            RotationState::Draining(_) => unreachable!(),
                         }
                     }
 
                     if ack.ack_up_to_records > 0 {
-                        let ack_result = Self::apply_acknowledgment(
-                            &ack,
-                            &submitted_records,
-                            &last_acked_records,
-                            &pending_batches,
-                            &last_ack_tx,
-                            #[cfg(feature = "test-hooks")]
-                            &ack_applied_gate,
-                        )
-                        .await;
+                        let ack_result = acknowledgments.apply(&ack).await;
                         if let Err(error) = ack_result {
                             if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
-                                rotation = RotationState::Draining {
+                                rotation = RotationState::Draining(DrainState {
                                     deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
                                     response_finished: false,
                                     terminal_error: Some(error),
-                                };
+                                });
                                 continue;
                             }
                             return Err(error);
@@ -1761,11 +1779,11 @@ impl ZerobusArrowStream {
                     let status: tonic::Status = error.into();
                     let error = ZerobusError::StreamClosedError(status);
                     if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
-                        rotation = RotationState::Draining {
+                        rotation = RotationState::Draining(DrainState {
                             deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
                             response_finished: true,
                             terminal_error: Some(error),
-                        };
+                        });
                         continue;
                     }
                     let _ = server_error_tx.send(Some(error.clone()));
@@ -1773,11 +1791,11 @@ impl ZerobusArrowStream {
                 }
                 None => {
                     if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
-                        rotation = RotationState::Draining {
+                        rotation = RotationState::Draining(DrainState {
                             deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
                             response_finished: true,
                             terminal_error: None,
-                        };
+                        });
                         continue;
                     }
                     return Err(ZerobusError::StreamClosedError(tonic::Status::unknown(

--- a/rust/sdk/src/arrow_stream.rs
+++ b/rust/sdk/src/arrow_stream.rs
@@ -9,22 +9,25 @@
 //! (Go, Python, Java, TypeScript) can use `ingest_ipc_batch` with pre-serialised
 //! Arrow IPC bytes.
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::task::Poll;
 
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
-use arrow_flight::{FlightClient, PutResult};
+use arrow_flight::{FlightClient, FlightData, PutResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 #[cfg(feature = "test-hooks")]
 use tokio::sync::Notify;
 use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, Semaphore};
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, Duration, Instant};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
+use tokio_util::sync::CancellationToken;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
 use tracing::{debug, error, info, instrument, warn};
@@ -44,6 +47,60 @@ use crate::ZerobusResult;
 
 /// Type alias for the batch sender channel, wrapped for thread-safe sharing.
 type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
+
+/// Reserve this much of a normal server grace period for request EOF and response drain.
+const ROTATION_DRAIN_TIMEOUT_MS: u64 = 500;
+
+type FlightResponseStream = Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>;
+type FlightRequestStream = Pin<Box<dyn Stream<Item = Result<FlightData, FlightError>> + Send>>;
+
+/// Stops one Flight request body without dropping the HTTP/2 stream and reports when
+/// tonic has polled that body to EOF.
+struct RequestBodyControl {
+    shutdown: CancellationToken,
+    eof_rx: watch::Receiver<bool>,
+}
+
+impl RequestBodyControl {
+    fn shutdown(&self) {
+        self.shutdown.cancel();
+    }
+
+    async fn wait_for_eof(&self) {
+        let mut eof_rx = self.eof_rx.clone();
+        loop {
+            if *eof_rx.borrow_and_update() {
+                return;
+            }
+            if eof_rx.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+}
+
+/// State owned by a single active DoPut connection.
+struct FlightConnection {
+    response_stream: FlightResponseStream,
+    batch_tx: mpsc::Sender<Result<RecordBatch, FlightError>>,
+    request_body: RequestBodyControl,
+}
+
+/// Server-initiated rotation has only three phases: normal traffic, waiting for the
+/// pre-signal acknowledgment snapshot, and transport drain.
+enum RotationState {
+    Open,
+    WaitingForAcks {
+        target_records: u64,
+        ack_deadline: Instant,
+        drain_deadline: Instant,
+    },
+    Draining {
+        deadline: Instant,
+        response_finished: bool,
+        terminal_error: Option<ZerobusError>,
+    },
+}
 
 /// Test-only barrier used to pause `reconnect` at a precise point — the new connection
 /// is established but pending ranges are not yet rebuilt — so a test can schedule a
@@ -427,7 +484,7 @@ impl ZerobusArrowStream {
         };
         let creation = RetryIf::spawn(strategy, create_attempt, should_retry).await;
 
-        let (response_stream, tx) = match creation {
+        let connection = match creation {
             Ok(result) => result,
             Err(e) => {
                 error!("Arrow Flight stream creation failed after retries: {}", e);
@@ -438,7 +495,7 @@ impl ZerobusArrowStream {
         // Store the sender.
         {
             let mut batch_tx = stream.batch_tx.lock().await;
-            *batch_tx = Some(tx);
+            *batch_tx = Some(connection.batch_tx.clone());
         }
 
         // Spawn the supervisor task.
@@ -461,7 +518,8 @@ impl ZerobusArrowStream {
             Arc::clone(&stream.last_acked_records),
             Arc::clone(&stream.is_paused),
             Arc::clone(&stream.ingest_mutex),
-            response_stream,
+            connection.response_stream,
+            connection.request_body,
             Arc::clone(&stream.sdk_identifier),
             #[cfg(feature = "test-hooks")]
             Arc::clone(&stream.reconnect_rebuild_gate),
@@ -483,7 +541,7 @@ impl ZerobusArrowStream {
     }
 
     /// Attempts to establish a Flight connection.
-    /// Returns the response stream and batch sender on success.
+    /// Returns the complete connection on success.
     async fn try_connect(
         endpoint: &str,
         tls_config: &Arc<dyn TlsConfig>,
@@ -492,10 +550,7 @@ impl ZerobusArrowStream {
         options: &ArrowStreamConfigurationOptions,
         headers_provider: &Arc<dyn HeadersProvider>,
         sdk_identifier: &str,
-    ) -> ZerobusResult<(
-        Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
-        mpsc::Sender<Result<RecordBatch, FlightError>>,
-    )> {
+    ) -> ZerobusResult<FlightConnection> {
         // Share one deadline across connection setup and auth-rejection invalidation.
         // This preserves the original auth error if a custom provider stalls instead of
         // reclassifying the attempt as a retryable setup timeout.
@@ -615,8 +670,64 @@ impl ZerobusArrowStream {
         Ok(client)
     }
 
+    /// Builds a request body that can be stopped at a FlightData boundary and observed
+    /// reaching EOF without dropping the surrounding HTTP/2 stream.
+    fn make_request_stream(
+        batch_rx: mpsc::Receiver<Result<RecordBatch, FlightError>>,
+        table_properties: &ArrowTableProperties,
+        options: &ArrowStreamConfigurationOptions,
+    ) -> ZerobusResult<(FlightRequestStream, RequestBodyControl)> {
+        let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
+        let schema = Arc::clone(&table_properties.schema);
+        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
+        let offset_counter = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let offset_counter_clone = Arc::clone(&offset_counter);
+        let mut encoded: FlightRequestStream = Box::pin(
+            FlightDataEncoderBuilder::new()
+                .with_schema(schema)
+                .with_options(ipc_write_options)
+                .build(batch_stream)
+                .enumerate()
+                .map(move |(idx, result)| {
+                    result.map(|mut flight_data| {
+                        if idx > 0 {
+                            let offset = offset_counter_clone
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            let metadata = FlightBatchMetadata::new(offset);
+                            if let Ok(bytes) = metadata.to_bytes() {
+                                flight_data.app_metadata = bytes.into();
+                            }
+                        }
+                        flight_data
+                    })
+                }),
+        );
+
+        let shutdown = CancellationToken::new();
+        let mut cancelled = Box::pin(shutdown.clone().cancelled_owned());
+        let (eof_tx, eof_rx) = watch::channel(false);
+        let controlled = futures::stream::poll_fn(move |cx| {
+            if cancelled.as_mut().poll(cx).is_ready() {
+                eof_tx.send_replace(true);
+                return Poll::Ready(None);
+            }
+            match encoded.as_mut().poll_next(cx) {
+                Poll::Ready(None) => {
+                    eof_tx.send_replace(true);
+                    Poll::Ready(None)
+                }
+                result => result,
+            }
+        });
+
+        Ok((
+            Box::pin(controlled),
+            RequestBodyControl { shutdown, eof_rx },
+        ))
+    }
+
     /// Starts the Flight stream with the given client.
-    /// Returns the response stream and batch sender for use by the supervisor.
+    /// Returns the complete active connection for use by the supervisor.
     ///
     /// This method waits for the server's "ready" signal (ack_up_to_offset = -1)
     /// to confirm that stream setup succeeded (auth, schema validation, table access).
@@ -626,43 +737,13 @@ impl ZerobusArrowStream {
         mut client: FlightClient,
         table_properties: &ArrowTableProperties,
         options: &ArrowStreamConfigurationOptions,
-    ) -> ZerobusResult<(
-        Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
-        mpsc::Sender<Result<RecordBatch, FlightError>>,
-    )> {
+    ) -> ZerobusResult<FlightConnection> {
         // Create channel for sending RecordBatches.
         let (batch_tx, batch_rx) =
             mpsc::channel::<Result<RecordBatch, FlightError>>(options.max_inflight_batches);
 
-        let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
-        let schema = Arc::clone(&table_properties.schema);
-        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
-
-        // Build the Flight data stream. FlightDataEncoderBuilder handles schema
-        // framing, dictionary encoding, and automatic batch chunking at 2 MiB.
-        // Each non-schema FlightData message gets a sequential wire offset in
-        // its app_metadata (index 0 is the schema message; data messages start at 1).
-        let offset_counter = Arc::new(std::sync::atomic::AtomicI64::new(0));
-        let offset_counter_clone = Arc::clone(&offset_counter);
-        let flight_data_stream = FlightDataEncoderBuilder::new()
-            .with_schema(schema)
-            .with_options(ipc_write_options)
-            .build(batch_stream)
-            .enumerate()
-            .map(move |(idx, result)| {
-                result.map(|mut flight_data| {
-                    // Skip schema message (idx 0); add metadata to data messages.
-                    if idx > 0 {
-                        let offset =
-                            offset_counter_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let metadata = FlightBatchMetadata::new(offset);
-                        if let Ok(bytes) = metadata.to_bytes() {
-                            flight_data.app_metadata = bytes.into();
-                        }
-                    }
-                    flight_data
-                })
-            });
+        let (flight_data_stream, request_body) =
+            Self::make_request_stream(batch_rx, table_properties, options)?;
 
         // Start the DoPut stream.
         let mut response_stream = client
@@ -731,7 +812,11 @@ impl ZerobusArrowStream {
             }
         }
 
-        Ok((response_stream, batch_tx))
+        Ok(FlightConnection {
+            response_stream: Box::pin(response_stream),
+            batch_tx,
+            request_body,
+        })
     }
 
     /// Spawns the supervisor task that manages the stream lifecycle and recovery.
@@ -760,7 +845,8 @@ impl ZerobusArrowStream {
         last_acked_records: Arc<AtomicU64>,
         is_paused: Arc<AtomicBool>,
         ingest_mutex: Arc<Mutex<()>>,
-        initial_response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
+        initial_response_stream: FlightResponseStream,
+        initial_request_body: RequestBodyControl,
         sdk_identifier: Arc<str>,
         #[cfg(feature = "test-hooks")] reconnect_rebuild_gate: ReconnectRebuildGate,
         #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
@@ -768,6 +854,7 @@ impl ZerobusArrowStream {
         tokio::spawn(async move {
             let ack_timeout = Duration::from_millis(options.server_lack_of_ack_timeout_ms);
             let mut response_stream = Some(initial_response_stream);
+            let mut request_body = Some(initial_request_body);
             // Carries a failed reconnect's real error into the next iteration's handling
             // instead of round-tripping a synthetic error through a dummy stream.
             let mut pending_error: Option<ZerobusError> = None;
@@ -793,6 +880,9 @@ impl ZerobusArrowStream {
                         response_stream
                             .take()
                             .expect("response_stream present when no pending reconnect error"),
+                        request_body
+                            .take()
+                            .expect("request_body present when no pending reconnect error"),
                         Arc::clone(&is_closed),
                         last_ack_tx.clone(),
                         Arc::clone(&pending_batches),
@@ -801,6 +891,8 @@ impl ZerobusArrowStream {
                         Arc::clone(&submitted_records),
                         Arc::clone(&last_acked_records),
                         Arc::clone(&is_paused),
+                        Arc::clone(&ingest_mutex),
+                        Arc::clone(&batch_tx),
                         &options,
                         #[cfg(feature = "test-hooks")]
                         Arc::clone(&ack_applied_gate),
@@ -900,11 +992,12 @@ impl ZerobusArrowStream {
                         .await;
 
                         match reconnect_result {
-                            Ok(Ok(new_response_stream)) => {
+                            Ok(Ok(connection)) => {
                                 info!("Supervisor: Recovery successful, resuming");
                                 recovery_attempts.store(0, Ordering::Relaxed);
                                 // is_paused was already cleared inside reconnect().
-                                response_stream = Some(new_response_stream);
+                                response_stream = Some(connection.response_stream);
+                                request_body = Some(connection.request_body);
                             }
                             Ok(Err(e)) => {
                                 warn!("Supervisor: Reconnection failed: {}", e);
@@ -1019,7 +1112,7 @@ impl ZerobusArrowStream {
         ingest_mutex: &Arc<Mutex<()>>,
         is_paused: &Arc<AtomicBool>,
         #[cfg(feature = "test-hooks")] reconnect_rebuild_gate: &ReconnectRebuildGate,
-    ) -> ZerobusResult<Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>> {
+    ) -> ZerobusResult<FlightConnection> {
         // Create new client.
         let client = Self::create_flight_client(
             endpoint,
@@ -1036,30 +1129,8 @@ impl ZerobusArrowStream {
         let (tx, batch_rx) =
             mpsc::channel::<Result<RecordBatch, FlightError>>(options.max_inflight_batches);
 
-        let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
-        let schema = Arc::clone(&table_properties.schema);
-        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
-
-        let offset_counter = Arc::new(std::sync::atomic::AtomicI64::new(0));
-        let offset_counter_clone = Arc::clone(&offset_counter);
-        let flight_data_stream = FlightDataEncoderBuilder::new()
-            .with_schema(schema)
-            .with_options(ipc_write_options)
-            .build(batch_stream)
-            .enumerate()
-            .map(move |(idx, result)| {
-                result.map(|mut flight_data| {
-                    if idx > 0 {
-                        let offset =
-                            offset_counter_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let metadata = FlightBatchMetadata::new(offset);
-                        if let Ok(bytes) = metadata.to_bytes() {
-                            flight_data.app_metadata = bytes.into();
-                        }
-                    }
-                    flight_data
-                })
-            });
+        let (flight_data_stream, request_body) =
+            Self::make_request_stream(batch_rx, table_properties, options)?;
 
         // Start the DoPut stream.
         let mut flight_client = client;
@@ -1162,7 +1233,11 @@ impl ZerobusArrowStream {
         // Clear the pause gate while still holding ingest_mutex.
         is_paused.store(false, Ordering::Relaxed);
 
-        Ok(response_stream)
+        Ok(FlightConnection {
+            response_stream: Box::pin(response_stream),
+            batch_tx: tx,
+            request_body,
+        })
     }
 
     /// Rebuilds `pending_batches` for replay after a reconnect and replays them over
@@ -1260,6 +1335,19 @@ impl ZerobusArrowStream {
         is_paused.store(true, Ordering::Relaxed);
         let mut tx = batch_tx.lock().await;
         *tx = None;
+    }
+
+    /// Pauses new sends and snapshots exactly the records submitted to this connection.
+    /// Ingests admitted after this critical section remain pending for replay and cannot
+    /// extend the active connection's acknowledgment target.
+    async fn pause_and_snapshot_submitted(
+        ingest_mutex: &Arc<Mutex<()>>,
+        is_paused: &Arc<AtomicBool>,
+        submitted_records: &AtomicU64,
+    ) -> u64 {
+        let _guard = ingest_mutex.lock().await;
+        is_paused.store(true, Ordering::Relaxed);
+        submitted_records.load(Ordering::Acquire)
     }
 
     /// Moves each pending batch's unacknowledged suffix to the failed list, dropping
@@ -1364,28 +1452,159 @@ impl ZerobusArrowStream {
         Ok(())
     }
 
-    /// Processes acknowledgments from the server response stream.
+    fn rotation_error() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::unavailable(
+            "Server requested graceful stream rotation",
+        ))
+    }
+
+    /// Records the latest rotation error without allowing a retryable transport status
+    /// to hide an earlier permanent peer or protocol failure.
+    fn update_rotation_error(current: &mut Option<ZerobusError>, candidate: ZerobusError) {
+        let preserves_permanent = current
+            .as_ref()
+            .map(|error| !error.is_retryable() && candidate.is_retryable())
+            .unwrap_or(false);
+        if !preserves_permanent {
+            *current = Some(candidate);
+        }
+    }
+
+    /// Splits the advertised grace into an ACK-wait portion and a bounded transport
+    /// drain. Very short grace periods skip ACK waiting and receive a best-effort local
+    /// drain window; the peer may already have closed in that case.
+    fn rotation_deadlines(
+        server_duration_ms: u64,
+        configured_ack_wait_ms: Option<u64>,
+    ) -> (Instant, Instant) {
+        let now = Instant::now();
+        let drain_budget = Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS);
+        let server_grace = Duration::from_millis(server_duration_ms);
+        let bounded_fallback = now + Duration::from_secs(365 * 24 * 60 * 60);
+        let server_deadline = now.checked_add(server_grace).unwrap_or(bounded_fallback);
+        let available_ack_wait = server_grace.saturating_sub(drain_budget);
+        let configured_ack_wait = configured_ack_wait_ms
+            .map(Duration::from_millis)
+            .unwrap_or(available_ack_wait);
+        let ack_wait = available_ack_wait.min(configured_ack_wait);
+        let ack_deadline = now.checked_add(ack_wait).unwrap_or(server_deadline);
+        let drain_deadline = if server_grace < drain_budget {
+            now + drain_budget
+        } else {
+            server_deadline
+        };
+        (ack_deadline, drain_deadline)
+    }
+
+    fn bounded_rotation_drain_deadline(close_deadline: Instant) -> Instant {
+        close_deadline.min(Instant::now() + Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS))
+    }
+
+    /// Half-closes the active request and drains the response under the rotation
+    /// deadline. Late acknowledgments are applied while tonic settles request EOF.
+    /// A real peer status or invalid acknowledgment outranks the synthetic retryable
+    /// rotation result.
+    #[allow(clippy::too_many_arguments)]
+    async fn close_request_and_drain_response(
+        response_stream: &mut FlightResponseStream,
+        request_body: &RequestBodyControl,
+        deadline: Instant,
+        mut response_finished: bool,
+        mut terminal_error: Option<ZerobusError>,
+        ingest_mutex: &Arc<Mutex<()>>,
+        is_paused: &Arc<AtomicBool>,
+        batch_tx: &BatchSender,
+        submitted_records: &Arc<AtomicU64>,
+        last_acked_records: &Arc<AtomicU64>,
+        pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
+        last_ack_tx: &watch::Sender<Option<OffsetId>>,
+        #[cfg(feature = "test-hooks")] ack_applied_gate: &AckAppliedGate,
+    ) -> ZerobusResult<()> {
+        Self::pause_and_detach_sender(ingest_mutex, is_paused, batch_tx).await;
+        request_body.shutdown();
+
+        let mut request_eof = Box::pin(request_body.wait_for_eof());
+        let mut request_finished = false;
+
+        loop {
+            if request_finished && response_finished {
+                return Err(terminal_error.unwrap_or_else(Self::rotation_error));
+            }
+            if Instant::now() >= deadline {
+                return Err(terminal_error.unwrap_or_else(Self::rotation_error));
+            }
+
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep_until(deadline) => {
+                    return Err(terminal_error.unwrap_or_else(Self::rotation_error));
+                }
+                _ = &mut request_eof, if !request_finished => {
+                    request_finished = true;
+                }
+                response = response_stream.next(), if !response_finished => {
+                    match response {
+                        Some(Ok(put_result)) => {
+                            match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
+                                Ok(ack) if ack.ack_up_to_records > 0 => {
+                                    if let Err(error) = Self::apply_acknowledgment(
+                                        &ack,
+                                        submitted_records,
+                                        last_acked_records,
+                                        pending_batches,
+                                        last_ack_tx,
+                                        #[cfg(feature = "test-hooks")]
+                                        ack_applied_gate,
+                                    )
+                                    .await
+                                    {
+                                        Self::update_rotation_error(&mut terminal_error, error);
+                                    }
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!("Failed to parse ack metadata while draining: {error}");
+                                }
+                            }
+                        }
+                        Some(Err(error)) => {
+                            let status: tonic::Status = error.into();
+                            Self::update_rotation_error(
+                                &mut terminal_error,
+                                ZerobusError::StreamClosedError(status),
+                            );
+                            response_finished = true;
+                        }
+                        None => response_finished = true,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Processes acknowledgments and the single server-initiated rotation path.
     ///
-    /// Uses record-based tracking: the server sends `ack_up_to_records` indicating
-    /// the cumulative number of records durably stored. We match this against
-    /// pending batches' record ranges to determine which batches are fully acked.
-    /// This correctly handles batches that were split into multiple Flight chunks
-    /// by `FlightDataEncoderBuilder`.
+    /// Rotation pauses sends and snapshots submitted records, waits only for that
+    /// connection-local target, then half-closes the request and drains late responses
+    /// before returning a retryable result to the supervisor.
     #[allow(clippy::too_many_arguments)]
     async fn process_acks(
-        mut response_stream: Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>,
+        mut response_stream: FlightResponseStream,
+        request_body: RequestBodyControl,
         is_closed: Arc<AtomicBool>,
-        last_ack_tx: tokio::sync::watch::Sender<Option<OffsetId>>,
+        last_ack_tx: watch::Sender<Option<OffsetId>>,
         pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
         ack_timeout: Duration,
         server_error_tx: watch::Sender<Option<ZerobusError>>,
         submitted_records: Arc<AtomicU64>,
         last_acked_records: Arc<AtomicU64>,
         is_paused: Arc<AtomicBool>,
+        ingest_mutex: Arc<Mutex<()>>,
+        batch_tx: BatchSender,
         options: &ArrowStreamConfigurationOptions,
         #[cfg(feature = "test-hooks")] ack_applied_gate: AckAppliedGate,
     ) -> ZerobusResult<()> {
-        let mut pause_deadline: Option<tokio::time::Instant> = None;
+        let mut rotation = RotationState::Open;
 
         loop {
             if is_closed.load(Ordering::Relaxed) {
@@ -1393,169 +1612,177 @@ impl ZerobusArrowStream {
                 return Ok(());
             }
 
-            // Check pause state: exit when deadline reached or all batches acked.
-            // Returns a retriable error to trigger recovery in the supervisor.
-            if let Some(deadline) = pause_deadline {
-                let now = tokio::time::Instant::now();
-                let all_acked = pending_batches.lock().await.is_empty();
-
-                if now >= deadline {
-                    info!("Graceful close timeout reached. Triggering recovery.");
-                    return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
-                        "Graceful close timeout reached",
-                    )));
-                } else if all_acked {
-                    info!("All in-flight batches acknowledged during graceful close. Triggering recovery.");
-                    return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
-                        "All in-flight batches acked during graceful close",
-                    )));
+            if let RotationState::WaitingForAcks {
+                target_records,
+                ack_deadline,
+                drain_deadline,
+            } = &rotation
+            {
+                if last_acked_records.load(Ordering::Acquire) >= *target_records
+                    || Instant::now() >= *ack_deadline
+                {
+                    rotation = RotationState::Draining {
+                        deadline: Self::bounded_rotation_drain_deadline(*drain_deadline),
+                        response_finished: false,
+                        terminal_error: None,
+                    };
+                    continue;
                 }
             }
 
-            // TODO: Anchor this timeout to the oldest pending batch. The current
-            // per-response timeout can spend most of its window while idle and restarts
-            // whenever any response arrives, even if it makes no ack progress.
-            let result = if let Some(deadline) = pause_deadline {
-                // TODO: Race graceful close against the active ack deadline and
-                // preserve the earliest close deadline when repeated signals arrive.
-                tokio::select! {
-                    biased;
-                    _ = tokio::time::sleep_until(deadline) => {
-                        continue;
+            if matches!(rotation, RotationState::Draining { .. }) {
+                let RotationState::Draining {
+                    deadline,
+                    response_finished,
+                    terminal_error,
+                } = std::mem::replace(&mut rotation, RotationState::Open)
+                else {
+                    unreachable!()
+                };
+                return Self::close_request_and_drain_response(
+                    &mut response_stream,
+                    &request_body,
+                    deadline,
+                    response_finished,
+                    terminal_error,
+                    &ingest_mutex,
+                    &is_paused,
+                    &batch_tx,
+                    &submitted_records,
+                    &last_acked_records,
+                    &pending_batches,
+                    &last_ack_tx,
+                    #[cfg(feature = "test-hooks")]
+                    &ack_applied_gate,
+                )
+                .await;
+            }
+
+            let response = match &rotation {
+                RotationState::Open => {
+                    match tokio::time::timeout(ack_timeout, response_stream.next()).await {
+                        Ok(response) => response,
+                        Err(_) => {
+                            let pending = pending_batches.lock().await;
+                            if !pending.is_empty() {
+                                error!(
+                                    pending_count = pending.len(),
+                                    "Server ack timeout with pending batches"
+                                );
+                                return Err(ZerobusError::StreamClosedError(
+                                    tonic::Status::deadline_exceeded("Server ack timeout"),
+                                ));
+                            }
+                            continue;
+                        }
                     }
-                    res = tokio::time::timeout(ack_timeout, response_stream.next()) => res,
                 }
-            } else {
-                tokio::time::timeout(ack_timeout, response_stream.next()).await
+                RotationState::WaitingForAcks { ack_deadline, .. } => {
+                    tokio::select! {
+                        _ = tokio::time::sleep_until(*ack_deadline) => continue,
+                        response = response_stream.next() => response,
+                    }
+                }
+                RotationState::Draining { .. } => unreachable!(),
             };
 
-            match result {
-                Ok(Some(Ok(put_result))) => {
-                    match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
-                        Ok(ack) => {
-                            // Handle close stream signal.
-                            if ack.is_close_signal() {
-                                if options.recovery {
-                                    let server_duration_ms =
-                                        ack.close_stream_duration_ms.unwrap_or(0);
-
-                                    let wait_duration_ms = match options
-                                        .stream_paused_max_wait_time_ms
-                                    {
-                                        None => server_duration_ms,
-                                        Some(0) => {
-                                            info!(
-                                                    "Server will close the stream in {}ms. Triggering stream recovery.",
-                                                    server_duration_ms
-                                                );
-                                            return Err(ZerobusError::StreamClosedError(
-                                                tonic::Status::unavailable(
-                                                    "Immediate recovery on close signal",
-                                                ),
-                                            ));
-                                        }
-                                        Some(max_wait) => {
-                                            std::cmp::min(max_wait, server_duration_ms)
-                                        }
-                                    };
-
-                                    if wait_duration_ms == 0 {
-                                        info!("Server will close the stream. Triggering immediate recovery.");
-                                        return Err(ZerobusError::StreamClosedError(
-                                            tonic::Status::unavailable(
-                                                "Immediate recovery on close signal",
-                                            ),
-                                        ));
-                                    }
-
-                                    is_paused.store(true, Ordering::Relaxed);
-                                    pause_deadline = Some(
-                                        tokio::time::Instant::now()
-                                            + Duration::from_millis(wait_duration_ms),
-                                    );
-                                    info!(
-                                        "Server will close the stream in {}ms. Entering graceful close period (waiting up to {}ms for in-flight acks).",
-                                        server_duration_ms, wait_duration_ms
-                                    );
-                                }
-                                // Process any ack data that came with the close signal.
-                                // Fall through to ack processing below only if there's
-                                // meaningful ack data (non-zero records count).
-                                if ack.ack_up_to_records == 0 {
-                                    continue;
-                                }
-                            }
-
-                            Self::apply_acknowledgment(
-                                &ack,
-                                &submitted_records,
-                                &last_acked_records,
-                                &pending_batches,
-                                &last_ack_tx,
-                                #[cfg(feature = "test-hooks")]
-                                &ack_applied_gate,
-                            )
-                            .await?;
+            match response {
+                Some(Ok(put_result)) => {
+                    let ack = match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
+                        Ok(ack) => ack,
+                        Err(error) => {
+                            warn!("Failed to parse ack metadata: {error}");
+                            continue;
                         }
-                        Err(e) => {
-                            warn!("Failed to parse ack metadata: {}", e);
+                    };
+
+                    if ack.is_close_signal() {
+                        let server_duration_ms = ack.close_stream_duration_ms.unwrap_or(0);
+                        let (new_ack_deadline, new_drain_deadline) = Self::rotation_deadlines(
+                            server_duration_ms,
+                            options.stream_paused_max_wait_time_ms,
+                        );
+
+                        match &mut rotation {
+                            RotationState::Open => {
+                                let target_records = Self::pause_and_snapshot_submitted(
+                                    &ingest_mutex,
+                                    &is_paused,
+                                    &submitted_records,
+                                )
+                                .await;
+                                rotation = RotationState::WaitingForAcks {
+                                    target_records,
+                                    ack_deadline: new_ack_deadline,
+                                    drain_deadline: new_drain_deadline,
+                                };
+                                info!(
+                                    server_duration_ms,
+                                    target_records, "Server requested graceful stream rotation"
+                                );
+                            }
+                            RotationState::WaitingForAcks {
+                                ack_deadline,
+                                drain_deadline,
+                                ..
+                            } => {
+                                *ack_deadline = (*ack_deadline).min(new_ack_deadline);
+                                *drain_deadline = (*drain_deadline).min(new_drain_deadline);
+                            }
+                            RotationState::Draining { .. } => unreachable!(),
+                        }
+                    }
+
+                    if ack.ack_up_to_records > 0 {
+                        let ack_result = Self::apply_acknowledgment(
+                            &ack,
+                            &submitted_records,
+                            &last_acked_records,
+                            &pending_batches,
+                            &last_ack_tx,
+                            #[cfg(feature = "test-hooks")]
+                            &ack_applied_gate,
+                        )
+                        .await;
+                        if let Err(error) = ack_result {
+                            if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
+                                rotation = RotationState::Draining {
+                                    deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
+                                    response_finished: false,
+                                    terminal_error: Some(error),
+                                };
+                                continue;
+                            }
+                            return Err(error);
                         }
                     }
                 }
-                Ok(Some(Err(e))) => {
-                    // A stream error while paused ends the graceful-close wait and
-                    // triggers recovery.
-                    if pause_deadline.is_some() {
-                        info!(
-                            "Stream error during graceful close period, triggering recovery: {}",
-                            e
-                        );
-                        return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
-                            "Stream error during graceful close",
-                        )));
-                    }
-                    error!("Flight stream error: {}", e);
-                    let status: tonic::Status = e.into();
+                Some(Err(error)) => {
+                    let status: tonic::Status = error.into();
                     let error = ZerobusError::StreamClosedError(status);
+                    if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
+                        rotation = RotationState::Draining {
+                            deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
+                            response_finished: true,
+                            terminal_error: Some(error),
+                        };
+                        continue;
+                    }
                     let _ = server_error_tx.send(Some(error.clone()));
                     return Err(error);
                 }
-                Ok(None) => {
-                    // During graceful close, stream end is expected.
-                    // Return retriable error to trigger recovery.
-                    if pause_deadline.is_some() {
-                        info!("Server closed stream during graceful close period, triggering recovery.");
-                        return Err(ZerobusError::StreamClosedError(tonic::Status::unavailable(
-                            "Server closed stream during graceful close",
-                        )));
-                    }
-                    debug!("Server closed the stream");
-                    let error = ZerobusError::StreamClosedError(tonic::Status::unknown(
-                        "Server closed the stream",
-                    ));
-                    // Returned to the supervisor, which publishes it (before + after
-                    // finalization) in its terminal branch.
-                    return Err(error);
-                }
-                Err(_timeout) => {
-                    // During graceful close, ack timeout is not an error.
-                    if pause_deadline.is_some() {
+                None => {
+                    if let RotationState::WaitingForAcks { drain_deadline, .. } = rotation {
+                        rotation = RotationState::Draining {
+                            deadline: Self::bounded_rotation_drain_deadline(drain_deadline),
+                            response_finished: true,
+                            terminal_error: None,
+                        };
                         continue;
                     }
-                    // Check if there are pending acks that should have been received.
-                    let pending = pending_batches.lock().await;
-                    if !pending.is_empty() {
-                        error!(
-                            pending_count = pending.len(),
-                            "Server ack timeout with pending batches"
-                        );
-                        let error = ZerobusError::StreamClosedError(
-                            tonic::Status::deadline_exceeded("Server ack timeout"),
-                        );
-                        // Returned to the supervisor, which publishes it (before + after
-                        // finalization) in its terminal branch.
-                        return Err(error);
-                    }
+                    return Err(ZerobusError::StreamClosedError(tonic::Status::unknown(
+                        "Server closed the stream",
+                    )));
                 }
             }
         }
@@ -2292,6 +2519,18 @@ mod tests {
         }
     }
 
+    fn inactive_rotation_controls() -> (RequestBodyControl, Arc<Mutex<()>>, BatchSender) {
+        let (_eof_tx, eof_rx) = watch::channel(true);
+        (
+            RequestBodyControl {
+                shutdown: CancellationToken::new(),
+                eof_rx,
+            },
+            Arc::new(Mutex::new(())),
+            Arc::new(Mutex::new(None)),
+        )
+    }
+
     /// An acknowledgement beyond the connection-local submitted-record count is a protocol
     /// violation and must not make unsent records appear durable.
     #[tokio::test]
@@ -2318,9 +2557,11 @@ mod tests {
         let (server_error_tx, _server_error_rx) = watch::channel(None);
         let submitted_records = Arc::new(AtomicU64::new(10));
         let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (request_body, ingest_mutex, batch_tx) = inactive_rotation_controls();
 
         let error = ZerobusArrowStream::process_acks(
             Box::pin(response_stream),
+            request_body,
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
@@ -2329,6 +2570,8 @@ mod tests {
             Arc::clone(&submitted_records),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(false)),
+            ingest_mutex,
+            batch_tx,
             &ArrowStreamConfigurationOptions::default(),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),
@@ -2378,9 +2621,11 @@ mod tests {
         let (server_error_tx, _server_error_rx) = watch::channel(None);
         let submitted_records = Arc::new(AtomicU64::new(10));
         let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (request_body, ingest_mutex, batch_tx) = inactive_rotation_controls();
 
         let error = ZerobusArrowStream::process_acks(
             Box::pin(response_stream),
+            request_body,
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
@@ -2389,6 +2634,8 @@ mod tests {
             Arc::clone(&submitted_records),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(true)),
+            ingest_mutex,
+            batch_tx,
             &ArrowStreamConfigurationOptions::default(),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),
@@ -2442,9 +2689,11 @@ mod tests {
         let (last_ack_tx, _last_ack_rx) = watch::channel(None);
         let (server_error_tx, _server_error_rx) = watch::channel(None);
         let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (request_body, ingest_mutex, batch_tx) = inactive_rotation_controls();
 
         let _stream_closed = ZerobusArrowStream::process_acks(
             Box::pin(response_stream),
+            request_body,
             Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             Arc::clone(&pending_batches),
@@ -2453,6 +2702,8 @@ mod tests {
             Arc::new(AtomicU64::new(10)),
             Arc::clone(&last_acked_records),
             Arc::new(AtomicBool::new(false)),
+            ingest_mutex,
+            batch_tx,
             &ArrowStreamConfigurationOptions::default(),
             #[cfg(feature = "test-hooks")]
             Arc::new(Mutex::new(None)),

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -3646,6 +3646,11 @@ mod arrow_flight_tests {
                             delay_ms: 0,
                             ack_up_to_records: 3,
                         },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 1,
+                            delay_ms: 0,
+                            ack_up_to_records: 4,
+                        },
                     ],
                 )
                 .await;
@@ -3694,11 +3699,23 @@ mod arrow_flight_tests {
             );
             let offset2 = stream.ingest_batch(batch2).await?;
 
+            // A third batch advances the mock script to the disconnect after the
+            // partial ACK for batch2. Recovery must replay only batch2's final three
+            // rows, followed by this batch.
+            let batch3 = create_test_record_batch(schema, vec![16], vec![Some("p")]);
+            let offset3 = stream.ingest_batch(batch3).await?;
+
             let result = stream.wait_for_offset(offset2).await;
             assert!(
                 result.is_ok(),
                 "Expected partial batch recovery to succeed: {:?}",
                 result
+            );
+            stream.wait_for_offset(offset3).await?;
+            assert_eq!(
+                mock_server.get_total_records_received().await,
+                20,
+                "recovery must replay only the three-record unacknowledged suffix"
             );
 
             stream.close().await?;
@@ -4836,13 +4853,44 @@ mod arrow_flight_tests {
 
     mod graceful_close_tests {
         use super::*;
-        use std::time::Instant;
+        use arrow_array::RecordBatch;
+        use arrow_schema::Schema as ArrowSchema;
+        use databricks_zerobus_ingest_sdk::ZerobusArrowStream;
+        use std::time::{Duration, Instant};
+
+        async fn build_rotation_stream(
+            server_url: String,
+            schema: Arc<ArrowSchema>,
+            ack_wait_ms: Option<u64>,
+        ) -> Result<ZerobusArrowStream, Box<dyn std::error::Error>> {
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            Ok(sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema)
+                .recovery(true)
+                .recovery_backoff_ms(10)
+                .recovery_retries(3)
+                .flush_timeout_ms(3_000)
+                .stream_paused_max_wait_time_ms(ack_wait_ms)
+                .build_arrow()
+                .await?)
+        }
+
+        fn one_batch(schema: Arc<ArrowSchema>) -> RecordBatch {
+            create_test_record_batch(schema, vec![1, 2, 3], vec![Some("a"), Some("b"), Some("c")])
+        }
 
         #[tokio::test]
-        async fn test_default_graceful_close_waits_for_full_server_duration(
+        async fn test_server_rotation_half_closes_before_reconnect(
         ) -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
-            info!("Starting test_default_graceful_close_waits_for_full_server_duration (arrow)");
+            info!("Starting test_server_rotation_half_closes_before_reconnect (arrow)");
 
             const SERVER_DURATION_MS: u64 = 1000;
 
@@ -4915,37 +4963,95 @@ mod arrow_flight_tests {
             let offset1 = stream.ingest_batch(batch1).await?;
             stream.wait_for_offset(offset1).await?;
 
-            // Ingest batch 2 - triggers graceful close signal. The client should wait
-            // for the full server duration before triggering recovery.
+            // Batch 2 triggers rotation. It is replayed only after the active request
+            // reaches EOF and the server response is drained.
             let batch2 = create_test_record_batch(
                 schema.clone(),
                 vec![7, 8, 9],
                 vec![Some("g"), Some("h"), Some("i")],
             );
-            let start = Instant::now();
             let offset2 = stream.ingest_batch(batch2).await?;
 
-            // Wait for batch 2 to be acked (after recovery replays it).
             stream.wait_for_offset(offset2).await?;
-            let elapsed = start.elapsed();
-
-            // Should have waited roughly the server duration before recovery.
-            assert!(
-                elapsed.as_millis() >= (SERVER_DURATION_MS as u128 - 200),
-                "Expected to wait at least ~{}ms for graceful close, but only waited {}ms",
-                SERVER_DURATION_MS,
-                elapsed.as_millis()
-            );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
 
             stream.close().await?;
             Ok(())
         }
 
         #[tokio::test]
-        async fn test_immediate_recovery_on_close_signal() -> Result<(), Box<dyn std::error::Error>>
-        {
+        async fn test_server_rotation_without_recovery_still_half_closes(
+        ) -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
-            info!("Starting test_immediate_recovery_on_close_signal (arrow)");
+            info!("Starting test_server_rotation_without_recovery_still_half_closes (arrow)");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::GracefulClose {
+                        duration_ms: 1_000,
+                        delay_ms: 0,
+                        ack_up_to_offset: None,
+                        ack_up_to_records: None,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(false)
+                .stream_paused_max_wait_time_ms(Some(0))
+                .build_arrow()
+                .await?;
+
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            let error = stream
+                .wait_for_offset(offset)
+                .await
+                .expect_err("rotation must terminate when recovery is disabled");
+            match error {
+                ZerobusError::StreamClosedError(status) => {
+                    assert_eq!(status.code(), tonic::Code::Unavailable);
+                    assert_eq!(
+                        status.message(),
+                        "Server requested graceful stream rotation"
+                    );
+                }
+                other => panic!("expected rotation error, got {other:?}"),
+            }
+
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while !stream.is_closed() {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("rotation must finalize the stream without reconnecting");
+
+            assert_eq!(mock_server.get_batch_count().await, 1, "must not reconnect");
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
+            let unacked = stream.get_unacked_batches().await?;
+            assert_eq!(unacked.len(), 1);
+            assert_eq!(unacked[0].num_rows(), 3);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_zero_ack_wait_still_half_closes() -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_zero_ack_wait_still_half_closes (arrow)");
 
             let (mock_server, server_url) = start_mock_flight_server().await?;
             let schema = create_test_arrow_schema();
@@ -4966,7 +5072,7 @@ mod arrow_flight_tests {
                             ack_up_to_offset: None,
                             ack_up_to_records: None,
                         },
-                        // After immediate recovery, ack batch 1.
+                        // After bounded transport cleanup and recovery, ack batch 1.
                         MockFlightResponse::BatchAck {
                             ack_up_to_offset: 0,
                             delay_ms: 0,
@@ -5002,8 +5108,8 @@ mod arrow_flight_tests {
             let offset0 = stream.ingest_batch(batch0).await?;
             stream.wait_for_offset(offset0).await?;
 
-            // Batch 1 triggers graceful close. With stream_paused_max_wait_time_ms=0,
-            // recovery should be triggered immediately.
+            // A zero configured wait skips only the ACK wait. The request must still
+            // half-close and the response receives a bounded drain opportunity.
             let batch1 = create_test_record_batch(
                 schema.clone(),
                 vec![4, 5, 6],
@@ -5015,12 +5121,14 @@ mod arrow_flight_tests {
             stream.wait_for_offset(offset1).await?;
             let elapsed = start.elapsed();
 
-            // Should recover quickly, not wait 10 seconds.
+            // Cleanup should be bounded well below the advertised 10-second grace.
             assert!(
-                elapsed.as_millis() < 5000,
-                "Expected immediate recovery, but waited {}ms",
+                elapsed.as_millis() < 2000,
+                "Expected bounded transport cleanup, but waited {}ms",
                 elapsed.as_millis()
             );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
 
             stream.close().await?;
             Ok(())
@@ -5100,6 +5208,8 @@ mod arrow_flight_tests {
                 SERVER_DURATION_MS,
                 elapsed.as_millis()
             );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
 
             stream.close().await?;
             Ok(())
@@ -5183,6 +5293,15 @@ mod arrow_flight_tests {
                 "Expected early exit from graceful close, but waited {}ms",
                 elapsed.as_millis()
             );
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while mock_server.get_request_half_close_count() == 0 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("the active request should reach EOF after the close-signal ACK");
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
 
             stream.close().await?;
             Ok(())
@@ -5201,18 +5320,21 @@ mod arrow_flight_tests {
                 .inject_responses(
                     TABLE_NAME,
                     vec![
-                        // Send graceful close after batch 0.
+                        // Acknowledge batch 0 with the close signal. Waiting for offset 0
+                        // then proves the pause and submitted-record snapshot are active.
                         MockFlightResponse::GracefulClose {
                             duration_ms: 5_000,
                             delay_ms: 0,
-                            ack_up_to_offset: None,
-                            ack_up_to_records: None,
+                            ack_up_to_offset: Some(0),
+                            ack_up_to_records: Some(3),
                         },
-                        // After recovery, ack both batches (batch 0 + batch 1 = 6 records).
+                        // Keep the active response open long enough to ingest while paused.
+                        MockFlightResponse::HoldResponseAfterRequestEof,
+                        // Only batch 1 is pending on the replacement connection.
                         MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 1,
+                            ack_up_to_offset: 0,
                             delay_ms: 0,
-                            ack_up_to_records: 6,
+                            ack_up_to_records: 3,
                         },
                     ],
                 )
@@ -5241,10 +5363,8 @@ mod arrow_flight_tests {
                 vec![1, 2, 3],
                 vec![Some("a"), Some("b"), Some("c")],
             );
-            let _offset0 = stream.ingest_batch(batch0).await?;
-
-            // Wait a bit for the graceful close signal to be processed.
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let offset0 = stream.ingest_batch(batch0).await?;
+            stream.wait_for_offset(offset0).await?;
 
             // Ingestion during the grace period should be accepted and buffered.
             // The batch will be replayed after recovery.
@@ -5258,7 +5378,201 @@ mod arrow_flight_tests {
 
             // After recovery, both batches should be acked.
             stream.wait_for_offset(offset1).await?;
+            assert_eq!(
+                mock_server.get_batch_count().await,
+                2,
+                "the post-signal batch must be sent only on the replacement connection"
+            );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
 
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_post_eof_ack_is_applied_before_replay(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 1_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        MockFlightResponse::BatchAckAfterRequestEof {
+                            ack_up_to_offset: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let mut stream = build_rotation_stream(server_url, schema.clone(), Some(0)).await?;
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            stream.wait_for_offset(offset).await?;
+
+            assert_eq!(
+                mock_server.get_batch_count().await,
+                1,
+                "late ACK avoids replay"
+            );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_post_eof_permanent_error_is_preserved(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 1_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        MockFlightResponse::ErrorAfterRequestEof {
+                            status: tonic::Status::invalid_argument("post-EOF rejection"),
+                        },
+                    ],
+                )
+                .await;
+
+            let stream = build_rotation_stream(server_url, schema.clone(), Some(0)).await?;
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            let error = stream
+                .wait_for_offset(offset)
+                .await
+                .expect_err("peer error must win");
+            match error {
+                ZerobusError::StreamClosedError(status) => {
+                    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+                    assert_eq!(status.message(), "post-EOF rejection");
+                }
+                other => panic!("expected permanent peer status, got {other:?}"),
+            }
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_rotation_drain_timeout_falls_back_to_reconnect(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 1_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        MockFlightResponse::HoldResponseAfterRequestEof,
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let mut stream = build_rotation_stream(server_url, schema.clone(), Some(0)).await?;
+            let started = Instant::now();
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            stream.wait_for_offset(offset).await?;
+
+            assert!(started.elapsed() >= Duration::from_millis(450));
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
+            stream.close().await?;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_invalid_close_ack_still_half_closes_request(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 1_000,
+                            delay_ms: 0,
+                            ack_up_to_offset: Some(0),
+                            ack_up_to_records: Some(4),
+                        },
+                        MockFlightResponse::ErrorAfterRequestEof {
+                            status: tonic::Status::unavailable("rotation grace expired"),
+                        },
+                    ],
+                )
+                .await;
+
+            let stream = build_rotation_stream(server_url, schema.clone(), Some(0)).await?;
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            let error = stream
+                .wait_for_offset(offset)
+                .await
+                .expect_err("invalid ACK must fail");
+            assert!(matches!(error, ZerobusError::InvalidStateError(_)));
+            assert_eq!(
+                mock_server.get_batch_count().await,
+                1,
+                "a retryable post-EOF status must not trigger replay after a permanent error"
+            );
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_zero_server_grace_uses_bounded_local_drain(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::GracefulClose {
+                            duration_ms: 0,
+                            delay_ms: 0,
+                            ack_up_to_offset: None,
+                            ack_up_to_records: None,
+                        },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 3,
+                        },
+                    ],
+                )
+                .await;
+
+            let mut stream = build_rotation_stream(server_url, schema.clone(), None).await?;
+            let offset = stream.ingest_batch(one_batch(schema)).await?;
+            stream.wait_for_offset(offset).await?;
+            assert_eq!(mock_server.get_request_half_close_count(), 1);
+            assert_eq!(mock_server.get_request_reset_count(), 0);
             stream.close().await?;
             Ok(())
         }

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -58,6 +59,15 @@ pub enum MockFlightResponse {
         /// Cumulative records acknowledged.
         ack_up_to_records: u64,
     },
+    /// Acknowledgment emitted only after the client cleanly half-closes its request.
+    BatchAckAfterRequestEof {
+        ack_up_to_offset: i64,
+        ack_up_to_records: u64,
+    },
+    /// Permanent status emitted only after the client cleanly half-closes its request.
+    ErrorAfterRequestEof { status: Status },
+    /// Keep the response open after request EOF to exercise the bounded drain fallback.
+    HoldResponseAfterRequestEof,
     /// Error response - sent immediately when a batch arrives.
     Error { status: Status, delay_ms: u64 },
     /// Reject a connection's setup: send this error instead of the ready signal on the
@@ -98,6 +108,10 @@ pub struct MockFlightServer {
     /// Observation of every `ack_up_to_records` value emitted on the auto-ack path,
     /// in emission order. Used by tests to assert acks are connection-relative.
     auto_ack_records: Arc<Mutex<Vec<u64>>>,
+    /// Number of request bodies that ended with a clean client half-close.
+    request_half_closes: Arc<AtomicU64>,
+    /// Number of request bodies that ended with a transport error/reset.
+    request_resets: Arc<AtomicU64>,
 }
 
 impl MockFlightServer {
@@ -109,6 +123,8 @@ impl MockFlightServer {
             row_count: Arc::new(Mutex::new(0)),
             response_indices: Arc::new(Mutex::new(HashMap::new())),
             auto_ack_records: Arc::new(Mutex::new(Vec::new())),
+            request_half_closes: Arc::new(AtomicU64::new(0)),
+            request_resets: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -142,6 +158,14 @@ impl MockFlightServer {
         self.auto_ack_records.lock().await.clone()
     }
 
+    pub fn get_request_half_close_count(&self) -> u64 {
+        self.request_half_closes.load(Ordering::Relaxed)
+    }
+
+    pub fn get_request_reset_count(&self) -> u64 {
+        self.request_resets.load(Ordering::Relaxed)
+    }
+
     /// Reset the server state
     #[allow(dead_code)]
     pub async fn reset(&self) {
@@ -153,6 +177,8 @@ impl MockFlightServer {
         *self.batch_count.lock().await = 0;
         *self.row_count.lock().await = 0;
         self.auto_ack_records.lock().await.clear();
+        self.request_half_closes.store(0, Ordering::Relaxed);
+        self.request_resets.store(0, Ordering::Relaxed);
     }
 }
 
@@ -233,6 +259,8 @@ impl FlightService for MockFlightServer {
         let row_count = Arc::clone(&self.row_count);
         let response_indices = Arc::clone(&self.response_indices);
         let auto_ack_records = Arc::clone(&self.auto_ack_records);
+        let request_half_closes = Arc::clone(&self.request_half_closes);
+        let request_resets = Arc::clone(&self.request_resets);
 
         tokio::spawn(async move {
             let mut stream_responses: Vec<MockFlightResponse> = Vec::new();
@@ -260,7 +288,19 @@ impl FlightService for MockFlightServer {
                 *indices.get(&table_name).unwrap_or(&0)
             };
 
-            while let Ok(Some(flight_data)) = stream.message().await {
+            let clean_request_eof = loop {
+                let flight_data = match stream.message().await {
+                    Ok(Some(flight_data)) => flight_data,
+                    Ok(None) => {
+                        request_half_closes.fetch_add(1, Ordering::Relaxed);
+                        break true;
+                    }
+                    Err(error) => {
+                        request_resets.fetch_add(1, Ordering::Relaxed);
+                        warn!("Client request stream reset: {error}");
+                        break false;
+                    }
+                };
                 // Handle schema message (first message has no app_metadata or empty app_metadata)
                 if is_first_message {
                     is_first_message = false;
@@ -410,6 +450,11 @@ impl FlightService for MockFlightServer {
                                 }
                             }
                         }
+                        MockFlightResponse::BatchAckAfterRequestEof { .. }
+                        | MockFlightResponse::ErrorAfterRequestEof { .. }
+                        | MockFlightResponse::HoldResponseAfterRequestEof => {
+                            debug!("Waiting for request EOF before sending scripted response");
+                        }
                         MockFlightResponse::Error { status, delay_ms } => {
                             // Error responses trigger immediately on first batch
                             if *delay_ms > 0 {
@@ -530,6 +575,47 @@ impl FlightService for MockFlightServer {
                         }
                     }
                 }
+            };
+
+            if clean_request_eof {
+                match stream_responses.get(response_index) {
+                    Some(MockFlightResponse::BatchAckAfterRequestEof {
+                        ack_up_to_offset,
+                        ack_up_to_records,
+                    }) => {
+                        let metadata = FlightAckMetadata {
+                            ack_up_to_offset: *ack_up_to_offset,
+                            ack_up_to_records: *ack_up_to_records,
+                        };
+                        let _ = tx
+                            .send(Ok(PutResult {
+                                app_metadata: serde_json::to_vec(&metadata).unwrap().into(),
+                            }))
+                            .await;
+                        response_index += 1;
+                        response_indices
+                            .lock()
+                            .await
+                            .insert(table_name.clone(), response_index);
+                    }
+                    Some(MockFlightResponse::ErrorAfterRequestEof { status }) => {
+                        let _ = tx.send(Err(status.clone())).await;
+                        response_index += 1;
+                        response_indices
+                            .lock()
+                            .await
+                            .insert(table_name.clone(), response_index);
+                    }
+                    Some(MockFlightResponse::HoldResponseAfterRequestEof) => {
+                        response_index += 1;
+                        response_indices
+                            .lock()
+                            .await
+                            .insert(table_name.clone(), response_index);
+                        std::future::pending::<()>().await;
+                    }
+                    _ => {}
+                }
             }
 
             debug!("Client stream ended");
@@ -595,6 +681,8 @@ async fn start_mock_flight_server_inner(
         row_count: Arc::clone(&mock_server.row_count),
         response_indices: Arc::clone(&mock_server.response_indices),
         auto_ack_records: Arc::clone(&mock_server.auto_ack_records),
+        request_half_closes: Arc::clone(&mock_server.request_half_closes),
+        request_resets: Arc::clone(&mock_server.request_resets),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Before this PR:

1. Zerobus sent a close signal that started a bounded grace period for the active Arrow Flight connection.
2. The SDK paused new sends, but decided whether it had finished waiting by checking whether the entire pending-batch collection was empty.
3. That collection mixed records already submitted on the closing connection with records accepted after the pause and buffered for replay.
4. The closing connection could never acknowledge those buffered records, so they could unnecessarily consume the grace period.
5. Recovery then dropped the bidirectional Flight call without first completing its request body and draining its response.
6. Tonic consequently cancelled the live HTTP/2 stream, producing `RESET(CANCEL)` on the server even when reconnect and replay later succeeded.

After this PR:

1. The SDK receives a server close signal and atomically pauses sends while snapshotting the record watermark submitted on the active connection.
2. It waits only for acknowledgments up to that connection-local target, bounded by the advertised grace and the configured ACK-wait cap.
3. Records accepted after the pause remain buffered for replay and do not extend the old connection's ACK target.
4. The SDK stops the request body at a `FlightData` boundary, emits request EOF, and drains late acknowledgments, peer status, or response EOF under the same bounded rotation deadline.
5. It reconnects and replays only the unacknowledged suffix when recovery is enabled. With recovery disabled, it still cleans up the active transport and leaves unacknowledged batches retrievable.
6. Permanent peer or protocol errors observed during rotation retain precedence over later retryable transport status.

To achieve this, the PR:

- Adds `RequestBodyControl` to half-close the active request without dropping the HTTP/2 stream.
- Uses one narrow rotation state machine: open, waiting for the submitted ACK snapshot, then draining.
- Reserves up to 500 ms of a normal server grace period for request EOF and response drain. A zero configured ACK wait skips only ACK waiting; bounded transport cleanup still runs.
- Applies acknowledgments received during the drain before reconnecting, which avoids replaying data that became durable after request EOF.
- Preserves only the permanent-error precedence required on the active rotated connection.
- Updates the Rust configuration documentation, README, changelogs, and C FFI field documentation. The FFI signature and ABI are unchanged.

This is intentionally scoped to normal server-initiated rotation. Explicit close during recovery and teardown of incomplete replacement requests retain their existing best-effort behavior and are follow-up work.

## How is this tested?

Added focused tests:

- `test_server_rotation_half_closes_before_reconnect`: the active request reaches EOF without a pre-EOF reset before replay starts.
- `test_server_rotation_without_recovery_still_half_closes`: cleanup still runs without reconnecting, and the unacknowledged batch remains retrievable.
- `test_zero_ack_wait_still_half_closes`: a zero ACK wait skips only ACK waiting and still performs bounded transport cleanup.
- `test_post_eof_ack_is_applied_before_replay`: an acknowledgment received after request EOF prevents unnecessary replay.
- `test_post_eof_permanent_error_is_preserved`: a permanent peer status received after request EOF is returned unchanged.
- `test_rotation_drain_timeout_falls_back_to_reconnect`: an open response cannot prevent bounded recovery.
- `test_invalid_close_ack_still_half_closes_request`: an invalid acknowledgment remains terminal even if a later retryable status arrives.
- `test_zero_server_grace_uses_bounded_local_drain`: a zero advertised grace still gets a bounded best-effort cleanup attempt.

Manual before/after comparison of the published Rust SDK 2.5.0 and these changes, verified from server-side logs:

- Before: the server observed one rotation-window `RESET(CANCEL)` before the post-rotation flush.
- After: the server observed a clean request `END_STREAM` followed by response `END_STREAM`, no rotation-window reset, successful recovery, and a completed post-rotation flush.
