### PR TITLE
[PureGo] Release v0.1.0

### DIFF
--- a/.github/workflows/release-purego.yml
+++ b/.github/workflows/release-purego.yml
@@ -25,6 +25,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate tag against SDK version
+        if: github.ref_type == 'tag'
+        working-directory: purego
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#purego/v}"
+          # Compare the X.Y.Z core so prerelease tags (purego/v1.2.0-rc1) still pass.
+          tag_core="${tag_version%%-*}"
+          src_version="$(sed -n 's/^const version = "\(.*\)"$/\1/p' zerobus/sdk.go)"
+          if [[ -z "$src_version" ]]; then
+            echo "Could not read the version const from purego/zerobus/sdk.go" >&2
+            exit 1
+          fi
+          if [[ "$tag_core" != "$src_version" ]]; then
+            echo "Tag $GITHUB_REF_NAME implies version $tag_core, but" \
+              "purego/zerobus/sdk.go declares $src_version" >&2
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches SDK version $src_version."
+
       - name: Get JFrog OIDC token
         shell: bash
         run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"

--- a/purego/CHANGELOG.md
+++ b/purego/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Version changelog
 
-All notable changes to the Zerobus pure-Go SDK are documented in this file.
-The v0.1.0 notes remain in `NEXT_CHANGELOG.md` until the version-bump pull
-request moves them here before the `purego/v0.1.0` tag is created.
+## Release v0.1.0
+
+Initial release of the Zerobus pure-Go SDK — a Go client for ingesting data into
+Databricks Delta tables. It speaks gRPC directly and links no Rust FFI, so it
+needs no cgo and no prebuilt native libraries. Requires Go 1.25 or later.
+
+### New Features and Improvements
+
+- Ingest into Databricks Delta tables over a `Stream` created from an `SDK`:
+  `New` dials lazily, `CreateStream` opens a stream for a table, and `Close`
+  tears down streams and the shared connection.
+- Two record formats: Protocol Buffers, the default, selected with
+  `WithProto(descriptorProto)`, and JSON, selected with `WithJSON()`. The
+  `IngestJSON*` methods queue JSON directly on JSON streams and convert it to
+  protobuf on proto streams, following protobuf JSON value rules for UC types
+  (`DATE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `BINARY`, `DECIMAL`, `VARIANT`, and
+  nested `STRUCT`/`ARRAY`/`MAP`).
+- Asynchronous, pipelined ingestion. `IngestRecordOffset` /
+  `IngestRecordsOffset` queue a record or batch and return the assigned offset
+  as a handle to wait on later; `Flush` waits once for all pending
+  acknowledgments, and `WaitForOffset` confirms a single offset for low-volume
+  callers that need per-record durability.
+- Context-aware variants of every blocking call — `IngestRecordOffsetContext`,
+  `IngestRecordsOffsetContext`, `IngestJSONOffsetContext`,
+  `IngestJSONRecordsOffsetContext`, `FlushContext`, and
+  `WaitForOffsetContext` — so cancellation can interrupt buffer backpressure.
+- Asynchronous acknowledgment notification via `WithAckCallback`, for continuous
+  streams that should not block in `Flush` or `WaitForOffset`.
+- Dynamic protobuf schemas from Unity Catalog. `FetchProtoDescriptorFromUC`
+  builds a descriptor from a UC table schema with no `protoc` step; fetch it
+  once and reuse the bytes for every stream on that table.
+  `Stream.MessageDescriptor`
+  exposes the compiled descriptor so callers can build `dynamicpb` messages and
+  skip JSON conversion entirely.
+- Stream creation is asynchronous by default: `CreateStream` returns after local
+  validation while first-open proceeds in the background. `WithWaitForReady`
+  makes it block until first-open succeeds or fails terminally.
+- Automatic recovery. Streams reconnect on recoverable failures (4 retries by
+  default) and can be made strict with `WithRecovery(RecoveryDisabled)`. After a
+  close or failure, `GetUnackedRecords` / `GetUnackedBatches` return the records
+  that were never acknowledged so they can be replayed.
+- Unity Catalog OAuth 2.0 client-credentials authentication, with the minted
+  token cached and shared across every stream on the SDK. For custom
+  authentication, implement `HeadersProvider` and use
+  `CreateStreamWithProvider`; `NewStaticHeadersProvider` supplies fixed headers
+  for tests or externally managed credentials.
+- Errors surface as `*Error`, carrying the failing operation, a wrapped cause
+  reachable through `errors.Is` / `errors.As`, and a retryability verdict that
+  the `Retryable(err)` helper reports.
+- Tunable buffering and timeouts through stream options:
+  `WithRecoveryRetries`, `WithRecoveryTimeout`, `WithRecoveryBackoff`,
+  `WithLackOfAckTimeout`, `WithMaxInflight`, `WithMaxBufferedPayloadBytes`,
+  `WithMaxBatchRecords`, `WithMaxPayloadBytes`, `WithStreamPausedMaxWait`, and
+  `WithFlushTimeout`.
+- SDK-level options for `WithApplicationName` (appended to the gRPC user-agent),
+  `WithTLSConfig`, `WithHTTPClient`, and `WithProtoDescriptorFetchTimeout`.
+- Stream introspection through `ID`, `ServerID`, and `IsClosed`.
+
+### Documentation
+
+- Added the SDK `README.md`, covering the quick start, the loop-then-`Flush`
+  ingestion pattern that keeps throughput off a per-record round trip, the
+  credential model, both record formats, dynamic proto with UC schema fetch, the
+  JSON value rules for UC types, error handling, recovery, the stream option
+  reference, and the release process.
+- Added package-level godoc for `zerobus` and doc comments across the public
+  API.
+- Added runnable examples under `examples/` for JSON (single and batch),
+  protobuf (single, batch, and a descriptor built at runtime), and Unity
+  Catalog-derived descriptors (JSON single, JSON batch, and runtime `dynamicpb`
+  messages), each reading its connection settings from the environment.
+
+### Internal Changes
+
+- Hermetic, network-free test suite covering the ingestion core (buffer,
+  watermark, ack model, supervisor), the gRPC transport and handshake, OAuth
+  token caching and credential invalidation, UC schema conversion, and dynamic
+  protobuf conversion. CI runs it under the race detector and again with cgo
+  disabled.
+- Added a build-only release validation workflow for the SDK and examples
+  modules.
+- Added a module-local Apache 2.0 license for Go module distribution.

--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -1,57 +1,17 @@
 # NEXT CHANGELOG
 
-## Release v0.1.0
+## Release v0.2.0
 
 ### New Features and Improvements
 
-- Added context-aware single-record and batch ingestion methods so cancellation
-  can interrupt buffer backpressure.
-- Exposed recovery timeout/backoff, lack-of-ack timeout, maximum batch records,
-  and server-pause wait controls as stream options.
-- Added opt-in wait-ready stream creation whose context bounds the complete
-  first-open process; asynchronous creation now preserves context values while
-  detaching caller cancellation.
-- Added `FetchProtoDescriptorFromUC` for building protobuf descriptors from
-  Unity Catalog table schemas. Each call issues a fresh Unity Catalog request:
-  fetch the descriptor once and reuse the returned bytes for every stream on
-  that table, and fetch again only when the table schema changes.
-- Added `Stream.IngestJSONOffset` and `Stream.IngestJSONRecordsOffset`. JSON
-  streams queue JSON directly; proto streams convert it before ingestion.
-
-### Deprecations
-
 ### Bug Fixes
-
-- Correctly normalize IPv6 Zerobus endpoints and reject plaintext HTTP
-  endpoints because the SDK always uses TLS.
-- Validate application names before adding them to the gRPC user-agent.
-- Return offset `-1` from failed ingest calls so callers can distinguish errors
-  from the first real offset.
-- Reuse compatible map entry descriptors when UC field names normalize to the
-  same protobuf name, and report incompatible collisions.
-- Report invalid Unity Catalog positions as schema errors.
-- Apply `MaxPayloadBytes` to encoded protobuf payloads instead of source JSON.
-- Reject unknown JSON fields instead of silently dropping them during dynamic
-  protobuf conversion.
-- Reject nullable collections and null collection values that protobuf cannot
-  represent without losing their semantics.
-- Classify Unity Catalog HTTP client timeouts and connection failures as
-  retryable while keeping TLS certificate failures terminal.
 
 ### Documentation
 
-- Clarified that callbacks may call stream methods, including `Close`.
-- Added an example that builds protobuf descriptors and messages directly in Go.
-- Finalized the README for the initial PureGo release.
-
 ### Internal Changes
 
-- Added UC schema and runtime dynamic-protobuf conversion helpers.
-- Added a build-only release validation workflow for the SDK and examples.
-- Added a module-local Apache 2.0 license for Go module distribution.
+### Breaking Changes
+
+### Deprecations
 
 ### API Changes
-
-- Protocol Buffers are now the default record type.
-- Added `Stream.MessageDescriptor` for constructing protobuf messages directly
-  from the configured schema.

--- a/purego/README.md
+++ b/purego/README.md
@@ -6,10 +6,6 @@ A native pure-Go Zerobus ingestion SDK.
 
 PureGo requires Go 1.25 or later.
 
-## Requirements
-
-PureGo requires Go 1.25 or later.
-
 ## Quick start
 
 ```go
@@ -230,6 +226,22 @@ Consumers can install a tagged module with:
 ```bash
 go get github.com/databricks/zerobus-sdk/purego@v0.1.0
 ```
+
+Cutting a release:
+
+- On the version-bump PR, move `NEXT_CHANGELOG.md` into `CHANGELOG.md` under a
+  `## Release v<semver>` heading — the release notes are extracted by matching
+  that exact heading — and reset `NEXT_CHANGELOG.md` for the next version.
+- Merge the bump PR, then tag its merge commit `purego/v<semver>`. The tag must
+  be reachable from `main`.
+- Dispatch the `zerobus-sdk-purego` workflow in
+  `secure-public-registry-releases-eng` with that tag, leaving `dry-run` on for a
+  rehearsal. It validates the tag and changelog heading, invokes
+  `release-purego.yml` here to build, vet, and test the module, scans the
+  `purego/` source, and creates the GitHub Release from `CHANGELOG.md`.
+- The Git tag is the version of record. Keep the `version` const in
+  `zerobus/sdk.go` (the gRPC user-agent) in sync with it; `release-purego.yml`
+  fails when a `purego/v*` tag disagrees.
 
 ## Regenerating the protobuf bindings
 

--- a/purego/README.md
+++ b/purego/README.md
@@ -234,11 +234,13 @@ Cutting a release:
   that exact heading — and reset `NEXT_CHANGELOG.md` for the next version.
 - Merge the bump PR, then tag its merge commit `purego/v<semver>`. The tag must
   be reachable from `main`.
-- Dispatch the `zerobus-sdk-purego` workflow in
-  `secure-public-registry-releases-eng` with that tag, leaving `dry-run` on for a
-  rehearsal. It validates the tag and changelog heading, invokes
-  `release-purego.yml` here to build, vet, and test the module, scans the
-  `purego/` source, and creates the GitHub Release from `CHANGELOG.md`.
+- Releases are driven from a separate secure release environment rather than
+  from this repository: a maintainer there dispatches the `zerobus-sdk-purego`
+  workflow with the tag, first with `dry-run` enabled as a rehearsal.
+- That workflow validates the tag and the `## Release v<semver>` changelog
+  heading, invokes `release-purego.yml` here to build, vet, and test the module,
+  and scans the `purego/` source. On a real (non-dry) run it then creates the
+  GitHub Release with notes taken from `CHANGELOG.md`.
 - The Git tag is the version of record. Keep the `version` const in
   `zerobus/sdk.go` (the gRPC user-agent) in sync with it; `release-purego.yml`
   fails when a `purego/v*` tag disagrees.

--- a/purego/zerobus/dynamic_proto_test.go
+++ b/purego/zerobus/dynamic_proto_test.go
@@ -85,23 +85,6 @@ func TestSDKFetchProtoDescriptorFromUC_RejectsClosedSDK(t *testing.T) {
 	}
 }
 
-// The deprecated alias must delegate, so it reports the same operation as the
-// method it forwards to.
-func TestSDKFetchProtoDescriptor_DelegatesToFromUC(t *testing.T) {
-	sdk := newSDK(nil, "https://zerobus", "https://uc", sdkConfig{})
-	sdk.mu.Lock()
-	sdk.closed = true
-	sdk.mu.Unlock()
-
-	_, err := sdk.FetchProtoDescriptor(
-		context.Background(), "main.sales.orders", "id", "secret",
-	)
-	var sdkErr *Error
-	if !errors.As(err, &sdkErr) || sdkErr.Op != "FetchProtoDescriptorFromUC" {
-		t.Fatalf("FetchProtoDescriptor() error = %v, want Op FetchProtoDescriptorFromUC", err)
-	}
-}
-
 func TestStreamEncodeJSONBatch(t *testing.T) {
 	desc := &descriptorpb.DescriptorProto{
 		Name: proto.String("Order"),

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -293,17 +293,6 @@ func (s *SDK) FetchProtoDescriptorFromUC(
 	return descBytes, nil
 }
 
-// FetchProtoDescriptor returns a protobuf descriptor built from a Unity Catalog
-// table schema.
-//
-// Deprecated: use FetchProtoDescriptorFromUC.
-func (s *SDK) FetchProtoDescriptor(
-	ctx context.Context,
-	tableName, clientID, clientSecret string,
-) ([]byte, error) {
-	return s.FetchProtoDescriptorFromUC(ctx, tableName, clientID, clientSecret)
-}
-
 func (s *SDK) createStream(
 	ctx context.Context,
 	op, tableName string,


### PR DESCRIPTION
## Summary

Prepares the first release of the pure-Go SDK. PureGo ships as source rather than a built artifact — the `purego/v0.1.0` tag *is* the release — so this PR only covers the changelog, docs, and release-workflow validation. Publishing is dispatched from a separate secure release environment, which invokes `release-purego.yml` here to build, vet, and test the module before scanning `purego/` and creating the GitHub Release.

- **Changelog** — promotes the `v0.1.0` notes into `CHANGELOG.md` and resets `NEXT_CHANGELOG.md` to a `v0.2.0` template matching the C++ SDK's layout. The notes are rewritten as a first-release description of what the SDK does, rather than a log of in-development diffs, so `Bug Fixes` and `API Changes` are dropped: nothing shipped before v0.1.0 to fix or change.
- **Version guard** — `release-purego.yml` now fails when a `purego/v*` tag disagrees with the `version` const in `purego/zerobus/sdk.go`. That const feeds the gRPC user-agent and nothing else keeps the two in sync, so a mismatch would otherwise ship a release reporting the wrong version. It compares only the `X.Y.Z` core, so prerelease tags still pass.
- **Drops the deprecated `SDK.FetchProtoDescriptor` alias** added in #699. Since v0.1.0 is the first release, the old name was never public, and shipping it would bake a day-one deprecation into the v0 API that semver then requires a major bump to remove.
- **Docs** — documents the release flow in `purego/README.md` and removes a duplicated `## Requirements` section.

## Test plan

- [x] Dispatched `release-purego.yml` against this branch as a pre-merge rehearsal — every step green ([run 31195155878](https://github.com/databricks/zerobus-sdk/actions/runs/31195155878))
- [x] `build`, `vet`, `gofmt`, `go test -race`, and `CGO_ENABLED=0 go test` clean for both the SDK and examples modules
- [x] `staticcheck ./...` clean, confirming the alias removal left no dead code
- [x] `go mod tidy` leaves no diff in either module, matching the workflow's `git diff --exit-code` steps
- [x] Version guard simulated with `GITHUB_REF_NAME=purego/v0.1.0` against `const version = "0.1.0"`: passes, and fails on a deliberate mismatch
- [x] Release-note extraction finds `## Release v0.1.0` and pulls all three sections with no stray headings
- [ ] Dry run against the tag before publishing