### PR TITLE
[Rust][Arrow] Make ACK deadlines pending-relative

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bug Fixes
 
+- **Arrow Flight — acknowledgment deadlines are pending-relative** (Beta): no
+  timer runs while a stream is idle. During normal stream operation, each batch
+  receives an absolute deadline when it becomes pending; responses and partial
+  acknowledgments do not extend it. Recovery refreshes the deadline when
+  replaying a batch on a replacement connection.
 - Fixed Arrow Flight recovery sender lifetime: replacement senders are now published
   only after pending replay succeeds, while initial supervisor handoff and failed or
   cancelled replay promptly drop redundant senders instead of retaining incomplete

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -12,7 +12,8 @@
   while a stream is idle. During normal stream operation, each batch receives
   an absolute deadline when it becomes pending; responses and partial
   acknowledgments do not extend it. Recovery refreshes the deadline when
-  replaying a batch on a replacement connection.
+  the full replay completes and ACK processing can resume on the replacement
+  connection.
 - Arrow Flight rejects unrepresentable timeout values: stream creation returns
   `InvalidArgument` when ACK or recovery deadlines exceed the platform
   monotonic-clock range. Server-advertised graceful-rotation periods are capped

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Bug Fixes
 
-- **Arrow Flight — acknowledgment deadlines are pending-relative** (Beta): no
-  timer runs while a stream is idle. During normal stream operation, each batch
-  receives an absolute deadline when it becomes pending; responses and partial
+- Arrow Flight acknowledgment deadlines are pending-relative: no timer runs
+  while a stream is idle. During normal stream operation, each batch receives
+  an absolute deadline when it becomes pending; responses and partial
   acknowledgments do not extend it. Recovery refreshes the deadline when
   replaying a batch on a replacement connection.
+- Arrow Flight rejects unrepresentable timeout values: stream creation returns
+  `InvalidArgument` when ACK or recovery deadlines exceed the platform
+  monotonic-clock range. Server-advertised graceful-rotation periods are capped
+  at one year.
 - Fixed Arrow Flight recovery sender lifetime: replacement senders are now published
   only after pending replay succeeds, while initial supervisor handoff and failed or
   cancelled replay promptly drop redundant senders instead of retaining incomplete

--- a/rust/README.md
+++ b/rust/README.md
@@ -805,6 +805,15 @@ Also accepts `0` or `no`.
 | `ack_callback` | `Option<Arc<dyn AckCallback>>` | `None` | Optional callback for acknowledgment notifications |
 | `callback_max_wait_time_ms` | `Option<u64>` | `None` | Maximum time to wait for callback processing to complete after closing the stream (`None` = wait indefinitely, `Some(x)` = wait up to `x` ms) |
 
+For Arrow Flight streams *(Beta)*, `server_lack_of_ack_timeout_ms` is an
+absolute limit on how long the oldest batch may remain pending during normal
+stream operation, not an inactivity timeout. No timer runs while the stream is
+idle. A batch's deadline starts when it becomes pending; responses and partial
+acknowledgments do not pause or extend it. Replayed batches receive a fresh
+deadline on the recovered connection. Configure this timeout together with
+`max_inflight_batches` so the server can acknowledge a full allowed backlog
+within the timeout.
+
 
 **Example:**
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -814,6 +814,10 @@ deadline on the recovered connection. Configure this timeout together with
 `max_inflight_batches` so the server can acknowledge a full allowed backlog
 within the timeout.
 
+Arrow stream construction rejects `recovery_timeout_ms` and
+`server_lack_of_ack_timeout_ms` values whose deadlines cannot be represented by
+the platform monotonic clock. Server-advertised graceful-rotation periods are
+capped at one year.
 
 **Example:**
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -810,7 +810,8 @@ absolute limit on how long the oldest batch may remain pending during normal
 stream operation, not an inactivity timeout. No timer runs while the stream is
 idle. A batch's deadline starts when it becomes pending; responses and partial
 acknowledgments do not pause or extend it. Replayed batches receive a fresh
-deadline on the recovered connection. Configure this timeout together with
+deadline after the full replay completes and acknowledgment processing can
+resume on the recovered connection. Configure this timeout together with
 `max_inflight_batches` so the server can acknowledge a full allowed backlog
 within the timeout.
 

--- a/rust/sdk/src/stream/arrow/acks.rs
+++ b/rust/sdk/src/stream/arrow/acks.rs
@@ -955,7 +955,7 @@ mod tests {
         let schema = one_col_schema();
         let sem = Arc::new(Semaphore::new(1));
         let mut pending = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
-        pending.set_enqueued_at(Instant::now() - ACK_TIMEOUT);
+        pending.refresh_enqueued_at(Instant::now() - ACK_TIMEOUT);
         let pending_batches = Arc::new(Mutex::new(vec![pending]));
         let response_stream = iter([Ok(PutResult {
             app_metadata: serde_json::to_vec(&FlightAckMetadata {
@@ -993,7 +993,7 @@ mod tests {
         let schema = one_col_schema();
         let sem = Arc::new(Semaphore::new(1));
         let mut pending = pending_batch(&sem, batch_with_rows(&schema, 10), 0, 0, 10);
-        pending.set_enqueued_at(Instant::now() - ACK_TIMEOUT);
+        pending.refresh_enqueued_at(Instant::now() - ACK_TIMEOUT);
         let pending_batches = Arc::new(Mutex::new(vec![pending]));
         let response_stream = iter([5, 10].map(|acked_records| {
             Ok(PutResult {
@@ -1040,9 +1040,9 @@ mod tests {
         let sem = Arc::new(Semaphore::new(2));
         let expired_at = Instant::now() - ACK_TIMEOUT;
         let mut first = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
-        first.set_enqueued_at(expired_at);
+        first.refresh_enqueued_at(expired_at);
         let mut second = pending_batch(&sem, batch_with_rows(&schema, 1), 1, 1, 2);
-        second.set_enqueued_at(expired_at);
+        second.refresh_enqueued_at(expired_at);
         let pending_batches = Arc::new(Mutex::new(vec![first, second]));
         let (processor, _request_body, _last_ack_rx) = ack_processor(
             Arc::clone(&pending_batches),

--- a/rust/sdk/src/stream/arrow/acks.rs
+++ b/rust/sdk/src/stream/arrow/acks.rs
@@ -27,6 +27,7 @@ use crate::offset_generator::OffsetId;
 use crate::ZerobusResult;
 
 const ROTATION_DRAIN_TIMEOUT_MS: u64 = 500;
+const MAX_SERVER_ROTATION_GRACE: Duration = Duration::from_secs(365 * 24 * 60 * 60);
 
 /// Owns the shared stream state and configuration used while processing ACKs.
 pub(super) struct AckProcessor {
@@ -316,19 +317,43 @@ impl AckProcessor {
         server_duration_ms: u64,
         configured_ack_wait_ms: Option<u64>,
     ) -> RotationDeadlines {
-        let now = Instant::now();
+        Self::rotation_deadlines_at(Instant::now(), server_duration_ms, configured_ack_wait_ms)
+    }
+
+    fn rotation_deadlines_at(
+        rotation_started_at: Instant,
+        server_duration_ms: u64,
+        configured_ack_wait_ms: Option<u64>,
+    ) -> RotationDeadlines {
         let drain_budget = Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS);
-        let server_grace = Duration::from_millis(server_duration_ms);
-        let bounded_fallback = now + Duration::from_secs(365 * 24 * 60 * 60);
-        let server_deadline = now.checked_add(server_grace).unwrap_or(bounded_fallback);
+        let advertised_server_grace = Duration::from_millis(server_duration_ms);
+        let server_grace = advertised_server_grace.min(MAX_SERVER_ROTATION_GRACE);
+        if server_grace != advertised_server_grace {
+            warn!(target: super::LOG_TARGET,
+                server_duration_ms,
+                max_server_rotation_grace_ms = MAX_SERVER_ROTATION_GRACE.as_millis(),
+                "Server rotation grace exceeds the client limit; clamping it"
+            );
+        }
+        let server_deadline = match rotation_started_at.checked_add(server_grace) {
+            Some(deadline) => deadline,
+            // No later deadline can be represented at this clock boundary.
+            None => rotation_started_at,
+        };
         let available_ack_wait = server_grace.saturating_sub(drain_budget);
         let configured_ack_wait = configured_ack_wait_ms
             .map(Duration::from_millis)
             .unwrap_or(available_ack_wait);
         let ack_wait = available_ack_wait.min(configured_ack_wait);
-        let ack_deadline = now.checked_add(ack_wait).unwrap_or(server_deadline);
+        let ack_deadline = match rotation_started_at.checked_add(ack_wait) {
+            Some(deadline) => deadline,
+            None => server_deadline,
+        };
         let drain_deadline = if server_grace < drain_budget {
-            now + drain_budget
+            match rotation_started_at.checked_add(drain_budget) {
+                Some(deadline) => deadline,
+                None => server_deadline,
+            }
         } else {
             server_deadline
         };
@@ -339,7 +364,13 @@ impl AckProcessor {
     }
 
     fn bounded_rotation_drain_deadline(close_deadline: Instant) -> Instant {
-        close_deadline.min(Instant::now() + Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS))
+        let now = Instant::now();
+        let bounded_deadline =
+            match now.checked_add(Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS)) {
+                Some(deadline) => deadline,
+                None => close_deadline,
+            };
+        close_deadline.min(bounded_deadline)
     }
 
     /// Half-closes the active request and drains the response under the rotation
@@ -410,7 +441,10 @@ impl AckProcessor {
 
     /// Returns the oldest submitted batch and its absolute ACK deadline while holding
     /// the pending lock that also synchronizes submitted-watermark publication.
-    async fn oldest_ack_deadline(&self, ack_timeout: Duration) -> Option<PendingAckDeadline> {
+    async fn oldest_ack_deadline(
+        &self,
+        ack_timeout: Duration,
+    ) -> ZerobusResult<Option<PendingAckDeadline>> {
         let pending = self.pending_batches.lock().await;
         let submitted_records = self.submitted_records.load(Ordering::Acquire);
         oldest_pending_ack_deadline(&pending, submitted_records, ack_timeout)
@@ -423,14 +457,16 @@ impl AckProcessor {
         &self,
         expected: PendingAckDeadline,
         ack_timeout: Duration,
-    ) -> Option<usize> {
+    ) -> ZerobusResult<Option<usize>> {
         let pending = self.pending_batches.lock().await;
         let submitted_records = self.submitted_records.load(Ordering::Acquire);
-        oldest_pending_ack_deadline(&pending, submitted_records, ack_timeout)
-            .filter(|current| {
-                current.identity == expected.identity && Instant::now() >= current.deadline
-            })
-            .map(|_| pending.len())
+        Ok(
+            oldest_pending_ack_deadline(&pending, submitted_records, ack_timeout)?
+                .filter(|current| {
+                    current.identity == expected.identity && Instant::now() >= current.deadline
+                })
+                .map(|_| pending.len()),
+        )
     }
 
     /// Waits without arming an ACK timeout while no submitted batch is pending.
@@ -569,7 +605,7 @@ impl AckProcessor {
             }
 
             let event = match &rotation {
-                RotationState::Open => match self.oldest_ack_deadline(ack_timeout).await {
+                RotationState::Open => match self.oldest_ack_deadline(ack_timeout).await? {
                     Some(pending_deadline) => {
                         self.wait_with_pending_deadline(
                             &mut response_stream,
@@ -598,7 +634,7 @@ impl AckProcessor {
                 AckEvent::RequestSendFailed => continue,
                 AckEvent::AckDeadline(expected) => {
                     if let Some(pending_count) =
-                        self.expired_pending_count(expected, ack_timeout).await
+                        self.expired_pending_count(expected, ack_timeout).await?
                     {
                         error!(target: super::LOG_TARGET,
                             pending_count,
@@ -703,6 +739,7 @@ mod tests {
     use super::super::RecordBatch;
     use super::{
         AckProcessor, FlightAckMetadata, OffsetId, PendingBatch, RequestBodyControl, ZerobusError,
+        MAX_SERVER_ROTATION_GRACE, ROTATION_DRAIN_TIMEOUT_MS,
     };
 
     fn one_col_schema() -> Arc<ArrowSchema> {
@@ -1016,10 +1053,14 @@ mod tests {
         let fired = processor
             .oldest_ack_deadline(ACK_TIMEOUT)
             .await
+            .expect("deadline calculation")
             .expect("expired head");
 
         assert_eq!(
-            processor.expired_pending_count(fired, ACK_TIMEOUT).await,
+            processor
+                .expired_pending_count(fired, ACK_TIMEOUT)
+                .await
+                .expect("deadline recheck"),
             Some(2)
         );
 
@@ -1028,6 +1069,22 @@ mod tests {
         assert!(processor
             .expired_pending_count(fired, ACK_TIMEOUT)
             .await
+            .expect("deadline recheck")
             .is_none());
+    }
+
+    #[test]
+    fn server_rotation_grace_is_capped() {
+        let rotation_started_at = Instant::now();
+        let deadlines = AckProcessor::rotation_deadlines_at(rotation_started_at, u64::MAX, None);
+
+        assert_eq!(
+            deadlines.drain.duration_since(rotation_started_at),
+            MAX_SERVER_ROTATION_GRACE
+        );
+        assert_eq!(
+            deadlines.ack.duration_since(rotation_started_at),
+            MAX_SERVER_ROTATION_GRACE - Duration::from_millis(ROTATION_DRAIN_TIMEOUT_MS)
+        );
     }
 }

--- a/rust/sdk/src/stream/arrow/acks.rs
+++ b/rust/sdk/src/stream/arrow/acks.rs
@@ -569,10 +569,6 @@ impl AckProcessor {
                 return Ok(());
             }
 
-            if self.request_send_failure.take() {
-                return Err(Self::request_send_error());
-            }
-
             if let RotationState::WaitingForAcks {
                 target_records,
                 deadlines,
@@ -631,7 +627,12 @@ impl AckProcessor {
 
             match event {
                 AckEvent::PendingBatchAvailable => continue,
-                AckEvent::RequestSendFailed => continue,
+                AckEvent::RequestSendFailed => {
+                    if self.request_send_failure.take() {
+                        return Err(Self::request_send_error());
+                    }
+                    continue;
+                }
                 AckEvent::AckDeadline(expected) => {
                     if let Some(pending_count) =
                         self.expired_pending_count(expected, ack_timeout).await?
@@ -730,9 +731,11 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::Int32Array;
+    use arrow_flight::error::FlightError;
     use arrow_flight::PutResult;
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
-    use futures::stream::iter;
+    use futures::stream::{iter, pending};
+    use futures::StreamExt as _;
     use tokio::sync::{watch, Mutex, Semaphore};
     use tokio::time::{Duration, Instant};
 
@@ -796,6 +799,83 @@ mod tests {
         match error {
             ZerobusError::StreamClosedError(status) => {
                 assert_eq!(status.code(), tonic::Code::Unavailable);
+            }
+            other => panic!("expected a stream-closed error, got {other:?}"),
+        }
+    }
+
+    /// A buffered ACK is authoritative even when the request sender has already
+    /// reported failure. Apply its durable watermark before asking recovery to replay.
+    #[tokio::test]
+    async fn ready_ack_is_applied_before_reported_request_send_failure() {
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let pending_batches = Arc::new(Mutex::new(vec![pending_batch(
+            &sem,
+            batch_with_rows(&schema, 10),
+            0,
+            0,
+            10,
+        )]));
+        let response_stream = iter([Ok(PutResult {
+            app_metadata: serde_json::to_vec(&FlightAckMetadata {
+                ack_up_to_offset: 0,
+                ack_up_to_records: 5,
+                close_stream_duration_ms: None,
+            })
+            .unwrap()
+            .into(),
+        })])
+        .chain(pending::<Result<PutResult, FlightError>>());
+        let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (processor, request_body, _last_ack_rx) = ack_processor(
+            Arc::clone(&pending_batches),
+            Arc::new(AtomicU64::new(10)),
+            Arc::clone(&last_acked_records),
+            false,
+        );
+        processor.request_send_failure.report();
+
+        let error = processor
+            .process(Box::pin(response_stream), request_body)
+            .await
+            .expect_err("the reported request-send failure must trigger recovery");
+
+        match error {
+            ZerobusError::StreamClosedError(status) => {
+                assert_eq!(status.code(), tonic::Code::Unavailable);
+            }
+            other => panic!("expected a stream-closed error, got {other:?}"),
+        }
+        assert_eq!(last_acked_records.load(Ordering::Acquire), 5);
+        assert_eq!(pending_batches.lock().await.len(), 1);
+    }
+
+    /// A peer status already buffered on the response stream must keep its real
+    /// error and retry classification instead of being masked by local send failure.
+    #[tokio::test]
+    async fn ready_server_error_wins_reported_request_send_failure() {
+        let response_stream = iter([Err::<PutResult, FlightError>(
+            tonic::Status::permission_denied("permanent server rejection").into(),
+        )]);
+        let (processor, request_body, _last_ack_rx) = ack_processor(
+            Arc::new(Mutex::new(Vec::new())),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            false,
+        );
+        processor.request_send_failure.report();
+
+        let error = processor
+            .process(Box::pin(response_stream), request_body)
+            .await
+            .expect_err("the ready server rejection must be returned");
+
+        assert!(!error.is_retryable());
+        match error {
+            ZerobusError::StreamClosedError(status) => {
+                assert_eq!(status.code(), tonic::Code::PermissionDenied);
+                assert_eq!(status.message(), "permanent server rejection");
             }
             other => panic!("expected a stream-closed error, got {other:?}"),
         }

--- a/rust/sdk/src/stream/arrow/acks.rs
+++ b/rust/sdk/src/stream/arrow/acks.rs
@@ -7,12 +7,16 @@ use std::mem::replace;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
+use arrow_flight::error::FlightError;
+use arrow_flight::PutResult;
 use futures::StreamExt;
-use tokio::sync::{watch, Mutex};
-use tokio::time::{sleep_until, timeout, Duration, Instant};
+use tokio::sync::{watch, Mutex, Notify};
+use tokio::time::{sleep_until, Duration, Instant};
 use tracing::{debug, error, info, warn};
 
-use super::batch::PendingBatch;
+use super::batch::{
+    oldest_pending_ack_deadline, PendingAckDeadline, PendingBatch, PendingBatchIdentity,
+};
 use super::connection::{FlightResponseStream, RequestBodyControl};
 use super::metadata::FlightAckMetadata;
 #[cfg(feature = "test-hooks")]
@@ -29,6 +33,8 @@ pub(super) struct AckProcessor {
     is_closed: Arc<AtomicBool>,
     last_ack_tx: watch::Sender<Option<OffsetId>>,
     pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
+    pending_notify: Arc<Notify>,
+    request_send_failure: Arc<RequestSendFailure>,
     server_error_tx: watch::Sender<Option<ZerobusError>>,
     submitted_records: Arc<AtomicU64>,
     last_acked_records: Arc<AtomicU64>,
@@ -38,6 +44,8 @@ pub(super) struct AckProcessor {
     options: ArrowStreamConfigurationOptions,
     #[cfg(feature = "test-hooks")]
     ack_applied_gate: AckAppliedGate,
+    #[cfg(feature = "test-hooks")]
+    ack_idle_gate: super::AckIdleGate,
 }
 
 /// State captured when rotation stops waiting for acknowledgments and begins transport
@@ -67,6 +75,38 @@ enum RotationState {
 struct RotationDeadlines {
     ack: Instant,
     drain: Instant,
+}
+
+/// Event that wakes the acknowledgment processor before transport drain begins.
+enum AckEvent {
+    Response(Option<Result<PutResult, FlightError>>),
+    PendingBatchAvailable,
+    RequestSendFailed,
+    AckDeadline(PendingAckDeadline),
+}
+
+/// Coalesces request-sender failures until the supervisor has paused the failed
+/// connection. The notification wakes an ACK processor that has no deadline armed.
+#[derive(Default)]
+pub(super) struct RequestSendFailure {
+    pending: AtomicBool,
+    notify: Notify,
+}
+
+impl RequestSendFailure {
+    pub(super) fn report(&self) {
+        if !self.pending.swap(true, Ordering::AcqRel) {
+            self.notify.notify_one();
+        }
+    }
+
+    fn take(&self) -> bool {
+        self.pending.swap(false, Ordering::AcqRel)
+    }
+
+    fn clear(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
 }
 
 /// Borrowed view of the active connection's acknowledgment bookkeeping.
@@ -198,6 +238,8 @@ impl AckProcessor {
             is_closed: Arc::clone(&stream.is_closed),
             last_ack_tx: stream.last_ack_tx.clone(),
             pending_batches: Arc::clone(&stream.pending_batches),
+            pending_notify: Arc::clone(&stream.pending_notify),
+            request_send_failure: Arc::clone(&stream.request_send_failure),
             server_error_tx: stream.server_error_tx.clone(),
             submitted_records: Arc::clone(&stream.submitted_records),
             last_acked_records: Arc::clone(&stream.last_acked_records),
@@ -207,6 +249,8 @@ impl AckProcessor {
             options: stream.options.clone(),
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::clone(&stream.ack_applied_gate),
+            #[cfg(feature = "test-hooks")]
+            ack_idle_gate: Arc::clone(&stream.ack_idle_gate),
         }
     }
 
@@ -223,6 +267,8 @@ impl AckProcessor {
             is_closed: Arc::new(AtomicBool::new(false)),
             last_ack_tx,
             pending_batches,
+            pending_notify: Arc::new(Notify::new()),
+            request_send_failure: Arc::new(RequestSendFailure::default()),
             server_error_tx,
             submitted_records,
             last_acked_records,
@@ -235,6 +281,8 @@ impl AckProcessor {
             },
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            ack_idle_gate: Arc::new(Mutex::new(None)),
         };
         (
             processor,
@@ -360,6 +408,97 @@ impl AckProcessor {
         }
     }
 
+    /// Returns the oldest submitted batch and its absolute ACK deadline while holding
+    /// the pending lock that also synchronizes submitted-watermark publication.
+    async fn oldest_ack_deadline(&self, ack_timeout: Duration) -> Option<PendingAckDeadline> {
+        let pending = self.pending_batches.lock().await;
+        let submitted_records = self.submitted_records.load(Ordering::Acquire);
+        oldest_pending_ack_deadline(&pending, submitted_records, ack_timeout)
+    }
+
+    /// Returns the pending count from the locked snapshot when a fired deadline still
+    /// belongs to the same expired head. This closes the race with an acknowledgment
+    /// that removes the head as the timer fires.
+    async fn expired_pending_count(
+        &self,
+        expected: PendingAckDeadline,
+        ack_timeout: Duration,
+    ) -> Option<usize> {
+        let pending = self.pending_batches.lock().await;
+        let submitted_records = self.submitted_records.load(Ordering::Acquire);
+        oldest_pending_ack_deadline(&pending, submitted_records, ack_timeout)
+            .filter(|current| {
+                current.identity == expected.identity && Instant::now() >= current.deadline
+            })
+            .map(|_| pending.len())
+    }
+
+    /// Waits without arming an ACK timeout while no submitted batch is pending.
+    async fn wait_while_idle(&self, response_stream: &mut FlightResponseStream) -> AckEvent {
+        #[cfg(feature = "test-hooks")]
+        if let Some(notify) = self.ack_idle_gate.lock().await.take() {
+            notify.notify_one();
+        }
+
+        tokio::select! {
+            biased;
+            response = response_stream.next() => AckEvent::Response(response),
+            _ = self.request_send_failure.notify.notified() => AckEvent::RequestSendFailed,
+            _ = self.pending_notify.notified() => AckEvent::PendingBatchAvailable,
+        }
+    }
+
+    /// Waits for a response while enforcing the oldest pending ACK deadline. A ready
+    /// response may win one already-expired tie for a given head; it cannot defer that
+    /// same head twice.
+    async fn wait_with_pending_deadline(
+        &self,
+        response_stream: &mut FlightResponseStream,
+        pending_deadline: PendingAckDeadline,
+        expiry_tie_winner: &mut Option<PendingBatchIdentity>,
+    ) -> AckEvent {
+        if *expiry_tie_winner == Some(pending_deadline.identity)
+            && Instant::now() >= pending_deadline.deadline
+        {
+            return AckEvent::AckDeadline(pending_deadline);
+        }
+
+        let event = tokio::select! {
+            biased;
+            response = response_stream.next() => AckEvent::Response(response),
+            _ = self.request_send_failure.notify.notified() => AckEvent::RequestSendFailed,
+            _ = sleep_until(pending_deadline.deadline) => {
+                AckEvent::AckDeadline(pending_deadline)
+            }
+        };
+
+        *expiry_tie_winner = if matches!(event, AckEvent::Response(_))
+            && Instant::now() >= pending_deadline.deadline
+        {
+            Some(pending_deadline.identity)
+        } else {
+            None
+        };
+        event
+    }
+
+    fn ack_timeout_error() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::deadline_exceeded("Server ack timeout"))
+    }
+
+    fn request_send_error() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::unavailable(
+            "Flight request stream closed while sending",
+        ))
+    }
+
+    /// Clears all coalesced failures from the old request sender. The supervisor calls
+    /// this only after pausing under `ingest_mutex`, so no later ingest can report a
+    /// failure for that connection.
+    pub(super) fn clear_request_send_failure(&self) {
+        self.request_send_failure.clear();
+    }
+
     /// Processes acknowledgments and the single server-initiated rotation path.
     ///
     /// Rotation pauses sends and snapshots submitted records, waits only for that
@@ -372,6 +511,7 @@ impl AckProcessor {
     ) -> ZerobusResult<()> {
         let ack_timeout = Duration::from_millis(self.options.server_lack_of_ack_timeout_ms);
         let mut rotation = RotationState::Open;
+        let mut expiry_tie_winner: Option<PendingBatchIdentity> = None;
         let request = RequestControl {
             request_body: &request_body,
             ingest_mutex: self.ingest_mutex.as_ref(),
@@ -391,6 +531,10 @@ impl AckProcessor {
             if self.is_closed.load(Ordering::Relaxed) {
                 debug!(target: super::LOG_TARGET, "Stream closed, stopping ack processor");
                 return Ok(());
+            }
+
+            if self.request_send_failure.take() {
+                return Err(Self::request_send_error());
             }
 
             if let RotationState::WaitingForAcks {
@@ -424,34 +568,47 @@ impl AckProcessor {
                 .await;
             }
 
-            let response = match &rotation {
-                RotationState::Open => match timeout(ack_timeout, response_stream.next()).await {
-                    Ok(response) => response,
-                    Err(_) => {
-                        let pending = self.pending_batches.lock().await;
-                        if !pending.is_empty() {
-                            error!(target: super::LOG_TARGET,
-                                pending_count = pending.len(),
-                                "Server ack timeout with pending batches"
-                            );
-                            return Err(ZerobusError::StreamClosedError(
-                                tonic::Status::deadline_exceeded("Server ack timeout"),
-                            ));
-                        }
-                        continue;
+            let event = match &rotation {
+                RotationState::Open => match self.oldest_ack_deadline(ack_timeout).await {
+                    Some(pending_deadline) => {
+                        self.wait_with_pending_deadline(
+                            &mut response_stream,
+                            pending_deadline,
+                            &mut expiry_tie_winner,
+                        )
+                        .await
                     }
+                    None => self.wait_while_idle(&mut response_stream).await,
                 },
                 RotationState::WaitingForAcks { deadlines, .. } => {
                     tokio::select! {
+                        biased;
+                        response = response_stream.next() => AckEvent::Response(response),
+                        _ = self.request_send_failure.notify.notified() => {
+                            AckEvent::RequestSendFailed
+                        }
                         _ = sleep_until(deadlines.ack) => continue,
-                        response = response_stream.next() => response,
                     }
                 }
                 RotationState::Draining(_) => unreachable!(),
             };
 
-            match response {
-                Some(Ok(put_result)) => {
+            match event {
+                AckEvent::PendingBatchAvailable => continue,
+                AckEvent::RequestSendFailed => continue,
+                AckEvent::AckDeadline(expected) => {
+                    if let Some(pending_count) =
+                        self.expired_pending_count(expected, ack_timeout).await
+                    {
+                        error!(target: super::LOG_TARGET,
+                            pending_count,
+                            "Server ack timeout with pending batches"
+                        );
+                        return Err(Self::ack_timeout_error());
+                    }
+                    continue;
+                }
+                AckEvent::Response(Some(Ok(put_result))) => {
                     let ack = match FlightAckMetadata::from_bytes(&put_result.app_metadata) {
                         Ok(ack) => ack,
                         Err(error) => {
@@ -499,7 +656,7 @@ impl AckProcessor {
                         }
                     }
                 }
-                Some(Err(error)) => {
+                AckEvent::Response(Some(Err(error))) => {
                     let status: tonic::Status = error.into();
                     let error = ZerobusError::StreamClosedError(status);
                     if let RotationState::WaitingForAcks { deadlines, .. } = rotation {
@@ -513,7 +670,7 @@ impl AckProcessor {
                     let _ = self.server_error_tx.send(Some(error.clone()));
                     return Err(error);
                 }
-                None => {
+                AckEvent::Response(None) => {
                     if let RotationState::WaitingForAcks { deadlines, .. } = rotation {
                         rotation = RotationState::Draining(DrainState {
                             deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
@@ -541,6 +698,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use futures::stream::iter;
     use tokio::sync::{watch, Mutex, Semaphore};
+    use tokio::time::{Duration, Instant};
 
     use super::super::RecordBatch;
     use super::{
@@ -592,6 +750,18 @@ mod tests {
             last_acked_records,
             is_paused,
         )
+    }
+
+    #[test]
+    fn request_send_error_is_retryable_unavailable() {
+        let error = AckProcessor::request_send_error();
+        assert!(error.is_retryable());
+        match error {
+            ZerobusError::StreamClosedError(status) => {
+                assert_eq!(status.code(), tonic::Code::Unavailable);
+            }
+            other => panic!("expected a stream-closed error, got {other:?}"),
+        }
     }
 
     /// An acknowledgement beyond the connection-local submitted-record count is a protocol
@@ -738,5 +908,126 @@ mod tests {
             .await;
 
         assert_eq!(last_acked_records.load(Ordering::Acquire), 5);
+    }
+
+    /// A response already ready at expiry is applied before deadline recovery.
+    #[tokio::test]
+    async fn ready_ack_wins_expired_deadline_tie() {
+        const ACK_TIMEOUT: Duration = Duration::from_millis(10);
+
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let mut pending = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
+        pending.set_enqueued_at(Instant::now() - ACK_TIMEOUT);
+        let pending_batches = Arc::new(Mutex::new(vec![pending]));
+        let response_stream = iter([Ok(PutResult {
+            app_metadata: serde_json::to_vec(&FlightAckMetadata {
+                ack_up_to_offset: 0,
+                ack_up_to_records: 1,
+                close_stream_duration_ms: None,
+            })
+            .unwrap()
+            .into(),
+        })]);
+        let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (mut processor, request_body, last_ack_rx) = ack_processor(
+            Arc::clone(&pending_batches),
+            Arc::new(AtomicU64::new(1)),
+            Arc::clone(&last_acked_records),
+            false,
+        );
+        processor.options.server_lack_of_ack_timeout_ms = ACK_TIMEOUT.as_millis() as u64;
+
+        let _stream_closed = processor
+            .process(Box::pin(response_stream), request_body)
+            .await;
+
+        assert_eq!(last_acked_records.load(Ordering::Acquire), 1);
+        assert_eq!(*last_ack_rx.borrow(), Some(0));
+        assert!(pending_batches.lock().await.is_empty());
+    }
+
+    /// Only one ready response may defer an already-expired pending head. Partial
+    /// progress does not grant the same head a second response-first tie.
+    #[tokio::test]
+    async fn expired_head_gets_only_one_ready_response() {
+        const ACK_TIMEOUT: Duration = Duration::from_millis(10);
+
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(1));
+        let mut pending = pending_batch(&sem, batch_with_rows(&schema, 10), 0, 0, 10);
+        pending.set_enqueued_at(Instant::now() - ACK_TIMEOUT);
+        let pending_batches = Arc::new(Mutex::new(vec![pending]));
+        let response_stream = iter([5, 10].map(|acked_records| {
+            Ok(PutResult {
+                app_metadata: serde_json::to_vec(&FlightAckMetadata {
+                    ack_up_to_offset: 0,
+                    ack_up_to_records: acked_records,
+                    close_stream_duration_ms: None,
+                })
+                .unwrap()
+                .into(),
+            })
+        }));
+        let last_acked_records = Arc::new(AtomicU64::new(0));
+        let (mut processor, request_body, _last_ack_rx) = ack_processor(
+            Arc::clone(&pending_batches),
+            Arc::new(AtomicU64::new(10)),
+            Arc::clone(&last_acked_records),
+            false,
+        );
+        processor.options.server_lack_of_ack_timeout_ms = ACK_TIMEOUT.as_millis() as u64;
+
+        let error = processor
+            .process(Box::pin(response_stream), request_body)
+            .await
+            .expect_err("second ready response must not defer the expired head");
+
+        match error {
+            ZerobusError::StreamClosedError(status) => {
+                assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+            }
+            other => panic!("expected ACK deadline error, got {other:?}"),
+        }
+        assert_eq!(last_acked_records.load(Ordering::Acquire), 5);
+        assert_eq!(pending_batches.lock().await.len(), 1);
+    }
+
+    /// A timer fired for a removed head cannot fail the next head, even when that next
+    /// batch is also already expired; it must receive its own response-first tie.
+    #[tokio::test]
+    async fn deadline_recheck_requires_same_pending_head() {
+        const ACK_TIMEOUT: Duration = Duration::from_millis(10);
+
+        let schema = one_col_schema();
+        let sem = Arc::new(Semaphore::new(2));
+        let expired_at = Instant::now() - ACK_TIMEOUT;
+        let mut first = pending_batch(&sem, batch_with_rows(&schema, 1), 0, 0, 1);
+        first.set_enqueued_at(expired_at);
+        let mut second = pending_batch(&sem, batch_with_rows(&schema, 1), 1, 1, 2);
+        second.set_enqueued_at(expired_at);
+        let pending_batches = Arc::new(Mutex::new(vec![first, second]));
+        let (processor, _request_body, _last_ack_rx) = ack_processor(
+            Arc::clone(&pending_batches),
+            Arc::new(AtomicU64::new(2)),
+            Arc::new(AtomicU64::new(0)),
+            false,
+        );
+        let fired = processor
+            .oldest_ack_deadline(ACK_TIMEOUT)
+            .await
+            .expect("expired head");
+
+        assert_eq!(
+            processor.expired_pending_count(fired, ACK_TIMEOUT).await,
+            Some(2)
+        );
+
+        pending_batches.lock().await.remove(0);
+
+        assert!(processor
+            .expired_pending_count(fired, ACK_TIMEOUT)
+            .await
+            .is_none());
     }
 }

--- a/rust/sdk/src/stream/arrow/batch.rs
+++ b/rust/sdk/src/stream/arrow/batch.rs
@@ -11,7 +11,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::time::{Duration, Instant};
 use tracing::debug;
 
-use super::RecordBatch;
+use super::{configured_deadline, RecordBatch};
 use crate::errors::ZerobusError;
 use crate::offset_generator::OffsetId;
 use crate::ZerobusResult;
@@ -148,16 +148,22 @@ pub(super) fn oldest_pending_ack_deadline(
     pending: &[PendingBatch],
     submitted_records: u64,
     ack_timeout: Duration,
-) -> Option<PendingAckDeadline> {
-    pending
+) -> ZerobusResult<Option<PendingAckDeadline>> {
+    let Some(batch) = pending
         .iter()
         .find(|batch| batch.start_record < submitted_records)
-        .map(|batch| PendingAckDeadline {
-            identity: batch.identity(),
-            // The public timeout is a u64 millisecond value. Tokio's supported
-            // 64-bit Instant implementations can represent that full range.
-            deadline: batch.enqueued_at + ack_timeout,
-        })
+    else {
+        return Ok(None);
+    };
+    let deadline = configured_deadline(
+        batch.enqueued_at,
+        ack_timeout,
+        "server_lack_of_ack_timeout_ms",
+    )?;
+    Ok(Some(PendingAckDeadline {
+        identity: batch.identity(),
+        deadline,
+    }))
 }
 
 /// Rebuilds pending batches with connection-relative ranges and transfers each retained
@@ -251,7 +257,29 @@ mod tests {
     use tokio::sync::Semaphore;
     use tokio::time::{Duration, Instant};
 
-    use super::{rebuild_pending_for_replay, PendingBatch, RecordBatch};
+    use crate::ZerobusError;
+
+    use super::{
+        oldest_pending_ack_deadline, rebuild_pending_for_replay, PendingBatch, RecordBatch,
+    };
+
+    #[allow(clippy::manual_div_ceil)]
+    fn latest_whole_second_instant(start: Instant) -> Instant {
+        let mut low = 0_u64;
+        let mut high = u64::MAX;
+        while low < high {
+            let mid = ((low as u128 + high as u128 + 1) / 2) as u64;
+            if start.checked_add(Duration::from_secs(mid)).is_some() {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        assert!(low < u64::MAX, "test requires a bounded Instant range");
+        start
+            .checked_add(Duration::from_secs(low))
+            .expect("largest whole-second Instant")
+    }
 
     fn pending_batch(rows: i32, start_record: u64, end_record: u64) -> PendingBatch {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
@@ -291,5 +319,20 @@ mod tests {
         let (_replay, _records) = rebuild_pending_for_replay(&mut pending, 0);
 
         assert!(pending[0].enqueued_at() > original);
+    }
+
+    #[test]
+    fn unrepresentable_ack_deadline_is_rejected() {
+        let mut batch = pending_batch(1, 0, 1);
+        batch.set_enqueued_at(latest_whole_second_instant(Instant::now()));
+
+        let error = oldest_pending_ack_deadline(&[batch], 1, Duration::from_secs(1))
+            .expect_err("an unrepresentable configured deadline must be rejected");
+        match error {
+            ZerobusError::InvalidArgument(message) => {
+                assert!(message.contains("server_lack_of_ack_timeout_ms"));
+            }
+            other => panic!("expected an invalid-argument error, got {other:?}"),
+        }
     }
 }

--- a/rust/sdk/src/stream/arrow/batch.rs
+++ b/rust/sdk/src/stream/arrow/batch.rs
@@ -57,12 +57,30 @@ impl PendingBatch {
         end_record: u64,
         permit: OwnedSemaphorePermit,
     ) -> Self {
+        Self::new_at(
+            batch,
+            offset_id,
+            start_record,
+            end_record,
+            Instant::now(),
+            permit,
+        )
+    }
+
+    fn new_at(
+        batch: RecordBatch,
+        offset_id: OffsetId,
+        start_record: u64,
+        end_record: u64,
+        enqueued_at: Instant,
+        permit: OwnedSemaphorePermit,
+    ) -> Self {
         Self {
             batch,
             offset_id,
             start_record,
             end_record,
-            enqueued_at: Instant::now(),
+            enqueued_at,
             permit,
         }
     }
@@ -130,8 +148,7 @@ impl PendingBatch {
         self.batch.num_rows()
     }
 
-    #[cfg(test)]
-    pub(super) fn set_enqueued_at(&mut self, enqueued_at: Instant) {
+    pub(super) fn refresh_enqueued_at(&mut self, enqueued_at: Instant) {
         self.enqueued_at = enqueued_at;
     }
 
@@ -166,6 +183,17 @@ pub(super) fn oldest_pending_ack_deadline(
     }))
 }
 
+/// Gives every replayed batch one shared ACK-budget origin immediately before
+/// acknowledgment processing resumes on the replacement connection.
+pub(super) fn refresh_pending_ack_deadlines(
+    pending: &mut [PendingBatch],
+    replay_completed_at: Instant,
+) {
+    for batch in pending {
+        batch.refresh_enqueued_at(replay_completed_at);
+    }
+}
+
 /// Rebuilds pending batches with connection-relative ranges and transfers each retained
 /// batch's backpressure permit to its replacement.
 pub(super) fn rebuild_pending_for_replay(
@@ -188,11 +216,12 @@ pub(super) fn rebuild_pending_for_replay(
         cumulative_records = end_record;
 
         replay.push(batch.clone());
-        rebuilt.push(PendingBatch::new(
+        rebuilt.push(PendingBatch::new_at(
             batch,
             pending_batch.offset_id,
             start_record,
             end_record,
+            pending_batch.enqueued_at,
             pending_batch.permit,
         ));
     }
@@ -260,7 +289,8 @@ mod tests {
     use crate::ZerobusError;
 
     use super::{
-        oldest_pending_ack_deadline, rebuild_pending_for_replay, PendingBatch, RecordBatch,
+        oldest_pending_ack_deadline, rebuild_pending_for_replay, refresh_pending_ack_deadlines,
+        PendingBatch, RecordBatch,
     };
 
     #[allow(clippy::manual_div_ceil)]
@@ -310,21 +340,33 @@ mod tests {
     }
 
     #[test]
-    fn replay_refreshes_pending_timestamp() {
+    fn replay_rebuild_preserves_pending_timestamp() {
         let mut batch = pending_batch(5, 0, 5);
         let original = Instant::now() - Duration::from_secs(1);
-        batch.set_enqueued_at(original);
+        batch.refresh_enqueued_at(original);
         let mut pending = vec![batch];
 
         let (_replay, _records) = rebuild_pending_for_replay(&mut pending, 0);
 
-        assert!(pending[0].enqueued_at() > original);
+        assert_eq!(pending[0].enqueued_at(), original);
+    }
+
+    #[test]
+    fn replay_deadlines_share_completion_timestamp() {
+        let mut pending = vec![pending_batch(1, 0, 1), pending_batch(1, 1, 2)];
+        let replay_completed_at = Instant::now();
+
+        refresh_pending_ack_deadlines(&mut pending, replay_completed_at);
+
+        assert!(pending
+            .iter()
+            .all(|batch| batch.enqueued_at() == replay_completed_at));
     }
 
     #[test]
     fn unrepresentable_ack_deadline_is_rejected() {
         let mut batch = pending_batch(1, 0, 1);
-        batch.set_enqueued_at(latest_whole_second_instant(Instant::now()));
+        batch.refresh_enqueued_at(latest_whole_second_instant(Instant::now()));
 
         let error = oldest_pending_ack_deadline(&[batch], 1, Duration::from_secs(1))
             .expect_err("an unrepresentable configured deadline must be rejected");

--- a/rust/sdk/src/stream/arrow/batch.rs
+++ b/rust/sdk/src/stream/arrow/batch.rs
@@ -8,6 +8,7 @@ use std::io::Cursor;
 use arrow_ipc::{reader::StreamReader, writer::IpcWriteOptions, CompressionType};
 use bytes::Bytes;
 use tokio::sync::OwnedSemaphorePermit;
+use tokio::time::{Duration, Instant};
 use tracing::debug;
 
 use super::RecordBatch;
@@ -25,8 +26,27 @@ pub(super) struct PendingBatch {
     /// Cumulative record count after this batch.
     /// Batch is fully acked when `acked_records >= end_record`.
     end_record: u64,
+    /// Time this batch most recently became pending on the active connection.
+    /// Only replay onto a replacement connection refreshes this timestamp.
+    enqueued_at: Instant,
     /// Backpressure permit; dropping it frees one `max_inflight_batches` slot.
     permit: OwnedSemaphorePermit,
+}
+
+/// Stable identity used to confirm that a fired ACK deadline still belongs to the
+/// same oldest pending batch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct PendingBatchIdentity {
+    offset_id: OffsetId,
+    start_record: u64,
+    end_record: u64,
+}
+
+/// The oldest submitted batch and its absolute acknowledgment deadline.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PendingAckDeadline {
+    pub(super) identity: PendingBatchIdentity,
+    pub(super) deadline: Instant,
 }
 
 impl PendingBatch {
@@ -42,6 +62,7 @@ impl PendingBatch {
             offset_id,
             start_record,
             end_record,
+            enqueued_at: Instant::now(),
             permit,
         }
     }
@@ -52,6 +73,14 @@ impl PendingBatch {
 
     pub(super) fn is_fully_acknowledged(&self, acked_records: u64) -> bool {
         acked_records >= self.end_record
+    }
+
+    fn identity(&self) -> PendingBatchIdentity {
+        PendingBatchIdentity {
+            offset_id: self.offset_id,
+            start_record: self.start_record,
+            end_record: self.end_record,
+        }
     }
 
     /// Returns the batch portion not durably acknowledged, avoiding duplicate retry of an
@@ -100,6 +129,35 @@ impl PendingBatch {
     pub(super) fn record_count(&self) -> usize {
         self.batch.num_rows()
     }
+
+    #[cfg(test)]
+    pub(super) fn set_enqueued_at(&mut self, enqueued_at: Instant) {
+        self.enqueued_at = enqueued_at;
+    }
+
+    #[cfg(test)]
+    pub(super) fn enqueued_at(&self) -> Instant {
+        self.enqueued_at
+    }
+}
+
+/// Calculates the absolute deadline for the oldest pending batch submitted on the
+/// active connection. Batches buffered after a graceful-close pause have ranges at
+/// or beyond `submitted_records` and are not awaiting an ACK from that connection.
+pub(super) fn oldest_pending_ack_deadline(
+    pending: &[PendingBatch],
+    submitted_records: u64,
+    ack_timeout: Duration,
+) -> Option<PendingAckDeadline> {
+    pending
+        .iter()
+        .find(|batch| batch.start_record < submitted_records)
+        .map(|batch| PendingAckDeadline {
+            identity: batch.identity(),
+            // The public timeout is a u64 millisecond value. Tokio's supported
+            // 64-bit Instant implementations can represent that full range.
+            deadline: batch.enqueued_at + ack_timeout,
+        })
 }
 
 /// Rebuilds pending batches with connection-relative ranges and transfers each retained
@@ -191,8 +249,9 @@ mod tests {
     use arrow_array::Int32Array;
     use arrow_schema::{DataType, Field, Schema};
     use tokio::sync::Semaphore;
+    use tokio::time::{Duration, Instant};
 
-    use super::{PendingBatch, RecordBatch};
+    use super::{rebuild_pending_for_replay, PendingBatch, RecordBatch};
 
     fn pending_batch(rows: i32, start_record: u64, end_record: u64) -> PendingBatch {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
@@ -220,5 +279,17 @@ mod tests {
     fn recovery_slice_drops_fully_acknowledged_batch() {
         let batch = pending_batch(5, 10, 15);
         assert!(batch.unacknowledged_suffix(15).is_none());
+    }
+
+    #[test]
+    fn replay_refreshes_pending_timestamp() {
+        let mut batch = pending_batch(5, 0, 5);
+        let original = Instant::now() - Duration::from_secs(1);
+        batch.set_enqueued_at(original);
+        let mut pending = vec![batch];
+
+        let (_replay, _records) = rebuild_pending_for_replay(&mut pending, 0);
+
+        assert!(pending[0].enqueued_at() > original);
     }
 }

--- a/rust/sdk/src/stream/arrow/connection.rs
+++ b/rust/sdk/src/stream/arrow/connection.rs
@@ -14,7 +14,7 @@ use arrow_flight::error::FlightError;
 use arrow_flight::{FlightClient, FlightData, PutResult};
 use futures::{stream::poll_fn, Stream, StreamExt};
 use tokio::sync::{mpsc, watch};
-use tokio::time::{timeout, Duration, Instant};
+use tokio::time::{timeout, timeout_at, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
@@ -23,7 +23,8 @@ use tracing::{error, info, warn};
 use super::batch::make_ipc_write_options;
 use super::metadata::{FlightAckMetadata, FlightBatchMetadata};
 use super::{
-    ArrowStreamConfigurationOptions, ArrowTableProperties, RecordBatch, ZerobusArrowStream,
+    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, RecordBatch,
+    ZerobusArrowStream,
 };
 use crate::errors::ZerobusError;
 use crate::headers_provider::HeadersProvider;
@@ -116,7 +117,9 @@ impl ZerobusArrowStream {
         // reclassifying the attempt as a retryable setup timeout.
         let attempt_timeout = Duration::from_millis(options.recovery_timeout_ms);
         let attempt_started = Instant::now();
-        let result = timeout(attempt_timeout, async {
+        let attempt_deadline =
+            configured_deadline(attempt_started, attempt_timeout, "recovery_timeout_ms")?;
+        let result = timeout_at(attempt_deadline, async {
             let client = Self::create_flight_client(
                 endpoint,
                 tls_config,
@@ -143,9 +146,8 @@ impl ZerobusArrowStream {
                 // Drop the rejected token so the next attempt re-mints. A provider must
                 // not be able to turn a known auth rejection into repeated generic
                 // timeout retries by stalling here.
-                let invalidate_timeout = attempt_timeout.saturating_sub(attempt_started.elapsed());
                 if error.is_auth_rejection()
-                    && timeout(invalidate_timeout, headers_provider.invalidate())
+                    && timeout_at(attempt_deadline, headers_provider.invalidate())
                         .await
                         .is_err()
                 {

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -78,6 +78,18 @@ struct ReconnectRebuildBarrier {
     proceed: Arc<Notify>,
 }
 
+/// Test-only barrier used to pause recovery after its first replay send, before the
+/// remaining backlog is sent and pending ACK timestamps are refreshed.
+#[cfg(feature = "test-hooks")]
+type ReplaySendGate = Arc<Mutex<Option<ReplaySendBarrier>>>;
+
+#[cfg(feature = "test-hooks")]
+#[derive(Clone)]
+struct ReplaySendBarrier {
+    reached: Arc<Notify>,
+    proceed: Arc<Notify>,
+}
+
 /// Test-only gate: when armed, the ACK processor fires the notify right after applying a
 /// non-empty ack (i.e. after storing `last_acked_records`), letting a test confirm a
 /// partial ack has landed before it proceeds.
@@ -232,6 +244,9 @@ pub struct ZerobusArrowStream {
     /// Test seam (see [`ReconnectRebuildGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     reconnect_rebuild_gate: ReconnectRebuildGate,
+    /// Test seam (see [`ReplaySendGate`]); compiled only under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    replay_send_gate: ReplaySendGate,
     /// Test seam (see [`AckAppliedGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     ack_applied_gate: AckAppliedGate,
@@ -328,6 +343,8 @@ impl ZerobusArrowStream {
             sdk_identifier,
             #[cfg(feature = "test-hooks")]
             reconnect_rebuild_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            replay_send_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
@@ -1001,6 +1018,20 @@ impl ZerobusArrowStream {
         let reached = Arc::new(Notify::new());
         let proceed = Arc::new(Notify::new());
         *self.reconnect_rebuild_gate.lock().await = Some(ReconnectRebuildBarrier {
+            reached: Arc::clone(&reached),
+            proceed: Arc::clone(&proceed),
+        });
+        (reached, proceed)
+    }
+
+    /// Test-only: pauses the next recovery after its first replay send and before the
+    /// remaining backlog is sent or its pending ACK timestamps are refreshed.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_replay_send_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {
+        let reached = Arc::new(Notify::new());
+        let proceed = Arc::new(Notify::new());
+        *self.replay_send_gate.lock().await = Some(ReplaySendBarrier {
             reached: Arc::clone(&reached),
             proceed: Arc::clone(&proceed),
         });

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -20,7 +20,7 @@ use arrow_flight::error::FlightError;
 use bytes::Bytes;
 use tokio::sync::{mpsc, watch, Mutex, Notify, Semaphore};
 use tokio::task::JoinHandle;
-use tokio::time::{timeout, Duration};
+use tokio::time::{timeout, Duration, Instant};
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::RetryIf;
 use tracing::{debug, error, info, instrument, warn};
@@ -48,6 +48,20 @@ mod supervisor;
 const LOG_TARGET: &str = module_path!();
 
 type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
+
+/// Converts a configured relative timeout into an absolute monotonic-clock deadline.
+pub(super) fn configured_deadline(
+    started_at: Instant,
+    timeout: Duration,
+    option_name: &str,
+) -> ZerobusResult<Instant> {
+    started_at.checked_add(timeout).ok_or_else(|| {
+        ZerobusError::InvalidArgument(format!(
+            "{option_name} ({}ms) exceeds the platform monotonic-clock range",
+            timeout.as_millis()
+        ))
+    })
+}
 
 /// Test-only barrier used to pause `reconnect` at a precise point — the new connection
 /// is established but pending ranges are not yet rebuilt — so a test can schedule a
@@ -252,6 +266,18 @@ impl ZerobusArrowStream {
                 "max_inflight_batches must be greater than 0".to_string(),
             ));
         }
+
+        let validation_started_at = Instant::now();
+        configured_deadline(
+            validation_started_at,
+            Duration::from_millis(options.recovery_timeout_ms),
+            "recovery_timeout_ms",
+        )?;
+        configured_deadline(
+            validation_started_at,
+            Duration::from_millis(options.server_lack_of_ack_timeout_ms),
+            "server_lack_of_ack_timeout_ms",
+        )?;
 
         let (last_ack_tx, _last_ack_rx) = watch::channel(None);
         let is_closed = Arc::new(AtomicBool::new(false));

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -18,9 +18,7 @@ use std::sync::Arc;
 
 use arrow_flight::error::FlightError;
 use bytes::Bytes;
-#[cfg(feature = "test-hooks")]
-use tokio::sync::Notify;
-use tokio::sync::{mpsc, watch, Mutex, Semaphore};
+use tokio::sync::{mpsc, watch, Mutex, Notify, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 use tokio_retry::strategy::FixedInterval;
@@ -71,6 +69,11 @@ struct ReconnectRebuildBarrier {
 /// partial ack has landed before it proceeds.
 #[cfg(feature = "test-hooks")]
 type AckAppliedGate = Arc<Mutex<Option<Arc<Notify>>>>;
+
+/// Test-only gate: when armed, the ACK processor fires the notify immediately before
+/// waiting without any pending-work deadline.
+#[cfg(feature = "test-hooks")]
+type AckIdleGate = Arc<Mutex<Option<Arc<Notify>>>>;
 
 /// Test-only barrier that parks `close()` after the supervisor and sender are gone but
 /// before pending batches are finalized, allowing cancellation-safe teardown tests.
@@ -173,6 +176,11 @@ pub struct ZerobusArrowStream {
     receiver_task: Arc<Mutex<Option<JoinHandle<ZerobusResult<()>>>>>,
     /// Accepted batches not yet fully acknowledged; retained for replay or retrieval.
     pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
+    /// Wakes the ACK processor when a batch is submitted after an idle period.
+    pending_notify: Arc<Notify>,
+    /// Carries a closed request-sender failure to the ACK processor so retained work
+    /// starts recovery even when no submitted batch is eligible for an ACK deadline.
+    request_send_failure: Arc<acks::RequestSendFailure>,
     /// Unacknowledged batch suffixes finalized after terminal failure or failed close.
     failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
     /// Count of recovery attempts.
@@ -213,6 +221,9 @@ pub struct ZerobusArrowStream {
     /// Test seam (see [`AckAppliedGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     ack_applied_gate: AckAppliedGate,
+    /// Test seam (see [`AckIdleGate`]); compiled only under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    ack_idle_gate: AckIdleGate,
     /// Test seam (see [`CloseFinalizeGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     close_finalize_gate: CloseFinalizeGate,
@@ -245,6 +256,8 @@ impl ZerobusArrowStream {
         let (last_ack_tx, _last_ack_rx) = watch::channel(None);
         let is_closed = Arc::new(AtomicBool::new(false));
         let pending_batches = Arc::new(Mutex::new(Vec::new()));
+        let pending_notify = Arc::new(Notify::new());
+        let request_send_failure = Arc::new(acks::RequestSendFailure::default());
         let failed_batches = Arc::new(Mutex::new(Vec::new()));
         let recovery_attempts = Arc::new(AtomicU32::new(0));
         let batch_tx = Arc::new(Mutex::new(None));
@@ -270,6 +283,8 @@ impl ZerobusArrowStream {
             close_flush_error: Mutex::new(None),
             receiver_task,
             pending_batches,
+            pending_notify,
+            request_send_failure,
             failed_batches,
             recovery_attempts,
             endpoint: endpoint.to_string(),
@@ -289,6 +304,8 @@ impl ZerobusArrowStream {
             reconnect_rebuild_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            ack_idle_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             close_finalize_gate: Arc::new(Mutex::new(None)),
         };
@@ -505,6 +522,7 @@ impl ZerobusArrowStream {
                         offset_id = offset_id,
                         "Send failed but recovery enabled - supervisor will handle recovery"
                     );
+                    self.request_send_failure.report();
                     return Ok(offset_id);
                 }
 
@@ -533,6 +551,9 @@ impl ZerobusArrowStream {
             self.submitted_records.store(end_record, Ordering::Release);
             send_permit.send(Ok(batch));
         }
+        // Notify after publishing `submitted_records`: waking earlier could let the ACK
+        // processor observe the batch as buffered-but-unsent and go idle again.
+        self.pending_notify.notify_one();
 
         debug!(offset_id = offset_id, "Batch queued for ingestion");
         Ok(offset_id)
@@ -969,6 +990,27 @@ impl ZerobusArrowStream {
         let notify = Arc::new(Notify::new());
         *self.ack_applied_gate.lock().await = Some(Arc::clone(&notify));
         notify
+    }
+
+    /// Test-only: arms a one-shot notification for the next time the ACK processor
+    /// enters its no-pending wait with no ACK deadline armed.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_ack_idle_notify(&self) -> Arc<Notify> {
+        let notify = Arc::new(Notify::new());
+        *self.ack_idle_gate.lock().await = Some(Arc::clone(&notify));
+        notify
+    }
+
+    /// Test-only: replaces the active batch sender with a sender whose receiver is
+    /// already closed, making the next `ingest_batch` exercise its `reserve()` failure.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn replace_batch_sender_with_closed_channel(&self) {
+        let _guard = self.ingest_mutex.lock().await;
+        let (closed_tx, closed_rx) = mpsc::channel(1);
+        drop(closed_rx);
+        *self.batch_tx.lock().await = Some(closed_tx);
     }
 
     /// Test-only: parks the next `close()` after supervisor/sender teardown but before

--- a/rust/sdk/src/stream/arrow/options.rs
+++ b/rust/sdk/src/stream/arrow/options.rs
@@ -74,8 +74,8 @@ pub struct ArrowStreamConfigurationOptions {
     /// when it becomes pending; responses and partial acknowledgments do not refresh it.
     /// Configure this timeout together with `max_inflight_batches` so the server can
     /// acknowledge a full allowed backlog in time. Replayed batches receive a fresh deadline
-    /// on the recovered connection. Expiry fails the stream and triggers recovery when
-    /// recovery is enabled.
+    /// after the full replay has completed and ACK processing can resume on the recovered
+    /// connection. Expiry fails the stream and triggers recovery when recovery is enabled.
     /// Values whose absolute deadline cannot be represented by the platform's
     /// monotonic clock are rejected when the stream is built.
     ///

--- a/rust/sdk/src/stream/arrow/options.rs
+++ b/rust/sdk/src/stream/arrow/options.rs
@@ -47,6 +47,8 @@ pub struct ArrowStreamConfigurationOptions {
     /// Timeout in milliseconds for each stream recovery attempt.
     ///
     /// If a recovery attempt takes longer than this, it will be retried.
+    /// Values whose absolute deadline cannot be represented by the platform's
+    /// monotonic clock are rejected when the stream is built.
     ///
     /// Default: 15,000 (15 seconds)
     pub recovery_timeout_ms: u64,
@@ -74,6 +76,8 @@ pub struct ArrowStreamConfigurationOptions {
     /// acknowledge a full allowed backlog in time. Replayed batches receive a fresh deadline
     /// on the recovered connection. Expiry fails the stream and triggers recovery when
     /// recovery is enabled.
+    /// Values whose absolute deadline cannot be represented by the platform's
+    /// monotonic clock are rejected when the stream is built.
     ///
     /// Default: 60,000 (60 seconds)
     pub server_lack_of_ack_timeout_ms: u64,
@@ -126,6 +130,7 @@ pub struct ArrowStreamConfigurationOptions {
     /// If the server advertises less than 500ms (including zero), the SDK skips the ACK
     /// wait and makes a best-effort local cleanup attempt for up to 500ms; the server may
     /// already have hard-closed, so clean peer shutdown cannot be guaranteed in that case.
+    /// Server-advertised grace periods longer than one year are capped at one year.
     /// Close signals are honored even when recovery is disabled: the SDK performs transport
     /// cleanup and terminates without reconnecting. Batches accepted while paused remain
     /// available through `get_unacked_batches()`.

--- a/rust/sdk/src/stream/arrow/options.rs
+++ b/rust/sdk/src/stream/arrow/options.rs
@@ -65,10 +65,15 @@ pub struct ArrowStreamConfigurationOptions {
     /// Default: 4
     pub recovery_retries: u32,
 
-    /// Timeout in milliseconds for waiting for server acknowledgements.
+    /// Maximum time in milliseconds that a batch may remain pending during normal stream
+    /// operation without being fully acknowledged on the active connection.
     ///
-    /// If no acknowledgement is received within this time (and there are pending batches),
-    /// the stream will be considered failed and recovery will be triggered (if enabled).
+    /// No timer runs while there are no pending batches. A batch's absolute deadline starts
+    /// when it becomes pending; responses and partial acknowledgments do not refresh it.
+    /// Configure this timeout together with `max_inflight_batches` so the server can
+    /// acknowledge a full allowed backlog in time. Replayed batches receive a fresh deadline
+    /// on the recovered connection. Expiry fails the stream and triggers recovery when
+    /// recovery is enabled.
     ///
     /// Default: 60,000 (60 seconds)
     pub server_lack_of_ack_timeout_ms: u64,

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -9,15 +9,15 @@ use std::sync::Arc;
 use arrow_flight::error::FlightError;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::{spawn, JoinHandle};
-use tokio::time::{sleep, timeout, timeout_at, Duration, Instant};
+use tokio::time::{sleep, timeout_at, Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use super::acks::{pause_and_detach_sender, AckProcessor};
 use super::batch::{rebuild_pending_for_replay, PendingBatch};
 use super::connection::{FlightConnection, FlightResponseStream, RequestBodyControl};
 use super::{
-    ArrowStreamConfigurationOptions, ArrowTableProperties, BatchSender, RecordBatch,
-    ZerobusArrowStream,
+    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchSender,
+    RecordBatch, ZerobusArrowStream,
 };
 use crate::errors::ZerobusError;
 use crate::headers_provider::HeadersProvider;
@@ -189,11 +189,21 @@ impl Supervisor {
 
                     let _ = self.server_error_tx.send(None);
 
-                    // Share one deadline across reconnect and auth-rejection
-                    // invalidation so refresh receives only the remaining recovery
-                    // timeout instead of starting a second full timeout.
-                    let recovery_deadline =
-                        Instant::now() + Duration::from_millis(self.options.recovery_timeout_ms);
+                    // Share one absolute timeout budget across reconnect and
+                    // auth-rejection invalidation.
+                    let recovery_timeout = Duration::from_millis(self.options.recovery_timeout_ms);
+                    let recovery_started = Instant::now();
+                    let recovery_deadline = match configured_deadline(
+                        recovery_started,
+                        recovery_timeout,
+                        "recovery_timeout_ms",
+                    ) {
+                        Ok(deadline) => deadline,
+                        Err(error) => {
+                            pending_error = Some(error);
+                            continue;
+                        }
+                    };
                     let reconnect_result = timeout_at(recovery_deadline, self.reconnect()).await;
 
                     match reconnect_result {
@@ -275,18 +285,30 @@ impl Supervisor {
                     // a terminal rejection. The stream is already finalized and waiters
                     // have the real error; bound the callback so the supervisor cannot
                     // remain alive indefinitely.
-                    if error.is_auth_rejection()
-                        && timeout(
+                    if error.is_auth_rejection() {
+                        match configured_deadline(
+                            Instant::now(),
                             Duration::from_millis(self.options.recovery_timeout_ms),
-                            self.headers_provider.invalidate(),
-                        )
-                        .await
-                        .is_err()
-                    {
-                        warn!(target: super::LOG_TARGET,
-                            timeout_ms = self.options.recovery_timeout_ms,
-                            "Terminal headers provider invalidation timed out"
-                        );
+                            "recovery_timeout_ms",
+                        ) {
+                            Ok(deadline) => {
+                                if timeout_at(deadline, self.headers_provider.invalidate())
+                                    .await
+                                    .is_err()
+                                {
+                                    warn!(target: super::LOG_TARGET,
+                                        timeout_ms = self.options.recovery_timeout_ms,
+                                        "Terminal headers provider invalidation timed out"
+                                    );
+                                }
+                            }
+                            Err(deadline_error) => {
+                                warn!(target: super::LOG_TARGET,
+                                    error = %deadline_error,
+                                    "Skipping terminal headers provider invalidation because its deadline is unrepresentable"
+                                );
+                            }
+                        }
                     }
                     return Err(error);
                 }

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -13,7 +13,7 @@ use tokio::time::{sleep, timeout_at, Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use super::acks::{pause_and_detach_sender, AckProcessor};
-use super::batch::{rebuild_pending_for_replay, PendingBatch};
+use super::batch::{rebuild_pending_for_replay, refresh_pending_ack_deadlines, PendingBatch};
 use super::connection::{FlightConnection, FlightResponseStream, RequestBodyControl};
 use super::{
     configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchSender,
@@ -47,6 +47,8 @@ pub(super) struct Supervisor {
     sdk_identifier: Arc<str>,
     #[cfg(feature = "test-hooks")]
     reconnect_rebuild_gate: super::ReconnectRebuildGate,
+    #[cfg(feature = "test-hooks")]
+    replay_send_gate: super::ReplaySendGate,
 }
 
 impl Supervisor {
@@ -73,6 +75,8 @@ impl Supervisor {
             sdk_identifier: Arc::clone(&stream.sdk_identifier),
             #[cfg(feature = "test-hooks")]
             reconnect_rebuild_gate: Arc::clone(&stream.reconnect_rebuild_gate),
+            #[cfg(feature = "test-hooks")]
+            replay_send_gate: Arc::clone(&stream.replay_send_gate),
         }
     }
 
@@ -360,6 +364,8 @@ impl Supervisor {
             &self.submitted_records,
             &self.last_acked_records,
             acked_before_disconnect,
+            #[cfg(feature = "test-hooks")]
+            Some(&self.replay_send_gate),
         )
         .await;
 
@@ -368,6 +374,13 @@ impl Supervisor {
         // cannot observe an unpaused stream without its active sender.
         Self::commit_reconnect_after_replay(replay_result, tx, &self.batch_tx, &self.is_paused)
             .await?;
+
+        // ACK processing cannot resume until reconnect returns. Refresh only after replay
+        // is fully committed so connection setup, backlog sends, and sender publication do
+        // not consume any batch's new ACK budget.
+        let mut pending = self.pending_batches.lock().await;
+        refresh_pending_ack_deadlines(&mut pending, Instant::now());
+        drop(pending);
 
         Ok((response_stream, request_body))
     }
@@ -395,7 +408,8 @@ impl Supervisor {
     /// The rebuilt pending set and the counter reset are installed together under the
     /// `pending_batches` lock, before any send: a replay-send failure keeps pending (and
     /// permits) intact, and no concurrent ingest can observe reset counters against stale
-    /// ranges. Caller holds `ingest_mutex`.
+    /// ranges. The caller refreshes pending ACK timestamps together only after replay is
+    /// committed, immediately before ACK processing can resume. Caller holds `ingest_mutex`.
     async fn replay_pending_batches(
         tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
@@ -403,6 +417,7 @@ impl Supervisor {
         submitted_records: &Arc<AtomicU64>,
         last_acked_records: &Arc<AtomicU64>,
         acked_before_disconnect: u64,
+        #[cfg(feature = "test-hooks")] replay_send_gate: Option<&super::ReplaySendGate>,
     ) -> ZerobusResult<()> {
         let replay_batches: Vec<RecordBatch> = {
             let mut pending = pending_batches.lock().await;
@@ -437,6 +452,18 @@ impl Supervisor {
                 )));
             }
             submitted_records.fetch_add(record_count, Ordering::Release);
+
+            #[cfg(feature = "test-hooks")]
+            {
+                let barrier = match replay_send_gate {
+                    Some(gate) => gate.lock().await.take(),
+                    None => None,
+                };
+                if let Some(barrier) = barrier {
+                    barrier.reached.notify_one();
+                    barrier.proceed.notified().await;
+                }
+            }
         }
 
         Ok(())
@@ -494,7 +521,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use futures::stream::iter;
     use tokio::sync::{mpsc, Mutex, Semaphore};
-    use tokio::time::{timeout, Duration};
+    use tokio::time::{timeout, Duration, Instant};
 
     use super::super::metadata::FlightAckMetadata;
     use super::{
@@ -600,6 +627,8 @@ mod tests {
             &submitted_records,
             &last_acked_records,
             acked_before_disconnect,
+            #[cfg(feature = "test-hooks")]
+            None,
         )
         .await
         .expect("replay should succeed");
@@ -622,10 +651,15 @@ mod tests {
     async fn replay_send_failure_retains_pending_permits_and_cumulative() {
         let schema = one_col_schema();
         let sem = Arc::new(Semaphore::new(4));
-        let pending = Arc::new(Mutex::new(vec![
+        let original_enqueued_at = Instant::now() - Duration::from_secs(1);
+        let mut pending_batches = vec![
             pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
             pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
-        ]));
+        ];
+        for batch in &mut pending_batches {
+            batch.refresh_enqueued_at(original_enqueued_at);
+        }
+        let pending = Arc::new(Mutex::new(pending_batches));
         assert_eq!(
             sem.available_permits(),
             2,
@@ -648,6 +682,8 @@ mod tests {
             &submitted,
             &last_acked,
             0,
+            #[cfg(feature = "test-hooks")]
+            None,
         )
         .await;
         assert!(res.is_err(), "replay must surface the send failure");
@@ -660,6 +696,12 @@ mod tests {
         );
         assert_eq!(guard[0].record_range(), (0, 3));
         assert_eq!(guard[1].record_range(), (3, 5));
+        assert!(
+            guard
+                .iter()
+                .all(|batch| batch.enqueued_at() == original_enqueued_at),
+            "failed replay must not refresh pending ACK timestamps"
+        );
         drop(guard);
 
         assert_eq!(
@@ -690,10 +732,15 @@ mod tests {
     async fn replay_success_reinstalls_and_sends_all() {
         let schema = one_col_schema();
         let sem = Arc::new(Semaphore::new(4));
-        let pending = Arc::new(Mutex::new(vec![
+        let original_enqueued_at = Instant::now() - Duration::from_secs(1);
+        let mut pending_batches = vec![
             pending_batch(&sem, batch_with_rows(&schema, 3), 0, 0, 3),
             pending_batch(&sem, batch_with_rows(&schema, 2), 1, 3, 5),
-        ]));
+        ];
+        for batch in &mut pending_batches {
+            batch.refresh_enqueued_at(original_enqueued_at);
+        }
+        let pending = Arc::new(Mutex::new(pending_batches));
         let cumulative = Arc::new(AtomicU64::new(0));
         let submitted = Arc::new(AtomicU64::new(0));
         let last_acked = Arc::new(AtomicU64::new(9));
@@ -707,11 +754,21 @@ mod tests {
             &submitted,
             &last_acked,
             0,
+            #[cfg(feature = "test-hooks")]
+            None,
         )
         .await;
         assert!(res.is_ok());
 
-        assert_eq!(pending.lock().await.len(), 2);
+        let pending_guard = pending.lock().await;
+        assert_eq!(pending_guard.len(), 2);
+        assert!(
+            pending_guard
+                .iter()
+                .all(|batch| batch.enqueued_at() == original_enqueued_at),
+            "the replay send phase must not start pending ACK deadlines"
+        );
+        drop(pending_guard);
         assert_eq!(cumulative.load(Ordering::Relaxed), 5);
         assert_eq!(submitted.load(Ordering::Acquire), 5);
         assert_eq!(last_acked.load(Ordering::Relaxed), 0);
@@ -747,6 +804,8 @@ mod tests {
             &submitted,
             &last_acked,
             4,
+            #[cfg(feature = "test-hooks")]
+            None,
         )
         .await;
         assert!(res.is_ok());

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -183,6 +183,7 @@ impl Supervisor {
                     // lifts the gate; failed attempts remain paused for retry/finalization.
                     pause_and_detach_sender(&self.ingest_mutex, &self.is_paused, &self.batch_tx)
                         .await;
+                    self.ack_processor.clear_request_send_failure();
 
                     sleep(Duration::from_millis(self.options.recovery_backoff_ms)).await;
 

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -2133,6 +2133,94 @@ mod arrow_flight_tests {
     mod timeout_tests {
         use super::*;
 
+        /// Idle time before ingestion must not consume a future batch's ACK deadline.
+        #[tokio::test]
+        async fn test_ack_timeout_starts_when_batch_becomes_pending(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            const ACK_TIMEOUT_MS: u64 = 1_000;
+            const IDLE_MS: u64 = 800;
+            const ACK_DELAY_MS: u64 = 400;
+            const PAST_OLD_DEADLINE_MS: u64 = ACK_TIMEOUT_MS - IDLE_MS + 1;
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: ACK_DELAY_MS,
+                        ack_up_to_records: 1,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .server_lack_of_ack_timeout_ms(ACK_TIMEOUT_MS)
+                .flush_timeout_ms(ACK_TIMEOUT_MS * 2)
+                .recovery(false)
+                .build_arrow()
+                .await?;
+
+            let ack_idle = stream.arm_ack_idle_notify().await;
+            tokio::time::timeout(std::time::Duration::from_secs(5), ack_idle.notified())
+                .await
+                .expect("ACK processor should enter its no-pending wait");
+
+            tokio::time::pause();
+            tokio::time::advance(std::time::Duration::from_millis(IDLE_MS)).await;
+
+            // Clone before ingestion so the one-shot notification cannot be missed.
+            let delayed_ack_armed = mock_server.delayed_ack_armed();
+            let batch = create_test_record_batch(schema, vec![2], vec![Some("target")]);
+            let offset = stream.ingest_batch(batch).await?;
+
+            // Keep this current-thread runtime runnable while the batch crosses the real
+            // loopback socket, preventing paused time from auto-advancing to a timer.
+            let delayed_ack_armed = delayed_ack_armed.notified();
+            tokio::pin!(delayed_ack_armed);
+            let watchdog = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while futures::poll!(delayed_ack_armed.as_mut()).is_pending() {
+                assert!(
+                    std::time::Instant::now() < watchdog,
+                    "mock server did not arm the delayed ACK"
+                );
+                tokio::task::yield_now().await;
+            }
+
+            // This crosses the old response-relative deadline, but remains well before
+            // the target batch's pending-relative deadline.
+            tokio::time::advance(std::time::Duration::from_millis(PAST_OLD_DEADLINE_MS)).await;
+            tokio::task::yield_now().await;
+            assert!(
+                !stream.is_closed(),
+                "idle time must not consume the target batch's ACK deadline"
+            );
+
+            tokio::time::advance(std::time::Duration::from_millis(
+                ACK_DELAY_MS - PAST_OLD_DEADLINE_MS,
+            ))
+            .await;
+            tokio::task::yield_now().await;
+            stream.wait_for_offset(offset).await?;
+            assert!(!stream.is_closed());
+
+            tokio::time::resume();
+            stream.close().await?;
+            Ok(())
+        }
+
         #[tokio::test]
         async fn test_ack_timeout() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
@@ -2184,6 +2272,62 @@ mod arrow_flight_tests {
                 err
             );
 
+            Ok(())
+        }
+
+        /// A batch accepted after the local request sender closes is buffered but not
+        /// submitted, so it has no ACK deadline on the failed connection. The send
+        /// failure itself must wake the supervisor and start recovery.
+        #[tokio::test]
+        async fn test_closed_request_sender_starts_recovery(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::HoldResponseAfterRequestEof],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .server_lack_of_ack_timeout_ms(30_000)
+                .flush_timeout_ms(60_000)
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(1)
+                .build_arrow()
+                .await?;
+
+            let (reconnect_reached, reconnect_proceed) =
+                stream.arm_reconnect_rebuild_barrier().await;
+            stream.replace_batch_sender_with_closed_channel().await;
+
+            let batch = create_test_record_batch(schema, vec![1], vec![Some("replay")]);
+            let offset = stream.ingest_batch(batch).await?;
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                reconnect_reached.notified(),
+            )
+            .await
+            .expect("request send failure must start recovery without an ACK deadline");
+            reconnect_proceed.notify_one();
+
+            stream.wait_for_offset(offset).await?;
+            assert_eq!(mock_server.get_batch_count().await, 1);
+            stream.close().await?;
             Ok(())
         }
 

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -11,8 +11,8 @@ mod arrow_flight_tests {
     use crate::utils::{
         advance_tokio_time_near_instant_limit, create_test_arrow_schema,
         create_test_dict_record_batch, create_test_dict_schema, create_test_record_batch,
-        record_batch_to_ipc_bytes, run_with_paused_time_watchdog, setup_tracing,
-        CountingHeadersProvider, HangingInvalidationHeadersProvider, TestHeadersProvider,
+        record_batch_to_ipc_bytes, setup_tracing, CountingHeadersProvider,
+        HangingInvalidationHeadersProvider, TestHeadersProvider,
     };
 
     const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
@@ -126,26 +126,12 @@ mod arrow_flight_tests {
         }
 
         #[tokio::test(start_paused = true)]
-        async fn test_max_recovery_timeout_does_not_overflow_initial_deadline(
+        async fn test_unrepresentable_recovery_timeout_is_rejected(
         ) -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
 
-            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let (_mock_server, server_url) = start_mock_flight_server().await?;
             let schema = create_test_arrow_schema();
-            mock_server
-                .inject_responses(
-                    TABLE_NAME,
-                    vec![MockFlightResponse::FailSetup {
-                        status: Status::unauthenticated("stale credential"),
-                    }],
-                )
-                .await;
-
-            let invalidations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-            let provider = Arc::new(CountingHeadersProvider {
-                get_headers_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-                invalidations: Arc::clone(&invalidations),
-            });
             let sdk = ZerobusSdk::builder()
                 .endpoint(server_url)
                 .unity_catalog_url("https://mock-uc.com")
@@ -154,32 +140,56 @@ mod arrow_flight_tests {
 
             advance_tokio_time_near_instant_limit().await;
 
-            let stream_result = run_with_paused_time_watchdog(
-                sdk.stream_builder()
-                    .table(TABLE_NAME)
-                    .headers_provider(provider)
-                    .arrow(schema)
-                    .recovery(true)
-                    .recovery_backoff_ms(0)
-                    .recovery_timeout_ms(u64::MAX)
-                    .recovery_retries(1)
-                    .build_arrow(),
-            )
-            .await;
+            let stream_result = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema)
+                .recovery_timeout_ms(u64::MAX)
+                .build_arrow()
+                .await;
 
             match stream_result {
-                Ok(stream) => {
-                    assert!(!stream.is_closed());
-                    assert_eq!(
-                        invalidations.load(std::sync::atomic::Ordering::SeqCst),
-                        1,
-                        "the rejected credential must still be invalidated"
-                    );
-                }
-                Err(ZerobusError::CreateStreamError(status)) => {
-                    assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+                Err(ZerobusError::InvalidArgument(message)) => {
+                    assert!(message.contains("recovery_timeout_ms"));
                 }
                 Err(error) => panic!("unexpected stream creation error: {error}"),
+                Ok(_) => panic!("unrepresentable recovery timeout was accepted"),
+            }
+
+            Ok(())
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_unrepresentable_ack_timeout_is_rejected(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            let (_mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            advance_tokio_time_near_instant_limit().await;
+
+            let stream_result = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema)
+                .server_lack_of_ack_timeout_ms(u64::MAX)
+                .build_arrow()
+                .await;
+
+            match stream_result {
+                Err(ZerobusError::InvalidArgument(message)) => {
+                    assert!(message.contains("server_lack_of_ack_timeout_ms"));
+                }
+                Err(error) => panic!("unexpected stream creation error: {error}"),
+                Ok(_) => panic!("unrepresentable ACK timeout was accepted"),
             }
 
             Ok(())
@@ -2190,10 +2200,10 @@ mod arrow_flight_tests {
             // loopback socket, preventing paused time from auto-advancing to a timer.
             let delayed_ack_armed = delayed_ack_armed.notified();
             tokio::pin!(delayed_ack_armed);
-            let watchdog = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let watchdog_started = std::time::Instant::now();
             while futures::poll!(delayed_ack_armed.as_mut()).is_pending() {
                 assert!(
-                    std::time::Instant::now() < watchdog,
+                    watchdog_started.elapsed() < std::time::Duration::from_secs(5),
                     "mock server did not arm the delayed ACK"
                 );
                 tokio::task::yield_now().await;
@@ -2993,6 +3003,67 @@ mod arrow_flight_tests {
 
     mod recovery_tests {
         use super::*;
+
+        /// The supervisor must surface a non-retryable configuration error if a timeout
+        /// that was representable at construction can no longer form a runtime deadline.
+        #[tokio::test(start_paused = true)]
+        async fn test_unrepresentable_runtime_recovery_deadline_is_rejected(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            const RECOVERY_TIMEOUT_MS: u64 = 32 * 365 * 24 * 60 * 60 * 1_000;
+
+            setup_tracing();
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::Error {
+                        status: tonic::Status::unavailable("Connection lost"),
+                        delay_ms: 0,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_timeout_ms(RECOVERY_TIMEOUT_MS)
+                .recovery_retries(1)
+                .build_arrow()
+                .await?;
+
+            advance_tokio_time_near_instant_limit().await;
+
+            let batch = create_test_record_batch(schema, vec![1], vec![Some("replay")]);
+            stream.ingest_batch(batch).await?;
+            let watchdog_started = std::time::Instant::now();
+            while !stream.is_closed() {
+                assert!(
+                    watchdog_started.elapsed() < std::time::Duration::from_secs(5),
+                    "near-limit recovery did not terminate"
+                );
+                tokio::task::yield_now().await;
+            }
+            match stream.flush().await {
+                Err(ZerobusError::InvalidArgument(message)) => {
+                    assert!(message.contains("recovery_timeout_ms"));
+                }
+                Err(error) => panic!("unexpected recovery error: {error}"),
+                Ok(()) => panic!("unrepresentable recovery deadline was accepted"),
+            }
+            assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
 
         /// close() during the reconnect rebuild window must slice with the pre-reconnect
         /// watermark. A barrier parks reconnect after the new connection is established but

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -454,12 +454,11 @@ mod arrow_flight_tests {
             Ok(())
         }
 
-        #[tokio::test]
+        #[tokio::test(start_paused = true)]
         async fn test_initial_auth_invalidation_timeout_preserves_one_retry_limit(
         ) -> Result<(), Box<dyn std::error::Error>> {
             const ATTEMPT_TIMEOUT_MS: u64 = 600;
             const SETUP_REJECTION_DELAY_MS: u64 = 300;
-            const MAX_TWO_ATTEMPT_DURATION_MS: u64 = 1_500;
 
             setup_tracing();
 
@@ -486,11 +485,14 @@ mod arrow_flight_tests {
                 )
                 .await;
 
+            let delayed_setup_armed = mock_server.delayed_setup_armed();
             let invalidations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let cancellations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let invalidation_armed = Arc::new(tokio::sync::Notify::new());
             let provider = Arc::new(HangingInvalidationHeadersProvider {
                 invalidations: Arc::clone(&invalidations),
                 cancellations: Arc::clone(&cancellations),
+                invalidation_armed: Arc::clone(&invalidation_armed),
             });
             let sdk = ZerobusSdk::builder()
                 .endpoint(server_url)
@@ -498,8 +500,7 @@ mod arrow_flight_tests {
                 .tls_config(Arc::new(NoTlsConfig))
                 .build()?;
 
-            let started = std::time::Instant::now();
-            let result = sdk
+            let build_stream = sdk
                 .stream_builder()
                 .table(TABLE_NAME)
                 .headers_provider(provider)
@@ -508,9 +509,24 @@ mod arrow_flight_tests {
                 .recovery_backoff_ms(0)
                 .recovery_timeout_ms(ATTEMPT_TIMEOUT_MS)
                 .recovery_retries(5)
-                .build_arrow()
-                .await;
-            let elapsed = started.elapsed();
+                .build_arrow();
+            let drive_attempt_deadlines = async {
+                for _ in 0..2 {
+                    // Do not advance until the server delay and then the client
+                    // invalidation are both known to be pending.
+                    run_with_paused_time_watchdog(delayed_setup_armed.notified()).await;
+                    tokio::time::advance(std::time::Duration::from_millis(
+                        SETUP_REJECTION_DELAY_MS,
+                    ))
+                    .await;
+                    run_with_paused_time_watchdog(invalidation_armed.notified()).await;
+                    tokio::time::advance(std::time::Duration::from_millis(
+                        ATTEMPT_TIMEOUT_MS - SETUP_REJECTION_DELAY_MS,
+                    ))
+                    .await;
+                }
+            };
+            let (result, ()) = tokio::join!(build_stream, drive_attempt_deadlines);
             let error = match result {
                 Ok(_) => panic!("stalled invalidation must not bypass the one-auth-retry limit"),
                 Err(error) => error,
@@ -521,10 +537,6 @@ mod arrow_flight_tests {
                 "the final auth rejection must be preserved, got: {error}"
             );
             assert!(!error.is_retryable());
-            assert!(
-                elapsed < std::time::Duration::from_millis(MAX_TWO_ATTEMPT_DURATION_MS),
-                "setup and invalidation must share each attempt timeout; elapsed: {elapsed:?}"
-            );
             assert_eq!(
                 invalidations.load(std::sync::atomic::Ordering::SeqCst),
                 2,
@@ -1652,6 +1664,7 @@ mod arrow_flight_tests {
             let provider = Arc::new(HangingInvalidationHeadersProvider {
                 invalidations: Arc::clone(&invalidations),
                 cancellations: Arc::clone(&cancellations),
+                ..Default::default()
             });
 
             let sdk = ZerobusSdk::builder()
@@ -1732,6 +1745,7 @@ mod arrow_flight_tests {
             let provider = Arc::new(HangingInvalidationHeadersProvider {
                 invalidations: Arc::clone(&invalidations),
                 cancellations: Arc::clone(&cancellations),
+                ..Default::default()
             });
 
             let sdk = ZerobusSdk::builder()

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -11,8 +11,8 @@ mod arrow_flight_tests {
     use crate::utils::{
         advance_tokio_time_near_instant_limit, create_test_arrow_schema,
         create_test_dict_record_batch, create_test_dict_schema, create_test_record_batch,
-        record_batch_to_ipc_bytes, setup_tracing, CountingHeadersProvider,
-        HangingInvalidationHeadersProvider, TestHeadersProvider,
+        record_batch_to_ipc_bytes, run_with_paused_time_watchdog, setup_tracing,
+        CountingHeadersProvider, HangingInvalidationHeadersProvider, TestHeadersProvider,
     };
 
     const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
@@ -3062,6 +3062,85 @@ mod arrow_flight_tests {
                 Ok(()) => panic!("unrepresentable recovery deadline was accepted"),
             }
             assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
+
+        /// Time spent replaying a recovered backlog must not consume the batches' ACK
+        /// budget before the replacement response processor can observe acknowledgments.
+        #[tokio::test(start_paused = true)]
+        async fn test_replay_ack_deadline_starts_after_replay_completes(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            const ACK_TIMEOUT_MS: u64 = 100;
+            const REPLAY_DELAY_MS: u64 = ACK_TIMEOUT_MS + 1;
+            const ACK_DELAY_MS: u64 = 50;
+
+            setup_tracing();
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 0,
+                        },
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("Connection lost"),
+                            delay_ms: 0,
+                        },
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 1,
+                            delay_ms: ACK_DELAY_MS,
+                            ack_up_to_records: 2,
+                        },
+                    ],
+                )
+                .await;
+
+            let delayed_ack_armed = mock_server.delayed_ack_armed();
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .max_inflight_batches(2)
+                .server_lack_of_ack_timeout_ms(ACK_TIMEOUT_MS)
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(1)
+                .build_arrow()
+                .await?;
+
+            let (replay_reached, replay_proceed) = stream.arm_replay_send_barrier().await;
+            let first = create_test_record_batch(schema.clone(), vec![1], vec![Some("first")]);
+            stream.ingest_batch(first).await?;
+            let second = create_test_record_batch(schema, vec![2], vec![Some("second")]);
+            let second_offset = stream.ingest_batch(second).await?;
+
+            run_with_paused_time_watchdog(replay_reached.notified()).await;
+            tokio::time::advance(std::time::Duration::from_millis(REPLAY_DELAY_MS)).await;
+            replay_proceed.notify_one();
+
+            // The mock notifies immediately before awaiting its delayed-ACK timer, so
+            // advancing time below cannot race timer registration.
+            run_with_paused_time_watchdog(delayed_ack_armed.notified()).await;
+            tokio::time::advance(std::time::Duration::from_millis(ACK_DELAY_MS)).await;
+            run_with_paused_time_watchdog(stream.wait_for_offset(second_offset)).await?;
+
+            assert!(!stream.is_closed());
+            assert_eq!(
+                mock_server.get_total_records_received().await,
+                4,
+                "both batches should be sent once initially and once during recovery"
+            );
             Ok(())
         }
 

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -14,7 +14,7 @@ use arrow_flight::{
 use futures::Stream;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time::sleep;
 use tonic::transport::{Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
@@ -112,6 +112,8 @@ pub struct MockFlightServer {
     request_half_closes: Arc<AtomicU64>,
     /// Number of request bodies that ended with a transport error/reset.
     request_resets: Arc<AtomicU64>,
+    /// One-shot observation that a scripted delayed ACK registered its timer.
+    delayed_ack_armed: Arc<Notify>,
 }
 
 impl MockFlightServer {
@@ -125,7 +127,14 @@ impl MockFlightServer {
             auto_ack_records: Arc::new(Mutex::new(Vec::new())),
             request_half_closes: Arc::new(AtomicU64::new(0)),
             request_resets: Arc::new(AtomicU64::new(0)),
+            delayed_ack_armed: Arc::new(Notify::new()),
         }
+    }
+
+    /// Returns a notification that fires immediately before the mock waits on a
+    /// scripted delayed ACK.
+    pub fn delayed_ack_armed(&self) -> Arc<Notify> {
+        Arc::clone(&self.delayed_ack_armed)
     }
 
     /// Inject responses for a specific table
@@ -261,6 +270,7 @@ impl FlightService for MockFlightServer {
         let auto_ack_records = Arc::clone(&self.auto_ack_records);
         let request_half_closes = Arc::clone(&self.request_half_closes);
         let request_resets = Arc::clone(&self.request_resets);
+        let delayed_ack_armed = Arc::clone(&self.delayed_ack_armed);
 
         tokio::spawn(async move {
             let mut stream_responses: Vec<MockFlightResponse> = Vec::new();
@@ -420,6 +430,7 @@ impl FlightService for MockFlightServer {
                                 .unwrap_or(false)
                             {
                                 if *delay_ms > 0 {
+                                    delayed_ack_armed.notify_one();
                                     sleep(Duration::from_millis(*delay_ms)).await;
                                 }
 
@@ -683,6 +694,7 @@ async fn start_mock_flight_server_inner(
         auto_ack_records: Arc::clone(&mock_server.auto_ack_records),
         request_half_closes: Arc::clone(&mock_server.request_half_closes),
         request_resets: Arc::clone(&mock_server.request_resets),
+        delayed_ack_armed: Arc::clone(&mock_server.delayed_ack_armed),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -114,6 +114,8 @@ pub struct MockFlightServer {
     request_resets: Arc<AtomicU64>,
     /// One-shot observation that a scripted delayed ACK registered its timer.
     delayed_ack_armed: Arc<Notify>,
+    /// Observation that a delayed setup rejection registered its timer.
+    delayed_setup_armed: Arc<Notify>,
 }
 
 impl MockFlightServer {
@@ -128,6 +130,7 @@ impl MockFlightServer {
             request_half_closes: Arc::new(AtomicU64::new(0)),
             request_resets: Arc::new(AtomicU64::new(0)),
             delayed_ack_armed: Arc::new(Notify::new()),
+            delayed_setup_armed: Arc::new(Notify::new()),
         }
     }
 
@@ -135,6 +138,12 @@ impl MockFlightServer {
     /// scripted delayed ACK.
     pub fn delayed_ack_armed(&self) -> Arc<Notify> {
         Arc::clone(&self.delayed_ack_armed)
+    }
+
+    /// Returns a notification that fires immediately before the mock waits on a
+    /// scripted delayed setup rejection.
+    pub fn delayed_setup_armed(&self) -> Arc<Notify> {
+        Arc::clone(&self.delayed_setup_armed)
     }
 
     /// Inject responses for a specific table
@@ -271,6 +280,7 @@ impl FlightService for MockFlightServer {
         let request_half_closes = Arc::clone(&self.request_half_closes);
         let request_resets = Arc::clone(&self.request_resets);
         let delayed_ack_armed = Arc::clone(&self.delayed_ack_armed);
+        let delayed_setup_armed = Arc::clone(&self.delayed_setup_armed);
 
         tokio::spawn(async move {
             let mut stream_responses: Vec<MockFlightResponse> = Vec::new();
@@ -333,6 +343,7 @@ impl FlightService for MockFlightServer {
                                 indices.insert(table_name.clone(), response_index);
                             }
                             if delay_ms > 0 {
+                                delayed_setup_armed.notify_one();
                                 sleep(Duration::from_millis(delay_ms)).await;
                             }
                             info!("Rejecting connection setup: {:?}", status);
@@ -495,6 +506,7 @@ impl FlightService for MockFlightServer {
                         }
                         MockFlightResponse::FailSetupAfter { status, delay_ms } => {
                             if *delay_ms > 0 {
+                                delayed_setup_armed.notify_one();
                                 sleep(Duration::from_millis(*delay_ms)).await;
                             }
                             let status = status.clone();
@@ -695,6 +707,7 @@ async fn start_mock_flight_server_inner(
         request_half_closes: Arc::clone(&mock_server.request_half_closes),
         request_resets: Arc::clone(&mock_server.request_resets),
         delayed_ack_armed: Arc::clone(&mock_server.delayed_ack_armed),
+        delayed_setup_armed: Arc::clone(&mock_server.delayed_setup_armed),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -17,7 +17,7 @@ use databricks::zerobus::{
 };
 use prost_types::Duration as ProtobufDuration;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
-use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio::sync::{mpsc, Mutex, Notify, Semaphore};
 use tokio::time::sleep;
 use tokio_stream::Stream;
 use tonic::transport::{Identity, ServerTlsConfig};
@@ -90,6 +90,8 @@ pub struct MockZerobusServer {
     write_count: Arc<Mutex<u64>>,
     /// Track response index across multiple connection attempts
     response_indices: Arc<Mutex<HashMap<String, usize>>>,
+    /// Observation that a delayed setup response registered its timer.
+    delayed_setup_armed: Arc<Notify>,
 }
 
 impl MockZerobusServer {
@@ -100,7 +102,15 @@ impl MockZerobusServer {
             max_offset_sent: Arc::new(Mutex::new(-1)),
             write_count: Arc::new(Mutex::new(0)),
             response_indices: Arc::new(Mutex::new(HashMap::new())),
+            delayed_setup_armed: Arc::new(Notify::new()),
         }
+    }
+
+    /// Returns a notification that fires immediately before the mock waits on a
+    /// scripted delayed setup response.
+    #[allow(dead_code)]
+    pub fn delayed_setup_armed(&self) -> Arc<Notify> {
+        Arc::clone(&self.delayed_setup_armed)
     }
 
     /// Inject responses for a specific stream (identified by table name for simplicity)
@@ -154,6 +164,7 @@ impl Zerobus for MockZerobusServer {
         let max_offset_sent = Arc::clone(&self.max_offset_sent);
         let write_count = Arc::clone(&self.write_count);
         let response_indices = Arc::clone(&self.response_indices);
+        let delayed_setup_armed = Arc::clone(&self.delayed_setup_armed);
 
         tokio::spawn(async move {
             let mut table_name = String::new();
@@ -236,6 +247,7 @@ impl Zerobus for MockZerobusServer {
                                         }
                                         MockResponse::Error { status, delay_ms } => {
                                             if *delay_ms > 0 {
+                                                delayed_setup_armed.notify_one();
                                                 sleep(Duration::from_millis(*delay_ms)).await;
                                             }
                                             info!(
@@ -438,6 +450,7 @@ async fn start_mock_server_inner(
         max_offset_sent: Arc::clone(&mock_server.max_offset_sent),
         write_count: Arc::clone(&mock_server.write_count),
         response_indices: Arc::clone(&mock_server.response_indices),
+        delayed_setup_armed: Arc::clone(&mock_server.delayed_setup_armed),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;

--- a/rust/tests/src/rust_tests.rs
+++ b/rust/tests/src/rust_tests.rs
@@ -582,12 +582,11 @@ mod stream_initialization_and_basic_lifecycle_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_initial_auth_invalidation_timeout_preserves_one_retry_limit(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const ATTEMPT_TIMEOUT_MS: u64 = 600;
         const SETUP_REJECTION_DELAY_MS: u64 = 300;
-        const MAX_TWO_ATTEMPT_DURATION_MS: u64 = 1_500;
 
         setup_tracing();
 
@@ -614,11 +613,14 @@ mod stream_initialization_and_basic_lifecycle_tests {
             )
             .await;
 
+        let delayed_setup_armed = mock_server.delayed_setup_armed();
         let invalidations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let cancellations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let invalidation_armed = Arc::new(tokio::sync::Notify::new());
         let provider = Arc::new(HangingInvalidationHeadersProvider {
             invalidations: Arc::clone(&invalidations),
             cancellations: Arc::clone(&cancellations),
+            invalidation_armed: Arc::clone(&invalidation_armed),
         });
         let sdk = ZerobusSdk::builder()
             .endpoint(server_url)
@@ -626,8 +628,7 @@ mod stream_initialization_and_basic_lifecycle_tests {
             .tls_config(Arc::new(NoTlsConfig))
             .build()?;
 
-        let started = std::time::Instant::now();
-        let result = sdk
+        let build_stream = sdk
             .stream_builder()
             .table(TABLE_NAME)
             .headers_provider(provider)
@@ -636,9 +637,22 @@ mod stream_initialization_and_basic_lifecycle_tests {
             .recovery_backoff_ms(0)
             .recovery_timeout_ms(ATTEMPT_TIMEOUT_MS)
             .recovery_retries(5)
-            .build()
-            .await;
-        let elapsed = started.elapsed();
+            .build();
+        let drive_attempt_deadlines = async {
+            for _ in 0..2 {
+                // Do not advance until the server delay and then the client
+                // invalidation are both known to be pending.
+                run_with_paused_time_watchdog(delayed_setup_armed.notified()).await;
+                tokio::time::advance(std::time::Duration::from_millis(SETUP_REJECTION_DELAY_MS))
+                    .await;
+                run_with_paused_time_watchdog(invalidation_armed.notified()).await;
+                tokio::time::advance(std::time::Duration::from_millis(
+                    ATTEMPT_TIMEOUT_MS - SETUP_REJECTION_DELAY_MS,
+                ))
+                .await;
+            }
+        };
+        let (result, ()) = tokio::join!(build_stream, drive_attempt_deadlines);
         let error = match result {
             Ok(_) => panic!("stalled invalidation must not bypass the one-auth-retry limit"),
             Err(error) => error,
@@ -649,10 +663,6 @@ mod stream_initialization_and_basic_lifecycle_tests {
             "the final auth rejection must be preserved, got: {error}"
         );
         assert!(!error.is_retryable());
-        assert!(
-            elapsed < std::time::Duration::from_millis(MAX_TWO_ATTEMPT_DURATION_MS),
-            "setup and invalidation must share each attempt timeout; elapsed: {elapsed:?}"
-        );
         assert_eq!(
             invalidations.load(std::sync::atomic::Ordering::SeqCst),
             2,

--- a/rust/tests/src/utils.rs
+++ b/rust/tests/src/utils.rs
@@ -106,6 +106,7 @@ impl HeadersProvider for CountingHeadersProvider {
 pub struct HangingInvalidationHeadersProvider {
     pub invalidations: Arc<std::sync::atomic::AtomicUsize>,
     pub cancellations: Arc<std::sync::atomic::AtomicUsize>,
+    pub invalidation_armed: Arc<tokio::sync::Notify>,
 }
 
 struct InvalidationCancellationGuard(Arc<std::sync::atomic::AtomicUsize>);
@@ -128,6 +129,7 @@ impl HeadersProvider for HangingInvalidationHeadersProvider {
     async fn invalidate(&self) {
         self.invalidations
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.invalidation_armed.notify_one();
         let _guard = InvalidationCancellationGuard(Arc::clone(&self.cancellations));
         std::future::pending::<()>().await;
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

For Arrow Flight streams, make `server_lack_of_ack_timeout_ms` an absolute deadline derived from the oldest batch pending during normal stream operation.

The previous response-relative timeout could consume most of a future batch window while the stream was idle, and responses without enough durable progress could start a new timeout window. Recovery timing therefore depended on response timing rather than how long submitted work had remained unacknowledged.

This PR:

- timestamps each pending batch and wakes the ACK processor when newly submitted work becomes pending;
- waits without an ACK timer while no submitted batch is pending;
- derives the active deadline from the oldest submitted batch and re-checks the same head under the pending lock before failing;
- allows one already-ready response to win an exact expiry tie without allowing repeated responses to defer the same expired head;
- preserves pending timestamps while rebuilding replay state, then refreshes all replayed batches together after replay completes so ACK processing receives a full timeout window on the replacement connection;
- validates configured ACK and recovery deadlines against the platform monotonic clock and caps server-advertised graceful-rotation periods at one year;
- wakes recovery when a closed request sender leaves accepted work buffered but not submitted, while allowing an already-ready ACK or server status to take precedence over the local send failure; and
- documents the pending-relative timeout behavior and its relationship with `max_inflight_batches`.

## How is this tested?

- `test_ack_timeout_starts_when_batch_becomes_pending`: verifies idle time does not consume a future batch ACK window.
- `ready_ack_wins_expired_deadline_tie`: verifies a ready ACK wins an exact deadline tie.
- `expired_head_gets_only_one_ready_response`: verifies repeated ready responses cannot defer the same expired head.
- `deadline_recheck_requires_same_pending_head`: verifies a fired deadline cannot fail a replacement head after an ACK race and returns the pending count from the validated snapshot.
- `replay_rebuild_preserves_pending_timestamp` and `replay_deadlines_share_completion_timestamp`: verify replay rebuild does not start deadlines early and all rebuilt batches share the replay-completion timestamp.
- `test_replay_ack_deadline_starts_after_replay_completes`: verifies slow multi-batch replay does not consume the recovered connection ACK window.
- `test_closed_request_sender_starts_recovery`: verifies an accepted but unsubmitted batch triggers recovery and is replayed when the request sender closes.
- `request_send_error_is_retryable_unavailable`: verifies the request-send failure retains its retryable transport classification.
- `ready_ack_is_applied_before_reported_request_send_failure`: verifies buffered durable progress is applied before recovery starts.
- `ready_server_error_wins_reported_request_send_failure`: verifies a real permanent server status is not masked by synthetic `Unavailable`.
- `test_unrepresentable_recovery_timeout_is_rejected`, `test_unrepresentable_ack_timeout_is_rejected`, and `test_unrepresentable_runtime_recovery_deadline_is_rejected`: verify unrepresentable configured and runtime deadlines return explicit errors.
- `unrepresentable_ack_deadline_is_rejected` and `server_rotation_grace_is_capped`: verify internal ACK deadline validation and the graceful-rotation cap.

Fixes #655.
