### PR TITLE
[PureGo] Remove UC descriptor cache

### DIFF
--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -11,8 +11,10 @@
 - Added opt-in wait-ready stream creation whose context bounds the complete
   first-open process; asynchronous creation now preserves context values while
   detaching caller cancellation.
-- Added `FetchProtoDescriptor` for building protobuf descriptors from Unity
-  Catalog table schemas.
+- Added `FetchProtoDescriptorFromUC` for building protobuf descriptors from
+  Unity Catalog table schemas. Each call issues a fresh Unity Catalog request:
+  fetch the descriptor once and reuse the returned bytes for every stream on
+  that table, and fetch again only when the table schema changes.
 - Added `Stream.IngestJSONOffset` and `Stream.IngestJSONRecordsOffset`. JSON
   streams queue JSON directly; proto streams convert it before ingestion.
 

--- a/purego/README.md
+++ b/purego/README.md
@@ -92,11 +92,19 @@ streams and convert it to protobuf on proto streams.
 Fetch the table schema explicitly, then create a regular proto stream. The
 stream can accept either protobuf bytes or JSON converted at ingest time.
 
+> **Fetch the descriptor once and reuse it.** `FetchProtoDescriptorFromUC`
+> performs a Unity Catalog request on every call and the SDK does not cache the
+> result. Call it once per table at startup, hold on to the returned bytes, and
+> pass them to `WithProto` for every stream you open on that table. Fetch again
+> only when the table schema changes. Calling it per stream — or per record —
+> puts a UC round-trip on your ingestion path.
+
 UC schema conversion rejects nullable array/map fields and collections that
 allow null elements or values because protobuf cannot preserve those
 distinctions. JSON ingestion also rejects explicit `null` collection fields.
 
 ```go
+// Fetch once at startup, then reuse `descriptor` for every stream on this table.
 descriptor, err := sdk.FetchProtoDescriptorFromUC(
     ctx,
     "catalog.schema.table",

--- a/purego/examples/dynamic/batch/main.go
+++ b/purego/examples/dynamic/batch/main.go
@@ -25,6 +25,7 @@ func main() {
 	defer sdk.Close()
 
 	ctx := context.Background()
+	// Fetch the descriptor once; reuse it for every stream on this table.
 	descriptor, err := sdk.FetchProtoDescriptorFromUC(
 		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
 	)

--- a/purego/examples/dynamic/proto/main.go
+++ b/purego/examples/dynamic/proto/main.go
@@ -57,6 +57,7 @@ func main() {
 	defer sdk.Close()
 
 	ctx := context.Background()
+	// Fetch the descriptor once; reuse it for every stream on this table.
 	descriptorBytes, err := sdk.FetchProtoDescriptorFromUC(
 		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
 	)

--- a/purego/examples/dynamic/single/main.go
+++ b/purego/examples/dynamic/single/main.go
@@ -14,20 +14,6 @@ import (
 	"github.com/databricks/zerobus-sdk/purego/zerobus"
 )
 
-func openStream(sdk *zerobus.SDK, cfg config.Settings) (*zerobus.Stream, error) {
-	ctx := context.Background()
-	descriptor, err := sdk.FetchProtoDescriptorFromUC(
-		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return sdk.CreateStream(
-		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
-		zerobus.WithProto(descriptor),
-	)
-}
-
 func main() {
 	cfg := config.Load()
 
@@ -38,7 +24,19 @@ func main() {
 	}
 	defer sdk.Close()
 
-	stream, err := openStream(sdk, cfg)
+	ctx := context.Background()
+	// Fetch the descriptor once; reuse it for every stream on this table.
+	descriptor, err := sdk.FetchProtoDescriptorFromUC(
+		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
+	)
+	if err != nil {
+		log.Fatalf("fetch descriptor: %v", err)
+	}
+
+	stream, err := sdk.CreateStream(
+		ctx, cfg.TableName, cfg.ClientID, cfg.ClientSecret,
+		zerobus.WithProto(descriptor),
+	)
 	if err != nil {
 		log.Fatalf("create stream: %v", err)
 	}

--- a/purego/zerobus/dynamic_proto_test.go
+++ b/purego/zerobus/dynamic_proto_test.go
@@ -85,6 +85,23 @@ func TestSDKFetchProtoDescriptorFromUC_RejectsClosedSDK(t *testing.T) {
 	}
 }
 
+// The deprecated alias must delegate, so it reports the same operation as the
+// method it forwards to.
+func TestSDKFetchProtoDescriptor_DelegatesToFromUC(t *testing.T) {
+	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
+	sdk.mu.Lock()
+	sdk.closed = true
+	sdk.mu.Unlock()
+
+	_, err := sdk.FetchProtoDescriptor(
+		context.Background(), "main.sales.orders", "id", "secret",
+	)
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Op != "FetchProtoDescriptorFromUC" {
+		t.Fatalf("FetchProtoDescriptor() error = %v, want Op FetchProtoDescriptorFromUC", err)
+	}
+}
+
 func TestStreamEncodeJSONBatch(t *testing.T) {
 	desc := &descriptorpb.DescriptorProto{
 		Name: proto.String("Order"),

--- a/purego/zerobus/dynamic_proto_test.go
+++ b/purego/zerobus/dynamic_proto_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,14 +23,14 @@ type retryableSchemaTestError struct{}
 func (retryableSchemaTestError) Error() string     { return "retryable" }
 func (retryableSchemaTestError) IsRetryable() bool { return true }
 
-func TestSDKFetchProtoDescriptor_CacheHit(t *testing.T) {
-	var tokenCalls atomic.Int32
+// The SDK does not cache descriptors: each call is a fresh UC round-trip that
+// returns an equivalent descriptor. Callers fetch once and reuse the bytes.
+func TestSDKFetchProtoDescriptor_FetchesOnEveryCall(t *testing.T) {
 	var schemaCalls atomic.Int32
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/oidc/v1/token":
-			tokenCalls.Add(1)
 			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
 		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
 			schemaCalls.Add(1)
@@ -66,13 +65,23 @@ func TestSDKFetchProtoDescriptor_CacheHit(t *testing.T) {
 		t.Fatalf("fetchProtoDescriptor() second call error = %v", err)
 	}
 	if string(b1) != string(b2) {
-		t.Fatalf("cached descriptor mismatch")
+		t.Fatal("descriptors from repeated fetches differ")
 	}
-	if tokenCalls.Load() != 1 {
-		t.Fatalf("token calls = %d, want 1", tokenCalls.Load())
+	if got := schemaCalls.Load(); got != 2 {
+		t.Fatalf("schema calls = %d, want 2 (no descriptor caching)", got)
 	}
-	if schemaCalls.Load() != 1 {
-		t.Fatalf("schema calls = %d, want 1", schemaCalls.Load())
+}
+
+func TestSDKFetchProtoDescriptorFromUC_RejectsClosedSDK(t *testing.T) {
+	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
+	sdk.mu.Lock()
+	sdk.closed = true
+	sdk.mu.Unlock()
+
+	if _, err := sdk.FetchProtoDescriptorFromUC(
+		context.Background(), "main.sales.orders", "id", "secret",
+	); err == nil || !strings.Contains(err.Error(), "SDK is closed") {
+		t.Fatalf("FetchProtoDescriptorFromUC() error = %v, want closed SDK error", err)
 	}
 }
 
@@ -176,94 +185,6 @@ func TestStreamJSONConversionRejectsUnsupportedDescriptor(t *testing.T) {
 				t.Fatalf("IngestJSONOffset() error = %v, want conversion error", err)
 			}
 		})
-	}
-}
-
-func TestSDKFetchProtoDescriptor_CacheIsCredentialScoped(t *testing.T) {
-	var tokenCalls atomic.Int32
-	var schemaCalls atomic.Int32
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/oidc/v1/token":
-			tokenCalls.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "abc"})
-		case strings.HasPrefix(r.URL.Path, "/api/2.1/unity-catalog/tables/"):
-			schemaCalls.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"name":         "orders",
-				"catalog_name": "main",
-				"schema_name":  "sales",
-				"columns": []map[string]any{
-					{"name": "id", "type_name": "LONG", "position": 0},
-				},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	sdk := newSDK(nil, "https://workspace.zerobus.cloud.databricks.com", server.URL, sdkConfig{
-		httpClient: server.Client(),
-	})
-	for _, credentials := range [][2]string{
-		{"id-1", "secret-1"},
-		{"id-2", "secret-1"},
-		{"id-1", "secret-2"},
-	} {
-		if _, err := sdk.fetchProtoDescriptor(
-			context.Background(), "main.sales.orders", credentials[0], credentials[1],
-		); err != nil {
-			t.Fatalf("fetchProtoDescriptor() error = %v", err)
-		}
-	}
-	if got := tokenCalls.Load(); got != 3 {
-		t.Fatalf("token calls = %d, want 3", got)
-	}
-	if got := schemaCalls.Load(); got != 3 {
-		t.Fatalf("schema calls = %d, want 3", got)
-	}
-}
-
-func TestSDKStoreDynamicDescriptor_PrunesExpiredEntries(t *testing.T) {
-	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
-	sdk.dynamicSchemaCache["old"] = cachedDescriptor{
-		descriptor: []byte("old"),
-		expiresAt:  time.Now().Add(-time.Second),
-	}
-	sdk.storeDynamicDescriptor("new", []byte("new"))
-	if len(sdk.dynamicSchemaCache) != 1 {
-		t.Fatalf("cache entries = %d, want 1", len(sdk.dynamicSchemaCache))
-	}
-	if _, ok := sdk.dynamicSchemaCache["new"]; !ok {
-		t.Fatal("new cache entry missing")
-	}
-}
-
-func TestSDKStoreDynamicDescriptor_EnforcesEntryLimit(t *testing.T) {
-	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
-	for i := range maxDynamicSchemaCacheEntries + 1 {
-		sdk.storeDynamicDescriptor(fmt.Sprintf("entry-%03d", i), []byte("descriptor"))
-	}
-	if got := len(sdk.dynamicSchemaCache); got != maxDynamicSchemaCacheEntries {
-		t.Fatalf("cache entries = %d, want %d", got, maxDynamicSchemaCacheEntries)
-	}
-	if _, ok := sdk.dynamicSchemaCache["entry-000"]; ok {
-		t.Fatal("oldest descriptor was not evicted")
-	}
-	if _, ok := sdk.dynamicSchemaCache[fmt.Sprintf("entry-%03d", maxDynamicSchemaCacheEntries)]; !ok {
-		t.Fatal("newest descriptor was not cached")
-	}
-}
-
-func TestSDKStoreDynamicDescriptor_DoesNotPopulateClosedSDK(t *testing.T) {
-	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
-	sdk.mu.Lock()
-	sdk.closed = true
-	sdk.mu.Unlock()
-	sdk.storeDynamicDescriptor("closed", []byte("descriptor"))
-	if len(sdk.dynamicSchemaCache) != 0 {
-		t.Fatal("closed SDK cache was populated")
 	}
 }
 

--- a/purego/zerobus/options.go
+++ b/purego/zerobus/options.go
@@ -34,7 +34,7 @@ func WithTLSConfig(tc *tls.Config) Option {
 }
 
 // WithProtoDescriptorFetchTimeout sets the timeout used by
-// FetchProtoDescriptor for Unity Catalog schema requests.
+// FetchProtoDescriptorFromUC for Unity Catalog schema requests.
 // A non-positive value keeps the default.
 func WithProtoDescriptorFetchTimeout(d time.Duration) Option {
 	return func(c *sdkConfig) { c.dynamicSchemaFetchTimeout = d }

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -40,6 +40,13 @@
 // validation while first-open runs in the background. Pass WithWaitForReady to
 // make CreateStream block until first-open succeeds or fails terminally.
 //
+// # Proto descriptors from Unity Catalog
+//
+// FetchProtoDescriptorFromUC builds a descriptor from a Unity Catalog table
+// schema. It is a plain remote call with no caching, so fetch the descriptor
+// once and reuse the bytes for every stream on that table; fetch again only
+// after the table schema changes.
+//
 // # Authentication
 //
 // CreateStream uses the Unity Catalog OAuth 2.0 client-credentials flow. For
@@ -49,7 +56,6 @@ package zerobus
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net"
@@ -102,26 +108,15 @@ type SDK struct {
 	tokenCache                *auth.SharedTokenCache
 	httpClient                *http.Client
 	dynamicSchemaFetchTimeout time.Duration
-	dynamicSchemaCache        map[string]cachedDescriptor
 
-	// mu guards the open-stream set, descriptor cache, and closed flag.
+	// mu guards the open-stream set and closed flag.
 	mu     sync.Mutex
 	closed bool
 	// Open streams owned by this SDK.
 	streams map[*Stream]struct{}
 }
 
-type cachedDescriptor struct {
-	descriptor []byte
-	expiresAt  time.Time
-	storedAt   time.Time
-}
-
-const (
-	defaultDynamicSchemaFetchTimeout = 10 * time.Second
-	defaultDynamicSchemaCacheTTL     = 5 * time.Minute
-	maxDynamicSchemaCacheEntries     = 128
-)
+const defaultDynamicSchemaFetchTimeout = 10 * time.Second
 
 // newSDK builds an SDK around an existing connection.
 func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string, cfg sdkConfig) *SDK {
@@ -136,7 +131,6 @@ func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string, cfg sdkCon
 		tokenCache:                auth.NewSharedTokenCache(),
 		httpClient:                cfg.httpClient,
 		dynamicSchemaFetchTimeout: fetchTimeout,
-		dynamicSchemaCache:        make(map[string]cachedDescriptor),
 		streams:                   make(map[*Stream]struct{}),
 	}
 }
@@ -200,7 +194,6 @@ func (s *SDK) Close() error {
 		open = append(open, st)
 	}
 	s.streams = nil
-	s.dynamicSchemaCache = make(map[string]cachedDescriptor)
 	s.mu.Unlock()
 
 	errs := make([]error, len(open)+1)
@@ -259,6 +252,23 @@ func (s *SDK) CreateStreamWithProvider(
 
 // FetchProtoDescriptorFromUC returns a protobuf descriptor built from a Unity
 // Catalog table schema.
+//
+// Every call performs a fresh Unity Catalog request; the SDK does not cache the
+// result. Fetch the descriptor once and reuse the returned bytes for every
+// stream on that table:
+//
+//	descriptor, err := sdk.FetchProtoDescriptorFromUC(ctx, table, clientID, clientSecret)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for range streamCount {
+//	    stream, err := sdk.CreateStream(ctx, table, clientID, clientSecret,
+//	        zerobus.WithProto(descriptor))
+//	    // ...
+//	}
+//
+// Calling it per stream, or worse per record, adds a Unity Catalog round-trip
+// to the hot path. Fetch again only when the table schema changes.
 func (s *SDK) FetchProtoDescriptorFromUC(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,
@@ -394,11 +404,6 @@ func (s *SDK) fetchProtoDescriptor(
 		return nil, fmt.Errorf("clientSecret is required")
 	}
 
-	cacheKey := dynamicSchemaCacheKey(s.ucEndpoint, tableName, clientID, clientSecret)
-	if desc, ok := s.getDynamicDescriptorFromCache(cacheKey); ok {
-		return desc, nil
-	}
-
 	fetcher, err := ucschema.New(ucschema.Config{
 		WorkspaceEndpoint: s.ucEndpoint,
 		ClientID:          clientID,
@@ -421,71 +426,7 @@ func (s *SDK) fetchProtoDescriptor(
 	if err != nil {
 		return nil, fmt.Errorf("serialize descriptor: %w", err)
 	}
-	s.storeDynamicDescriptor(cacheKey, descBytes)
 	return descBytes, nil
-}
-
-func (s *SDK) getDynamicDescriptorFromCache(
-	cacheKey string,
-) ([]byte, bool) {
-	now := time.Now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed {
-		return nil, false
-	}
-	item, ok := s.dynamicSchemaCache[cacheKey]
-	if !ok {
-		return nil, false
-	}
-	if now.After(item.expiresAt) {
-		delete(s.dynamicSchemaCache, cacheKey)
-		return nil, false
-	}
-	dup := append([]byte(nil), item.descriptor...)
-	return dup, true
-}
-
-func (s *SDK) storeDynamicDescriptor(
-	cacheKey string,
-	desc []byte,
-) {
-	now := time.Now()
-	item := cachedDescriptor{
-		descriptor: append([]byte(nil), desc...),
-		expiresAt:  now.Add(defaultDynamicSchemaCacheTTL),
-		storedAt:   now,
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed {
-		return
-	}
-	for key, cached := range s.dynamicSchemaCache {
-		if now.After(cached.expiresAt) {
-			delete(s.dynamicSchemaCache, key)
-		}
-	}
-	delete(s.dynamicSchemaCache, cacheKey)
-	if len(s.dynamicSchemaCache) >= maxDynamicSchemaCacheEntries {
-		var oldestKey string
-		var oldestTime time.Time
-		for key, cached := range s.dynamicSchemaCache {
-			if oldestKey == "" || cached.storedAt.Before(oldestTime) {
-				oldestKey = key
-				oldestTime = cached.storedAt
-			}
-		}
-		if oldestKey != "" {
-			delete(s.dynamicSchemaCache, oldestKey)
-		}
-	}
-	s.dynamicSchemaCache[cacheKey] = item
-}
-
-func dynamicSchemaCacheKey(ucEndpoint, tableName, clientID, clientSecret string) string {
-	credential := sha256.Sum256([]byte(clientID + "\x00" + clientSecret))
-	return ucEndpoint + "\x00" + tableName + "\x00" + string(credential[:])
 }
 
 func dynamicSchemaErrorRetryable(err error) bool {

--- a/purego/zerobus/zerobus_test.go
+++ b/purego/zerobus/zerobus_test.go
@@ -801,7 +801,7 @@ func waitFor(t *testing.T, cond func() bool, what string) {
 	}
 }
 
-func TestFetchProtoDescriptorPublicFlow(t *testing.T) {
+func TestFetchProtoDescriptorFromUCPublicFlow(t *testing.T) {
 	uc := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/oidc/v1/token":
@@ -867,14 +867,14 @@ func TestFetchProtoDescriptorPublicFlow(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	descriptorBytes, err := sdk.FetchProtoDescriptor(
+	descriptorBytes, err := sdk.FetchProtoDescriptorFromUC(
 		ctx,
 		"main.sales.orders",
 		"id",
 		"secret",
 	)
 	if err != nil {
-		t.Fatalf("FetchProtoDescriptor() error = %v", err)
+		t.Fatalf("FetchProtoDescriptorFromUC() error = %v", err)
 	}
 	dynamic, err := sdk.CreateStream(
 		ctx,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removes the Unity Catalog descriptor cache from the PureGo SDK and documents the fetch-once-and-reuse contract in its place.

**WHAT:**

- Delete the cache from `purego/zerobus/sdk.go`: the `dynamicSchemaCache` field, `cachedDescriptor` struct, the 5-minute TTL and 128-entry constants, `getDynamicDescriptorFromCache`, `storeDynamicDescriptor`, the SHA-256 credential-scoped `dynamicSchemaCacheKey`, and the cache reset in `Close`. `fetchProtoDescriptor` now goes straight to UC, and `SDK.mu` guards only the open-stream set and the closed flag.
- Document the contract where a reader will actually hit it: the `FetchProtoDescriptorFromUC` godoc (with a reuse-across-streams snippet and an explicit warning that per-stream calls put a UC round-trip on the ingestion path), a new "Proto descriptors from Unity Catalog" section in the package godoc, and a callout in the README's dynamic-proto section.
- Move the descriptor fetch in `examples/dynamic/single` out of its `openStream` helper and into `main`, since bundling fetch into stream creation is exactly the pattern that now costs a round-trip per stream. The `batch` and `proto` examples already fetched once and only gain a comment.
- Correct the `NEXT_CHANGELOG.md` entry to the current API name and state the fetch-once semantics.

**WHY:**

Per [@andrijast-db's review feedback](https://github.com/databricks/zerobus-sdk/pull/678#issuecomment-5215843901): fetching the descriptor is now an explicit standalone call rather than a step inside stream creation, so a caller can fetch once and reuse the bytes for every stream on a table. That makes the cache's cost/benefit negative — it bought a TTL, an entry limit, a credential-scoped key, and a proposed `RefreshProtoDescriptorFromUC` escape hatch, in exchange for saving a round-trip that correct callers do not make in the first place.

Deleting it also resolves #676 by construction rather than by implementing the lifecycle machinery that issue proposed. There is no stale descriptor to invalidate because every call is fresh, no cache key to coalesce misses on, and no shared in-flight work whose cancellation needs isolating. OAuth token minting is still shared across streams via `auth.SharedTokenCache`, which is unaffected by this change.

This supersedes #678, which is now closed.

Note for reviewers: `FetchProtoDescriptor` remains as a `Deprecated:` alias for `FetchProtoDescriptorFromUC`. Both names landed in #666 and v0.1.0 has not shipped, so it is deprecating a name no user has seen. I left it alone to keep this PR scoped to the cache removal, but I am happy to delete it here if you would rather not carry it into the first release.

## How is this tested?

- `cd purego && go test -race ./...` — all packages pass.
- `cd purego && go vet ./...` and `gofmt -l .` — clean.
- `cd purego/examples && go build ./... && go vet ./...` — clean.

Test changes:

- `TestSDKFetchProtoDescriptor_CacheHit` became `TestSDKFetchProtoDescriptor_FetchesOnEveryCall`. It now asserts two UC schema requests for two fetches, pinning the no-caching behavior instead of the old "1 request" expectation, and still checks that repeated fetches return equivalent descriptors.
- Added `TestSDKFetchProtoDescriptorFromUC_RejectsClosedSDK`. The closed-SDK guard was previously only exercised through the deleted `storeDynamicDescriptor` test, so this keeps it covered against the public API.
- Deleted the four tests whose subject no longer exists: cache-hit counting, credential-scoped cache keys, expired-entry pruning, and the entry limit.

Closes #676