### PR TITLE
[C#] Fix package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Zerobus is a high-throughput streaming service for direct data ingestion into Da
 | TypeScript | [`typescript/`](typescript/) | [`@databricks/zerobus-ingest-sdk`](https://www.npmjs.com/package/@databricks/zerobus-ingest-sdk)               |
 | Java       | [`java/`](java/)             | [`com.databricks:zerobus-ingest-sdk`](https://central.sonatype.com/artifact/com.databricks/zerobus-ingest-sdk) |
 | C++        | [`cpp/`](cpp/)               | Source / CMake (`zerobus::zerobus`)                                                                            |
-| C#         | [`dotnet/`](dotnet/)         | [`Databricks.Zerobus`](https://www.nuget.org/packages/Databricks.Zerobus)                                      |
+| C#         | [`dotnet/`](dotnet/)         | [`Databricks.Zerobus.Ingest.Sdk`](https://www.nuget.org/packages/Databricks.Zerobus.Ingest.Sdk)                |
 
 ## Platform Support
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,4 +1,4 @@
-# Databricks.Zerobus — .NET SDK
+# Databricks.Zerobus.Ingest.Sdk — .NET SDK
 
 High-performance .NET SDK for streaming data ingestion into Databricks Delta tables using the Zerobus service. Built on the same Rust core as the Go SDK, exposed via P/Invoke (C FFI bindings).
 
@@ -43,7 +43,7 @@ stream.WaitForOffset(offset);
 ### NuGet (when published)
 
 ```bash
-dotnet add package Databricks.Zerobus
+dotnet add package Databricks.Zerobus.Ingest.Sdk
 ```
 
 ### From Source
@@ -439,7 +439,7 @@ dotnet/
 ## Architecture
 
 ```
-.NET SDK (Databricks.Zerobus)
+.NET SDK (Databricks.Zerobus.Ingest.Sdk)
     ↓ P/Invoke
 Rust FFI (zerobus-ffi / libzerobus_ffi)
     ↓

--- a/dotnet/src/Zerobus/Zerobus.csproj
+++ b/dotnet/src/Zerobus/Zerobus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Databricks.Zerobus</RootNamespace>
     <AssemblyName>Databricks.Zerobus</AssemblyName>
-    <PackageId>Databricks.Zerobus</PackageId>
+    <PackageId>Databricks.Zerobus.Ingest.Sdk</PackageId>
     <Version>0.1.0</Version>
     <Authors>Databricks</Authors>
     <Company>Databricks</Company>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Change package name from `Databricks.Zerobus` to `Databricks.Zerobus.Ingest.Sdk`
## How is this tested?