### PR TITLE
[PureGo] Improve descriptor cache lifecycle

### DIFF
--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -11,8 +11,12 @@
 - Added opt-in wait-ready stream creation whose context bounds the complete
   first-open process; asynchronous creation now preserves context values while
   detaching caller cancellation.
-- Added `FetchProtoDescriptor` for building protobuf descriptors from Unity
-  Catalog table schemas.
+- Added `FetchProtoDescriptorFromUC` for building protobuf descriptors from
+  Unity Catalog table schemas.
+- Added `RefreshProtoDescriptorFromUC` for bypassing and replacing a cached
+  descriptor after a table schema change.
+- Coalesced concurrent descriptor fetches for the same table and credentials
+  while preserving independent caller cancellation.
 - Added `Stream.IngestJSONOffset` and `Stream.IngestJSONRecordsOffset`. JSON
   streams queue JSON directly; proto streams convert it before ingestion.
 

--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -15,8 +15,8 @@
   Unity Catalog table schemas.
 - Added `RefreshProtoDescriptorFromUC` for bypassing and replacing a cached
   descriptor after a table schema change.
-- Coalesced concurrent descriptor fetches for the same table and credentials
-  while preserving independent caller cancellation.
+- Coalesced compatible descriptor requests while keeping refreshes newer than
+  ordinary fetches, preserving caller cancellation, and stopping abandoned work.
 - Added `Stream.IngestJSONOffset` and `Stream.IngestJSONRecordsOffset`. JSON
   streams queue JSON directly; proto streams convert it before ingestion.
 

--- a/purego/README.md
+++ b/purego/README.md
@@ -92,6 +92,20 @@ streams and convert it to protobuf on proto streams.
 Fetch the table schema explicitly, then create a regular proto stream. The
 stream can accept either protobuf bytes or JSON converted at ingest time.
 
+Fetched descriptors are cached for five minutes, up to 128 entries per SDK.
+Concurrent fetches for the same table and credentials share one UC request.
+After changing a table schema, call `RefreshProtoDescriptorFromUC` to bypass
+the cached entry and replace it with a fresh descriptor:
+
+```go
+descriptor, err := sdk.RefreshProtoDescriptorFromUC(
+    ctx,
+    "catalog.schema.table",
+    clientID,
+    clientSecret,
+)
+```
+
 UC schema conversion rejects nullable array/map fields and collections that
 allow null elements or values because protobuf cannot preserve those
 distinctions. JSON ingestion also rejects explicit `null` collection fields.

--- a/purego/README.md
+++ b/purego/README.md
@@ -93,7 +93,10 @@ Fetch the table schema explicitly, then create a regular proto stream. The
 stream can accept either protobuf bytes or JSON converted at ingest time.
 
 Fetched descriptors are cached for five minutes, up to 128 entries per SDK.
-Concurrent fetches for the same table and credentials share one UC request.
+Concurrent refreshes share one request and never join an older ordinary fetch.
+Ordinary cache misses coalesce, or join an active refresh when no cached
+descriptor is available.
+Shared work stops when all waiting callers cancel or the SDK closes.
 After changing a table schema, call `RefreshProtoDescriptorFromUC` to bypass
 the cached entry and replace it with a fresh descriptor:
 

--- a/purego/examples/README.md
+++ b/purego/examples/README.md
@@ -65,6 +65,10 @@ go run ./dynamic/batch
 go run ./dynamic/proto
 ```
 
+The dynamic examples use `FetchProtoDescriptorFromUC`, which caches successful
+results. In a long-lived SDK, use `RefreshProtoDescriptorFromUC` after changing
+the table schema.
+
 ## Regenerating the proto bindings
 
 The proto single and batch examples use bindings generated from

--- a/purego/zerobus/dynamic_proto_test.go
+++ b/purego/zerobus/dynamic_proto_test.go
@@ -35,10 +35,11 @@ func waitForDescriptorFetchWaiters(
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		sdk.mu.Lock()
-		fetch := sdk.dynamicSchemaFetches[cacheKey]
 		got := 0
-		if fetch != nil {
-			got = fetch.waiters
+		for key, fetch := range sdk.dynamicSchemaFetches {
+			if key.cacheKey == cacheKey {
+				got += fetch.waiters
+			}
 		}
 		sdk.mu.Unlock()
 		if got == want {
@@ -165,6 +166,392 @@ func TestSDKRefreshProtoDescriptorFromUC_BypassesAndReplacesCache(t *testing.T) 
 	}
 	if got := tokenCalls.Load(); got != 2 {
 		t.Fatalf("token calls = %d, want 2", got)
+	}
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls = %d, want 2", got)
+	}
+}
+
+func TestSDKRefreshProtoDescriptorFromUC_DoesNotJoinOlderFetch(t *testing.T) {
+	var schemaCalls atomic.Int32
+	oldFetchStarted := make(chan struct{})
+	releaseOldFetch := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOldFetch) }) }
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			call := schemaCalls.Add(1)
+			columns := []map[string]any{
+				{"name": "id", "type_name": "LONG", "position": 0},
+			}
+			if call == 1 {
+				close(oldFetchStarted)
+				<-releaseOldFetch
+			} else {
+				columns = append(columns, map[string]any{
+					"name": "note", "type_name": "STRING", "position": 1,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns":      columns,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	ordinaryResult := make(chan []byte, 1)
+	ordinaryErr := make(chan error, 1)
+	go func() {
+		desc, err := sdk.FetchProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		ordinaryResult <- desc
+		ordinaryErr <- err
+	}()
+	select {
+	case <-oldFetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ordinary fetch did not start")
+	}
+
+	refreshCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	refreshed, err := sdk.RefreshProtoDescriptorFromUC(
+		refreshCtx, "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("RefreshProtoDescriptorFromUC() error = %v", err)
+	}
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls before releasing old fetch = %d, want 2", got)
+	}
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	for i := range maxDynamicSchemaCacheEntries {
+		sdk.storeDynamicDescriptor(
+			fmt.Sprintf("other-%03d", i),
+			[]byte("other"),
+		)
+	}
+	sdk.mu.Lock()
+	_, refreshedStillCached := sdk.dynamicSchemaCache[cacheKey]
+	sdk.mu.Unlock()
+	if refreshedStillCached {
+		t.Fatal("refreshed descriptor was not evicted for the test")
+	}
+
+	release()
+	if err := <-ordinaryErr; err != nil {
+		t.Fatalf("ordinary fetch error = %v", err)
+	}
+	ordinary := <-ordinaryResult
+	if string(ordinary) == string(refreshed) {
+		t.Fatal("test descriptors unexpectedly match")
+	}
+	sdk.mu.Lock()
+	_, staleWasCached := sdk.dynamicSchemaCache[cacheKey]
+	sdk.mu.Unlock()
+	if staleWasCached {
+		t.Fatal("older fetch repopulated the evicted cache entry")
+	}
+	cached, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("FetchProtoDescriptorFromUC() after refresh error = %v", err)
+	}
+	if string(cached) != string(refreshed) {
+		t.Fatal("older fetch overwrote the refreshed descriptor")
+	}
+	if got := schemaCalls.Load(); got != 3 {
+		t.Fatalf("schema calls = %d, want 3", got)
+	}
+}
+
+func TestSDKRefreshProtoDescriptorFromUC_FailureStillSupersedesOlderFetch(t *testing.T) {
+	var schemaCalls atomic.Int32
+	oldFetchStarted := make(chan struct{})
+	releaseOldFetch := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseOldFetch) }) }
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			switch schemaCalls.Add(1) {
+			case 1:
+				close(oldFetchStarted)
+				<-releaseOldFetch
+			case 2:
+				http.Error(w, "refresh failed", http.StatusInternalServerError)
+				return
+			}
+			columns := []map[string]any{
+				{"name": "id", "type_name": "LONG", "position": 0},
+			}
+			if schemaCalls.Load() >= 3 {
+				columns = append(columns, map[string]any{
+					"name": "note", "type_name": "STRING", "position": 1,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns":      columns,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	ordinaryResult := make(chan []byte, 1)
+	ordinaryErr := make(chan error, 1)
+	go func() {
+		desc, err := sdk.FetchProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		ordinaryResult <- desc
+		ordinaryErr <- err
+	}()
+	select {
+	case <-oldFetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ordinary fetch did not start")
+	}
+
+	if _, err := sdk.RefreshProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	); err == nil {
+		t.Fatal("failing refresh returned nil error")
+	}
+	release()
+	if err := <-ordinaryErr; err != nil {
+		t.Fatalf("ordinary fetch error = %v", err)
+	}
+	oldDescriptor := <-ordinaryResult
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	sdk.mu.Lock()
+	_, oldWasCached := sdk.dynamicSchemaCache[cacheKey]
+	sdk.mu.Unlock()
+	if oldWasCached {
+		t.Fatal("pre-refresh fetch populated the cache after refresh failed")
+	}
+
+	fresh, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("fetch after failed refresh error = %v", err)
+	}
+	if string(fresh) == string(oldDescriptor) {
+		t.Fatal("fetch after failed refresh returned the old descriptor")
+	}
+	if got := schemaCalls.Load(); got != 3 {
+		t.Fatalf("schema calls = %d, want 3", got)
+	}
+}
+
+func TestSDKRefreshProtoDescriptorFromUC_CoalescesAndIsolatesCancellation(t *testing.T) {
+	var schemaCalls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRefresh) }) }
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			call := schemaCalls.Add(1)
+			columns := []map[string]any{
+				{"name": "id", "type_name": "LONG", "position": 0},
+			}
+			if call == 2 {
+				close(refreshStarted)
+				<-releaseRefresh
+				columns = append(columns, map[string]any{
+					"name": "note", "type_name": "STRING", "position": 1,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns":      columns,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	if _, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	); err != nil {
+		t.Fatalf("initial fetch error = %v", err)
+	}
+
+	leaderResult := make(chan []byte, 1)
+	leaderErr := make(chan error, 1)
+	go func() {
+		desc, err := sdk.RefreshProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		leaderResult <- desc
+		leaderErr <- err
+	}()
+	select {
+	case <-refreshStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresh request did not start")
+	}
+
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	sdk.mu.Lock()
+	delete(sdk.dynamicSchemaCache, cacheKey)
+	sdk.mu.Unlock()
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	go func() {
+		_, err := sdk.RefreshProtoDescriptorFromUC(
+			waiterCtx, "main.sales.orders", "id", "secret",
+		)
+		waiterResult <- err
+	}()
+	ordinaryResult := make(chan []byte, 1)
+	ordinaryErr := make(chan error, 1)
+	go func() {
+		desc, err := sdk.FetchProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		ordinaryResult <- desc
+		ordinaryErr <- err
+	}()
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, 3)
+	cancelWaiter()
+	if err := <-waiterResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled refresh error = %v, want context.Canceled", err)
+	}
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, 2)
+
+	release()
+	if err := <-leaderErr; err != nil {
+		t.Fatalf("leader refresh error = %v", err)
+	}
+	refreshed := <-leaderResult
+	if err := <-ordinaryErr; err != nil {
+		t.Fatalf("ordinary fetch error = %v", err)
+	}
+	if ordinary := <-ordinaryResult; string(ordinary) != string(refreshed) {
+		t.Fatal("ordinary cache miss did not join the refresh")
+	}
+	cached, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("cached fetch error = %v", err)
+	}
+	if string(cached) != string(refreshed) {
+		t.Fatal("refresh result was not cached")
+	}
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls = %d, want 2", got)
+	}
+}
+
+func TestSDKFetchProtoDescriptor_CacheHitDoesNotJoinFailingRefresh(t *testing.T) {
+	var schemaCalls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRefresh) }) }
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			if schemaCalls.Add(1) == 2 {
+				close(refreshStarted)
+				<-releaseRefresh
+				http.Error(w, "refresh failed", http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns": []map[string]any{
+					{"name": "id", "type_name": "LONG", "position": 0},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	cachedDescriptor, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("initial fetch error = %v", err)
+	}
+	refreshResult := make(chan error, 1)
+	go func() {
+		_, err := sdk.RefreshProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		refreshResult <- err
+	}()
+	select {
+	case <-refreshStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresh request did not start")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	duringRefresh, err := sdk.FetchProtoDescriptorFromUC(
+		fetchCtx, "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("cache hit during refresh error = %v", err)
+	}
+	if string(duringRefresh) != string(cachedDescriptor) {
+		t.Fatal("cache hit during refresh returned different descriptor")
+	}
+
+	release()
+	if err := <-refreshResult; err == nil {
+		t.Fatal("failing refresh returned nil error")
 	}
 	if got := schemaCalls.Load(); got != 2 {
 		t.Fatalf("schema calls = %d, want 2", got)
@@ -344,6 +731,188 @@ func TestSDKFetchProtoDescriptor_CallerCancellationDoesNotCancelSharedFetch(t *t
 	}
 }
 
+func TestSDKFetchProtoDescriptor_LastCancellationStopsFetch(t *testing.T) {
+	schemaStarted := make(chan struct{})
+	schemaCancelled := make(chan struct{})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			close(schemaStarted)
+			<-r.Context().Done()
+			close(schemaCancelled)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient:                server.Client(),
+		dynamicSchemaFetchTimeout: time.Minute,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := sdk.FetchProtoDescriptorFromUC(
+			ctx, "main.sales.orders", "id", "secret",
+		)
+		result <- err
+	}()
+	select {
+	case <-schemaStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema request did not start")
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("fetch error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled fetch did not return")
+	}
+	select {
+	case <-schemaCancelled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared schema request was not cancelled")
+	}
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, 0)
+}
+
+func TestSDKCloseCancelsDescriptorFetch(t *testing.T) {
+	schemaStarted := make(chan struct{})
+	schemaCancelled := make(chan struct{})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			close(schemaStarted)
+			<-r.Context().Done()
+			close(schemaCancelled)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sdk, err := New(
+		"https://workspace.zerobus.cloud.databricks.com",
+		server.URL,
+		WithHTTPClient(server.Client()),
+		WithProtoDescriptorFetchTimeout(time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := sdk.FetchProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		result <- err
+	}()
+	select {
+	case <-schemaStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema request did not start")
+	}
+
+	if err := sdk.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, errSDKClosed) {
+			t.Fatalf("fetch error = %v, want SDK closed", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch waiter was not released by Close")
+	}
+	select {
+	case <-schemaCancelled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema request was not cancelled by Close")
+	}
+}
+
+func TestSDKFetchProtoDescriptor_FailedSharedFetchCanRetry(t *testing.T) {
+	var schemaCalls atomic.Int32
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			if schemaCalls.Add(1) == 1 {
+				close(firstStarted)
+				<-releaseFirst
+				http.Error(w, "temporary failure", http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns": []map[string]any{
+					{"name": "id", "type_name": "LONG", "position": 0},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	const callers = 2
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			<-start
+			_, err := sdk.FetchProtoDescriptorFromUC(
+				context.Background(), "main.sales.orders", "id", "secret",
+			)
+			errs <- err
+		}()
+	}
+	close(start)
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared failing request did not start")
+	}
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, callers)
+	release()
+	for range callers {
+		if err := <-errs; err == nil {
+			t.Fatal("shared failing fetch returned nil error")
+		}
+	}
+
+	if _, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	); err != nil {
+		t.Fatalf("retry after shared failure error = %v", err)
+	}
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls = %d, want 2", got)
+	}
+}
+
 func TestStreamEncodeJSONBatch(t *testing.T) {
 	desc := &descriptorpb.DescriptorProto{
 		Name: proto.String("Order"),
@@ -490,6 +1059,50 @@ func TestSDKFetchProtoDescriptor_CacheIsCredentialScoped(t *testing.T) {
 	}
 	if got := schemaCalls.Load(); got != 3 {
 		t.Fatalf("schema calls = %d, want 3", got)
+	}
+}
+
+func TestSDKFetchProtoDescriptor_ExpiredEntryRefetches(t *testing.T) {
+	var schemaCalls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			schemaCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns": []map[string]any{
+					{"name": "id", "type_name": "LONG", "position": 0},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	sdk.dynamicSchemaCache[cacheKey] = cachedDescriptor{
+		descriptor: []byte("stale"),
+		expiresAt:  time.Now().Add(-time.Second),
+	}
+	desc, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	if err != nil {
+		t.Fatalf("FetchProtoDescriptorFromUC() error = %v", err)
+	}
+	if string(desc) == "stale" {
+		t.Fatal("expired descriptor was returned")
+	}
+	if got := schemaCalls.Load(); got != 1 {
+		t.Fatalf("schema calls = %d, want 1", got)
 	}
 }
 

--- a/purego/zerobus/dynamic_proto_test.go
+++ b/purego/zerobus/dynamic_proto_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,6 +24,32 @@ type retryableSchemaTestError struct{}
 
 func (retryableSchemaTestError) Error() string     { return "retryable" }
 func (retryableSchemaTestError) IsRetryable() bool { return true }
+
+func waitForDescriptorFetchWaiters(
+	t *testing.T,
+	sdk *SDK,
+	cacheKey string,
+	want int,
+) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		sdk.mu.Lock()
+		fetch := sdk.dynamicSchemaFetches[cacheKey]
+		got := 0
+		if fetch != nil {
+			got = fetch.waiters
+		}
+		sdk.mu.Unlock()
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("descriptor fetch waiters = %d, want %d", got, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
 
 func TestSDKFetchProtoDescriptor_CacheHit(t *testing.T) {
 	var tokenCalls atomic.Int32
@@ -73,6 +100,247 @@ func TestSDKFetchProtoDescriptor_CacheHit(t *testing.T) {
 	}
 	if schemaCalls.Load() != 1 {
 		t.Fatalf("schema calls = %d, want 1", schemaCalls.Load())
+	}
+}
+
+func TestSDKRefreshProtoDescriptorFromUC_BypassesAndReplacesCache(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var schemaCalls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			tokenCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			call := schemaCalls.Add(1)
+			columns := []map[string]any{
+				{"name": "id", "type_name": "LONG", "position": 0},
+			}
+			if call > 1 {
+				columns = append(columns, map[string]any{
+					"name": "note", "type_name": "STRING", "position": 1,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns":      columns,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	ctx := context.Background()
+	first, err := sdk.FetchProtoDescriptorFromUC(ctx, "main.sales.orders", "id", "secret")
+	if err != nil {
+		t.Fatalf("FetchProtoDescriptorFromUC() first call error = %v", err)
+	}
+	cached, err := sdk.FetchProtoDescriptorFromUC(ctx, "main.sales.orders", "id", "secret")
+	if err != nil {
+		t.Fatalf("FetchProtoDescriptorFromUC() cached call error = %v", err)
+	}
+	if string(first) != string(cached) {
+		t.Fatal("cached descriptor differs from first fetch")
+	}
+
+	refreshed, err := sdk.RefreshProtoDescriptorFromUC(ctx, "main.sales.orders", "id", "secret")
+	if err != nil {
+		t.Fatalf("RefreshProtoDescriptorFromUC() error = %v", err)
+	}
+	if string(first) == string(refreshed) {
+		t.Fatal("refresh returned the stale descriptor")
+	}
+	afterRefresh, err := sdk.FetchProtoDescriptorFromUC(ctx, "main.sales.orders", "id", "secret")
+	if err != nil {
+		t.Fatalf("FetchProtoDescriptorFromUC() after refresh error = %v", err)
+	}
+	if string(refreshed) != string(afterRefresh) {
+		t.Fatal("refreshed descriptor was not cached")
+	}
+	if got := tokenCalls.Load(); got != 2 {
+		t.Fatalf("token calls = %d, want 2", got)
+	}
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls = %d, want 2", got)
+	}
+}
+
+func TestSDKFetchProtoDescriptor_CoalescesConcurrentMisses(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var schemaCalls atomic.Int32
+	schemaStarted := make(chan struct{}, 1)
+	releaseSchema := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseSchema) }) }
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			tokenCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			schemaCalls.Add(1)
+			select {
+			case schemaStarted <- struct{}{}:
+			default:
+			}
+			<-releaseSchema
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns": []map[string]any{
+					{"name": "id", "type_name": "LONG", "position": 0},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	const callers = 16
+	results := make([][]byte, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = sdk.FetchProtoDescriptorFromUC(
+				context.Background(), "main.sales.orders", "id", "secret",
+			)
+		}()
+	}
+	close(start)
+
+	select {
+	case <-schemaStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema request did not start")
+	}
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, callers)
+	release()
+	wg.Wait()
+
+	for i := range callers {
+		if errs[i] != nil {
+			t.Fatalf("caller %d error = %v", i, errs[i])
+		}
+		if len(results[i]) == 0 {
+			t.Fatalf("caller %d returned an empty descriptor", i)
+		}
+		if string(results[i]) != string(results[0]) {
+			t.Fatalf("caller %d returned a different descriptor", i)
+		}
+	}
+	if got := tokenCalls.Load(); got != 1 {
+		t.Fatalf("token calls = %d, want 1", got)
+	}
+	if got := schemaCalls.Load(); got != 1 {
+		t.Fatalf("schema calls = %d, want 1", got)
+	}
+}
+
+func TestSDKFetchProtoDescriptor_CallerCancellationDoesNotCancelSharedFetch(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var schemaCalls atomic.Int32
+	schemaStarted := make(chan struct{}, 1)
+	releaseSchema := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseSchema) }) }
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oidc/v1/token":
+			tokenCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
+		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
+			schemaCalls.Add(1)
+			select {
+			case schemaStarted <- struct{}{}:
+			default:
+			}
+			<-releaseSchema
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":         "orders",
+				"catalog_name": "main",
+				"schema_name":  "sales",
+				"columns": []map[string]any{
+					{"name": "id", "type_name": "LONG", "position": 0},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer release()
+
+	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
+		httpClient: server.Client(),
+	})
+	leaderResult := make(chan error, 1)
+	go func() {
+		_, err := sdk.FetchProtoDescriptorFromUC(
+			context.Background(), "main.sales.orders", "id", "secret",
+		)
+		leaderResult <- err
+	}()
+	select {
+	case <-schemaStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("schema request did not start")
+	}
+
+	cacheKey := dynamicSchemaCacheKey(server.URL, "main.sales.orders", "id", "secret")
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	go func() {
+		_, err := sdk.FetchProtoDescriptorFromUC(
+			waiterCtx, "main.sales.orders", "id", "secret",
+		)
+		waiterResult <- err
+	}()
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, 2)
+	cancelWaiter()
+	select {
+	case err := <-waiterResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled waiter error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled waiter did not return")
+	}
+	waitForDescriptorFetchWaiters(t, sdk, cacheKey, 1)
+
+	release()
+	select {
+	case err := <-leaderResult:
+		if err != nil {
+			t.Fatalf("shared fetch error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared fetch did not complete")
+	}
+	if got := tokenCalls.Load(); got != 1 {
+		t.Fatalf("token calls = %d, want 1", got)
+	}
+	if got := schemaCalls.Load(); got != 1 {
+		t.Fatalf("schema calls = %d, want 1", got)
 	}
 }
 

--- a/purego/zerobus/options.go
+++ b/purego/zerobus/options.go
@@ -34,7 +34,7 @@ func WithTLSConfig(tc *tls.Config) Option {
 }
 
 // WithProtoDescriptorFetchTimeout sets the timeout used by
-// FetchProtoDescriptor for Unity Catalog schema requests.
+// FetchProtoDescriptorFromUC and RefreshProtoDescriptorFromUC.
 // A non-positive value keeps the default.
 func WithProtoDescriptorFetchTimeout(d time.Duration) Option {
 	return func(c *sdkConfig) { c.dynamicSchemaFetchTimeout = d }

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -103,7 +103,9 @@ type SDK struct {
 	httpClient                *http.Client
 	dynamicSchemaFetchTimeout time.Duration
 	dynamicSchemaCache        map[string]cachedDescriptor
-	dynamicSchemaFetches      map[string]*descriptorFetch
+	dynamicSchemaFetches      map[descriptorFetchKey]*descriptorFetch
+	descriptorGeneration      uint64
+	descriptorFetchWG         sync.WaitGroup
 
 	// mu guards the open-stream set, descriptor cache/fetches, and closed flag.
 	mu     sync.Mutex
@@ -116,19 +118,36 @@ type cachedDescriptor struct {
 	descriptor []byte
 	expiresAt  time.Time
 	storedAt   time.Time
+	generation uint64
+}
+
+type descriptorFetchKey struct {
+	cacheKey string
+	refresh  bool
 }
 
 type descriptorFetch struct {
+	key        descriptorFetchKey
 	done       chan struct{}
 	descriptor []byte
 	err        error
 	waiters    int
+	generation uint64
+	ctx        context.Context
+	cancel     context.CancelCauseFunc
+	completed  bool
+	superseded bool
 }
 
 const (
 	defaultDynamicSchemaFetchTimeout = 10 * time.Second
 	defaultDynamicSchemaCacheTTL     = 5 * time.Minute
 	maxDynamicSchemaCacheEntries     = 128
+)
+
+var (
+	errSDKClosed                = errors.New("SDK is closed")
+	errDescriptorFetchAbandoned = errors.New("descriptor fetch abandoned")
 )
 
 // newSDK builds an SDK around an existing connection.
@@ -145,7 +164,7 @@ func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string, cfg sdkCon
 		httpClient:                cfg.httpClient,
 		dynamicSchemaFetchTimeout: fetchTimeout,
 		dynamicSchemaCache:        make(map[string]cachedDescriptor),
-		dynamicSchemaFetches:      make(map[string]*descriptorFetch),
+		dynamicSchemaFetches:      make(map[descriptorFetchKey]*descriptorFetch),
 		streams:                   make(map[*Stream]struct{}),
 	}
 }
@@ -210,7 +229,15 @@ func (s *SDK) Close() error {
 	}
 	s.streams = nil
 	s.dynamicSchemaCache = make(map[string]cachedDescriptor)
+	for key, fetch := range s.dynamicSchemaFetches {
+		delete(s.dynamicSchemaFetches, key)
+		s.completeDescriptorFetchLocked(fetch, nil, errSDKClosed)
+		if fetch.cancel != nil {
+			fetch.cancel(errSDKClosed)
+		}
+	}
 	s.mu.Unlock()
+	s.descriptorFetchWG.Wait()
 
 	errs := make([]error, len(open)+1)
 	var wg sync.WaitGroup
@@ -287,8 +314,8 @@ func (s *SDK) FetchProtoDescriptorFromUC(
 
 // RefreshProtoDescriptorFromUC fetches a fresh Unity Catalog table schema,
 // replaces its cached descriptor, and returns it. Concurrent refreshes for the
-// same table and credentials share one request. Cancelling one caller stops
-// only that caller's wait; it does not cancel the shared fetch.
+// same table and credentials share one request. Cancelling a caller does not
+// cancel a fetch that another caller still needs.
 func (s *SDK) RefreshProtoDescriptorFromUC(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,
@@ -311,7 +338,7 @@ func (s *SDK) fetchProtoDescriptorFromUC(
 	if s.isClosed() {
 		return nil, &Error{
 			Op:        op,
-			cause:     fmt.Errorf("SDK is closed"),
+			cause:     errSDKClosed,
 			retryable: false,
 		}
 	}
@@ -398,7 +425,7 @@ func (s *SDK) createStreamConfigured(
 		s.mu.Unlock()
 		// Stop the stream created before Close won the race.
 		_ = core.Terminate()
-		return nil, &Error{Op: op, cause: fmt.Errorf("SDK is closed"), retryable: false}
+		return nil, &Error{Op: op, cause: errSDKClosed, retryable: false}
 	}
 	s.streams[st] = struct{}{}
 	s.mu.Unlock()
@@ -451,7 +478,9 @@ func (s *SDK) fetchProtoDescriptorCached(
 	}
 
 	cacheKey := dynamicSchemaCacheKey(s.ucEndpoint, tableName, clientID, clientSecret)
-	desc, cached, fetch, leader, err := s.cachedDescriptorOrJoinFetch(cacheKey, !refresh)
+	desc, cached, fetch, leader, err := s.cachedDescriptorOrJoinFetch(
+		ctx, cacheKey, refresh,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -459,10 +488,8 @@ func (s *SDK) fetchProtoDescriptorCached(
 		return desc, nil
 	}
 	if leader {
-		sharedCtx := context.WithoutCancel(ctx)
 		go s.runDescriptorFetch(
-			sharedCtx,
-			cacheKey,
+			fetch.ctx,
 			tableName,
 			clientID,
 			clientSecret,
@@ -502,16 +529,24 @@ func (s *SDK) loadProtoDescriptor(
 }
 
 func (s *SDK) cachedDescriptorOrJoinFetch(
+	ctx context.Context,
 	cacheKey string,
-	allowCached bool,
+	refresh bool,
 ) ([]byte, bool, *descriptorFetch, bool, error) {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return nil, false, nil, false, fmt.Errorf("SDK is closed")
+		return nil, false, nil, false, errSDKClosed
 	}
-	if allowCached {
+	refreshKey := descriptorFetchKey{cacheKey: cacheKey, refresh: true}
+	if refresh {
+		if fetch, ok := s.dynamicSchemaFetches[refreshKey]; ok {
+			fetch.waiters++
+			return nil, false, fetch, false, nil
+		}
+	}
+	if !refresh {
 		if item, ok := s.dynamicSchemaCache[cacheKey]; ok {
 			if now.After(item.expiresAt) {
 				delete(s.dynamicSchemaCache, cacheKey)
@@ -520,54 +555,116 @@ func (s *SDK) cachedDescriptorOrJoinFetch(
 				return dup, true, nil, false, nil
 			}
 		}
+		if fetch, ok := s.dynamicSchemaFetches[refreshKey]; ok {
+			fetch.waiters++
+			return nil, false, fetch, false, nil
+		}
 	}
-	if fetch, ok := s.dynamicSchemaFetches[cacheKey]; ok {
-		fetch.waiters++
-		return nil, false, fetch, false, nil
+	fetchKey := descriptorFetchKey{cacheKey: cacheKey, refresh: refresh}
+	if !refresh {
+		if fetch, ok := s.dynamicSchemaFetches[fetchKey]; ok && !fetch.superseded {
+			fetch.waiters++
+			return nil, false, fetch, false, nil
+		}
+	} else {
+		// Starting a refresh establishes a freshness barrier even if it fails.
+		ordinaryKey := descriptorFetchKey{cacheKey: cacheKey}
+		if ordinary := s.dynamicSchemaFetches[ordinaryKey]; ordinary != nil {
+			ordinary.superseded = true
+		}
 	}
+	sharedCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
+	s.descriptorGeneration++
 	fetch := &descriptorFetch{
-		done:    make(chan struct{}),
-		waiters: 1,
+		key:        fetchKey,
+		done:       make(chan struct{}),
+		waiters:    1,
+		generation: s.descriptorGeneration,
+		ctx:        sharedCtx,
+		cancel:     cancel,
 	}
-	s.dynamicSchemaFetches[cacheKey] = fetch
+	s.dynamicSchemaFetches[fetchKey] = fetch
+	s.descriptorFetchWG.Add(1)
 	return nil, false, fetch, true, nil
 }
 
 func (s *SDK) runDescriptorFetch(
 	ctx context.Context,
-	cacheKey, tableName, clientID, clientSecret string,
+	tableName, clientID, clientSecret string,
 	fetch *descriptorFetch,
 ) {
+	defer s.descriptorFetchWG.Done()
 	desc, err := s.loadProtoDescriptor(ctx, tableName, clientID, clientSecret)
 
 	s.mu.Lock()
-	if err == nil && !s.closed {
-		s.storeDynamicDescriptorLocked(cacheKey, desc, time.Now())
+	defer s.mu.Unlock()
+	if fetch.completed {
+		return
 	}
-	fetch.descriptor = append([]byte(nil), desc...)
-	fetch.err = err
-	if current := s.dynamicSchemaFetches[cacheKey]; current == fetch {
-		delete(s.dynamicSchemaFetches, cacheKey)
+	current := s.dynamicSchemaFetches[fetch.key] == fetch
+	if err == nil && !s.closed && current {
+		if !fetch.superseded {
+			item, cached := s.dynamicSchemaCache[fetch.key.cacheKey]
+			if !cached || fetch.generation >= item.generation {
+				s.storeDynamicDescriptorLocked(
+					fetch.key.cacheKey, desc, time.Now(), fetch.generation,
+				)
+			}
+		}
 	}
-	close(fetch.done)
-	s.mu.Unlock()
+	if current {
+		delete(s.dynamicSchemaFetches, fetch.key)
+	}
+	s.completeDescriptorFetchLocked(fetch, desc, err)
 }
 
 func (s *SDK) waitForDescriptorFetch(
 	ctx context.Context,
 	fetch *descriptorFetch,
 ) ([]byte, error) {
-	defer func() {
-		s.mu.Lock()
-		fetch.waiters--
-		s.mu.Unlock()
-	}()
+	var desc []byte
+	var err error
 	select {
 	case <-fetch.done:
-		return append([]byte(nil), fetch.descriptor...), fetch.err
+		desc = append([]byte(nil), fetch.descriptor...)
+		err = fetch.err
 	case <-ctx.Done():
-		return nil, context.Cause(ctx)
+		err = context.Cause(ctx)
 	}
+	s.leaveDescriptorFetch(fetch)
+	return desc, err
+}
+
+func (s *SDK) leaveDescriptorFetch(fetch *descriptorFetch) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if fetch.waiters > 0 {
+		fetch.waiters--
+	}
+	if fetch.waiters != 0 || fetch.completed {
+		return
+	}
+	if current := s.dynamicSchemaFetches[fetch.key]; current == fetch {
+		delete(s.dynamicSchemaFetches, fetch.key)
+	}
+	s.completeDescriptorFetchLocked(fetch, nil, errDescriptorFetchAbandoned)
+	if fetch.cancel != nil {
+		fetch.cancel(errDescriptorFetchAbandoned)
+	}
+}
+
+func (s *SDK) completeDescriptorFetchLocked(
+	fetch *descriptorFetch,
+	desc []byte,
+	err error,
+) {
+	if fetch.completed {
+		return
+	}
+	fetch.descriptor = append([]byte(nil), desc...)
+	fetch.err = err
+	fetch.completed = true
+	close(fetch.done)
 }
 
 func (s *SDK) storeDynamicDescriptor(
@@ -580,18 +677,21 @@ func (s *SDK) storeDynamicDescriptor(
 	if s.closed {
 		return
 	}
-	s.storeDynamicDescriptorLocked(cacheKey, desc, now)
+	s.descriptorGeneration++
+	s.storeDynamicDescriptorLocked(cacheKey, desc, now, s.descriptorGeneration)
 }
 
 func (s *SDK) storeDynamicDescriptorLocked(
 	cacheKey string,
 	desc []byte,
 	now time.Time,
+	generation uint64,
 ) {
 	item := cachedDescriptor{
 		descriptor: append([]byte(nil), desc...),
 		expiresAt:  now.Add(defaultDynamicSchemaCacheTTL),
 		storedAt:   now,
+		generation: generation,
 	}
 	for key, cached := range s.dynamicSchemaCache {
 		if now.After(cached.expiresAt) {

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -103,8 +103,9 @@ type SDK struct {
 	httpClient                *http.Client
 	dynamicSchemaFetchTimeout time.Duration
 	dynamicSchemaCache        map[string]cachedDescriptor
+	dynamicSchemaFetches      map[string]*descriptorFetch
 
-	// mu guards the open-stream set, descriptor cache, and closed flag.
+	// mu guards the open-stream set, descriptor cache/fetches, and closed flag.
 	mu     sync.Mutex
 	closed bool
 	// Open streams owned by this SDK.
@@ -115,6 +116,13 @@ type cachedDescriptor struct {
 	descriptor []byte
 	expiresAt  time.Time
 	storedAt   time.Time
+}
+
+type descriptorFetch struct {
+	done       chan struct{}
+	descriptor []byte
+	err        error
+	waiters    int
 }
 
 const (
@@ -137,6 +145,7 @@ func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string, cfg sdkCon
 		httpClient:                cfg.httpClient,
 		dynamicSchemaFetchTimeout: fetchTimeout,
 		dynamicSchemaCache:        make(map[string]cachedDescriptor),
+		dynamicSchemaFetches:      make(map[string]*descriptorFetch),
 		streams:                   make(map[*Stream]struct{}),
 	}
 }
@@ -258,24 +267,60 @@ func (s *SDK) CreateStreamWithProvider(
 }
 
 // FetchProtoDescriptorFromUC returns a protobuf descriptor built from a Unity
-// Catalog table schema.
+// Catalog table schema. Successful descriptors are cached for five minutes,
+// with at most 128 entries per SDK. Concurrent misses for the same table and
+// credentials share one request. Use RefreshProtoDescriptorFromUC to bypass a
+// cached descriptor after a schema change.
 func (s *SDK) FetchProtoDescriptorFromUC(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,
 ) ([]byte, error) {
+	return s.fetchProtoDescriptorFromUC(
+		ctx,
+		"FetchProtoDescriptorFromUC",
+		tableName,
+		clientID,
+		clientSecret,
+		false,
+	)
+}
+
+// RefreshProtoDescriptorFromUC fetches a fresh Unity Catalog table schema,
+// replaces its cached descriptor, and returns it. Concurrent refreshes for the
+// same table and credentials share one request. Cancelling one caller stops
+// only that caller's wait; it does not cancel the shared fetch.
+func (s *SDK) RefreshProtoDescriptorFromUC(
+	ctx context.Context,
+	tableName, clientID, clientSecret string,
+) ([]byte, error) {
+	return s.fetchProtoDescriptorFromUC(
+		ctx,
+		"RefreshProtoDescriptorFromUC",
+		tableName,
+		clientID,
+		clientSecret,
+		true,
+	)
+}
+
+func (s *SDK) fetchProtoDescriptorFromUC(
+	ctx context.Context,
+	op, tableName, clientID, clientSecret string,
+	refresh bool,
+) ([]byte, error) {
 	if s.isClosed() {
 		return nil, &Error{
-			Op:        "FetchProtoDescriptorFromUC",
+			Op:        op,
 			cause:     fmt.Errorf("SDK is closed"),
 			retryable: false,
 		}
 	}
-	descBytes, err := s.fetchProtoDescriptor(
-		ctx, tableName, clientID, clientSecret,
+	descBytes, err := s.fetchProtoDescriptorCached(
+		ctx, tableName, clientID, clientSecret, refresh,
 	)
 	if err != nil {
 		return nil, &Error{
-			Op:        "FetchProtoDescriptorFromUC",
+			Op:        op,
 			cause:     err,
 			retryable: dynamicSchemaErrorRetryable(err),
 		}
@@ -383,6 +428,14 @@ func (s *SDK) fetchProtoDescriptor(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,
 ) ([]byte, error) {
+	return s.fetchProtoDescriptorCached(ctx, tableName, clientID, clientSecret, false)
+}
+
+func (s *SDK) fetchProtoDescriptorCached(
+	ctx context.Context,
+	tableName, clientID, clientSecret string,
+	refresh bool,
+) ([]byte, error) {
 	tableName = strings.TrimSpace(tableName)
 	if tableName == "" {
 		return nil, fmt.Errorf("table name is required")
@@ -393,12 +446,36 @@ func (s *SDK) fetchProtoDescriptor(
 	if strings.TrimSpace(clientSecret) == "" {
 		return nil, fmt.Errorf("clientSecret is required")
 	}
-
-	cacheKey := dynamicSchemaCacheKey(s.ucEndpoint, tableName, clientID, clientSecret)
-	if desc, ok := s.getDynamicDescriptorFromCache(cacheKey); ok {
-		return desc, nil
+	if err := ctx.Err(); err != nil {
+		return nil, context.Cause(ctx)
 	}
 
+	cacheKey := dynamicSchemaCacheKey(s.ucEndpoint, tableName, clientID, clientSecret)
+	desc, cached, fetch, leader, err := s.cachedDescriptorOrJoinFetch(cacheKey, !refresh)
+	if err != nil {
+		return nil, err
+	}
+	if cached {
+		return desc, nil
+	}
+	if leader {
+		sharedCtx := context.WithoutCancel(ctx)
+		go s.runDescriptorFetch(
+			sharedCtx,
+			cacheKey,
+			tableName,
+			clientID,
+			clientSecret,
+			fetch,
+		)
+	}
+	return s.waitForDescriptorFetch(ctx, fetch)
+}
+
+func (s *SDK) loadProtoDescriptor(
+	ctx context.Context,
+	tableName, clientID, clientSecret string,
+) ([]byte, error) {
 	fetcher, err := ucschema.New(ucschema.Config{
 		WorkspaceEndpoint: s.ucEndpoint,
 		ClientID:          clientID,
@@ -421,29 +498,76 @@ func (s *SDK) fetchProtoDescriptor(
 	if err != nil {
 		return nil, fmt.Errorf("serialize descriptor: %w", err)
 	}
-	s.storeDynamicDescriptor(cacheKey, descBytes)
 	return descBytes, nil
 }
 
-func (s *SDK) getDynamicDescriptorFromCache(
+func (s *SDK) cachedDescriptorOrJoinFetch(
 	cacheKey string,
-) ([]byte, bool) {
+	allowCached bool,
+) ([]byte, bool, *descriptorFetch, bool, error) {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return nil, false
+		return nil, false, nil, false, fmt.Errorf("SDK is closed")
 	}
-	item, ok := s.dynamicSchemaCache[cacheKey]
-	if !ok {
-		return nil, false
+	if allowCached {
+		if item, ok := s.dynamicSchemaCache[cacheKey]; ok {
+			if now.After(item.expiresAt) {
+				delete(s.dynamicSchemaCache, cacheKey)
+			} else {
+				dup := append([]byte(nil), item.descriptor...)
+				return dup, true, nil, false, nil
+			}
+		}
 	}
-	if now.After(item.expiresAt) {
-		delete(s.dynamicSchemaCache, cacheKey)
-		return nil, false
+	if fetch, ok := s.dynamicSchemaFetches[cacheKey]; ok {
+		fetch.waiters++
+		return nil, false, fetch, false, nil
 	}
-	dup := append([]byte(nil), item.descriptor...)
-	return dup, true
+	fetch := &descriptorFetch{
+		done:    make(chan struct{}),
+		waiters: 1,
+	}
+	s.dynamicSchemaFetches[cacheKey] = fetch
+	return nil, false, fetch, true, nil
+}
+
+func (s *SDK) runDescriptorFetch(
+	ctx context.Context,
+	cacheKey, tableName, clientID, clientSecret string,
+	fetch *descriptorFetch,
+) {
+	desc, err := s.loadProtoDescriptor(ctx, tableName, clientID, clientSecret)
+
+	s.mu.Lock()
+	if err == nil && !s.closed {
+		s.storeDynamicDescriptorLocked(cacheKey, desc, time.Now())
+	}
+	fetch.descriptor = append([]byte(nil), desc...)
+	fetch.err = err
+	if current := s.dynamicSchemaFetches[cacheKey]; current == fetch {
+		delete(s.dynamicSchemaFetches, cacheKey)
+	}
+	close(fetch.done)
+	s.mu.Unlock()
+}
+
+func (s *SDK) waitForDescriptorFetch(
+	ctx context.Context,
+	fetch *descriptorFetch,
+) ([]byte, error) {
+	defer func() {
+		s.mu.Lock()
+		fetch.waiters--
+		s.mu.Unlock()
+	}()
+	select {
+	case <-fetch.done:
+		return append([]byte(nil), fetch.descriptor...), fetch.err
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	}
 }
 
 func (s *SDK) storeDynamicDescriptor(
@@ -451,15 +575,23 @@ func (s *SDK) storeDynamicDescriptor(
 	desc []byte,
 ) {
 	now := time.Now()
-	item := cachedDescriptor{
-		descriptor: append([]byte(nil), desc...),
-		expiresAt:  now.Add(defaultDynamicSchemaCacheTTL),
-		storedAt:   now,
-	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return
+	}
+	s.storeDynamicDescriptorLocked(cacheKey, desc, now)
+}
+
+func (s *SDK) storeDynamicDescriptorLocked(
+	cacheKey string,
+	desc []byte,
+	now time.Time,
+) {
+	item := cachedDescriptor{
+		descriptor: append([]byte(nil), desc...),
+		expiresAt:  now.Add(defaultDynamicSchemaCacheTTL),
+		storedAt:   now,
 	}
 	for key, cached := range s.dynamicSchemaCache {
 		if now.After(cached.expiresAt) {


### PR DESCRIPTION
## Summary

- Add `RefreshProtoDescriptorFromUC` so callers can bypass a stale cached descriptor and replace it after a Unity Catalog table schema change.
- Rename/clarify the fetch API as `FetchProtoDescriptorFromUC` (with `FetchProtoDescriptor` kept as a deprecated alias).
- Coalesce compatible concurrent descriptor requests for the same table and credentials:
  - ordinary cache misses share one UC fetch
  - concurrent refreshes share one refresh request and never join an older ordinary fetch
  - ordinary misses may join an in-flight refresh when no cached descriptor is available
- Preserve independent caller cancellation: canceling one waiter does not cancel shared work still needed by others; abandoned fetches stop when the last waiter leaves.
- Cancel in-flight descriptor fetches on `SDK.Close`, wait for them to finish, and keep cache writes generation-aware so superseded/stale results cannot overwrite fresher entries.
- Document the 5-minute / 128-entry cache limits and coalescing/refresh behavior in the README and godoc.
- Add regression coverage for refresh bypass, refresh-vs-fetch precedence, coalescing, cancellation isolation, last-waiter abandonment, Close cancellation, and failed shared-fetch retry.

## Test plan

- [x] `cd purego && go test -race ./...`
- [x] `cd purego && go vet ./...`
- [x] `cd purego/examples && go test ./...`

Closes #676