### PR TITLE
[Rust][FFI] Add Arrow C Data ingestion - zero copy

### DIFF
--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -64,6 +64,9 @@ Any change to the Rust SDK's public API surface has cascading effects:
 ## Feature flags
 
 - `arrow-flight` — Arrow Flight support (Beta). API is stabilising but may still change before GA.
+- `internal-arrow-c-data` — Unsupported wrapper-only C Data importer shared by
+  the repository's native bindings. Disabled by default; external Rust users
+  must not depend on its API stability.
 - `zeroparser` — Zero-copy, single-pass protobuf parser driven by `prost_types::DescriptorProto`. Off by default; opt-in for downstream consumers. Source under `sdk/src/zeroparser/`; see its README for details.
 - `testing` — Test utilities.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -269,6 +269,9 @@ name = "arrow-schema"
 version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "arrow-select"
@@ -2854,6 +2857,7 @@ dependencies = [
  "tonic-types",
  "tracing",
  "tracing-subscriber",
+ "zerobus-ffi",
 ]
 
 [[package]]
@@ -4042,7 +4046,9 @@ dependencies = [
 name = "zerobus-ffi"
 version = "1.5.0"
 dependencies = [
+ "arrow-array",
  "arrow-ipc",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "cbindgen",

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ### Internal Changes
 
+- Added Arrow C Data `RecordBatch` conversion behind a disabled-by-default
+  wrapper-only SDK feature so current and future native bindings can share one
+  ownership implementation. No supported Rust SDK or Flight behavior changed.
 - Reorganized Arrow Flight under `stream/arrow/` with focused API, connection,
   ACK, supervisor, and batch modules and no public API changes. Its tracing
   target now follows the module path:

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -7,12 +7,14 @@ license = "Apache-2.0"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+# `rlib` is used only by workspace integration tests that call the real C ABI.
+# Published FFI artifacts remain the static and dynamic libraries.
+crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
-databricks-zerobus-ingest-sdk = { path = "../sdk", version = "2.0.1", features = ["arrow-flight", "testing"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", version = "2.0.1", features = ["arrow-flight", "internal-arrow-c-data", "testing"] }
 
-# Arrow IPC for serializing/deserializing RecordBatches across the FFI boundary
+# Arrow IPC fallback plus schema and unacknowledged-batch serialization.
 arrow-ipc.workspace = true
 
 # FFI helpers
@@ -33,6 +35,10 @@ serde_json.workspace = true
 # Logging
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+
+[dev-dependencies]
+arrow-array = { workspace = true, features = ["ffi"] }
+arrow-schema = { workspace = true, features = ["ffi"] }
 
 [build-dependencies]
 cbindgen.workspace = true

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### New Features and Improvements
 
+- Added `zerobus_arrow_stream_ingest_c_data`, an ownership-transferring Arrow C
+  Data Interface ingestion API. It imports a canonical `ArrowArray` and
+  `ArrowSchema` without an IPC encode/decode round trip, then uses the existing
+  Flight encoder for dictionaries, compression, chunking, and framing.
 - Add callback-based async overloads for all previously blocking stream operations: stream creation (`zerobus_sdk_create_stream_async`, `zerobus_sdk_create_stream_with_headers_provider_async`), stream recreation (`zerobus_sdk_recreate_stream_async`), offset-returning ingest calls (`zerobus_stream_ingest_proto_record_async`, `zerobus_stream_ingest_json_record_async`, `zerobus_stream_ingest_proto_records_async`, `zerobus_stream_ingest_json_records_async`), completion methods (`zerobus_stream_wait_for_offset_async`, `zerobus_stream_flush_async`, `zerobus_stream_close_async`), and unacked-record retrieval (`zerobus_stream_get_unacked_records_async`). These APIs return immediately after validation/scheduling and complete via callbacks; caller-owned string/descriptor/config inputs are copied before return, and SDK/stream handles must remain valid until callback completion.
 
 ### Bug Fixes
@@ -28,6 +32,10 @@
 
 ### Internal Changes
 
+- Reused the Rust SDK's wrapper-only importer to implement the C Data API added
+  in this release. This internal extraction introduces no further changes to
+  that API's ABI, ownership contract, errors, or generated header beyond the
+  additions described under New Features.
 - Add headers-provider ownership tests: `free_user_data` fires once on `Drop` and once on failed create, a null destroy callback is a no-op, and a teardown test that reproduces the recovery-vs-teardown race (a blocking in-flight `get_headers` on one `Arc` clone while another is dropped) asserts the free is deferred until the callback returns. Test-only; no ABI or behavior change.
 - Fix the darwin static-library build in `release-ffi.yml`: invoke `cargo-zigbuild rustc` (the binary directly) instead of `cargo zigbuild rustc`, which routed `rustc` as a positional into the zigbuild subcommand and failed with `unexpected argument 'rustc'`. Release tooling only; no ABI or behavior change.
 - Add ack-callback live-teardown / use-after-free tests. They drive the real `CallbackAckCallback` bridge over a heap-allocated `user_data` through the real callback-handler task, then tear it down via the production teardown code, asserting no callback fires after teardown returns and that `user_data` is safe to release at that point. All teardown paths are covered: drain-within-`callback_max_wait_time_ms`, wait-indefinitely, and a callback still synchronously in-flight when a bounded budget expires — which the drain aborts but cannot preempt, so the callback outlives `teardown()` and `user_data` must stay alive until it finishes. Test-only; no ABI or behavior change.

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -8,6 +8,6 @@ namespace = "zerobus"
 cpp_compat = true
 
 [export]
-include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CZerobusProtoSchema"]
+include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CArrowArray", "CArrowSchema", "CZerobusProtoSchema"]
 
 [export.rename]

--- a/rust/ffi/src/arrow.rs
+++ b/rust/ffi/src/arrow.rs
@@ -380,7 +380,11 @@ pub extern "C" fn zerobus_arrow_stream_ingest_c_data(
 ) -> i64 {
     ffi_guard(result, -1, move || {
         if array.is_null() || schema.is_null() {
-            write_error_result(result, "ArrowArray and ArrowSchema pointers are required", false);
+            write_error_result(
+                result,
+                "ArrowArray and ArrowSchema pointers are required",
+                false,
+            );
             return -1;
         }
 
@@ -388,7 +392,11 @@ pub extern "C" fn zerobus_arrow_stream_ingest_c_data(
         let schema = unsafe { FFI_ArrowSchema::from_raw(schema.cast::<FFI_ArrowSchema>()) };
 
         if array.is_released() || schema.release.is_none() {
-            write_error_result(result, "Arrow C Data input has already been released", false);
+            write_error_result(
+                result,
+                "Arrow C Data input has already been released",
+                false,
+            );
             return -1;
         }
 

--- a/rust/ffi/src/arrow.rs
+++ b/rust/ffi/src/arrow.rs
@@ -1,8 +1,12 @@
 //! Arrow Flight FFI surface.
 
+use crate::arrow_c_data::{CArrowArray, CArrowSchema};
 use crate::common::*;
 use arrow_ipc::{reader::StreamReader, writer::StreamWriter, CompressionType};
 use bytes::Bytes;
+use databricks_zerobus_ingest_sdk::internal::arrow_c_data::{
+    import_c_data_record_batch, FFI_ArrowArray, FFI_ArrowSchema,
+};
 use databricks_zerobus_ingest_sdk::{
     HeadersProvider, RecordBatch, StreamBuilder, ZerobusArrowStream, ZerobusError, ZerobusResult,
 };
@@ -343,6 +347,77 @@ pub extern "C" fn zerobus_arrow_stream_ingest_batch(
                     unsafe {
                         *result = CResult::error(err);
                     }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingests one canonical Arrow C Data Interface RecordBatch.
+///
+/// When both `array` and `schema` are non-null, this function consumes them on
+/// every success or error path. Their release callbacks are cleared before
+/// validation, and the imported buffers may remain owned by the stream until
+/// acknowledgment, recovery finalization, or stream destruction.
+///
+/// Every non-null pointer must address a valid, properly aligned canonical
+/// `ArrowArray` / `ArrowSchema` structure satisfying the Arrow C Data
+/// Interface. All referenced children, dictionaries, buffers, `private_data`,
+/// and release callbacks must remain valid for the lifetime required by the
+/// producer contract. After ownership transfer, the SDK may invoke release
+/// asynchronously on an internal runtime thread. Release callbacks must
+/// therefore be thread-safe and must not unwind or throw across the C ABI.
+///
+/// Malformed, dangling, or malicious structures are caller undefined behavior
+/// and cannot be safely validated by this function.
+#[no_mangle]
+pub extern "C" fn zerobus_arrow_stream_ingest_c_data(
+    stream: *mut CArrowStream,
+    array: *mut CArrowArray,
+    schema: *mut CArrowSchema,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if array.is_null() || schema.is_null() {
+            write_error_result(result, "ArrowArray and ArrowSchema pointers are required", false);
+            return -1;
+        }
+
+        let array = unsafe { FFI_ArrowArray::from_raw(array.cast::<FFI_ArrowArray>()) };
+        let schema = unsafe { FFI_ArrowSchema::from_raw(schema.cast::<FFI_ArrowSchema>()) };
+
+        if array.is_released() || schema.release.is_none() {
+            write_error_result(result, "Arrow C Data input has already been released", false);
+            return -1;
+        }
+
+        let stream_ref = match validate_arrow_stream_ptr(stream) {
+            Ok(stream) => stream,
+            Err(message) => {
+                write_error_result(result, message, false);
+                return -1;
+            }
+        };
+
+        let batch = match unsafe { import_c_data_record_batch(array, schema) } {
+            Ok(batch) => batch,
+            Err(error) => {
+                if !result.is_null() {
+                    unsafe { *result = CResult::error(error) };
+                }
+                return -1;
+            }
+        };
+
+        match RUNTIME.block_on(stream_ref.ingest_batch(batch)) {
+            Ok(offset) => {
+                write_success_result(result);
+                offset
+            }
+            Err(error) => {
+                if !result.is_null() {
+                    unsafe { *result = CResult::error(error) };
                 }
                 -1
             }

--- a/rust/ffi/src/arrow_c_data.rs
+++ b/rust/ffi/src/arrow_c_data.rs
@@ -1,0 +1,116 @@
+//! C-specific Arrow C Data ABI marker types and boundary tests.
+
+/// Opaque C ABI view of a canonical Arrow C Data Interface ArrowArray.
+#[repr(C)]
+pub struct CArrowArray {
+    _private: [u8; 0],
+}
+
+/// Opaque C ABI view of a canonical Arrow C Data Interface ArrowSchema.
+#[repr(C)]
+pub struct CArrowSchema {
+    _private: [u8; 0],
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use arrow_array::{Array, ArrayRef, Int32Array, StructArray};
+    use arrow_schema::{Field, Schema};
+    use databricks_zerobus_ingest_sdk::internal::arrow_c_data::{FFI_ArrowArray, FFI_ArrowSchema};
+
+    use crate::{zerobus_arrow_stream_ingest_c_data, CArrowArray, CArrowSchema, CResult};
+
+    struct CountingRelease {
+        inner_release: Option<unsafe extern "C" fn(*mut FFI_ArrowArray)>,
+        inner_private_data: *mut std::ffi::c_void,
+        releases: Arc<AtomicUsize>,
+    }
+
+    unsafe extern "C" fn counting_release(array: *mut FFI_ArrowArray) {
+        let array = unsafe { &mut *array };
+        let state = unsafe { Box::from_raw(array.private_data.cast::<CountingRelease>()) };
+        array.release = state.inner_release;
+        array.private_data = state.inner_private_data;
+        state.releases.fetch_add(1, Ordering::SeqCst);
+        if let Some(release) = state.inner_release {
+            unsafe { release(array) };
+        }
+    }
+
+    fn count_releases(array: &mut FFI_ArrowArray, releases: Arc<AtomicUsize>) {
+        let state = Box::new(CountingRelease {
+            inner_release: array.release,
+            inner_private_data: array.private_data,
+            releases,
+        });
+        array.release = Some(counting_release);
+        array.private_data = Box::into_raw(state).cast();
+    }
+
+    fn export_batch(
+        schema: &Schema,
+        columns: Vec<ArrayRef>,
+        releases: Arc<AtomicUsize>,
+    ) -> (FFI_ArrowArray, FFI_ArrowSchema) {
+        let struct_array = StructArray::new(schema.fields().clone(), columns, None);
+        let mut array = FFI_ArrowArray::new(&struct_array.to_data());
+        count_releases(&mut array, releases);
+        let schema = FFI_ArrowSchema::try_from(schema).unwrap();
+        (array, schema)
+    }
+
+    #[test]
+    fn ffi_consumes_array_and_schema_before_stream_validation() {
+        use std::ptr;
+
+        let schema = Schema::new(vec![Field::new("id", arrow_schema::DataType::Int32, false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (mut array, mut schema_ffi) =
+            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        let mut result = CResult::success();
+
+        let offset = zerobus_arrow_stream_ingest_c_data(
+            ptr::null_mut(),
+            (&mut array as *mut FFI_ArrowArray).cast::<CArrowArray>(),
+            (&mut schema_ffi as *mut FFI_ArrowSchema).cast::<CArrowSchema>(),
+            &mut result,
+        );
+
+        assert_eq!(offset, -1);
+        assert!(!result.success);
+        assert!(array.release.is_none());
+        assert!(schema_ffi.release.is_none());
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+        crate::zerobus_free_error_message(result.error_message);
+    }
+
+    #[test]
+    fn ffi_null_input_does_not_transfer_the_other_input() {
+        use std::ptr;
+
+        let schema = Schema::new(vec![Field::new("id", arrow_schema::DataType::Int32, false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (mut array, schema_ffi) =
+            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        let mut result = CResult::success();
+
+        let offset = zerobus_arrow_stream_ingest_c_data(
+            ptr::null_mut(),
+            (&mut array as *mut FFI_ArrowArray).cast::<CArrowArray>(),
+            ptr::null_mut(),
+            &mut result,
+        );
+
+        assert_eq!(offset, -1);
+        assert!(!result.success);
+        assert!(array.release.is_some());
+        assert_eq!(releases.load(Ordering::SeqCst), 0);
+        drop(array);
+        drop(schema_ffi);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+        crate::zerobus_free_error_message(result.error_message);
+    }
+}

--- a/rust/ffi/src/arrow_c_data.rs
+++ b/rust/ffi/src/arrow_c_data.rs
@@ -68,8 +68,11 @@ mod tests {
 
         let schema = Schema::new(vec![Field::new("id", arrow_schema::DataType::Int32, false)]);
         let releases = Arc::new(AtomicUsize::new(0));
-        let (mut array, mut schema_ffi) =
-            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        let (mut array, mut schema_ffi) = export_batch(
+            &schema,
+            vec![Arc::new(Int32Array::from(vec![1]))],
+            Arc::clone(&releases),
+        );
         let mut result = CResult::success();
 
         let offset = zerobus_arrow_stream_ingest_c_data(
@@ -93,8 +96,11 @@ mod tests {
 
         let schema = Schema::new(vec![Field::new("id", arrow_schema::DataType::Int32, false)]);
         let releases = Arc::new(AtomicUsize::new(0));
-        let (mut array, schema_ffi) =
-            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        let (mut array, schema_ffi) = export_batch(
+            &schema,
+            vec![Arc::new(Int32Array::from(vec![1]))],
+            Arc::clone(&releases),
+        );
         let mut result = CResult::success();
 
         let offset = zerobus_arrow_stream_ingest_c_data(

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -18,7 +18,9 @@ extern crate libc;
 // A comment between each declaration breaks rustfmt's contiguous-`mod` grouping,
 // so it cannot alphabetize them and reorder the generated header.
 mod common;
-// arrow must follow common and precede builder/sdk/stream/proto_schema.
+// C Data types must precede the Arrow entry points that reference them.
+mod arrow_c_data;
+// arrow must follow common and arrow_c_data and precede builder/sdk/stream/proto_schema.
 mod arrow;
 // builder follows arrow.
 mod builder;
@@ -34,14 +36,14 @@ mod proto_schema;
 mod tests;
 
 pub use arrow::*;
+pub use arrow_c_data::*;
 pub use builder::*;
 pub use common::*;
-pub use proto_schema::*;
-pub use sdk::*;
-pub use stream::*;
-
 // Re-exported SDK types referenced via `crate::` paths by the test module.
 #[cfg(test)]
 pub(crate) use databricks_zerobus_ingest_sdk::databricks::zerobus::RecordType;
 #[cfg(test)]
 pub(crate) use databricks_zerobus_ingest_sdk::ZerobusError;
+pub use proto_schema::*;
+pub use sdk::*;
+pub use stream::*;

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -87,6 +87,20 @@ typedef struct CResult {
 typedef struct CHeaders (*HeadersProviderCallback)(void *user_data);
 
 /**
+ * Opaque C ABI view of a canonical Arrow C Data Interface ArrowArray.
+ */
+typedef struct CArrowArray {
+  uint8_t _private[0];
+} CArrowArray;
+
+/**
+ * Opaque C ABI view of a canonical Arrow C Data Interface ArrowSchema.
+ */
+typedef struct CArrowSchema {
+  uint8_t _private[0];
+} CArrowSchema;
+
+/**
  * An array of Arrow IPC-encoded batches, returned by `zerobus_arrow_stream_get_unacked_batches`.
  * Must be freed with `zerobus_arrow_free_batch_array`.
  */
@@ -301,6 +315,30 @@ int64_t zerobus_arrow_stream_ingest_batch(struct CArrowStream *stream,
                                           const uint8_t *ipc_bytes,
                                           uintptr_t ipc_len,
                                           struct CResult *result);
+
+/**
+ * Ingests one canonical Arrow C Data Interface RecordBatch.
+ *
+ * When both `array` and `schema` are non-null, this function consumes them on
+ * every success or error path. Their release callbacks are cleared before
+ * validation, and the imported buffers may remain owned by the stream until
+ * acknowledgment, recovery finalization, or stream destruction.
+ *
+ * Every non-null pointer must address a valid, properly aligned canonical
+ * `ArrowArray` / `ArrowSchema` structure satisfying the Arrow C Data
+ * Interface. All referenced children, dictionaries, buffers, `private_data`,
+ * and release callbacks must remain valid for the lifetime required by the
+ * producer contract. After ownership transfer, the SDK may invoke release
+ * asynchronously on an internal runtime thread. Release callbacks must
+ * therefore be thread-safe and must not unwind or throw across the C ABI.
+ *
+ * Malformed, dangling, or malicious structures are caller undefined behavior
+ * and cannot be safely validated by this function.
+ */
+int64_t zerobus_arrow_stream_ingest_c_data(struct CArrowStream *stream,
+                                           struct CArrowArray *array,
+                                           struct CArrowSchema *schema,
+                                           struct CResult *result);
 
 /**
  * Ingests one Arrow RecordBatch supplied as Arrow IPC stream bytes.

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -67,6 +67,12 @@ prost-build = { version = "0.14", optional = true }
 default = []
 # Arrow Flight is in Beta
 arrow-flight = ["dep:arrow-flight", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-ipc", "dep:futures", "dep:tonic-types"]
+# Wrapper-only Arrow C Data importer. Not a supported public Rust SDK feature.
+internal-arrow-c-data = [
+    "arrow-flight",
+    "arrow-array/ffi",
+    "arrow-schema/ffi",
+]
 # Zero-copy protobuf parser.
 zeroparser = ["dep:self_cell", "dep:prost-build"]
 testing = ["dep:futures"]

--- a/rust/sdk/src/internal.rs
+++ b/rust/sdk/src/internal.rs
@@ -1,0 +1,12 @@
+//! Unsupported implementation details shared by Zerobus-maintained bindings.
+//!
+//! Items in this module are not covered by the public Rust SDK stability
+//! contract and may change without deprecation.
+
+/// Arrow C Data conversion used by Zerobus native bindings.
+#[doc(hidden)]
+pub mod arrow_c_data {
+    pub use crate::stream::arrow_c_data::{
+        import_c_data_record_batch, FFI_ArrowArray, FFI_ArrowSchema,
+    };
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -94,6 +94,10 @@ pub use tls_config::{SecureTlsConfig, TlsConfig};
 #[cfg(feature = "zeroparser")]
 pub mod zeroparser;
 
+#[cfg(feature = "internal-arrow-c-data")]
+#[doc(hidden)]
+pub mod internal;
+
 /// The type of the stream connection created with the server.
 /// Currently we only support ephemeral streams on the server side, so we support only that in the SDK as well.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/sdk/src/stream/arrow/c_data.rs
+++ b/rust/sdk/src/stream/arrow/c_data.rs
@@ -174,11 +174,17 @@ mod tests {
             Arc::new(StringArray::from(vec!["x", "y"])),
         )
         .unwrap();
-        let schema =
-            Schema::new(vec![Field::new("category", dictionary.data_type().clone(), false)]);
+        let schema = Schema::new(vec![Field::new(
+            "category",
+            dictionary.data_type().clone(),
+            false,
+        )]);
         let releases = Arc::new(AtomicUsize::new(0));
-        let (array, schema_ffi) =
-            export_batch(&schema, vec![Arc::new(dictionary.clone())], Arc::clone(&releases));
+        let (array, schema_ffi) = export_batch(
+            &schema,
+            vec![Arc::new(dictionary.clone())],
+            Arc::clone(&releases),
+        );
 
         let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
         let actual = batch
@@ -254,8 +260,11 @@ mod tests {
     fn import_rejects_already_released_input() {
         let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
         let releases = Arc::new(AtomicUsize::new(0));
-        let (mut array, mut schema_ffi) =
-            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        let (mut array, mut schema_ffi) = export_batch(
+            &schema,
+            vec![Arc::new(Int32Array::from(vec![1]))],
+            Arc::clone(&releases),
+        );
         release_ffi_array(&mut array);
         release_ffi_schema(&mut schema_ffi);
 
@@ -270,8 +279,11 @@ mod tests {
     fn import_preserves_nested_struct_list_until_all_batch_owners_drop() {
         let (schema, source_batch) = nested_struct_list_batch();
         let releases = Arc::new(AtomicUsize::new(0));
-        let (array, schema_ffi) =
-            export_batch(schema.as_ref(), source_batch.columns().to_vec(), Arc::clone(&releases));
+        let (array, schema_ffi) = export_batch(
+            schema.as_ref(),
+            source_batch.columns().to_vec(),
+            Arc::clone(&releases),
+        );
         drop(source_batch);
         drop(schema);
 
@@ -369,7 +381,10 @@ mod tests {
         );
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from(vec![100, 200, 300])), Arc::new(nested_array)],
+            vec![
+                Arc::new(Int32Array::from(vec![100, 200, 300])),
+                Arc::new(nested_array),
+            ],
         )
         .unwrap();
         (schema, batch)
@@ -434,7 +449,10 @@ mod tests {
         let ipc_started = Instant::now();
         for _ in 0..BENCHMARK_ITERATIONS {
             let mut reader = StreamReader::try_new(Cursor::new(ipc.as_slice()), None).unwrap();
-            assert_eq!(reader.next().unwrap().unwrap().num_rows(), BENCHMARK_ROW_COUNT);
+            assert_eq!(
+                reader.next().unwrap().unwrap().num_rows(),
+                BENCHMARK_ROW_COUNT
+            );
         }
         let ipc_elapsed = ipc_started.elapsed();
 

--- a/rust/sdk/src/stream/arrow/c_data.rs
+++ b/rust/sdk/src/stream/arrow/c_data.rs
@@ -1,0 +1,473 @@
+pub use arrow_array::ffi::FFI_ArrowArray;
+pub use arrow_schema::ffi::FFI_ArrowSchema;
+
+use arrow_array::{RecordBatch, RecordBatchOptions, StructArray};
+use arrow_schema::{DataType, Schema};
+use std::sync::Arc;
+
+use crate::{ZerobusError, ZerobusResult};
+
+/// Imports an owned Arrow C Data Interface record batch.
+///
+/// # Safety
+///
+/// `array` and `schema` must satisfy every Arrow C Data Interface invariant.
+/// Both values are consumed on success and error.
+/// All retained buffers, children, dictionaries, `private_data`, and release
+/// callbacks must support asynchronous cross-thread retention until released.
+/// Release callbacks may run on an arbitrary SDK runtime thread; they must be
+/// thread-safe and must not unwind.
+pub unsafe fn import_c_data_record_batch(
+    array: FFI_ArrowArray,
+    schema: FFI_ArrowSchema,
+) -> ZerobusResult<RecordBatch> {
+    if array.is_released() || schema.release.is_none() {
+        return Err(ZerobusError::InvalidArgument(
+            "Arrow C Data input has already been released".to_string(),
+        ));
+    }
+
+    let schema = Schema::try_from(&schema).map_err(|error| {
+        ZerobusError::InvalidArgument(format!("Invalid Arrow C Data schema: {error}"))
+    })?;
+    let data_type = DataType::Struct(schema.fields().clone());
+    let data =
+        unsafe { arrow_array::ffi::from_ffi_and_data_type(array, data_type) }.map_err(|error| {
+            ZerobusError::InvalidArgument(format!("Invalid Arrow C Data array: {error}"))
+        })?;
+    let row_count = data.len();
+    let (_, columns, nulls) = StructArray::from(data).into_parts();
+    if nulls.is_some_and(|nulls| nulls.null_count() != 0) {
+        return Err(ZerobusError::InvalidArgument(
+            "Arrow C Data RecordBatch cannot contain null top-level rows".to_string(),
+        ));
+    }
+
+    RecordBatch::try_new_with_options(
+        Arc::new(schema),
+        columns,
+        &RecordBatchOptions::new().with_row_count(Some(row_count)),
+    )
+    .map_err(|error| {
+        ZerobusError::InvalidArgument(format!("Invalid Arrow C Data RecordBatch: {error}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use arrow_array::builder::NullBufferBuilder;
+    use arrow_array::ffi::FFI_ArrowArray;
+    use arrow_array::types::Int32Type;
+    use arrow_array::{
+        Array, ArrayRef, DictionaryArray, Int32Array, ListArray, StringArray, StructArray,
+    };
+    use arrow_array::{RecordBatch, RecordBatchOptions};
+    use arrow_schema::ffi::FFI_ArrowSchema;
+    use arrow_schema::{DataType, Field, Fields, Schema};
+
+    use crate::ZerobusError;
+
+    use super::import_c_data_record_batch;
+
+    struct CountingRelease {
+        inner_release: Option<unsafe extern "C" fn(*mut FFI_ArrowArray)>,
+        inner_private_data: *mut std::ffi::c_void,
+        releases: Arc<AtomicUsize>,
+    }
+
+    unsafe extern "C" fn counting_release(array: *mut FFI_ArrowArray) {
+        let array = unsafe { &mut *array };
+        let state = unsafe { Box::from_raw(array.private_data.cast::<CountingRelease>()) };
+        array.release = state.inner_release;
+        array.private_data = state.inner_private_data;
+        state.releases.fetch_add(1, Ordering::SeqCst);
+        if let Some(release) = state.inner_release {
+            unsafe { release(array) };
+        }
+    }
+
+    fn count_releases(array: &mut FFI_ArrowArray, releases: Arc<AtomicUsize>) {
+        let state = Box::new(CountingRelease {
+            inner_release: array.release,
+            inner_private_data: array.private_data,
+            releases,
+        });
+        array.release = Some(counting_release);
+        array.private_data = Box::into_raw(state).cast();
+    }
+
+    fn export_batch(
+        schema: &Schema,
+        columns: Vec<ArrayRef>,
+        releases: Arc<AtomicUsize>,
+    ) -> (FFI_ArrowArray, FFI_ArrowSchema) {
+        let struct_array = StructArray::new(schema.fields().clone(), columns, None);
+        let mut array = FFI_ArrowArray::new(&struct_array.to_data());
+        count_releases(&mut array, releases);
+        let schema = FFI_ArrowSchema::try_from(schema).unwrap();
+        (array, schema)
+    }
+
+    #[test]
+    fn import_preserves_values_and_schema_metadata() {
+        let metadata = HashMap::from([("source".to_string(), "c-data".to_string())]);
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ])
+        .with_metadata(metadata.clone());
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (array, schema_ffi) = export_batch(
+            &schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
+            ],
+            Arc::clone(&releases),
+        );
+
+        let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.schema().metadata(), &metadata);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &Int32Array::from(vec![1, 2, 3])
+        );
+        assert_eq!(releases.load(Ordering::SeqCst), 0);
+        drop(batch);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn imported_owner_survives_clone_and_slice() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (array, schema_ffi) = export_batch(
+            &schema,
+            vec![Arc::new(Int32Array::from(vec![10, 20, 30]))],
+            Arc::clone(&releases),
+        );
+        let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+        let clone = batch.clone();
+        let slice = batch.slice(1, 2);
+
+        drop(batch);
+        drop(clone);
+        assert_eq!(releases.load(Ordering::SeqCst), 0);
+        drop(slice);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn import_preserves_dictionary_values() {
+        let dictionary = DictionaryArray::<Int32Type>::try_new(
+            Int32Array::from(vec![0, 1, 0]),
+            Arc::new(StringArray::from(vec!["x", "y"])),
+        )
+        .unwrap();
+        let schema =
+            Schema::new(vec![Field::new("category", dictionary.data_type().clone(), false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (array, schema_ffi) =
+            export_batch(&schema, vec![Arc::new(dictionary.clone())], Arc::clone(&releases));
+
+        let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+        let actual = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<DictionaryArray<Int32Type>>()
+            .unwrap();
+        assert_eq!(actual, &dictionary);
+        drop(batch);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    fn release_ffi_array(array: &mut FFI_ArrowArray) {
+        if let Some(release) = array.release {
+            unsafe { release(array) };
+        }
+    }
+
+    fn release_ffi_schema(schema: &mut FFI_ArrowSchema) {
+        if let Some(release) = schema.release {
+            unsafe { release(schema) };
+        }
+    }
+
+    #[test]
+    fn import_zero_column_struct_with_explicit_row_count() {
+        let schema = Schema::new(Vec::<Field>::new());
+        let releases = Arc::new(AtomicUsize::new(0));
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(schema.clone()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(5)),
+        )
+        .unwrap();
+        let struct_array = StructArray::from(batch);
+        let mut array = FFI_ArrowArray::new(&struct_array.to_data());
+        count_releases(&mut array, Arc::clone(&releases));
+        let schema_ffi = FFI_ArrowSchema::try_from(&schema).unwrap();
+
+        let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+
+        assert_eq!(batch.num_rows(), 5);
+        assert_eq!(batch.num_columns(), 0);
+        drop(batch);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn import_rejects_nullable_top_level_rows() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let mut nulls = NullBufferBuilder::new(1);
+        nulls.append_null();
+        let struct_array = StructArray::new(
+            schema.fields().clone(),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+            nulls.finish(),
+        );
+        let mut array = FFI_ArrowArray::new(&struct_array.to_data());
+        count_releases(&mut array, Arc::clone(&releases));
+        let schema_ffi = FFI_ArrowSchema::try_from(&schema).unwrap();
+
+        let error = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap_err();
+
+        assert!(matches!(error, ZerobusError::InvalidArgument(_)));
+        assert!(error
+            .to_string()
+            .contains("cannot contain null top-level rows"));
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn import_rejects_already_released_input() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (mut array, mut schema_ffi) =
+            export_batch(&schema, vec![Arc::new(Int32Array::from(vec![1]))], Arc::clone(&releases));
+        release_ffi_array(&mut array);
+        release_ffi_schema(&mut schema_ffi);
+
+        let error = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap_err();
+
+        assert!(matches!(error, ZerobusError::InvalidArgument(_)));
+        assert!(error.to_string().contains("has already been released"));
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn import_preserves_nested_struct_list_until_all_batch_owners_drop() {
+        let (schema, source_batch) = nested_struct_list_batch();
+        let releases = Arc::new(AtomicUsize::new(0));
+        let (array, schema_ffi) =
+            export_batch(schema.as_ref(), source_batch.columns().to_vec(), Arc::clone(&releases));
+        drop(source_batch);
+        drop(schema);
+
+        let batch = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+        let nested = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(
+            nested
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &Int32Array::from(vec![1, 2, 3]),
+        );
+        let lists = nested
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow_array::ListArray>()
+            .unwrap();
+        assert_eq!(lists.value_offsets(), &[0, 2, 2, 3]);
+        assert_eq!(
+            lists
+                .values()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &Int32Array::from(vec![10, 11, 30]),
+        );
+
+        let clone = batch.clone();
+        let slice = batch.slice(1, 2);
+        drop(batch);
+        drop(clone);
+        assert_eq!(releases.load(Ordering::SeqCst), 0);
+        drop(slice);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
+    }
+
+    const BENCHMARK_ROW_COUNT: usize = 65_536;
+    const BENCHMARK_ITERATIONS: u32 = 1_000;
+
+    fn primitive_batch(row_count: usize) -> (Arc<Schema>, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..row_count as i32)),
+                Arc::new(arrow_array::Float64Array::from_iter_values(
+                    (0..row_count).map(|value| value as f64),
+                )),
+            ],
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn string_batch(row_count: usize) -> (Arc<Schema>, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from_iter_values(
+                (0..row_count).map(|value| format!("value-{value}")),
+            ))],
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn nested_struct_list_batch() -> (Arc<Schema>, RecordBatch) {
+        let values = ListArray::from_iter_primitive::<Int32Type, _, _>([
+            Some(vec![Some(10), Some(11)]),
+            Some(vec![]),
+            Some(vec![Some(30)]),
+        ]);
+        let child_fields: Fields = vec![
+            Field::new("inner_id", DataType::Int32, false),
+            Field::new("values", values.data_type().clone(), false),
+        ]
+        .into();
+        let nested_type = DataType::Struct(child_fields.clone());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("nested", nested_type, false),
+        ]));
+        let nested_array = StructArray::new(
+            child_fields,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3])), Arc::new(values)],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![100, 200, 300])), Arc::new(nested_array)],
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn nested_batch(row_count: usize) -> (Arc<Schema>, RecordBatch) {
+        let child_fields: Fields = vec![Field::new("inner_id", DataType::Int32, false)].into();
+        let nested_type = DataType::Struct(child_fields.clone());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("nested", nested_type, false),
+        ]));
+        let nested_array = StructArray::new(
+            child_fields,
+            vec![Arc::new(Int32Array::from_iter_values(0..row_count as i32))],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..row_count as i32)),
+                Arc::new(nested_array),
+            ],
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn dictionary_batch(row_count: usize) -> (Arc<Schema>, RecordBatch) {
+        let dictionary = DictionaryArray::<Int32Type>::try_new(
+            Int32Array::from_iter_values((0..row_count).map(|value| (value % 256) as i32)),
+            Arc::new(StringArray::from_iter_values(
+                (0..256).map(|value| format!("category-{value}")),
+            )),
+        )
+        .unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "category",
+            dictionary.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(dictionary)]).unwrap();
+        (schema, batch)
+    }
+
+    fn benchmark_conversion_shape(shape: &str, schema: Arc<Schema>, batch: RecordBatch) {
+        use std::io::Cursor;
+        use std::time::Instant;
+
+        use arrow_ipc::reader::StreamReader;
+        use arrow_ipc::writer::StreamWriter;
+
+        assert_eq!(batch.num_rows(), BENCHMARK_ROW_COUNT);
+
+        let mut ipc = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut ipc, schema.as_ref()).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let ipc_started = Instant::now();
+        for _ in 0..BENCHMARK_ITERATIONS {
+            let mut reader = StreamReader::try_new(Cursor::new(ipc.as_slice()), None).unwrap();
+            assert_eq!(reader.next().unwrap().unwrap().num_rows(), BENCHMARK_ROW_COUNT);
+        }
+        let ipc_elapsed = ipc_started.elapsed();
+
+        let c_data_started = Instant::now();
+        for _ in 0..BENCHMARK_ITERATIONS {
+            let struct_array = StructArray::from(batch.clone());
+            let array = FFI_ArrowArray::new(&struct_array.to_data());
+            let schema_ffi = FFI_ArrowSchema::try_from(schema.as_ref()).unwrap();
+            let imported = unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap();
+            assert_eq!(imported.num_rows(), BENCHMARK_ROW_COUNT);
+        }
+        let c_data_elapsed = c_data_started.elapsed();
+
+        eprintln!(
+            "shape={shape} ipc_decode_ns_per_iter={} c_data_import_ns_per_iter={}",
+            ipc_elapsed.as_nanos() / u128::from(BENCHMARK_ITERATIONS),
+            c_data_elapsed.as_nanos() / u128::from(BENCHMARK_ITERATIONS),
+        );
+    }
+
+    #[test]
+    #[ignore = "manual conversion benchmark"]
+    fn benchmark_ipc_materialization_against_c_data_import() {
+        let (schema, batch) = primitive_batch(BENCHMARK_ROW_COUNT);
+        benchmark_conversion_shape("primitive", schema, batch);
+
+        let (schema, batch) = string_batch(BENCHMARK_ROW_COUNT);
+        benchmark_conversion_shape("string", schema, batch);
+
+        let (schema, batch) = nested_batch(BENCHMARK_ROW_COUNT);
+        benchmark_conversion_shape("nested", schema, batch);
+
+        let (schema, batch) = dictionary_batch(BENCHMARK_ROW_COUNT);
+        benchmark_conversion_shape("dictionary", schema, batch);
+    }
+}

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -6,8 +6,9 @@
 //! This directory module provides [`ZerobusArrowStream`] for ingesting Arrow
 //! [`RecordBatch`] data into Databricks Delta tables using Arrow Flight. Native Rust
 //! callers use [`ZerobusArrowStream::ingest_batch`] with `RecordBatch` values; FFI
-//! callers (Go, Python, Java, TypeScript) use
-//! [`ZerobusArrowStream::ingest_ipc_batch`] with pre-serialised Arrow IPC bytes.
+//! wrappers can use [`ZerobusArrowStream::ingest_ipc_batch`] with pre-serialised
+//! Arrow IPC bytes. The C FFI can also import canonical Arrow C Data through the
+//! wrapper-only shared importer before calling [`ZerobusArrowStream::ingest_batch`].
 //!
 //! `ZerobusArrowStream` owns caller-facing state. Transport setup, acknowledgment
 //! processing, pending-batch mechanics, and recovery supervision live in private
@@ -37,6 +38,9 @@ use crate::offset_generator::{OffsetId, OffsetIdGenerator};
 use crate::proxy::ConnectorFactory;
 use crate::tls_config::TlsConfig;
 use crate::ZerobusResult;
+
+#[cfg(feature = "internal-arrow-c-data")]
+pub(crate) mod c_data;
 
 mod acks;
 mod batch;

--- a/rust/sdk/src/stream/mod.rs
+++ b/rust/sdk/src/stream/mod.rs
@@ -10,6 +10,9 @@
 mod arrow;
 mod grpc;
 
+#[cfg(feature = "internal-arrow-c-data")]
+pub(crate) use arrow::c_data as arrow_c_data;
+
 #[cfg(feature = "arrow-flight")]
 pub(crate) use arrow::ArrowTableProperties;
 #[cfg(feature = "arrow-flight")]

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/multiplexed_stream_tests.rs"
 name = "arrow_tests"
 path = "src/arrow_tests.rs"
 
+[[test]]
+name = "arrow_c_data_ffi_tests"
+path = "src/arrow_c_data_ffi_tests.rs"
+
 [dependencies]
 async-trait.workspace = true
 prost.workspace = true
@@ -32,7 +36,8 @@ tonic-prost.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "test-hooks", "arrow-flight", "zeroparser"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "test-hooks", "arrow-flight", "internal-arrow-c-data", "zeroparser"] }
+zerobus-ffi = { path = "../ffi" }
 
 # Arrow Flight test dependencies
 arrow-flight.workspace = true

--- a/rust/tests/src/arrow_c_data_ffi_tests.rs
+++ b/rust/tests/src/arrow_c_data_ffi_tests.rs
@@ -1,0 +1,324 @@
+#[allow(dead_code)]
+mod mock_arrow_flight;
+mod utils;
+
+use std::sync::Arc;
+
+use arrow_array::{Array, RecordBatch, StructArray};
+use arrow_schema::Schema;
+use databricks_zerobus_ingest_sdk::internal::arrow_c_data::{FFI_ArrowArray, FFI_ArrowSchema};
+
+use crate::mock_arrow_flight::{start_mock_flight_server, MockFlightResponse};
+use crate::utils::{create_test_arrow_schema, create_test_record_batch};
+
+const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
+
+mod ffi_c_data_lifetime_tests {
+    use std::ffi::{c_void, CStr, CString};
+    use std::ptr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use tonic::Status;
+    use zerobus_ffi::{
+        zerobus_arrow_get_default_config, zerobus_arrow_stream_flush, zerobus_arrow_stream_free,
+        zerobus_arrow_stream_ingest_c_data, zerobus_free_error_message, zerobus_sdk_builder_build,
+        zerobus_sdk_builder_disable_tls, zerobus_sdk_builder_endpoint, zerobus_sdk_builder_new,
+        zerobus_sdk_create_arrow_stream_with_headers_provider, zerobus_sdk_free, CArrowArray,
+        CArrowSchema, CHeaders, CResult,
+    };
+
+    use super::{
+        create_test_arrow_schema, create_test_record_batch, start_mock_flight_server, Arc, Array,
+        FFI_ArrowArray, FFI_ArrowSchema, MockFlightResponse, RecordBatch, Schema, StructArray,
+        TABLE_NAME,
+    };
+
+    struct CountingArrayRelease {
+        inner_release: Option<unsafe extern "C" fn(*mut FFI_ArrowArray)>,
+        inner_private_data: *mut c_void,
+        releases: Arc<AtomicUsize>,
+    }
+
+    struct CountingSchemaRelease {
+        inner_release: Option<unsafe extern "C" fn(*mut FFI_ArrowSchema)>,
+        inner_private_data: *mut c_void,
+        releases: Arc<AtomicUsize>,
+    }
+
+    unsafe extern "C" fn counting_array_release(array: *mut FFI_ArrowArray) {
+        let array = unsafe { &mut *array };
+        let state = unsafe { Box::from_raw(array.private_data.cast::<CountingArrayRelease>()) };
+        array.release = state.inner_release;
+        array.private_data = state.inner_private_data;
+        state.releases.fetch_add(1, Ordering::SeqCst);
+        if let Some(release) = state.inner_release {
+            unsafe { release(array) };
+        }
+    }
+
+    unsafe extern "C" fn counting_schema_release(schema: *mut FFI_ArrowSchema) {
+        let schema = unsafe { &mut *schema };
+        let state = unsafe { Box::from_raw(schema.private_data.cast::<CountingSchemaRelease>()) };
+        schema.release = state.inner_release;
+        schema.private_data = state.inner_private_data;
+        state.releases.fetch_add(1, Ordering::SeqCst);
+        if let Some(release) = state.inner_release {
+            unsafe { release(schema) };
+        }
+    }
+
+    fn exported_counting_batch(
+        batch: RecordBatch,
+        array_releases: Arc<AtomicUsize>,
+        schema_releases: Arc<AtomicUsize>,
+    ) -> (FFI_ArrowArray, FFI_ArrowSchema) {
+        let schema = batch.schema();
+        let struct_array = StructArray::from(batch);
+        let mut array = FFI_ArrowArray::new(&struct_array.to_data());
+        let array_state = Box::new(CountingArrayRelease {
+            inner_release: array.release,
+            inner_private_data: array.private_data,
+            releases: array_releases,
+        });
+        array.release = Some(counting_array_release);
+        array.private_data = Box::into_raw(array_state).cast();
+
+        let mut schema = FFI_ArrowSchema::try_from(schema.as_ref()).unwrap();
+        let schema_state = Box::new(CountingSchemaRelease {
+            inner_release: schema.release,
+            inner_private_data: schema.private_data,
+            releases: schema_releases,
+        });
+        schema.release = Some(counting_schema_release);
+        schema.private_data = Box::into_raw(schema_state).cast();
+        (array, schema)
+    }
+
+    fn schema_ipc_bytes(schema: &Schema) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut writer = arrow_ipc::writer::StreamWriter::try_new(&mut bytes, schema).unwrap();
+        writer.finish().unwrap();
+        bytes
+    }
+
+    extern "C" fn empty_headers(_user_data: *mut c_void) -> CHeaders {
+        CHeaders {
+            headers: ptr::null_mut(),
+            count: 0,
+            error_message: ptr::null_mut(),
+        }
+    }
+
+    fn take_result_error(result: &mut CResult) -> Option<String> {
+        if result.error_message.is_null() {
+            return None;
+        }
+        let message = unsafe { CStr::from_ptr(result.error_message) }
+            .to_string_lossy()
+            .into_owned();
+        zerobus_free_error_message(result.error_message);
+        result.error_message = ptr::null_mut();
+        Some(message)
+    }
+
+    async fn create_ffi_stream(
+        server_url: String,
+        schema: Arc<Schema>,
+    ) -> Result<(usize, usize), String> {
+        tokio::task::spawn_blocking(move || {
+            let endpoint = CString::new(server_url).unwrap();
+            let builder = zerobus_sdk_builder_new();
+            zerobus_sdk_builder_endpoint(builder, endpoint.as_ptr());
+            zerobus_sdk_builder_disable_tls(builder);
+            let mut result = CResult {
+                success: true,
+                error_message: ptr::null_mut(),
+                is_retryable: false,
+            };
+            let sdk = zerobus_sdk_builder_build(builder, &mut result);
+            if sdk.is_null() {
+                return Err(take_result_error(&mut result)
+                    .unwrap_or_else(|| "SDK builder returned null".to_string()));
+            }
+
+            let table_name = CString::new(TABLE_NAME).unwrap();
+            let schema_bytes = schema_ipc_bytes(schema.as_ref());
+            let options = zerobus_arrow_get_default_config();
+            let stream = zerobus_sdk_create_arrow_stream_with_headers_provider(
+                sdk,
+                table_name.as_ptr(),
+                schema_bytes.as_ptr(),
+                schema_bytes.len(),
+                empty_headers,
+                ptr::null_mut(),
+                None,
+                &options,
+                &mut result,
+            );
+            if stream.is_null() {
+                let error = take_result_error(&mut result)
+                    .unwrap_or_else(|| "Arrow stream builder returned null".to_string());
+                zerobus_sdk_free(sdk);
+                return Err(error);
+            }
+            Ok((sdk as usize, stream as usize))
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn ingest_ffi_batch(
+        stream: usize,
+        mut array: FFI_ArrowArray,
+        mut schema: FFI_ArrowSchema,
+    ) -> Result<i64, String> {
+        tokio::task::spawn_blocking(move || {
+            let mut result = CResult {
+                success: true,
+                error_message: ptr::null_mut(),
+                is_retryable: false,
+            };
+            let offset = zerobus_arrow_stream_ingest_c_data(
+                stream as *mut _,
+                (&mut array as *mut FFI_ArrowArray).cast::<CArrowArray>(),
+                (&mut schema as *mut FFI_ArrowSchema).cast::<CArrowSchema>(),
+                &mut result,
+            );
+            assert!(array.release.is_none(), "array ownership must transfer");
+            assert!(schema.release.is_none(), "schema ownership must transfer");
+            if result.success {
+                Ok(offset)
+            } else {
+                Err(take_result_error(&mut result)
+                    .unwrap_or_else(|| "C Data ingest failed without a message".to_string()))
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn flush_ffi_stream(stream: usize) -> Result<(), String> {
+        tokio::task::spawn_blocking(move || {
+            let mut result = CResult {
+                success: true,
+                error_message: ptr::null_mut(),
+                is_retryable: false,
+            };
+            let flushed = zerobus_arrow_stream_flush(stream as *mut _, &mut result);
+            if flushed {
+                Ok(())
+            } else {
+                Err(take_result_error(&mut result)
+                    .unwrap_or_else(|| "Arrow stream flush failed without a message".to_string()))
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn free_ffi_handles(sdk: usize, stream: usize) {
+        tokio::task::spawn_blocking(move || {
+            zerobus_arrow_stream_free(stream as *mut _);
+            zerobus_sdk_free(sdk as *mut _);
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn wait_for_release_count(releases: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while releases.load(Ordering::SeqCst) != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("release callback did not run before timeout");
+    }
+
+    #[tokio::test]
+    async fn ffi_c_data_owner_releases_once_after_ack_and_flush(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (mock_server, server_url) = start_mock_flight_server().await?;
+        let schema = create_test_arrow_schema();
+        mock_server
+            .inject_responses(
+                TABLE_NAME,
+                vec![MockFlightResponse::BatchAck {
+                    ack_up_to_offset: 0,
+                    delay_ms: 200,
+                    ack_up_to_records: 3,
+                }],
+            )
+            .await;
+        let (sdk, stream) = create_ffi_stream(server_url, Arc::clone(&schema)).await?;
+        let array_releases = Arc::new(AtomicUsize::new(0));
+        let schema_releases = Arc::new(AtomicUsize::new(0));
+        let batch =
+            create_test_record_batch(schema, vec![1, 2, 3], vec![Some("a"), Some("b"), Some("c")]);
+        let (array, schema) = exported_counting_batch(
+            batch,
+            Arc::clone(&array_releases),
+            Arc::clone(&schema_releases),
+        );
+
+        assert_eq!(ingest_ffi_batch(stream, array, schema).await?, 0);
+        assert_eq!(schema_releases.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            array_releases.load(Ordering::SeqCst),
+            0,
+            "array owner must remain alive while the batch is pending"
+        );
+
+        flush_ffi_stream(stream).await?;
+        wait_for_release_count(array_releases.as_ref(), 1).await;
+        assert_eq!(schema_releases.load(Ordering::SeqCst), 1);
+
+        free_ffi_handles(sdk, stream).await;
+        assert_eq!(array_releases.load(Ordering::SeqCst), 1);
+        assert_eq!(schema_releases.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ffi_c_data_failed_owner_releases_once_when_stream_is_freed(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (mock_server, server_url) = start_mock_flight_server().await?;
+        let schema = create_test_arrow_schema();
+        mock_server
+            .inject_responses(
+                TABLE_NAME,
+                vec![MockFlightResponse::Error {
+                    status: Status::invalid_argument("terminal C Data test failure"),
+                    delay_ms: 50,
+                }],
+            )
+            .await;
+        let (sdk, stream) = create_ffi_stream(server_url, Arc::clone(&schema)).await?;
+        let array_releases = Arc::new(AtomicUsize::new(0));
+        let schema_releases = Arc::new(AtomicUsize::new(0));
+        let batch = create_test_record_batch(schema, vec![1], vec![Some("retained until free")]);
+        let (array, schema) = exported_counting_batch(
+            batch,
+            Arc::clone(&array_releases),
+            Arc::clone(&schema_releases),
+        );
+
+        assert_eq!(ingest_ffi_batch(stream, array, schema).await?, 0);
+        assert_eq!(schema_releases.load(Ordering::SeqCst), 1);
+        let error = flush_ffi_stream(stream)
+            .await
+            .expect_err("terminal server error must fail flush");
+        assert!(error.contains("terminal C Data test failure"));
+        assert_eq!(
+            array_releases.load(Ordering::SeqCst),
+            0,
+            "failed unacknowledged owner must remain available for recovery"
+        );
+
+        free_ffi_handles(sdk, stream).await;
+        wait_for_release_count(array_releases.as_ref(), 1).await;
+        assert_eq!(schema_releases.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+}

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -4,6 +4,11 @@ mod utils;
 mod arrow_flight_tests {
     use std::sync::Arc;
 
+    use arrow_array::{Array, RecordBatch, StructArray};
+    use arrow_schema::DataType;
+    use databricks_zerobus_ingest_sdk::internal::arrow_c_data::{
+        import_c_data_record_batch, FFI_ArrowArray, FFI_ArrowSchema,
+    };
     use databricks_zerobus_ingest_sdk::{NoTlsConfig, ZerobusError, ZerobusSdk};
     use tracing::info;
 
@@ -30,9 +35,24 @@ mod arrow_flight_tests {
             .to_vec()
     }
 
+    /// Exports a batch to canonical Arrow C Data owners and imports it through the
+    /// production shared importer before Flight encoding.
+    ///
+    /// This helper validates C-Data-shaped `RecordBatch` compatibility with the Flight
+    /// pipeline only. Ownership transfer and released-input behavior are covered by
+    /// `rust/ffi` Task 1/2 tests — do not use this helper to assert ownership semantics.
+    fn import_through_c_data(batch: RecordBatch) -> RecordBatch {
+        let schema = batch.schema();
+        let struct_array = StructArray::from(batch);
+        let array = FFI_ArrowArray::new(&struct_array.to_data());
+        let schema_ffi = FFI_ArrowSchema::try_from(schema.as_ref()).unwrap();
+        unsafe { import_c_data_record_batch(array, schema_ffi) }.unwrap()
+    }
+
     mod stream_creation_tests {
-        use super::*;
         use tonic::Status;
+
+        use super::*;
 
         #[tokio::test]
         async fn test_successful_arrow_stream_creation() -> Result<(), Box<dyn std::error::Error>> {
@@ -4762,6 +4782,58 @@ mod arrow_flight_tests {
         }
 
         #[tokio::test]
+        async fn test_c_data_imported_batch_with_compression(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_c_data_imported_batch_with_compression");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: 0,
+                        ack_up_to_records: 1,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .ipc_compression(Some(arrow_ipc::CompressionType::ZSTD))
+                .build_arrow()
+                .await?;
+
+            let batch = create_test_record_batch(schema, vec![1], vec![Some("c-data")]);
+            let imported = import_through_c_data(batch);
+            let offset = stream.ingest_batch(imported).await?;
+            stream.flush().await?;
+            assert_eq!(offset, 0);
+
+            assert_eq!(mock_server.get_total_records_received().await, 1);
+            assert_eq!(mock_server.get_batch_count().await, 1);
+            assert_eq!(
+                mock_server.get_zstd_compressed_record_batch_count().await,
+                1,
+                "expected ZSTD compression metadata on the wire IPC record batch",
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
         async fn test_mixed_ingest_batch_and_ipc() -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();
             info!("Starting test_mixed_ingest_batch_and_ipc");
@@ -4902,6 +4974,63 @@ mod arrow_flight_tests {
             // Without chunking the whole batch lands in one Flight message
             // (batch_count == 1, max_offset == 0).  With chunking in place each
             // chunk gets its own physical offset, so both counters grow.
+            let batch_count = mock_server.get_batch_count().await;
+            assert!(
+                batch_count >= 2,
+                "Expected large batch to be split into ≥2 Flight messages (chunks), got {batch_count}",
+            );
+
+            let max_offset = mock_server.get_max_offset_received().await;
+            assert!(
+                max_offset >= 1,
+                "Expected max wire offset ≥1 (multiple chunks), got {max_offset}",
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_c_data_imported_large_batch_is_split_into_chunks(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_c_data_imported_large_batch_is_split_into_chunks");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 1,
+                        delay_ms: 0,
+                        ack_up_to_records: LARGE_BATCH_ROWS as u64,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .flush_timeout_ms(10_000)
+                .build_arrow()
+                .await?;
+
+            let batch =
+                create_large_test_record_batch(schema, LARGE_BATCH_ROWS, PAYLOAD_BYTES_PER_ROW);
+            let imported = import_through_c_data(batch);
+            let offset = stream.ingest_batch(imported).await?;
+            stream.flush().await?;
+            assert_eq!(offset, 0);
+
             let batch_count = mock_server.get_batch_count().await;
             assert!(
                 batch_count >= 2,
@@ -5154,6 +5283,72 @@ mod arrow_flight_tests {
             stream.wait_for_offset(offset).await?;
 
             assert!(mock_server.get_batch_count().await >= 1);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_c_data_imported_dictionary_batch() -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            info!("Starting test_c_data_imported_dictionary_batch");
+
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_dict_schema();
+
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::BatchAck {
+                        ack_up_to_offset: 0,
+                        delay_ms: 0,
+                        ack_up_to_records: 3,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .build_arrow()
+                .await?;
+
+            let batch = create_test_dict_record_batch(
+                schema,
+                vec![1, 2, 3],
+                vec![Some("a"), Some("b"), Some("a")],
+            );
+            let imported = import_through_c_data(batch);
+            assert!(
+                matches!(imported.column(1).data_type(), DataType::Dictionary(_, _)),
+                "test setup: imported batch must retain dictionary encoding before Flight",
+            );
+            let offset = stream.ingest_batch(imported).await?;
+            stream.flush().await?;
+            assert_eq!(offset, 0);
+
+            assert_eq!(mock_server.get_total_records_received().await, 3);
+            assert_eq!(
+                mock_server.get_record_batch_message_count().await,
+                1,
+                "expected a RecordBatch IPC message on the wire",
+            );
+            assert!(
+                !mock_server.wire_ipc_schema_has_dictionary_encoding().await,
+                "Flight encoder should hydrate dictionary columns before IPC encoding",
+            );
+            assert_eq!(
+                mock_server.get_decoded_utf8_columns().await,
+                vec![vec![Some("a".to_string()), Some("b".to_string()), Some("a".to_string()),]],
+                "hydrated dictionary payload must preserve logical values",
+            );
 
             Ok(())
         }

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -5346,7 +5346,11 @@ mod arrow_flight_tests {
             );
             assert_eq!(
                 mock_server.get_decoded_utf8_columns().await,
-                vec![vec![Some("a".to_string()), Some("b".to_string()), Some("a".to_string()),]],
+                vec![vec![
+                    Some("a".to_string()),
+                    Some("b".to_string()),
+                    Some("a".to_string()),
+                ]],
                 "hydrated dictionary payload must preserve logical values",
             );
 

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -744,7 +744,10 @@ impl FlightService for MockFlightServer {
                         };
                         let ack_bytes = serde_json::to_vec(&ack_metadata).unwrap();
 
-                        debug!("Auto-acking offset: {}, records: {}", metadata.offset_id, records);
+                        debug!(
+                            "Auto-acking offset: {}, records: {}",
+                            metadata.offset_id, records
+                        );
                         let put_result = PutResult {
                             app_metadata: ack_bytes.into(),
                         };

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -6,11 +6,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use arrow_array::{Array, StringArray};
 use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
+use arrow_schema::Schema;
 use futures::Stream;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use serde::{Deserialize, Serialize};
@@ -19,6 +21,59 @@ use tokio::time::sleep;
 use tonic::transport::{Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, error, info, warn};
+
+/// Observations extracted from an Arrow IPC message header on the wire.
+struct IpcWireObservation {
+    dictionary_messages: u64,
+    record_batch_messages: u64,
+    zstd_record_batches: u64,
+    rows: u64,
+    schema_has_dictionary_encoding: bool,
+}
+
+fn observe_ipc_data_header(data_header: &[u8]) -> IpcWireObservation {
+    let mut observation = IpcWireObservation {
+        dictionary_messages: 0,
+        record_batch_messages: 0,
+        zstd_record_batches: 0,
+        rows: 0,
+        schema_has_dictionary_encoding: false,
+    };
+
+    let Some(msg) = arrow_ipc::root_as_message(data_header).ok() else {
+        return observation;
+    };
+
+    if let Some(schema) = msg.header_as_schema() {
+        if let Some(fields) = schema.fields() {
+            for idx in 0..fields.len() {
+                let field = fields.get(idx);
+                if field.dictionary().is_some() {
+                    observation.schema_has_dictionary_encoding = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if msg.header_as_dictionary_batch().is_some() {
+        observation.dictionary_messages = 1;
+    }
+
+    if let Some(record_batch) = msg.header_as_record_batch() {
+        observation.record_batch_messages = 1;
+        if record_batch
+            .compression()
+            .map(|compression| compression.codec() == arrow_ipc::CompressionType::ZSTD)
+            .unwrap_or(false)
+        {
+            observation.zstd_record_batches = 1;
+        }
+        observation.rows = record_batch.length() as u64;
+    }
+
+    observation
+}
 
 /// Metadata sent with each FlightData batch from the client.
 /// Must match the SDK's FlightBatchMetadata format.
@@ -116,6 +171,16 @@ pub struct MockFlightServer {
     delayed_ack_armed: Arc<Notify>,
     /// Observation that a delayed setup rejection registered its timer.
     delayed_setup_armed: Arc<Notify>,
+    /// Record-batch IPC messages whose header declares ZSTD body compression.
+    zstd_compressed_record_batch_count: Arc<Mutex<u64>>,
+    /// IPC messages carrying a DictionaryBatch header (distinct from record batches).
+    dictionary_message_count: Arc<Mutex<u64>>,
+    /// IPC messages carrying a RecordBatch header.
+    record_batch_message_count: Arc<Mutex<u64>>,
+    /// True when any observed IPC schema message declares dictionary encoding.
+    wire_ipc_schema_has_dictionary_encoding: Arc<Mutex<bool>>,
+    /// Logical UTF-8 column values decoded from received record batches.
+    decoded_utf8_columns: Arc<Mutex<Vec<Vec<Option<String>>>>>,
 }
 
 impl MockFlightServer {
@@ -131,6 +196,11 @@ impl MockFlightServer {
             request_resets: Arc::new(AtomicU64::new(0)),
             delayed_ack_armed: Arc::new(Notify::new()),
             delayed_setup_armed: Arc::new(Notify::new()),
+            zstd_compressed_record_batch_count: Arc::new(Mutex::new(0)),
+            dictionary_message_count: Arc::new(Mutex::new(0)),
+            record_batch_message_count: Arc::new(Mutex::new(0)),
+            wire_ipc_schema_has_dictionary_encoding: Arc::new(Mutex::new(false)),
+            decoded_utf8_columns: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -184,6 +254,32 @@ impl MockFlightServer {
         self.request_resets.load(Ordering::Relaxed)
     }
 
+    /// Record-batch IPC messages whose header declares ZSTD body compression.
+    pub async fn get_zstd_compressed_record_batch_count(&self) -> u64 {
+        *self.zstd_compressed_record_batch_count.lock().await
+    }
+
+    /// IPC messages carrying a DictionaryBatch header.
+    #[allow(dead_code)]
+    pub async fn get_dictionary_message_count(&self) -> u64 {
+        *self.dictionary_message_count.lock().await
+    }
+
+    /// IPC messages carrying a RecordBatch header.
+    pub async fn get_record_batch_message_count(&self) -> u64 {
+        *self.record_batch_message_count.lock().await
+    }
+
+    /// Whether any observed IPC schema message declares dictionary encoding.
+    pub async fn wire_ipc_schema_has_dictionary_encoding(&self) -> bool {
+        *self.wire_ipc_schema_has_dictionary_encoding.lock().await
+    }
+
+    /// Logical UTF-8 column values decoded from received record batches.
+    pub async fn get_decoded_utf8_columns(&self) -> Vec<Vec<Option<String>>> {
+        self.decoded_utf8_columns.lock().await.clone()
+    }
+
     /// Reset the server state
     #[allow(dead_code)]
     pub async fn reset(&self) {
@@ -197,6 +293,11 @@ impl MockFlightServer {
         self.auto_ack_records.lock().await.clear();
         self.request_half_closes.store(0, Ordering::Relaxed);
         self.request_resets.store(0, Ordering::Relaxed);
+        *self.zstd_compressed_record_batch_count.lock().await = 0;
+        *self.dictionary_message_count.lock().await = 0;
+        *self.record_batch_message_count.lock().await = 0;
+        *self.wire_ipc_schema_has_dictionary_encoding.lock().await = false;
+        self.decoded_utf8_columns.lock().await.clear();
     }
 }
 
@@ -281,6 +382,13 @@ impl FlightService for MockFlightServer {
         let request_resets = Arc::clone(&self.request_resets);
         let delayed_ack_armed = Arc::clone(&self.delayed_ack_armed);
         let delayed_setup_armed = Arc::clone(&self.delayed_setup_armed);
+        let zstd_compressed_record_batch_count =
+            Arc::clone(&self.zstd_compressed_record_batch_count);
+        let dictionary_message_count = Arc::clone(&self.dictionary_message_count);
+        let record_batch_message_count = Arc::clone(&self.record_batch_message_count);
+        let wire_ipc_schema_has_dictionary_encoding =
+            Arc::clone(&self.wire_ipc_schema_has_dictionary_encoding);
+        let decoded_utf8_columns = Arc::clone(&self.decoded_utf8_columns);
 
         tokio::spawn(async move {
             let mut stream_responses: Vec<MockFlightResponse> = Vec::new();
@@ -292,6 +400,7 @@ impl FlightService for MockFlightServer {
             // auto-acks (the server derives ack_up_to_records per connection).
             let mut expected_offset: i64 = 0;
             let mut connection_record_count: u64 = 0;
+            let mut wire_schema: Option<Arc<Schema>> = None;
 
             // Load configured responses
             {
@@ -321,10 +430,37 @@ impl FlightService for MockFlightServer {
                         break false;
                     }
                 };
+                let observation = if !flight_data.data_header.is_empty() {
+                    observe_ipc_data_header(&flight_data.data_header)
+                } else {
+                    IpcWireObservation {
+                        dictionary_messages: 0,
+                        record_batch_messages: 0,
+                        zstd_record_batches: 0,
+                        rows: 0,
+                        schema_has_dictionary_encoding: false,
+                    }
+                };
+                if observation.schema_has_dictionary_encoding {
+                    *wire_ipc_schema_has_dictionary_encoding.lock().await = true;
+                }
+                if observation.dictionary_messages > 0 {
+                    let mut count = dictionary_message_count.lock().await;
+                    *count += observation.dictionary_messages;
+                }
+                if observation.record_batch_messages > 0 {
+                    let mut count = record_batch_message_count.lock().await;
+                    *count += observation.record_batch_messages;
+                }
+                if observation.zstd_record_batches > 0 {
+                    let mut count = zstd_compressed_record_batch_count.lock().await;
+                    *count += observation.zstd_record_batches;
+                }
                 // Handle schema message (first message has no app_metadata or empty app_metadata)
                 if is_first_message {
                     is_first_message = false;
                     if flight_data.app_metadata.is_empty() {
+                        wire_schema = Schema::try_from(&flight_data).ok().map(Arc::new);
                         // A scripted FailSetup rejects this connection's setup: send the
                         // error instead of the ready signal (simulates a reconnect failure).
                         let setup_failure = match stream_responses.get(response_index) {
@@ -410,19 +546,42 @@ impl FlightService for MockFlightServer {
                         *count += 1;
                     }
 
-                    // Decode the IPC data_header flatbuffer to get the actual row count.
-                    let rows = arrow_ipc::root_as_message(&flight_data.data_header)
-                        .ok()
-                        .and_then(|msg| msg.header_as_record_batch())
-                        .map(|rb| rb.length() as u64)
-                        .unwrap_or(0);
-                    if rows > 0 {
+                    // Decode row counts from record-batch IPC headers when batch metadata is present.
+                    if observation.rows > 0 {
                         // Connection-local counter drives acks (mirrors the server's
                         // per-connection cumulative tracker); the global row_count is
                         // kept only as a cross-connection observation metric.
-                        connection_record_count += rows;
+                        connection_record_count += observation.rows;
                         let mut count = row_count.lock().await;
-                        *count += rows;
+                        *count += observation.rows;
+                    }
+                    if observation.record_batch_messages > 0 {
+                        if let Some(schema) = &wire_schema {
+                            match arrow_flight::utils::flight_data_to_arrow_batch(
+                                &flight_data,
+                                Arc::clone(schema),
+                                &HashMap::new(),
+                            ) {
+                                Ok(batch) => {
+                                    let mut decoded = decoded_utf8_columns.lock().await;
+                                    for column in batch.columns() {
+                                        if let Some(strings) =
+                                            column.as_any().downcast_ref::<StringArray>()
+                                        {
+                                            decoded.push(
+                                                strings
+                                                    .iter()
+                                                    .map(|value| value.map(str::to_string))
+                                                    .collect(),
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(error) => {
+                                    warn!("Failed to decode received record batch: {error}");
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -585,10 +744,7 @@ impl FlightService for MockFlightServer {
                         };
                         let ack_bytes = serde_json::to_vec(&ack_metadata).unwrap();
 
-                        debug!(
-                            "Auto-acking offset: {}, records: {}",
-                            metadata.offset_id, records
-                        );
+                        debug!("Auto-acking offset: {}, records: {}", metadata.offset_id, records);
                         let put_result = PutResult {
                             app_metadata: ack_bytes.into(),
                         };
@@ -708,6 +864,15 @@ async fn start_mock_flight_server_inner(
         request_resets: Arc::clone(&mock_server.request_resets),
         delayed_ack_armed: Arc::clone(&mock_server.delayed_ack_armed),
         delayed_setup_armed: Arc::clone(&mock_server.delayed_setup_armed),
+        zstd_compressed_record_batch_count: Arc::clone(
+            &mock_server.zstd_compressed_record_batch_count,
+        ),
+        dictionary_message_count: Arc::clone(&mock_server.dictionary_message_count),
+        record_batch_message_count: Arc::clone(&mock_server.record_batch_message_count),
+        wire_ipc_schema_has_dictionary_encoding: Arc::clone(
+            &mock_server.wire_ipc_schema_has_dictionary_encoding,
+        ),
+        decoded_utf8_columns: Arc::clone(&mock_server.decoded_utf8_columns),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add zerobus_arrow_stream_ingest_c_data, an additive C API that transfers canonical ArrowArray/ArrowSchema ownership without an IPC encode/decode round trip while still be able to use existing Flight encoding (compression, chunking, dictionary hydration, ACK, recovery, and error behavior is preserved)
- Add the disabled-by-default internal-arrow-c-data SDK feature so Zerobus native bindings can share one importer, Arrow type identity, validation, and ownership implementation.
- Retain C-specific pointer handling, panic containment, runtime bridging, and ABI marker types in zerobus-ffi.
- Add rlib output only for workspace integration tests that call the real C ABI; shipped FFI artifacts remain static/dynamic libraries.
- Add dedicated C ABI lifetime coverage for release-after-ACK and terminal retention, plus wire-level compression, chunking, dictionary payload, and nested ownership tests.

## How is this tested?

arrow_c_data_ffi_tests added