### PR TITLE
[Python] Fix wait_for_offset regression; release 1.6.1

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Version changelog
 
+## Release v1.6.1
+
+### Bug Fixes
+
+- Fix `ZerobusStream.wait_for_offset(offset)` raising `TypeError: missing 1 required positional argument: 'timeout_sec'` on the synchronous record stream (issue #726). The PyO3 0.20 → 0.29 upgrade dropped the implicit `None` default for `Option<T>` arguments, which silently made `timeout_sec` required. Restored the default via `#[pyo3(signature = ...)]`. The same fix restores optional arguments on `RecordAcknowledgment.wait_for_ack`, `ZerobusSdk.create_stream`, and `ZerobusSdk.create_stream_with_headers_provider`.
+
+### Documentation
+
+- Document `stream_paused_max_wait_time_ms` on `ArrowStreamConfigurationOptions` in the Arrow type stub so it matches the already-supported runtime option.
+
 ## Release v1.6.0
 
 ### New Features and Improvements

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Documentation
 
-- Document `stream_paused_max_wait_time_ms` on `ArrowStreamConfigurationOptions` in the Arrow type stub so it matches the already-supported runtime option.
-
 ### Internal Changes
 
 ### Breaking Changes

--- a/python/rust/Cargo.lock
+++ b/python/rust/Cargo.lock
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "zerobus-python"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/python/rust/Cargo.toml
+++ b/python/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerobus-python"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 rust-version = "1.88"
 

--- a/python/rust/src/sync_wrapper.rs
+++ b/python/rust/src/sync_wrapper.rs
@@ -50,6 +50,7 @@ pub struct RecordAcknowledgment {
 impl RecordAcknowledgment {
     /// Wait for the acknowledgment and return the offset ID.
     /// This method can only be called once.
+    #[pyo3(signature = (_timeout_sec = None))]
     pub fn wait_for_ack(&mut self, py: Python, _timeout_sec: Option<f64>) -> PyResult<i64> {
         if self.done {
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
@@ -192,6 +193,7 @@ impl ZerobusStream {
     }
 
     /// Wait for a specific offset to be acknowledged
+    #[pyo3(signature = (offset, timeout_sec = None))]
     fn wait_for_offset(&self, py: Python, offset: i64, timeout_sec: Option<f64>) -> PyResult<()> {
         let _ = timeout_sec; // Timeout is handled internally by the Rust SDK
         let stream = self.inner.clone();
@@ -338,6 +340,7 @@ impl ZerobusSdk {
     }
 
     /// Create a new stream with OAuth authentication
+    #[pyo3(signature = (client_id, client_secret, table_properties, options = None))]
     fn create_stream(
         &self,
         py: Python,
@@ -369,6 +372,7 @@ impl ZerobusSdk {
     }
 
     /// Create a new stream with custom headers provider
+    #[pyo3(signature = (table_properties, headers_provider, options = None))]
     fn create_stream_with_headers_provider(
         &self,
         py: Python,

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -19,8 +19,7 @@ class TestNativeBindingSignatures(unittest.TestCase):
         self.assertIs(
             params[param_name].default,
             None,
-            f"{fn.__qualname__} parameter '{param_name}' must default to None, "
-            f"got {params[param_name].default!r}",
+            f"{fn.__qualname__} parameter '{param_name}' must default to None, " f"got {params[param_name].default!r}",
         )
 
     def test_sync_wait_for_offset_timeout_optional(self):
@@ -35,25 +34,19 @@ class TestNativeBindingSignatures(unittest.TestCase):
             self.fail(f"wait_for_offset(offset) is not bindable: {exc}")
 
     def test_sync_wait_for_ack_timeout_optional(self):
-        self._assert_optional(
-            core.sync.RecordAcknowledgment.wait_for_ack, "_timeout_sec"
-        )
+        self._assert_optional(core.sync.RecordAcknowledgment.wait_for_ack, "_timeout_sec")
 
     def test_sync_create_stream_options_optional(self):
         self._assert_optional(core.sync.ZerobusSdk.create_stream, "options")
 
     def test_sync_create_stream_with_headers_provider_options_optional(self):
-        self._assert_optional(
-            core.sync.ZerobusSdk.create_stream_with_headers_provider, "options"
-        )
+        self._assert_optional(core.sync.ZerobusSdk.create_stream_with_headers_provider, "options")
 
     def test_async_create_stream_options_optional(self):
         self._assert_optional(core.aio.ZerobusSdk.create_stream, "options")
 
     def test_async_create_stream_with_headers_provider_options_optional(self):
-        self._assert_optional(
-            core.aio.ZerobusSdk.create_stream_with_headers_provider, "options"
-        )
+        self._assert_optional(core.aio.ZerobusSdk.create_stream_with_headers_provider, "options")
 
     def test_async_wait_for_offset_accepts_offset_only(self):
         sig = inspect.signature(core.aio.ZerobusStream.wait_for_offset)

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -1,0 +1,67 @@
+"""Regression tests for native binding signatures (issue #726).
+
+Optional arguments must keep their ``None`` default. PyO3 0.23+ dropped the
+implicit default for ``Option<T>`` arguments, so it only survives with an
+explicit ``#[pyo3(signature = ...)]`` attribute. These tests need only the
+built extension (no network, no credentials).
+"""
+
+import inspect
+import unittest
+
+from zerobus import _zerobus_core as core
+
+
+class TestNativeBindingSignatures(unittest.TestCase):
+    def _assert_optional(self, fn, param_name):
+        params = inspect.signature(fn).parameters
+        self.assertIn(param_name, params)
+        self.assertIs(
+            params[param_name].default,
+            None,
+            f"{fn.__qualname__} parameter '{param_name}' must default to None, "
+            f"got {params[param_name].default!r}",
+        )
+
+    def test_sync_wait_for_offset_timeout_optional(self):
+        self._assert_optional(core.sync.ZerobusStream.wait_for_offset, "timeout_sec")
+
+    def test_sync_wait_for_offset_accepts_offset_only(self):
+        # The public wrapper calls self._inner.wait_for_offset(offset).
+        sig = inspect.signature(core.sync.ZerobusStream.wait_for_offset)
+        try:
+            sig.bind(object(), 0)
+        except TypeError as exc:
+            self.fail(f"wait_for_offset(offset) is not bindable: {exc}")
+
+    def test_sync_wait_for_ack_timeout_optional(self):
+        self._assert_optional(
+            core.sync.RecordAcknowledgment.wait_for_ack, "_timeout_sec"
+        )
+
+    def test_sync_create_stream_options_optional(self):
+        self._assert_optional(core.sync.ZerobusSdk.create_stream, "options")
+
+    def test_sync_create_stream_with_headers_provider_options_optional(self):
+        self._assert_optional(
+            core.sync.ZerobusSdk.create_stream_with_headers_provider, "options"
+        )
+
+    def test_async_create_stream_options_optional(self):
+        self._assert_optional(core.aio.ZerobusSdk.create_stream, "options")
+
+    def test_async_create_stream_with_headers_provider_options_optional(self):
+        self._assert_optional(
+            core.aio.ZerobusSdk.create_stream_with_headers_provider, "options"
+        )
+
+    def test_async_wait_for_offset_accepts_offset_only(self):
+        sig = inspect.signature(core.aio.ZerobusStream.wait_for_offset)
+        try:
+            sig.bind(object(), 0)
+        except TypeError as exc:
+            self.fail(f"async wait_for_offset(offset) is not bindable: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/zerobus/__init__.py
+++ b/python/zerobus/__init__.py
@@ -49,7 +49,7 @@ import zerobus._zerobus_core as _core
 from zerobus.sdk.shared.arrow import ArrowStreamConfigurationOptions, IPCCompression
 from zerobus.sdk.sync import ZerobusArrowStream, ZerobusSdk, ZerobusStream
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 # Re-export common types
 TableProperties = _core.TableProperties


### PR DESCRIPTION
## Summary

Fixes #726 — `ZerobusStream.wait_for_offset(offset)` raised `TypeError: missing 1 required positional argument: 'timeout_sec'` on **every** call through the public sync API on 1.5.0 and 1.6.0.

### Root cause
The PyO3 `0.20 → 0.29` upgrade (#652) dropped the rule where an `Option<T>` argument implicitly defaults to `None`. Without an explicit `#[pyo3(signature = ...)]`, `timeout_sec` silently became a **required** argument in the generated Python signature — with no change to any source line:

| Version | PyO3 | Binding signature |
| --- | --- | --- |
| 1.4.0 | 0.20.3 | `(offset, timeout_sec=None)` |
| 1.5.0 / 1.6.0 | 0.29.0 | `(offset, timeout_sec)` |

The SDK's own wrapper calls `self._inner.wait_for_offset(offset)`, so it could never satisfy the second signature.

### Fix
Restore the optional defaults with `#[pyo3(signature = ...)]` on the four affected **sync** bindings:
- `ZerobusStream.wait_for_offset` (the crash)
- `RecordAcknowledgment.wait_for_ack`
- `ZerobusSdk.create_stream`
- `ZerobusSdk.create_stream_with_headers_provider`

The async surface already carried the attribute and was unaffected. The Rust bodies are untouched (`wait_for_offset` already discards `timeout_sec`), so this is a pure signature restoration back to 1.4.0 behavior — additive, non-breaking.

### Why it shipped unnoticed
No example exercised the broken combination (sync **record** stream + explicit `wait_for_offset`). The JSON/proto examples use `flush()`; the Arrow examples call `wait_for_offset` on the Arrow stream, whose binding never had a `timeout_sec` argument. `tests/test_signatures.py` closes that coverage gap — 8 tests asserting the optional defaults survive, needing neither network nor credentials. Verified they fail on the unfixed binding and pass with the fix.

## Release v1.6.1
Patch on top of the current released line (1.6.0). Bumped the version in `rust/Cargo.toml`, `Cargo.lock`, and `zerobus/__init__.py`; moved `NEXT_CHANGELOG.md` into `CHANGELOG.md` and reset the template.

> Note on versioning: 1.6.1 (not 1.5.1) because this branch is on the already-released 1.6.0 codebase; a 1.5.1 would sort below 1.6.0 and `pip` would never hand it to users on the latest release. A 1.5.x backport, if wanted, is a separate branch off the `python/v1.5.0` tag.

## Test plan
- `python -m unittest tests.test_signatures tests.test_smoke` → 30 passing.
- Negative control: reverted the binding fix, rebuilt → the 5 sync signature tests fail with the exact reported `TypeError`; the 3 async tests stay green.

This pull request and its description were written by Isaac.