### PR TITLE
Fix release-ffi

### DIFF
--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -116,6 +116,12 @@ jobs:
         if: matrix.zigbuild
         run: cargo install cargo-zigbuild --locked --version 0.19.8
 
+      - name: Install mingw-w64 (windows-gnu dlltool)
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mingw-w64
+          
       - name: Build FFI library
         if: '!matrix.zigbuild'
         run: cargo build --release -p zerobus-ffi --target ${{ matrix.target }}


### PR DESCRIPTION
## What changes are proposed in this pull request?
`windows-gnu-x86_64` job was failing. That job cross-compiles `x86_64-pc-windows-gnu` from a Linux runner with cargo zigbuild. Zig covers the linker, but compiling windows-sys still shells out to MinGW’s dlltool, and the runner didn't have it installed.
Fix was to install MinGW on that matrix entry before the build.

## How is this tested?

Manually ran the release