### PR TITLE
[Rust][Arrow] Coordinate explicit close with recovery

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -18,6 +18,10 @@
   `InvalidArgument` when ACK or recovery deadlines exceed the platform
   monotonic-clock range. Server-advertised graceful-rotation periods are capped
   at one year.
+- Fixed Arrow Flight explicit close during recovery. Close now interrupts recovery
+  backoff, connection setup, ready-signal waiting, and replay; the supervisor finalizes
+  exactly once, preserves real peer/authentication errors, and retains only the correct
+  unacknowledged batch suffixes.
 - Fixed Arrow Flight recovery sender lifetime: replacement senders are now published
   only after pending replay succeeds, while initial supervisor handoff and failed or
   cancelled replay promptly drop redundant senders instead of retaining incomplete

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -63,17 +63,78 @@ pub(super) fn configured_deadline(
     })
 }
 
+/// Level-triggered explicit-close state shared with the supervisor.
+///
+/// `Requested` interrupts recovery while leaving active ACK processing alive for the close
+/// flush. `FlushCompleted` lets the supervisor stop ACK processing and own finalization.
+#[derive(Clone, Debug)]
+enum CloseState {
+    Open,
+    Requested(CloseRequest),
+    FlushCompleted {
+        request: CloseRequest,
+        result: ZerobusResult<()>,
+    },
+    Finalized,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CloseRequest {
+    target_offset: Option<OffsetId>,
+}
+
+impl CloseState {
+    fn request(&self) -> Option<CloseRequest> {
+        match self {
+            Self::Requested(request) | Self::FlushCompleted { request, .. } => Some(*request),
+            Self::Open | Self::Finalized => None,
+        }
+    }
+
+    fn has_started(&self) -> bool {
+        !matches!(self, Self::Open)
+    }
+
+    fn outcome_candidate(
+        &self,
+        acknowledged_offset: Option<OffsetId>,
+        terminal_error: Option<ZerobusError>,
+    ) -> (ZerobusResult<()>, bool) {
+        let target_acknowledged = self
+            .request()
+            .and_then(|request| request.target_offset)
+            .is_some_and(|target| {
+                acknowledged_offset.is_some_and(|acknowledged| acknowledged >= target)
+            });
+        if target_acknowledged {
+            (Ok(()), false)
+        } else if let Some(error) = terminal_error {
+            (Err(error), true)
+        } else if let Self::FlushCompleted { result, .. } = self {
+            (result.clone(), false)
+        } else {
+            (Ok(()), false)
+        }
+    }
+}
+
 /// Test-only barrier used to pause `reconnect` at a precise point — the new connection
 /// is established but pending ranges are not yet rebuilt — so a test can schedule a
 /// concurrent ingest or `close()`.
+type TestBarrierGate = Arc<Mutex<Option<TestBarrier>>>;
+
 #[cfg(feature = "test-hooks")]
-type ReconnectRebuildGate = Arc<Mutex<Option<ReconnectRebuildBarrier>>>;
+type ReconnectRebuildGate = TestBarrierGate;
+
+#[cfg(feature = "test-hooks")]
+type RecoveryBackoffGate = TestBarrierGate;
+
+type ReplayProgressGate = TestBarrierGate;
 
 /// Paired notifications for [`ReconnectRebuildGate`]: `reached` fires when reconnect
-/// hits the barrier; `proceed` releases it (or a test aborts via `close()` instead).
-#[cfg(feature = "test-hooks")]
+/// hits the barrier; `proceed` releases it (or explicit close cancels reconnect instead).
 #[derive(Clone)]
-struct ReconnectRebuildBarrier {
+struct TestBarrier {
     reached: Arc<Notify>,
     proceed: Arc<Notify>,
 }
@@ -101,7 +162,7 @@ type AckAppliedGate = Arc<Mutex<Option<Arc<Notify>>>>;
 #[cfg(feature = "test-hooks")]
 type AckIdleGate = Arc<Mutex<Option<Arc<Notify>>>>;
 
-/// Test-only barrier that parks `close()` after the supervisor and sender are gone but
+/// Test-only barrier that parks supervisor-owned close finalization after sender detach but
 /// before pending batches are finalized, allowing cancellation-safe teardown tests.
 #[cfg(feature = "test-hooks")]
 type CloseFinalizeGate = Arc<Mutex<Option<CloseFinalizeBarrier>>>;
@@ -195,9 +256,11 @@ pub struct ZerobusArrowStream {
     is_closed: Arc<AtomicBool>,
     /// Separates resumable teardown from final closure so retries skip flushing while
     /// new ingests remain rejected.
-    close_teardown_started: AtomicBool,
-    /// Retains the first flush failure so resumed close calls return the same outcome.
-    close_flush_error: Mutex<Option<ZerobusError>>,
+    close_teardown_started: Arc<AtomicBool>,
+    /// Coordinates one resumable explicit-close request with the recovery supervisor.
+    close_state_tx: watch::Sender<CloseState>,
+    /// Stored before finalization and returned by every completed `close()` call.
+    close_outcome: Arc<Mutex<Option<ZerobusResult<()>>>>,
     /// Handle to the supervisor task that processes acknowledgments and recovery.
     receiver_task: Arc<Mutex<Option<JoinHandle<ZerobusResult<()>>>>>,
     /// Accepted batches not yet fully acknowledged; retained for replay or retrieval.
@@ -247,6 +310,12 @@ pub struct ZerobusArrowStream {
     /// Test seam (see [`ReplaySendGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     replay_send_gate: ReplaySendGate,
+    /// Test seam that parks the supervisor at recovery backoff.
+    #[cfg(feature = "test-hooks")]
+    recovery_backoff_gate: RecoveryBackoffGate,
+    /// Test seam that parks replay after its first successful batch handoff.
+    #[cfg(feature = "test-hooks")]
+    replay_progress_gate: ReplayProgressGate,
     /// Test seam (see [`AckAppliedGate`]); compiled only under `test-hooks`.
     #[cfg(feature = "test-hooks")]
     ack_applied_gate: AckAppliedGate,
@@ -311,6 +380,7 @@ impl ZerobusArrowStream {
         let inflight = Arc::new(Semaphore::new(options.max_inflight_batches));
 
         let (server_error_tx, server_error_rx) = watch::channel(None);
+        let (close_state_tx, _close_state_rx) = watch::channel(CloseState::Open);
 
         let stream = Self {
             table_properties,
@@ -320,8 +390,9 @@ impl ZerobusArrowStream {
             last_ack_tx,
             _last_ack_rx,
             is_closed,
-            close_teardown_started: AtomicBool::new(false),
-            close_flush_error: Mutex::new(None),
+            close_teardown_started: Arc::new(AtomicBool::new(false)),
+            close_state_tx,
+            close_outcome: Arc::new(Mutex::new(None)),
             receiver_task,
             pending_batches,
             pending_notify,
@@ -345,6 +416,10 @@ impl ZerobusArrowStream {
             reconnect_rebuild_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             replay_send_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            recovery_backoff_gate: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            replay_progress_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
             ack_applied_gate: Arc::new(Mutex::new(None)),
             #[cfg(feature = "test-hooks")]
@@ -645,6 +720,16 @@ impl ZerobusArrowStream {
         offset_to_wait: OffsetId,
         operation_name: &str,
     ) -> ZerobusResult<()> {
+        self.wait_for_offset_with_close(offset_to_wait, operation_name, true)
+            .await
+    }
+
+    async fn wait_for_offset_with_close(
+        &self,
+        offset_to_wait: OffsetId,
+        operation_name: &str,
+        closing_is_terminal: bool,
+    ) -> ZerobusResult<()> {
         let flush_timeout = Duration::from_millis(self.options.flush_timeout_ms);
         let mut offset_rx = self.last_ack_tx.subscribe();
         let mut error_rx = self.server_error_rx.clone();
@@ -675,9 +760,9 @@ impl ZerobusArrowStream {
                 // state. Re-read first because the watermark can be published between the
                 // read above and observing that state. Otherwise prefer the real terminal
                 // error over a generic one.
-                if self.is_closed.load(Ordering::Relaxed)
-                    || self.close_teardown_started.load(Ordering::Acquire)
-                {
+                let closing =
+                    closing_is_terminal && self.close_teardown_started.load(Ordering::Acquire);
+                if self.is_closed.load(Ordering::Relaxed) || closing {
                     if let Some(ack_offset) = *offset_rx.borrow_and_update() {
                         if ack_offset >= offset_to_wait {
                             return Ok(());
@@ -825,8 +910,9 @@ impl ZerobusArrowStream {
     /// Flushes pending work, stops background I/O, and retains unacknowledged batches for
     /// retrieval.
     ///
-    /// While the stream is active, the first call attempts one flush before teardown. If
-    /// teardown is interrupted, a later call resumes it without flushing again.
+    /// The first call publishes one close request before attempting a flush. This stops any
+    /// recovery phase promptly while allowing ACKs already in flight to complete. The recovery
+    /// supervisor owns finalization and stores one result for all repeated calls.
     ///
     /// # Returns
     ///
@@ -839,10 +925,9 @@ impl ZerobusArrowStream {
     ///
     /// # Cancellation safety
     ///
-    /// Cancelling before teardown begins does not itself close the stream, although an
-    /// independent terminal failure may do so. Once teardown starts, further ingests are
-    /// rejected; call `close()` again to resume incomplete teardown without repeating a
-    /// completed flush.
+    /// Once the close request is published, further ingests are rejected. Cancelling the
+    /// future does not cancel that request: call `close()` again to resume the flush and
+    /// supervisor finalization. A completed flush or final outcome is never recomputed.
     ///
     /// # Examples
     ///
@@ -856,91 +941,84 @@ impl ZerobusArrowStream {
     /// ```
     #[instrument(level = "debug", skip_all, fields(table_name = %self.table_properties.table_name))]
     pub async fn close(&mut self) -> ZerobusResult<()> {
-        let close_teardown_started = self.close_teardown_started.load(Ordering::Acquire);
-        if self.is_closed.load(Ordering::Relaxed) && !close_teardown_started {
-            // Already closed. If the supervisor closed it on a terminal failure, surface
-            // that error rather than reporting success — otherwise the common
-            // ingest-then-close() pattern would hide failed batches (retrievable via
-            // get_unacked_batches()). A clean prior close() has no stored error.
-            if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                return Err(server_error);
-            }
-            if let Some(close_error) = self.close_flush_error.lock().await.clone() {
-                return Err(close_error);
-            }
-            return Ok(());
-        }
-
         info!(
             table_name = %self.table_properties.table_name,
             "Closing Arrow Flight stream"
         );
+        let mut close_rx = self.close_state_tx.subscribe();
 
-        // Retain a completed flush result before publishing teardown so retries after
-        // teardown starts skip another flush and return the same outcome.
-        let flush_result = if close_teardown_started {
-            match self.close_flush_error.lock().await.clone() {
-                Some(error) => Err(error),
-                None => Ok(()),
+        loop {
+            let state = self.close_state_tx.borrow().clone();
+            match state {
+                CloseState::Open => {
+                    if self.is_closed.load(Ordering::Relaxed) {
+                        if let Some(outcome) = self.close_outcome.lock().await.clone() {
+                            return outcome;
+                        }
+                        if let Some(server_error) = self.server_error_rx.borrow().clone() {
+                            return Err(server_error);
+                        }
+                        return Ok(());
+                    }
+
+                    // Safe Rust requires exclusive access for close(), so after setting the
+                    // ingest gate we can snapshot the target and publish the request without
+                    // an await or an admission race.
+                    self.close_teardown_started.store(true, Ordering::Release);
+                    let requested = CloseState::Requested(CloseRequest {
+                        target_offset: self.offset_generator.last(),
+                    });
+                    self.close_state_tx.send_if_modified(move |state| {
+                        if matches!(state, CloseState::Open) {
+                            *state = requested;
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                }
+                CloseState::Requested(request) => {
+                    let flush_result = match request.target_offset {
+                        Some(offset) => {
+                            self.wait_for_offset_with_close(offset, "Flush", false)
+                                .await
+                        }
+                        None => Ok(()),
+                    };
+
+                    // Do not overwrite a terminal outcome that the supervisor published
+                    // while the flush was resolving. Otherwise store the flush result and
+                    // wake the supervisor without another cancellation point.
+                    if let Err(error) = &flush_result {
+                        warn!(
+                            "Flush failed during close: {}. Draining pending batches to the failed set.",
+                            error
+                        );
+                    }
+                    let completed = CloseState::FlushCompleted {
+                        request,
+                        result: flush_result,
+                    };
+                    self.close_state_tx.send_if_modified(move |state| {
+                        if matches!(state, CloseState::Requested(_)) {
+                            *state = completed;
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                }
+                CloseState::FlushCompleted { .. } => {
+                    if close_rx.changed().await.is_err() {
+                        std::future::pending::<()>().await;
+                    }
+                }
+                CloseState::Finalized => {
+                    let outcome = self.close_outcome.lock().await.clone().unwrap_or(Ok(()));
+                    return outcome;
+                }
             }
-        } else {
-            let result = self.flush().await;
-            *self.close_flush_error.lock().await = result.as_ref().err().cloned();
-            self.close_teardown_started.store(true, Ordering::Release);
-            result
-        };
-        if let Err(e) = &flush_result {
-            warn!(
-                "Flush failed during close: {}. Draining pending batches to the failed set.",
-                e
-            );
         }
-
-        // Reap the supervisor (abort + await) BEFORE clearing the sender, so an in-flight
-        // reconnect can't reinstall batch_tx after we clear it, and no ACK processing /
-        // reconnect mutates pending_batches or last_acked_records while we drain. Join in
-        // place and only clear receiver_task once the join completes, so a close()
-        // cancelled during the await doesn't drop the handle — a retry re-joins it.
-        {
-            let mut task = self.receiver_task.lock().await;
-            if let Some(handle) = task.as_mut() {
-                handle.abort();
-                let _ = handle.await;
-            }
-            *task = None;
-        }
-
-        // Detach the sender now that nothing can reinstall it.
-        {
-            let mut tx = self.batch_tx.lock().await;
-            *tx = None;
-        }
-
-        // Test seam: cancel close after teardown became irreversible but before finalization.
-        #[cfg(feature = "test-hooks")]
-        {
-            let barrier = self.close_finalize_gate.lock().await.take();
-            if let Some(barrier) = barrier {
-                barrier.reached.notify_one();
-                barrier.proceed.notified().await;
-            }
-        }
-
-        // Finalize under ingest_mutex so the pending drain is serialized with
-        // ingest_batch. Keep close_teardown_started set while finalization is in flight,
-        // then clear it immediately afterward; cancellation before completion remains
-        // resumable even if closure was already published.
-        Supervisor::finalize_closed(
-            &self.ingest_mutex,
-            &self.is_closed,
-            &self.pending_batches,
-            &self.failed_batches,
-            &self.last_acked_records,
-        )
-        .await;
-        self.close_teardown_started.store(false, Ordering::Release);
-
-        flush_result
     }
 
     /// Returns the un-acknowledged batches after the stream has been closed, for manual
@@ -1000,9 +1078,7 @@ impl ZerobusArrowStream {
         Ok(self.failed_batches.lock().await.clone())
     }
 
-    /// Returns true once terminal finalization publishes closure. Interrupted teardown
-    /// remains false until finalization begins; cancellation during finalization may leave
-    /// this true while `close_teardown_started` marks teardown as resumable.
+    /// Returns true once supervisor-owned terminal finalization publishes closure.
     pub fn is_closed(&self) -> bool {
         self.is_closed.load(Ordering::Relaxed)
     }
@@ -1011,13 +1087,41 @@ impl ZerobusArrowStream {
     /// establishing the connection but before rebuilding pending ranges/watermark,
     /// firing the returned `reached` notify, then waits on `proceed`. A test either
     /// releases `proceed` to let recovery finish, or drives a concurrent `close()`
-    /// (which reaps the paused supervisor) without releasing it.
+    /// (which cancels reconnect and lets the supervisor finalize) without releasing it.
     #[cfg(feature = "test-hooks")]
     #[doc(hidden)]
     pub async fn arm_reconnect_rebuild_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {
         let reached = Arc::new(Notify::new());
         let proceed = Arc::new(Notify::new());
-        *self.reconnect_rebuild_gate.lock().await = Some(ReconnectRebuildBarrier {
+        *self.reconnect_rebuild_gate.lock().await = Some(TestBarrier {
+            reached: Arc::clone(&reached),
+            proceed: Arc::clone(&proceed),
+        });
+        (reached, proceed)
+    }
+
+    /// Test-only: parks recovery immediately before its configured backoff. Explicit
+    /// close must release the parked supervisor without the test notifying `proceed`.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_recovery_backoff_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {
+        let reached = Arc::new(Notify::new());
+        let proceed = Arc::new(Notify::new());
+        *self.recovery_backoff_gate.lock().await = Some(TestBarrier {
+            reached: Arc::clone(&reached),
+            proceed: Arc::clone(&proceed),
+        });
+        (reached, proceed)
+    }
+
+    /// Test-only: parks reconnect replay after the first replacement batch is handed off.
+    /// The replacement response stream has not yet been polled at this point.
+    #[cfg(feature = "test-hooks")]
+    #[doc(hidden)]
+    pub async fn arm_replay_progress_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {
+        let reached = Arc::new(Notify::new());
+        let proceed = Arc::new(Notify::new());
+        *self.replay_progress_gate.lock().await = Some(TestBarrier {
             reached: Arc::clone(&reached),
             proceed: Arc::clone(&proceed),
         });
@@ -1070,8 +1174,9 @@ impl ZerobusArrowStream {
         *self.batch_tx.lock().await = Some(closed_tx);
     }
 
-    /// Test-only: parks the next `close()` after supervisor/sender teardown but before
-    /// finalization. Dropping the close future at that point simulates cancellation.
+    /// Test-only: parks supervisor-owned finalization after sender detach. Dropping the
+    /// waiting close future at that point simulates cancellation without stopping the
+    /// finalizer.
     #[cfg(feature = "test-hooks")]
     #[doc(hidden)]
     pub async fn arm_close_finalize_barrier(&self) -> (Arc<Notify>, Arc<Notify>) {

--- a/rust/sdk/src/stream/arrow/options.rs
+++ b/rust/sdk/src/stream/arrow/options.rs
@@ -136,8 +136,10 @@ pub struct ArrowStreamConfigurationOptions {
     /// available through `get_unacked_batches()`.
     ///
     /// The clean half-close guarantee applies to the active connection during normal
-    /// server rotation. Explicit close during recovery remains best-effort and may abort
-    /// an incomplete replacement request.
+    /// server rotation. Explicit close interrupts any recovery phase, cancels an incomplete
+    /// replacement request, and retains its unacknowledged suffixes for retrieval. As with
+    /// any lost acknowledgment, retrying those suffixes can duplicate records the server
+    /// made durable before the replacement connection was interrupted.
     ///
     /// Default: `None` (use the available server grace period)
     pub stream_paused_max_wait_time_ms: Option<u64>,

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -3,6 +3,7 @@
 //! `Supervisor` owns cloned connection configuration and shared stream state.
 //! It is the sole task that reconnects, replays pending work, and finalizes failures.
 
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -17,13 +18,23 @@ use super::batch::{rebuild_pending_for_replay, refresh_pending_ack_deadlines, Pe
 use super::connection::{FlightConnection, FlightResponseStream, RequestBodyControl};
 use super::{
     configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchSender,
-    RecordBatch, ZerobusArrowStream,
+    CloseState, RecordBatch, ZerobusArrowStream,
 };
 use crate::errors::ZerobusError;
 use crate::headers_provider::HeadersProvider;
+use crate::offset_generator::OffsetId;
 use crate::proxy::ConnectorFactory;
 use crate::tls_config::TlsConfig;
 use crate::ZerobusResult;
+
+const EXPLICIT_CLOSE_INTERRUPTED_RECOVERY: &str = "Explicit close interrupted recovery";
+
+#[derive(Default)]
+struct ReplayGates<'a> {
+    #[cfg(feature = "test-hooks")]
+    replay_send: Option<&'a super::ReplaySendGate>,
+    replay_progress: Option<&'a super::ReplayProgressGate>,
+}
 
 pub(super) struct Supervisor {
     endpoint: String,
@@ -35,6 +46,10 @@ pub(super) struct Supervisor {
     ack_processor: AckProcessor,
     batch_tx: BatchSender,
     is_closed: Arc<AtomicBool>,
+    close_teardown_started: Arc<AtomicBool>,
+    close_state_tx: watch::Sender<CloseState>,
+    close_outcome: Arc<Mutex<Option<ZerobusResult<()>>>>,
+    last_ack_tx: watch::Sender<Option<OffsetId>>,
     pending_batches: Arc<Mutex<Vec<PendingBatch>>>,
     failed_batches: Arc<Mutex<Vec<RecordBatch>>>,
     recovery_attempts: Arc<AtomicU32>,
@@ -49,6 +64,12 @@ pub(super) struct Supervisor {
     reconnect_rebuild_gate: super::ReconnectRebuildGate,
     #[cfg(feature = "test-hooks")]
     replay_send_gate: super::ReplaySendGate,
+    #[cfg(feature = "test-hooks")]
+    recovery_backoff_gate: super::RecoveryBackoffGate,
+    #[cfg(feature = "test-hooks")]
+    replay_progress_gate: super::ReplayProgressGate,
+    #[cfg(feature = "test-hooks")]
+    close_finalize_gate: super::CloseFinalizeGate,
 }
 
 impl Supervisor {
@@ -63,6 +84,10 @@ impl Supervisor {
             ack_processor: AckProcessor::new(stream),
             batch_tx: Arc::clone(&stream.batch_tx),
             is_closed: Arc::clone(&stream.is_closed),
+            close_teardown_started: Arc::clone(&stream.close_teardown_started),
+            close_state_tx: stream.close_state_tx.clone(),
+            close_outcome: Arc::clone(&stream.close_outcome),
+            last_ack_tx: stream.last_ack_tx.clone(),
             pending_batches: Arc::clone(&stream.pending_batches),
             failed_batches: Arc::clone(&stream.failed_batches),
             recovery_attempts: Arc::clone(&stream.recovery_attempts),
@@ -77,6 +102,12 @@ impl Supervisor {
             reconnect_rebuild_gate: Arc::clone(&stream.reconnect_rebuild_gate),
             #[cfg(feature = "test-hooks")]
             replay_send_gate: Arc::clone(&stream.replay_send_gate),
+            #[cfg(feature = "test-hooks")]
+            recovery_backoff_gate: Arc::clone(&stream.recovery_backoff_gate),
+            #[cfg(feature = "test-hooks")]
+            replay_progress_gate: Arc::clone(&stream.replay_progress_gate),
+            #[cfg(feature = "test-hooks")]
+            close_finalize_gate: Arc::clone(&stream.close_finalize_gate),
         }
     }
 
@@ -86,6 +117,122 @@ impl Supervisor {
     ) -> JoinHandle<ZerobusResult<()>> {
         let (response_stream, request_body) = initial_connection.into_supervisor_io();
         spawn(self.run(response_stream, request_body))
+    }
+
+    fn close_has_started(&self) -> bool {
+        self.close_state_tx.borrow().has_started()
+    }
+
+    async fn wait_for_close_request(close_rx: &mut watch::Receiver<CloseState>) {
+        loop {
+            if close_rx.borrow_and_update().has_started() {
+                return;
+            }
+            if close_rx.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+
+    async fn wait_for_flush_completion(close_rx: &mut watch::Receiver<CloseState>) {
+        loop {
+            if matches!(
+                &*close_rx.borrow_and_update(),
+                CloseState::FlushCompleted { .. } | CloseState::Finalized
+            ) {
+                return;
+            }
+            if close_rx.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+
+    async fn process_until_flush_completion<F>(
+        process: F,
+        close_rx: &mut watch::Receiver<CloseState>,
+    ) -> ZerobusResult<()>
+    where
+        F: Future<Output = ZerobusResult<()>>,
+    {
+        tokio::pin!(process);
+        tokio::select! {
+            // Poll ACK/error processing first even when FlushCompleted is already visible.
+            // A ready response must be applied before close selects its stable outcome.
+            biased;
+            result = &mut process => result,
+            _ = Self::wait_for_flush_completion(close_rx) => Ok(()),
+        }
+    }
+
+    async fn select_reconnect_before_close<R, RF, CF>(
+        reconnect: RF,
+        close_requested: CF,
+    ) -> Option<R>
+    where
+        RF: Future<Output = R>,
+        CF: Future<Output = ()>,
+    {
+        tokio::pin!(reconnect);
+        tokio::pin!(close_requested);
+        tokio::select! {
+            // Preserve a newer, already-observed reconnect result when close becomes
+            // ready simultaneously; a pending reconnect is still dropped on close.
+            biased;
+            result = &mut reconnect => Some(result),
+            _ = &mut close_requested => None,
+        }
+    }
+
+    /// Selects and stores one terminal outcome, detaches the active sender, then performs
+    /// finalization exactly once. An acknowledged close target wins a concurrent error;
+    /// otherwise a concrete supervisor error wins close's synthetic flush result.
+    async fn finish(&self, terminal_error: Option<ZerobusError>) -> ZerobusResult<()> {
+        let state = self.close_state_tx.borrow().clone();
+        let (candidate, terminal_won) =
+            state.outcome_candidate(*self.last_ack_tx.borrow(), terminal_error);
+
+        let outcome = {
+            let mut stored = self.close_outcome.lock().await;
+            stored.get_or_insert_with(|| candidate.clone()).clone()
+        };
+
+        if terminal_won {
+            if let Err(error) = &outcome {
+                let _ = self.server_error_tx.send(Some(error.clone()));
+            }
+        }
+
+        // Detaching the final sender serializes with ingest. Explicit close drops the active
+        // ACK/RPC future after FlushCompleted; only server rotation promises request-body EOF.
+        pause_and_detach_sender(&self.ingest_mutex, &self.is_paused, &self.batch_tx).await;
+
+        #[cfg(feature = "test-hooks")]
+        {
+            let barrier = self.close_finalize_gate.lock().await.take();
+            if let Some(barrier) = barrier {
+                barrier.reached.notify_one();
+                barrier.proceed.notified().await;
+            }
+        }
+
+        Self::finalize_closed(
+            &self.ingest_mutex,
+            &self.is_closed,
+            &self.pending_batches,
+            &self.failed_batches,
+            &self.last_acked_records,
+        )
+        .await;
+        self.close_teardown_started.store(false, Ordering::Release);
+        self.close_state_tx.send_replace(CloseState::Finalized);
+
+        if terminal_won {
+            if let Err(error) = &outcome {
+                let _ = self.server_error_tx.send(Some(error.clone()));
+            }
+        }
+        outcome
     }
 
     async fn run(
@@ -103,6 +250,7 @@ impl Supervisor {
         // classify as non-retryable — while still surfacing the original error if
         // retries are ultimately exhausted.
         let mut reconnect_auth_retry = false;
+        let mut close_rx = self.close_state_tx.subscribe();
 
         loop {
             if self.is_closed.load(Ordering::Relaxed) {
@@ -116,16 +264,15 @@ impl Supervisor {
             let result = if let Some(e) = pending_error.take() {
                 Err(e)
             } else {
-                self.ack_processor
-                    .process(
-                        response_stream
-                            .take()
-                            .expect("response_stream present when no pending reconnect error"),
-                        request_body
-                            .take()
-                            .expect("request_body present when no pending reconnect error"),
-                    )
-                    .await
+                let process = self.ack_processor.process(
+                    response_stream
+                        .take()
+                        .expect("response_stream present when no pending reconnect error"),
+                    request_body
+                        .take()
+                        .expect("request_body present when no pending reconnect error"),
+                );
+                Self::process_until_flush_completion(process, &mut close_rx).await
             };
 
             // Check if stream was closed during processing.
@@ -134,10 +281,17 @@ impl Supervisor {
                 return result;
             }
 
+            // A close request linearizes before any recovery work. Active ACK processing
+            // reaches here only after either a real result or close's flush completion.
+            if self.close_has_started() {
+                return self.finish(result.as_ref().err().cloned()).await;
+            }
+
             // Handle the result.
             match result {
                 Ok(()) => {
-                    // Stream ended gracefully.
+                    // Defensive: AckProcessor currently returns Ok only after is_closed,
+                    // which the fast path above handles before this match.
                     debug!(target: super::LOG_TARGET, "Supervisor: process_acks completed successfully");
                     return Ok(());
                 }
@@ -154,23 +308,7 @@ impl Supervisor {
                             max_retries = self.options.recovery_retries,
                             "Supervisor: Max recovery retries exceeded"
                         );
-                        // Publish the terminal error before finalization (so a waiter
-                        // checking is_closed right after it already sees the real error;
-                        // reconnect-failure errors carried via pending_error are never
-                        // pre-published by ACK processing) and again after (to wake
-                        // already-parked waiters). finalize_closed also drains pending
-                        // under ingest_mutex so a concurrent ingest can't be omitted.
-                        let _ = self.server_error_tx.send(Some(error.clone()));
-                        Self::finalize_closed(
-                            &self.ingest_mutex,
-                            &self.is_closed,
-                            &self.pending_batches,
-                            &self.failed_batches,
-                            &self.last_acked_records,
-                        )
-                        .await;
-                        let _ = self.server_error_tx.send(Some(error.clone()));
-                        return result;
+                        return self.finish(Some(error.clone())).await;
                     }
 
                     info!(target: super::LOG_TARGET,
@@ -189,7 +327,30 @@ impl Supervisor {
                         .await;
                     self.ack_processor.clear_request_send_failure();
 
-                    sleep(Duration::from_millis(self.options.recovery_backoff_ms)).await;
+                    let recovery_error = error.clone();
+                    #[cfg(feature = "test-hooks")]
+                    {
+                        let barrier = self.recovery_backoff_gate.lock().await.take();
+                        if let Some(barrier) = barrier {
+                            barrier.reached.notify_one();
+                            tokio::select! {
+                                biased;
+                                _ = Self::wait_for_close_request(&mut close_rx) => {
+                                    return self.finish(Some(recovery_error.clone())).await;
+                                }
+                                _ = barrier.proceed.notified() => {}
+                            }
+                        }
+                    }
+                    tokio::select! {
+                        // A close request stops backoff immediately and preserves the error
+                        // that caused recovery.
+                        biased;
+                        _ = Self::wait_for_close_request(&mut close_rx) => {
+                            return self.finish(Some(recovery_error)).await;
+                        }
+                        _ = sleep(Duration::from_millis(self.options.recovery_backoff_ms)) => {}
+                    }
 
                     let _ = self.server_error_tx.send(None);
 
@@ -208,10 +369,29 @@ impl Supervisor {
                             continue;
                         }
                     };
-                    let reconnect_result = timeout_at(recovery_deadline, self.reconnect()).await;
-
+                    let reconnect_result = match Self::select_reconnect_before_close(
+                        timeout_at(recovery_deadline, self.reconnect()),
+                        Self::wait_for_close_request(&mut close_rx),
+                    )
+                    .await
+                    {
+                        Some(result) => result,
+                        // Dropping reconnect cancels connector/header work, DoPut setup,
+                        // ready-signal waiting, or a partial replay as one operation.
+                        None => {
+                            return self.finish(Some(recovery_error.clone())).await;
+                        }
+                    };
                     match reconnect_result {
                         Ok(Ok((new_response_stream, new_request_body))) => {
+                            // `commit_reconnect_after_replay` checks the close flag while
+                            // holding ingest_mutex. If close begins after it returns, do not
+                            // install the returned connection into the supervisor loop. Replay
+                            // handoffs without observed ACKs remain retrievable by design;
+                            // retrying them has the transport's normal at-least-once semantics.
+                            if self.close_has_started() {
+                                return self.finish(Some(recovery_error)).await;
+                            }
                             info!(target: super::LOG_TARGET, "Supervisor: Recovery successful, resuming");
                             self.recovery_attempts.store(0, Ordering::Relaxed);
                             // is_paused was already cleared inside reconnect().
@@ -219,18 +399,30 @@ impl Supervisor {
                             request_body = Some(new_request_body);
                         }
                         Ok(Err(e)) => {
+                            // The reconnect result is newer and more specific than the
+                            // error that initiated recovery unless sender commit returned
+                            // its private signal that close won the atomic race.
+                            if self.close_has_started() {
+                                let error = Self::close_reconnect_error(e, recovery_error);
+                                return self.finish(Some(error)).await;
+                            }
                             warn!(target: super::LOG_TARGET, "Supervisor: Reconnection failed: {}", e);
                             // Ask the provider to invalidate cached authentication
                             // state after an auth rejection, then retry even though
                             // such errors are otherwise non-retryable. Preserve this
                             // reconnect error if refresh or later recovery cannot proceed.
                             if e.is_auth_rejection() {
-                                match timeout_at(
-                                    recovery_deadline,
-                                    self.headers_provider.invalidate(),
-                                )
-                                .await
-                                {
+                                let invalidation = tokio::select! {
+                                    biased;
+                                    _ = Self::wait_for_close_request(&mut close_rx) => {
+                                        return self.finish(Some(e.clone())).await;
+                                    }
+                                    result = timeout_at(
+                                        recovery_deadline,
+                                        self.headers_provider.invalidate(),
+                                    ) => result,
+                                };
+                                match invalidation {
                                     Ok(()) => reconnect_auth_retry = true,
                                     Err(_) => {
                                         warn!(target: super::LOG_TARGET,
@@ -238,27 +430,16 @@ impl Supervisor {
                                             "Recovery deadline reached while invalidating \
                                              the headers provider; terminating recovery"
                                         );
-                                        // A custom provider must not stall recovery
-                                        // indefinitely. Close with the original auth
-                                        // rejection; publish before and after
-                                        // finalization for waiter race-freedom.
-                                        let _ = self.server_error_tx.send(Some(e.clone()));
-                                        Self::finalize_closed(
-                                            &self.ingest_mutex,
-                                            &self.is_closed,
-                                            &self.pending_batches,
-                                            &self.failed_batches,
-                                            &self.last_acked_records,
-                                        )
-                                        .await;
-                                        let _ = self.server_error_tx.send(Some(e.clone()));
-                                        return Err(e);
+                                        return self.finish(Some(e)).await;
                                     }
                                 }
                             }
                             pending_error = Some(e);
                         }
                         Err(_timeout) => {
+                            if self.close_has_started() {
+                                return self.finish(Some(recovery_error)).await;
+                            }
                             warn!(target: super::LOG_TARGET, "Supervisor: Reconnection timed out");
                             pending_error = Some(ZerobusError::ConnectionTimeout(format!(
                                 "Reconnection timed out after {}ms",
@@ -269,22 +450,7 @@ impl Supervisor {
                 }
                 Err(error) => {
                     error!(target: super::LOG_TARGET, "Supervisor: Non-retriable error, closing stream: {}", error);
-                    // Publish the terminal error before finalization (so a waiter
-                    // checking is_closed right after it already sees the real error;
-                    // reconnect-failure errors carried via pending_error are never
-                    // pre-published by ACK processing) and again after (to wake
-                    // already-parked waiters). finalize_closed drains pending under
-                    // ingest_mutex so a concurrent ingest can't be omitted.
-                    let _ = self.server_error_tx.send(Some(error.clone()));
-                    Self::finalize_closed(
-                        &self.ingest_mutex,
-                        &self.is_closed,
-                        &self.pending_batches,
-                        &self.failed_batches,
-                        &self.last_acked_records,
-                    )
-                    .await;
-                    let _ = self.server_error_tx.send(Some(error.clone()));
+                    let outcome = self.finish(Some(error.clone())).await;
                     // Ask the provider to invalidate cached authentication state after
                     // a terminal rejection. The stream is already finalized and waiters
                     // have the real error; bound the callback so the supervisor cannot
@@ -314,7 +480,7 @@ impl Supervisor {
                             }
                         }
                     }
-                    return Err(error);
+                    return outcome;
                 }
             }
         }
@@ -364,16 +530,34 @@ impl Supervisor {
             &self.submitted_records,
             &self.last_acked_records,
             acked_before_disconnect,
-            #[cfg(feature = "test-hooks")]
-            Some(&self.replay_send_gate),
+            ReplayGates {
+                #[cfg(feature = "test-hooks")]
+                replay_send: Some(&self.replay_send_gate),
+                replay_progress: {
+                    #[cfg(feature = "test-hooks")]
+                    {
+                        Some(&self.replay_progress_gate)
+                    }
+                    #[cfg(not(feature = "test-hooks"))]
+                    {
+                        None
+                    }
+                },
+            },
         )
         .await;
 
         // Commit the replacement sender only after replay succeeds. While ingest_mutex
         // remains held, publish the sender before clearing the pause gate so normal ingest
         // cannot observe an unpaused stream without its active sender.
-        Self::commit_reconnect_after_replay(replay_result, tx, &self.batch_tx, &self.is_paused)
-            .await?;
+        Self::commit_reconnect_after_replay(
+            replay_result,
+            tx,
+            &self.batch_tx,
+            &self.is_paused,
+            &self.close_teardown_started,
+        )
+        .await?;
 
         // ACK processing cannot resume until reconnect returns. Refresh only after replay
         // is fully committed so connection setup, backlog sends, and sender publication do
@@ -391,14 +575,51 @@ impl Supervisor {
         tx: mpsc::Sender<Result<RecordBatch, FlightError>>,
         batch_tx: &BatchSender,
         is_paused: &AtomicBool,
+        close_teardown_started: &AtomicBool,
     ) -> ZerobusResult<()> {
         replay_result?;
+        if close_teardown_started.load(Ordering::Acquire) {
+            return Err(Self::explicit_close_recovery_cancellation());
+        }
         {
             let mut tx_guard = batch_tx.lock().await;
             *tx_guard = Some(tx.clone());
+            // Close may begin after the first check. Ingest cannot observe this temporary
+            // sender because reconnect still holds ingest_mutex; remove it before lifting
+            // the pause gate so no replacement is published after close begins.
+            if close_teardown_started.load(Ordering::Acquire) {
+                *tx_guard = None;
+                return Err(Self::explicit_close_recovery_cancellation());
+            }
         }
         is_paused.store(false, Ordering::Relaxed);
         Ok(())
+    }
+
+    fn explicit_close_recovery_cancellation() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::cancelled(
+            EXPLICIT_CLOSE_INTERRUPTED_RECOVERY,
+        ))
+    }
+
+    fn is_explicit_close_recovery_cancellation(error: &ZerobusError) -> bool {
+        matches!(
+            error,
+            ZerobusError::StreamClosedError(status)
+                if status.code() == tonic::Code::Cancelled
+                    && status.message() == EXPLICIT_CLOSE_INTERRUPTED_RECOVERY
+        )
+    }
+
+    fn close_reconnect_error(
+        reconnect_error: ZerobusError,
+        recovery_error: ZerobusError,
+    ) -> ZerobusError {
+        if Self::is_explicit_close_recovery_cancellation(&reconnect_error) {
+            recovery_error
+        } else {
+            reconnect_error
+        }
     }
 
     /// Rebuilds `pending_batches` for replay after a reconnect and replays them over
@@ -417,7 +638,7 @@ impl Supervisor {
         submitted_records: &Arc<AtomicU64>,
         last_acked_records: &Arc<AtomicU64>,
         acked_before_disconnect: u64,
-        #[cfg(feature = "test-hooks")] replay_send_gate: Option<&super::ReplaySendGate>,
+        replay_gates: ReplayGates<'_>,
     ) -> ZerobusResult<()> {
         let replay_batches: Vec<RecordBatch> = {
             let mut pending = pending_batches.lock().await;
@@ -444,7 +665,11 @@ impl Supervisor {
         // held by the caller); pending stays intact on failure. The replacement response
         // stream is not polled until replay returns, so publishing after each successful
         // handoff cannot race a valid acknowledgement on this connection.
-        for batch in replay_batches {
+        let replay_barrier = match replay_gates.replay_progress {
+            Some(gate) => gate.lock().await.take(),
+            None => None,
+        };
+        for (index, batch) in replay_batches.into_iter().enumerate() {
             let record_count = batch.num_rows() as u64;
             if tx.send(Ok(batch)).await.is_err() {
                 return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
@@ -452,10 +677,15 @@ impl Supervisor {
                 )));
             }
             submitted_records.fetch_add(record_count, Ordering::Release);
-
+            if index == 0 {
+                if let Some(barrier) = &replay_barrier {
+                    barrier.reached.notify_one();
+                    barrier.proceed.notified().await;
+                }
+            }
             #[cfg(feature = "test-hooks")]
             {
-                let barrier = match replay_send_gate {
+                let barrier = match replay_gates.replay_send {
                     Some(gate) => gate.lock().await.take(),
                     None => None,
                 };
@@ -514,19 +744,20 @@ impl Supervisor {
 mod tests {
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::Arc;
+    use std::task::Poll;
 
     use arrow_array::Int32Array;
     use arrow_flight::error::FlightError;
     use arrow_flight::PutResult;
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use futures::stream::iter;
-    use tokio::sync::{mpsc, Mutex, Semaphore};
+    use tokio::sync::{mpsc, watch, Mutex, Semaphore};
     use tokio::time::{timeout, Duration, Instant};
 
     use super::super::metadata::FlightAckMetadata;
     use super::{
-        pause_and_detach_sender, AckProcessor, BatchSender, PendingBatch, RecordBatch, Supervisor,
-        ZerobusError,
+        pause_and_detach_sender, AckProcessor, BatchSender, CloseState, PendingBatch, RecordBatch,
+        ReplayGates, Supervisor, ZerobusError, ZerobusResult,
     };
     use crate::offset_generator::OffsetId;
 
@@ -559,18 +790,105 @@ mod tests {
         )
     }
 
+    fn flush_completed_state(
+        target_offset: Option<OffsetId>,
+        result: ZerobusResult<()>,
+    ) -> CloseState {
+        CloseState::FlushCompleted {
+            request: super::super::CloseRequest { target_offset },
+            result,
+        }
+    }
+
+    #[tokio::test]
+    async fn ready_process_error_wins_over_visible_flush_completion() {
+        let (close_tx, mut close_rx) = watch::channel(CloseState::Open);
+        close_tx.send_replace(flush_completed_state(
+            Some(0),
+            Err(ZerobusError::StreamClosedError(
+                tonic::Status::deadline_exceeded("Flush timed out"),
+            )),
+        ));
+
+        let result = Supervisor::process_until_flush_completion(
+            async {
+                Err(ZerobusError::StreamClosedError(
+                    tonic::Status::unauthenticated("ready peer rejection"),
+                ))
+            },
+            &mut close_rx,
+        )
+        .await
+        .expect_err("a ready peer error must win");
+        assert!(result.to_string().contains("ready peer rejection"));
+    }
+
+    #[tokio::test]
+    async fn ready_ack_work_is_polled_before_visible_flush_completion() {
+        let (close_tx, mut close_rx) = watch::channel(CloseState::Open);
+        close_tx.send_replace(flush_completed_state(Some(0), Ok(())));
+        let process_polled = Arc::new(AtomicBool::new(false));
+        let process_polled_clone = Arc::clone(&process_polled);
+        let process = std::future::poll_fn(move |_cx| {
+            process_polled_clone.store(true, Ordering::Release);
+            Poll::<ZerobusResult<()>>::Pending
+        });
+
+        timeout(
+            Duration::from_secs(1),
+            Supervisor::process_until_flush_completion(process, &mut close_rx),
+        )
+        .await
+        .expect("visible FlushCompleted must stop pending processing")
+        .expect("flush completion is clean");
+        assert!(process_polled.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn ready_reconnect_result_wins_over_ready_close_request() {
+        let selected = Supervisor::select_reconnect_before_close(
+            std::future::ready("reconnect result"),
+            std::future::ready(()),
+        )
+        .await;
+
+        assert_eq!(selected, Some("reconnect result"));
+    }
+
+    #[test]
+    fn empty_close_target_does_not_mask_terminal_error() {
+        let state = flush_completed_state(None, Ok(()));
+        let (outcome, terminal_won) = state.outcome_candidate(
+            None,
+            Some(ZerobusError::CreateStreamError(
+                tonic::Status::unauthenticated("idle stream rejected"),
+            )),
+        );
+        assert!(terminal_won);
+        assert!(outcome
+            .expect_err("terminal error must win an empty close")
+            .to_string()
+            .contains("idle stream rejected"));
+    }
+
     #[tokio::test]
     async fn failed_replay_leaves_sender_detached_and_closes_request_channel() {
         let (tx, mut request_rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(1);
         let batch_tx: BatchSender = Arc::new(Mutex::new(None));
         let is_paused = AtomicBool::new(true);
+        let close_teardown_started = AtomicBool::new(false);
         let replay_result = Err(ZerobusError::StreamClosedError(tonic::Status::internal(
             "failed replay",
         )));
 
-        let result =
-            Supervisor::commit_reconnect_after_replay(replay_result, tx, &batch_tx, &is_paused)
-                .await;
+        let result = Supervisor::commit_reconnect_after_replay(
+            replay_result,
+            tx,
+            &batch_tx,
+            &is_paused,
+            &close_teardown_started,
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(batch_tx.lock().await.is_none());
@@ -627,8 +945,7 @@ mod tests {
             &submitted_records,
             &last_acked_records,
             acked_before_disconnect,
-            #[cfg(feature = "test-hooks")]
-            None,
+            ReplayGates::default(),
         )
         .await
         .expect("replay should succeed");
@@ -682,8 +999,7 @@ mod tests {
             &submitted,
             &last_acked,
             0,
-            #[cfg(feature = "test-hooks")]
-            None,
+            ReplayGates::default(),
         )
         .await;
         assert!(res.is_err(), "replay must surface the send failure");
@@ -754,8 +1070,7 @@ mod tests {
             &submitted,
             &last_acked,
             0,
-            #[cfg(feature = "test-hooks")]
-            None,
+            ReplayGates::default(),
         )
         .await;
         assert!(res.is_ok());
@@ -804,8 +1119,7 @@ mod tests {
             &submitted,
             &last_acked,
             4,
-            #[cfg(feature = "test-hooks")]
-            None,
+            ReplayGates::default(),
         )
         .await;
         assert!(res.is_ok());

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -402,7 +402,7 @@ impl Supervisor {
                             // The reconnect result is newer and more specific than the
                             // error that initiated recovery unless sender commit returned
                             // its private signal that close won the atomic race.
-                            if self.close_has_started() {
+                            if Self::should_finalize_reconnect_error(self.close_has_started(), &e) {
                                 let error = Self::close_reconnect_error(e, recovery_error);
                                 return self.finish(Some(error)).await;
                             }
@@ -609,6 +609,13 @@ impl Supervisor {
                 if status.code() == tonic::Code::Cancelled
                     && status.message() == EXPLICIT_CLOSE_INTERRUPTED_RECOVERY
         )
+    }
+
+    fn should_finalize_reconnect_error(
+        close_has_started: bool,
+        reconnect_error: &ZerobusError,
+    ) -> bool {
+        close_has_started || Self::is_explicit_close_recovery_cancellation(reconnect_error)
     }
 
     fn close_reconnect_error(
@@ -869,6 +876,24 @@ mod tests {
             .expect_err("terminal error must win an empty close")
             .to_string()
             .contains("idle stream rejected"));
+    }
+
+    #[test]
+    fn explicit_close_cancellation_finalizes_before_close_publication() {
+        let reconnect_error = Supervisor::explicit_close_recovery_cancellation();
+        assert!(Supervisor::should_finalize_reconnect_error(
+            false,
+            &reconnect_error
+        ));
+
+        let recovery_error =
+            ZerobusError::StreamClosedError(tonic::Status::unavailable("transport lost"));
+        let selected = Supervisor::close_reconnect_error(reconnect_error, recovery_error);
+        assert!(matches!(
+            selected,
+            ZerobusError::StreamClosedError(status)
+                if status.code() == tonic::Code::Unavailable
+        ));
     }
 
     #[tokio::test]

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -1158,10 +1158,10 @@ mod arrow_flight_tests {
             Ok(())
         }
 
-        /// Cancelling close after supervisor/sender teardown must leave the stream in a
-        /// resumable Closing state: new ingests are rejected, retrieval remains disabled,
-        /// and resumed/repeated close calls return the original flush error without waiting
-        /// for flush_timeout again.
+        /// Cancelling close while its supervisor-owned finalizer is parked must leave the
+        /// stream in a resumable Closing state: new ingests are rejected, retrieval remains
+        /// disabled, and resumed/repeated close calls return the stored flush error without
+        /// waiting for flush_timeout again or rerunning finalization.
         #[tokio::test]
         async fn test_cancelled_close_rejects_ingest_and_resumes_teardown(
         ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1200,7 +1200,7 @@ mod arrow_flight_tests {
                 create_test_record_batch(schema.clone(), vec![1], vec![Some("pending")]);
             stream.ingest_batch(pending_batch).await?;
 
-            let (reached, _proceed) = stream.arm_close_finalize_barrier().await;
+            let (reached, proceed) = stream.arm_close_finalize_barrier().await;
             let mut close_future = Box::pin(stream.close());
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 tokio::select! {
@@ -1228,6 +1228,10 @@ mod arrow_flight_tests {
                 "unacked retrieval is allowed only after Closed"
             );
 
+            // The close future no longer owns finalization: cancelling it leaves the
+            // supervisor parked at the same finalization point. Release that work, then
+            // resume close by observing the already-stored result.
+            proceed.notify_one();
             let resumed = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
                 .await
                 .expect("resumed close must skip flush and finish promptly")
@@ -3158,11 +3162,344 @@ mod arrow_flight_tests {
             Ok(())
         }
 
+        #[tokio::test]
+        async fn test_close_interrupts_recovery_backoff() -> Result<(), Box<dyn std::error::Error>>
+        {
+            setup_tracing();
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![MockFlightResponse::Error {
+                        status: tonic::Status::unavailable("backoff connection lost"),
+                        delay_ms: 0,
+                    }],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(60_000)
+                .recovery_retries(5)
+                .flush_timeout_ms(60_000)
+                .build_arrow()
+                .await?;
+
+            let (reached, _proceed) = stream.arm_recovery_backoff_barrier().await;
+            stream
+                .ingest_batch(create_test_record_batch(
+                    schema,
+                    vec![1],
+                    vec![Some("pending")],
+                ))
+                .await?;
+            tokio::time::timeout(std::time::Duration::from_secs(5), reached.notified())
+                .await
+                .expect("recovery should reach backoff");
+
+            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
+                .await
+                .expect("close must interrupt recovery backoff")
+                .expect_err("the recovery-triggering peer error should be preserved");
+            assert!(error.to_string().contains("backoff connection lost"));
+            assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_close_interrupts_reconnect_do_put_handshake(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            let handshake_reached = Arc::new(tokio::sync::Notify::new());
+            let release_handshake = Arc::new(tokio::sync::Notify::new());
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("handshake reconnect lost"),
+                            delay_ms: 0,
+                        },
+                        MockFlightResponse::HoldDoPut {
+                            reached: Arc::clone(&handshake_reached),
+                            proceed: Arc::clone(&release_handshake),
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .flush_timeout_ms(60_000)
+                .build_arrow()
+                .await?;
+
+            stream
+                .ingest_batch(create_test_record_batch(
+                    schema,
+                    vec![1],
+                    vec![Some("pending")],
+                ))
+                .await?;
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                handshake_reached.notified(),
+            )
+            .await
+            .expect("reconnect should be waiting for DoPut to return");
+
+            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
+                .await
+                .expect("close must cancel the reconnect DoPut handshake")
+                .expect_err("the recovery-triggering peer error should be preserved");
+            assert!(error.to_string().contains("handshake reconnect lost"));
+            release_handshake.notify_one();
+            assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_close_interrupts_reconnect_ready_wait(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            let ready_wait_reached = Arc::new(tokio::sync::Notify::new());
+            let release_ready = Arc::new(tokio::sync::Notify::new());
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("ready reconnect lost"),
+                            delay_ms: 0,
+                        },
+                        MockFlightResponse::HoldSetup {
+                            reached: Arc::clone(&ready_wait_reached),
+                            proceed: Arc::clone(&release_ready),
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .flush_timeout_ms(60_000)
+                .build_arrow()
+                .await?;
+
+            stream
+                .ingest_batch(create_test_record_batch(
+                    schema,
+                    vec![1],
+                    vec![Some("pending")],
+                ))
+                .await?;
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                ready_wait_reached.notified(),
+            )
+            .await
+            .expect("reconnect should be waiting for the ready signal");
+
+            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
+                .await
+                .expect("close must cancel ready-signal waiting")
+                .expect_err("the recovery-triggering peer error should be preserved");
+            assert!(error.to_string().contains("ready reconnect lost"));
+            release_ready.notify_one();
+            assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_close_preserves_reconnect_auth_rejection(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("initial transport loss"),
+                            delay_ms: 0,
+                        },
+                        MockFlightResponse::FailSetup {
+                            status: tonic::Status::unauthenticated("reconnect token rejected"),
+                        },
+                    ],
+                )
+                .await;
+
+            let invalidations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let cancellations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let provider = Arc::new(HangingInvalidationHeadersProvider {
+                invalidations: Arc::clone(&invalidations),
+                cancellations: Arc::clone(&cancellations),
+                ..Default::default()
+            });
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(provider)
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .recovery_timeout_ms(60_000)
+                .flush_timeout_ms(60_000)
+                .build_arrow()
+                .await?;
+
+            stream
+                .ingest_batch(create_test_record_batch(
+                    schema,
+                    vec![1],
+                    vec![Some("pending")],
+                ))
+                .await?;
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while invalidations.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("reconnect auth invalidation should start");
+
+            let first = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
+                .await
+                .expect("close must cancel auth invalidation")
+                .expect_err("auth rejection should remain the close outcome");
+            assert!(first.to_string().contains("reconnect token rejected"));
+            assert_eq!(cancellations.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+            let repeated = stream
+                .close()
+                .await
+                .expect_err("repeated close should return the stored auth rejection");
+            assert_eq!(first.to_string(), repeated.to_string());
+            assert_eq!(stream.get_unacked_batches().await?.len(), 1);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_close_during_partial_replay_retains_exact_unacked_suffixes(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+            let (mock_server, server_url) = start_mock_flight_server().await?;
+            let schema = create_test_arrow_schema();
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockFlightResponse::BatchAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                            ack_up_to_records: 1,
+                        },
+                        MockFlightResponse::Error {
+                            status: tonic::Status::unavailable("partial replay lost"),
+                            delay_ms: 0,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url)
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let mut stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .arrow(schema.clone())
+                .recovery(true)
+                .recovery_backoff_ms(0)
+                .recovery_retries(5)
+                .flush_timeout_ms(60_000)
+                .build_arrow()
+                .await?;
+
+            let ack_applied = stream.arm_ack_applied_notify().await;
+            let (replay_reached, _proceed) = stream.arm_replay_progress_barrier().await;
+            stream
+                .ingest_batch(create_test_record_batch(
+                    schema.clone(),
+                    vec![1, 2, 3],
+                    vec![Some("a"), Some("b"), Some("c")],
+                ))
+                .await?;
+            tokio::time::timeout(std::time::Duration::from_secs(5), ack_applied.notified())
+                .await
+                .expect("partial acknowledgement should be applied");
+            stream
+                .ingest_batch(create_test_record_batch(schema, vec![4], vec![Some("d")]))
+                .await?;
+            tokio::time::timeout(std::time::Duration::from_secs(5), replay_reached.notified())
+                .await
+                .expect("replay should stop after its first replacement handoff");
+
+            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
+                .await
+                .expect("close must cancel partial replay")
+                .expect_err("the recovery-triggering peer error should be preserved");
+            assert!(error.to_string().contains("partial replay lost"));
+
+            let unacked = stream.get_unacked_batches().await?;
+            assert_eq!(unacked.len(), 2);
+            assert_eq!(batch_ids(&unacked[0]), vec![2, 3]);
+            assert_eq!(batch_ids(&unacked[1]), vec![4]);
+            Ok(())
+        }
+
         /// close() during the reconnect rebuild window must slice with the pre-reconnect
         /// watermark. A barrier parks reconnect after the new connection is established but
-        /// before pending ranges/watermark are rebuilt; close() then reaps the parked
-        /// supervisor and drains with the pre-reconnect watermark/ranges, so A is sliced to
-        /// its un-acked suffix (ids [2, 3]) and B is retained whole.
+        /// before pending ranges/watermark are rebuilt; close() then cancels reconnect and
+        /// lets the supervisor drain with the pre-reconnect watermark/ranges, so A is sliced
+        /// to its un-acked suffix (ids [2, 3]) and B is retained whole.
         #[tokio::test]
         async fn test_close_during_reconnect_rebuild_window_slices_correctly(
         ) -> Result<(), Box<dyn std::error::Error>> {
@@ -3238,7 +3575,7 @@ mod arrow_flight_tests {
                 .await
                 .expect("reconnect should reach the rebuild barrier");
 
-            // close() reaps the parked supervisor and drains with the pre-rebuild state.
+            // close() cancels parked reconnect and the supervisor drains pre-rebuild state.
             let _ = stream.close().await;
 
             let unacked = stream.get_unacked_batches().await?;
@@ -3480,7 +3817,7 @@ mod arrow_flight_tests {
                 .build_arrow()
                 .await?;
 
-            // Park the reconnect; do not release it — close() reaps it instead.
+            // Park reconnect; do not release it — close() cancels that phase instead.
             let (reached, _proceed) = stream.arm_reconnect_rebuild_barrier().await;
 
             let batch = create_test_record_batch(schema.clone(), vec![1], vec![Some("a")]);
@@ -3490,16 +3827,14 @@ mod arrow_flight_tests {
                 .await
                 .expect("reconnect should reach the rebuild barrier");
 
-            // close() must return (its flush times out at 200ms) without hanging or
-            // panicking, reaping the parked supervisor along the way.
+            // close() must return the recovery-triggering error without waiting for its
+            // 200ms flush timeout, and the supervisor finalizes the parked recovery.
             let close_result =
                 tokio::time::timeout(std::time::Duration::from_secs(5), stream.close())
                     .await
                     .expect("close() must not hang while a reconnect is parked");
-            assert!(
-                close_result.is_err(),
-                "close() should surface the flush timeout"
-            );
+            let close_error = close_result.expect_err("close() should preserve recovery failure");
+            assert!(close_error.to_string().contains("Connection lost"));
 
             // The un-acked batch was moved to the failed set and is retrievable.
             let unacked = stream.get_unacked_batches().await?;

--- a/rust/tests/src/mock_arrow_flight.rs
+++ b/rust/tests/src/mock_arrow_flight.rs
@@ -76,6 +76,16 @@ pub enum MockFlightResponse {
     FailSetup { status: Status },
     /// Reject a connection's setup after a delay.
     FailSetupAfter { status: Status, delay_ms: u64 },
+    /// Park the DoPut RPC before returning its response stream to the client.
+    HoldDoPut {
+        reached: Arc<Notify>,
+        proceed: Arc<Notify>,
+    },
+    /// Park setup after receiving the schema but before emitting the ready signal.
+    HoldSetup {
+        reached: Arc<Notify>,
+        proceed: Arc<Notify>,
+    },
     /// Close stream (drop the connection) - useful for testing recovery.
     CloseStream { delay_ms: u64 },
     /// Graceful close signal - sends a close signal with grace period duration.
@@ -268,6 +278,34 @@ impl FlightService for MockFlightServer {
 
         info!("Received DoPut request for table: {}", table_name);
 
+        // A scripted DoPut hold models the RPC/HTTP2 handshake itself: the client has
+        // opened the request but `FlightServiceClient::do_put().await` has not returned.
+        // Consume it here so the spawned response task begins at the following script item.
+        let do_put_hold = {
+            let response_map = self.responses.lock().await;
+            let response_index = {
+                let indices = self.response_indices.lock().await;
+                *indices.get(&table_name).unwrap_or(&0)
+            };
+            match response_map
+                .get(&table_name)
+                .and_then(|responses| responses.get(response_index))
+            {
+                Some(MockFlightResponse::HoldDoPut { reached, proceed }) => {
+                    Some((response_index, Arc::clone(reached), Arc::clone(proceed)))
+                }
+                _ => None,
+            }
+        };
+        if let Some((response_index, reached, proceed)) = do_put_hold {
+            self.response_indices
+                .lock()
+                .await
+                .insert(table_name.clone(), response_index + 1);
+            reached.notify_one();
+            proceed.notified().await;
+        }
+
         let mut stream = request.into_inner();
         let (tx, rx) = mpsc::channel(100);
 
@@ -325,6 +363,20 @@ impl FlightService for MockFlightServer {
                 if is_first_message {
                     is_first_message = false;
                     if flight_data.app_metadata.is_empty() {
+                        if let Some(MockFlightResponse::HoldSetup { reached, proceed }) =
+                            stream_responses.get(response_index)
+                        {
+                            let reached = Arc::clone(reached);
+                            let proceed = Arc::clone(proceed);
+                            response_index += 1;
+                            {
+                                let mut indices = response_indices.lock().await;
+                                indices.insert(table_name.clone(), response_index);
+                            }
+                            reached.notify_one();
+                            proceed.notified().await;
+                        }
+
                         // A scripted FailSetup rejects this connection's setup: send the
                         // error instead of the ready signal (simulates a reconnect failure).
                         let setup_failure = match stream_responses.get(response_index) {
@@ -517,6 +569,12 @@ impl FlightService for MockFlightServer {
                             }
                             let _ = tx.send(Err(status)).await;
                             return;
+                        }
+                        MockFlightResponse::HoldDoPut { .. } => {
+                            unreachable!("HoldDoPut is consumed by the DoPut handler")
+                        }
+                        MockFlightResponse::HoldSetup { .. } => {
+                            unreachable!("HoldSetup is consumed by the schema message")
                         }
                         MockFlightResponse::CloseStream { delay_ms } => {
                             // CloseStream triggers immediately - simulates server closing without ack


### PR DESCRIPTION
## What changes are proposed in this pull request?

Arrow explicit close previously began supervisor teardown only after its flush attempt completed. If the supervisor was recovering, backoff, connection setup, ready-signal waiting, authentication invalidation, or replay could therefore continue until a separate timeout resolved that phase.

This PR coordinates close and recovery through one level-triggered close state and one supervisor-owned finalization path.

- Interrupt recovery backoff, reconnect setup, ready-signal waiting, authentication invalidation, and partial replay when close is requested.
- Keep active ACK processing alive until the close flush completes, then let the supervisor detach the sender and finalize exactly once.
- Prevent a replacement sender from being published after close teardown begins.
- Preserve an already-ready ACK, peer error, or reconnect authentication rejection instead of masking it with an older transport error or synthetic flush timeout.
- Rebuild replay state from the durable watermark and retain only the correct unacknowledged batch suffixes when close interrupts a partial replay.
- Keep cancelled and repeated close calls resumable and idempotent through one stored outcome.
- Preserve the pending-relative ACK deadline behavior introduced by #654 when replay and close coordination overlap.

### Intentionally deferred

- Support for concurrent ingest and close across an FFI boundary, which remains documented as unsupported.
- Fallback finalization after an abnormal supervisor exit or panic.
- Reuse of the original close deadline after a close future is cancelled and resumed.
- Post-finalization credential invalidation timing and cleanup.
- Publication-gap micro-races outside the supported concurrency contract.
- Replace the private close-cancellation sentinel with [typed internal reconnect/commit outcomes](https://github.com/databricks/zerobus-sdk/issues/679).
- Additional duplicate-waiter and header-provider-specific cancellation coverage.

No public API, FFI signature, or ABI changes are introduced.

## How is this tested?

- `test_close_interrupts_recovery_backoff`: close interrupts a parked recovery backoff and preserves the triggering error.
- `test_close_interrupts_reconnect_do_put_handshake`: close cancels a blocked reconnect DoPut handshake.
- `test_close_interrupts_reconnect_ready_wait`: close cancels reconnect ready-signal waiting.
- `test_close_preserves_reconnect_auth_rejection`: a reconnect authentication rejection wins over the older transport failure and remains stable across repeated close calls.
- `test_close_during_partial_replay_retains_exact_unacked_suffixes`: close during partial replay retains only the durable-watermark suffix and later pending batches.
- `ready_process_error_wins_over_visible_flush_completion`: a ready peer error is processed before a simultaneous close-flush completion.
- `ready_ack_work_is_polled_before_visible_flush_completion`: ready ACK work is processed before a simultaneous close-flush completion.
- `ready_reconnect_result_wins_over_ready_close_request`: a completed reconnect result is not discarded when close becomes ready at the same time.
- `empty_close_target_does_not_mask_terminal_error`: closing an empty stream preserves its terminal error.
- `explicit_close_cancellation_finalizes_before_close_publication`: a private close cancellation preserves the original recovery error before close-state publication becomes visible.

Fixes #657.