### PR TITLE
[Java] Preserve unacked data on close

### DIFF
--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -13,6 +13,10 @@
 - Arrow builders now reject unsupported ACK callbacks instead of silently
   discarding them. Configuring `ackCallback` before calling `ArrowStreamBuilder.build()`
   throws `IllegalStateException`.
+- Fixed proto, JSON, and Arrow stream recovery losing unacknowledged data during `close()`. Closed
+  native streams now remain available until Java has cached their recovery records or batches, and
+  recreation releases retained source streams after copying their recovery data. Failed recreation
+  attempts also release their temporary native streams.
 
 ### Documentation
 

--- a/java/src/main/java/com/databricks/zerobus/BaseZerobusStream.java
+++ b/java/src/main/java/com/databricks/zerobus/BaseZerobusStream.java
@@ -117,23 +117,42 @@ abstract class BaseZerobusStream implements AutoCloseable {
   public void close() throws ZerobusException {
     long handle = nativeHandle;
     if (handle != 0) {
-      // Close the stream first (flushes pending records)
-      nativeClose(handle);
-
-      // Cache unacked records before destroying the handle (for recreateStream)
+      ZerobusException closeFailure = null;
       try {
-        cachedUnackedRecords = nativeGetUnackedRecords(handle);
-        cachedUnackedBatches = nativeGetUnackedBatches(handle);
-      } catch (Exception e) {
-        logger.warn("Failed to cache unacked records: {}", e.getMessage());
-        cachedUnackedRecords = new ArrayList<>();
-        cachedUnackedBatches = new ArrayList<>();
+        // Close the stream first (flushes pending records).
+        nativeClose(handle);
+      } catch (ZerobusException e) {
+        // Closing marks the Rust stream closed even when flushing fails. Keep going so its
+        // unacknowledged records can be recovered before the native handle is destroyed.
+        closeFailure = e;
       }
 
-      // Now destroy the handle
+      // Cache unacked records before destroying the handle (for recreateStream)
+      List<byte[]> unackedRecords;
+      List<EncodedBatch> unackedBatches;
+      try {
+        unackedRecords = nativeGetUnackedRecords(handle);
+        unackedBatches = nativeGetUnackedBatches(handle);
+      } catch (ZerobusException cacheFailure) {
+        // Retain the native handle so callers can retry recovery instead of reporting an empty
+        // result and silently losing data.
+        if (closeFailure != null) {
+          closeFailure.addSuppressed(cacheFailure);
+          throw closeFailure;
+        }
+        throw cacheFailure;
+      }
+      cachedUnackedRecords = unackedRecords;
+      cachedUnackedBatches = unackedBatches;
+
+      // Recovery data is safely owned by Java; the native stream can now be destroyed.
       nativeHandle = 0;
       nativeDestroy(handle);
       logger.info("Stream closed");
+
+      if (closeFailure != null) {
+        throw closeFailure;
+      }
     }
   }
 
@@ -159,6 +178,46 @@ abstract class BaseZerobusStream implements AutoCloseable {
    */
   protected List<EncodedBatch> getCachedUnackedBatches() {
     return cachedUnackedBatches != null ? cachedUnackedBatches : new ArrayList<>();
+  }
+
+  /**
+   * Ensures recovery batches are owned by Java and releases any retained native source stream.
+   *
+   * <p>A failed {@link #close()} can leave the closed Rust stream alive when its recovery data
+   * could not be copied. Recreation calls this method to retry that copy before creating a
+   * replacement stream.
+   */
+  final List<EncodedBatch> cacheAndReleaseUnackedBatches() throws ZerobusException {
+    long handle = nativeHandle;
+    if (handle == 0) {
+      return getCachedUnackedBatches();
+    }
+
+    List<EncodedBatch> batches = nativeGetUnackedBatches(handle);
+    List<byte[]> records = new ArrayList<>();
+    for (EncodedBatch batch : batches) {
+      records.addAll(batch.getRecords());
+    }
+    cachedUnackedBatches = batches;
+    cachedUnackedRecords = records;
+    nativeHandle = 0;
+    nativeDestroy(handle);
+    return batches;
+  }
+
+  /** Returns Java-owned recovery records, releasing any retained native source stream. */
+  final List<byte[]> cacheAndReleaseUnackedRecords() throws ZerobusException {
+    cacheAndReleaseUnackedBatches();
+    return getCachedUnackedRecords();
+  }
+
+  /** Destroys a replacement stream whose recovery replay failed, without flushing it again. */
+  final void discardFailedRecreation() {
+    long handle = nativeHandle;
+    if (handle != 0) {
+      nativeHandle = 0;
+      nativeDestroy(handle);
+    }
   }
 
   /**
@@ -218,11 +277,11 @@ abstract class BaseZerobusStream implements AutoCloseable {
 
   private native void nativeFlush(long handle);
 
-  private native void nativeClose(long handle);
+  private native void nativeClose(long handle) throws ZerobusException;
 
   private native boolean nativeIsClosed(long handle);
 
-  protected native List<byte[]> nativeGetUnackedRecords(long handle);
+  protected native List<byte[]> nativeGetUnackedRecords(long handle) throws ZerobusException;
 
-  protected native List<EncodedBatch> nativeGetUnackedBatches(long handle);
+  protected native List<EncodedBatch> nativeGetUnackedBatches(long handle) throws ZerobusException;
 }

--- a/java/src/main/java/com/databricks/zerobus/ZerobusArrowStream.java
+++ b/java/src/main/java/com/databricks/zerobus/ZerobusArrowStream.java
@@ -184,21 +184,38 @@ public class ZerobusArrowStream implements AutoCloseable {
   public void close() throws ZerobusException {
     long handle = nativeHandle;
     if (handle != 0) {
-      // Close the stream first (flushes pending batches)
-      nativeClose(handle);
-
-      // Cache unacked batches before destroying the handle (for recreateArrowStream)
+      ZerobusException closeFailure = null;
       try {
-        cachedUnackedBatches = nativeGetUnackedBatches(handle);
-      } catch (Exception e) {
-        logger.warn("Failed to cache unacked batches: {}", e.getMessage());
-        cachedUnackedBatches = new ArrayList<>();
+        // Close the stream first (flushes pending batches).
+        nativeClose(handle);
+      } catch (ZerobusException e) {
+        // Preserve any unacknowledged batches even when close reports a flush failure.
+        closeFailure = e;
       }
 
-      // Now destroy the handle
+      // Cache unacked batches before destroying the handle (for recreateArrowStream)
+      List<byte[]> unackedBatches;
+      try {
+        unackedBatches = nativeGetUnackedBatches(handle);
+      } catch (ZerobusException cacheFailure) {
+        // Retain the native handle so callers can retry recovery instead of reporting an empty
+        // result and silently losing data.
+        if (closeFailure != null) {
+          closeFailure.addSuppressed(cacheFailure);
+          throw closeFailure;
+        }
+        throw cacheFailure;
+      }
+      cachedUnackedBatches = unackedBatches;
+
+      // Recovery data is safely owned by Java; the native stream can now be destroyed.
       nativeHandle = 0;
       nativeDestroy(handle);
       logger.info("Arrow stream closed");
+
+      if (closeFailure != null) {
+        throw closeFailure;
+      }
     }
   }
 
@@ -273,6 +290,29 @@ public class ZerobusArrowStream implements AutoCloseable {
     return headersProvider;
   }
 
+  /** Ensures recovery batches are owned by Java and releases any retained native source stream. */
+  List<byte[]> cacheAndReleaseUnackedBatches() throws ZerobusException {
+    long handle = nativeHandle;
+    if (handle == 0) {
+      return cachedUnackedBatches != null ? cachedUnackedBatches : new ArrayList<>();
+    }
+
+    List<byte[]> batches = nativeGetUnackedBatches(handle);
+    cachedUnackedBatches = batches;
+    nativeHandle = 0;
+    nativeDestroy(handle);
+    return batches;
+  }
+
+  /** Destroys a replacement stream whose recovery replay failed, without flushing it again. */
+  void discardFailedRecreation() {
+    long handle = nativeHandle;
+    if (handle != 0) {
+      nativeHandle = 0;
+      nativeDestroy(handle);
+    }
+  }
+
   /**
    * Ingests a pre-serialized Arrow IPC batch. Package-private for use by {@link
    * ZerobusSdk#recreateArrowStream} during re-ingestion of unacked batches.
@@ -340,12 +380,12 @@ public class ZerobusArrowStream implements AutoCloseable {
 
   private native void nativeFlush(long handle);
 
-  private native void nativeClose(long handle);
+  private native void nativeClose(long handle) throws ZerobusException;
 
   private native boolean nativeIsClosed(long handle);
 
   private native String nativeGetTableName(long handle);
 
   @SuppressWarnings("unchecked")
-  private native List<byte[]> nativeGetUnackedBatches(long handle);
+  private native List<byte[]> nativeGetUnackedBatches(long handle) throws ZerobusException;
 }

--- a/java/src/main/java/com/databricks/zerobus/ZerobusSdk.java
+++ b/java/src/main/java/com/databricks/zerobus/ZerobusSdk.java
@@ -1,6 +1,8 @@
 package com.databricks.zerobus;
 
 import com.google.protobuf.Message;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -554,7 +556,7 @@ public class ZerobusSdk implements AutoCloseable {
     // Get unacked batches from the closed stream
     List<EncodedBatch> unackedBatches;
     try {
-      unackedBatches = closedStream.getUnackedBatches();
+      unackedBatches = closedStream.cacheAndReleaseUnackedBatches();
     } catch (ZerobusException e) {
       CompletableFuture<ZerobusProtoStream> failed = new CompletableFuture<>();
       failed.completeExceptionally(e);
@@ -589,13 +591,19 @@ public class ZerobusSdk implements AutoCloseable {
                   closedStream.getHeadersProvider());
 
           // Re-ingest unacked records
+          boolean replaySucceeded = false;
           try {
             for (EncodedBatch batch : unackedBatches) {
               newStream.ingestRecordsOffset(batch.getRecords());
             }
             newStream.flush();
+            replaySucceeded = true;
           } catch (ZerobusException e) {
             throw new RuntimeException("Failed to re-ingest unacked records", e);
+          } finally {
+            if (!replaySucceeded) {
+              newStream.discardFailedRecreation();
+            }
           }
 
           return newStream;
@@ -625,7 +633,11 @@ public class ZerobusSdk implements AutoCloseable {
     // Get unacked records from the closed stream
     List<String> unackedRecords;
     try {
-      unackedRecords = closedStream.getUnackedRecords();
+      List<byte[]> encodedRecords = closedStream.cacheAndReleaseUnackedRecords();
+      unackedRecords = new ArrayList<>(encodedRecords.size());
+      for (byte[] record : encodedRecords) {
+        unackedRecords.add(new String(record, StandardCharsets.UTF_8));
+      }
     } catch (ZerobusException e) {
       CompletableFuture<ZerobusJsonStream> failed = new CompletableFuture<>();
       failed.completeExceptionally(e);
@@ -659,13 +671,19 @@ public class ZerobusSdk implements AutoCloseable {
                   closedStream.getHeadersProvider());
 
           // Re-ingest unacked records
+          boolean replaySucceeded = false;
           try {
             for (String json : unackedRecords) {
               newStream.ingestRecordOffset(json);
             }
             newStream.flush();
+            replaySucceeded = true;
           } catch (ZerobusException e) {
             throw new RuntimeException("Failed to re-ingest unacked records", e);
+          } finally {
+            if (!replaySucceeded) {
+              newStream.discardFailedRecreation();
+            }
           }
 
           return newStream;
@@ -690,7 +708,7 @@ public class ZerobusSdk implements AutoCloseable {
 
     List<byte[]> unackedBatches;
     try {
-      unackedBatches = closedStream.getUnackedBatches();
+      unackedBatches = closedStream.cacheAndReleaseUnackedBatches();
     } catch (ZerobusException e) {
       CompletableFuture<ZerobusArrowStream> failed = new CompletableFuture<>();
       failed.completeExceptionally(e);
@@ -722,13 +740,19 @@ public class ZerobusSdk implements AutoCloseable {
                   closedStream.getClientSecret(),
                   closedStream.getHeadersProvider());
 
+          boolean replaySucceeded = false;
           try {
             for (byte[] batchIpc : unackedBatches) {
               newStream.ingestBatchIpc(batchIpc);
             }
             newStream.flush();
+            replaySucceeded = true;
           } catch (ZerobusException e) {
             throw new RuntimeException("Failed to re-ingest unacked Arrow batches", e);
+          } finally {
+            if (!replaySucceeded) {
+              newStream.discardFailedRecreation();
+            }
           }
 
           return newStream;
@@ -792,13 +816,19 @@ public class ZerobusSdk implements AutoCloseable {
                   closedStream.getClientSecret());
 
           // Re-ingest unacked records as raw bytes
+          boolean replaySucceeded = false;
           try {
             for (byte[] record : unackedRecords) {
               newStream.nativeIngestRecordOffset(newStream.nativeHandle, record, false);
             }
             newStream.flush();
+            replaySucceeded = true;
           } catch (ZerobusException e) {
             throw new RuntimeException("Failed to re-ingest unacked records", e);
+          } finally {
+            if (!replaySucceeded) {
+              newStream.discardFailedRecreation();
+            }
           }
 
           return newStream;

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4069,15 +4069,22 @@ name = "zerobus-jni"
 version = "1.3.0"
 dependencies = [
  "arrow-array",
+ "arrow-flight",
  "arrow-ipc",
  "arrow-schema",
  "async-trait",
  "databricks-zerobus-ingest-sdk",
+ "futures",
  "jni",
  "prost",
  "prost-types",
+ "rcgen",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
 ]
 

--- a/rust/jni/Cargo.toml
+++ b/rust/jni/Cargo.toml
@@ -31,3 +31,14 @@ arrow-ipc = { workspace = true, features = ["lz4", "zstd"] }
 [features]
 default = []
 test-helpers = []
+
+[dev-dependencies]
+arrow-flight.workspace = true
+databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["arrow-flight", "testing"] }
+futures.workspace = true
+rcgen = "0.13"
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["net"] }
+tonic = { workspace = true, features = ["transport"] }

--- a/rust/jni/src/arrow_stream.rs
+++ b/rust/jni/src/arrow_stream.rs
@@ -48,6 +48,16 @@ impl NativeArrowStreamHandle {
     }
 }
 
+async fn close_native_stream(
+    stream_handle: &NativeArrowStreamHandle,
+) -> databricks_zerobus_ingest_sdk::ZerobusResult<()> {
+    let mut guard = stream_handle.stream.lock().await;
+    if let Some(stream) = guard.as_mut() {
+        stream.close().await?;
+    }
+    Ok(())
+}
+
 /// Destroy an Arrow stream handle.
 ///
 /// # JNI Signature
@@ -228,13 +238,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusArrowStream_nativeClos
     let stream_handle = unsafe { NativeArrowStreamHandle::borrow_from_raw(handle) };
 
     // Block on the async operation
-    let result = block_on(async {
-        let mut guard = stream_handle.stream.lock().await;
-        if let Some(mut stream) = guard.take() {
-            stream.close().await?;
-        }
-        Ok::<_, databricks_zerobus_ingest_sdk::ZerobusError>(())
-    });
+    let result = block_on(close_native_stream(stream_handle));
 
     if let Err(e) = result {
         throw_from_zerobus_error(&mut env, &e);
@@ -411,3 +415,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusArrowStream_nativeGetU
 
     list
 }
+
+#[cfg(test)]
+#[path = "arrow_stream/tests.rs"]
+mod tests;

--- a/rust/jni/src/arrow_stream/tests.rs
+++ b/rust/jni/src/arrow_stream/tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+use arrow_array::{Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use databricks_zerobus_ingest_sdk::{NoTlsConfig, ZerobusSdk};
+
+#[allow(dead_code, clippy::single_component_path_imports)]
+#[path = "../../../tests/src/mock_arrow_flight.rs"]
+mod mock_arrow_flight;
+
+use mock_arrow_flight::{start_mock_flight_server, MockFlightResponse};
+
+#[tokio::test]
+async fn close_keeps_unacked_batches_available_for_java_recovery(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
+
+    let (mock_server, server_url) = start_mock_flight_server().await?;
+    mock_server
+        .inject_responses(
+            TABLE_NAME,
+            vec![MockFlightResponse::Error {
+                status: tonic::Status::invalid_argument("permanent failure"),
+                delay_ms: 0,
+            }],
+        )
+        .await;
+
+    let sdk = ZerobusSdk::builder()
+        .endpoint(server_url)
+        .unity_catalog_url("https://mock-uc.com")
+        .tls_config(Arc::new(NoTlsConfig))
+        .build()?;
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("message", DataType::Utf8, true),
+    ]));
+    let stream = sdk
+        .stream_builder()
+        .table(TABLE_NAME)
+        .no_auth()
+        .arrow(Arc::clone(&schema))
+        .recovery(false)
+        .build_arrow()
+        .await?;
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1])),
+            Arc::new(StringArray::from(vec![Some("unacked")])),
+        ],
+    )?;
+
+    let offset = stream.ingest_batch(batch).await?;
+    assert!(stream.wait_for_offset(offset).await.is_err());
+
+    let handle = NativeArrowStreamHandle::new(stream, String::new(), String::new());
+    assert!(close_native_stream(&handle).await.is_err());
+
+    let guard = handle.stream.lock().await;
+    let closed_stream = guard
+        .as_ref()
+        .expect("native close must retain the Rust stream until Java retrieves unacked data");
+    let unacked = closed_stream.get_unacked_batches().await?;
+    assert_eq!(unacked.len(), 1);
+
+    Ok(())
+}

--- a/rust/jni/src/stream.rs
+++ b/rust/jni/src/stream.rs
@@ -50,6 +50,16 @@ impl NativeStreamHandle {
     }
 }
 
+async fn close_native_stream(
+    stream_handle: &NativeStreamHandle,
+) -> databricks_zerobus_ingest_sdk::ZerobusResult<()> {
+    let mut guard = stream_handle.stream.lock().await;
+    if let Some(stream) = guard.as_mut() {
+        stream.close().await?;
+    }
+    Ok(())
+}
+
 /// Destroy a stream handle.
 ///
 /// # JNI Signature
@@ -390,13 +400,7 @@ pub extern "system" fn Java_com_databricks_zerobus_BaseZerobusStream_nativeClose
     let stream_handle = unsafe { NativeStreamHandle::borrow_from_raw(handle) };
 
     // Block on the async operation
-    let result = block_on(async {
-        let mut guard = stream_handle.stream.lock().await;
-        if let Some(mut stream) = guard.take() {
-            stream.close().await?;
-        }
-        Ok::<_, databricks_zerobus_ingest_sdk::ZerobusError>(())
-    });
+    let result = block_on(close_native_stream(stream_handle));
 
     if let Err(e) = result {
         throw_from_zerobus_error(&mut env, &e);
@@ -510,6 +514,10 @@ pub extern "system" fn Java_com_databricks_zerobus_BaseZerobusStream_nativeGetUn
 
     list
 }
+
+#[cfg(test)]
+#[path = "stream/tests.rs"]
+mod tests;
 
 /// Get unacked batches as a list of EncodedBatch objects.
 ///

--- a/rust/jni/src/stream/tests.rs
+++ b/rust/jni/src/stream/tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use databricks_zerobus_ingest_sdk::{EncodedRecord, NoTlsConfig, ZerobusSdk};
+use prost_types::{field_descriptor_proto, DescriptorProto, FieldDescriptorProto};
+
+#[allow(dead_code)]
+#[path = "../../../tests/src/mock_grpc.rs"]
+mod mock_grpc;
+
+use mock_grpc::{start_mock_server, MockResponse};
+
+#[tokio::test]
+async fn close_keeps_unacked_proto_records_available_for_java_recovery(
+) -> Result<(), Box<dyn std::error::Error>> {
+    const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
+
+    let (mock_server, server_url) = start_mock_server().await?;
+    mock_server
+        .inject_responses(
+            TABLE_NAME,
+            vec![
+                MockResponse::CreateStream {
+                    stream_id: "proto-stream".to_string(),
+                    delay_ms: 0,
+                },
+                MockResponse::Error {
+                    status: tonic::Status::invalid_argument("permanent failure"),
+                    delay_ms: 50,
+                },
+            ],
+        )
+        .await;
+
+    let sdk = ZerobusSdk::builder()
+        .endpoint(server_url)
+        .unity_catalog_url("https://mock-uc.com")
+        .tls_config(Arc::new(NoTlsConfig))
+        .build()?;
+    let stream = sdk
+        .stream_builder()
+        .table(TABLE_NAME)
+        .no_auth()
+        .compiled_proto(DescriptorProto {
+            name: Some("TestMessage".to_string()),
+            field: vec![
+                FieldDescriptorProto {
+                    name: Some("id".to_string()),
+                    number: Some(1),
+                    r#type: Some(field_descriptor_proto::Type::Int64 as i32),
+                    ..Default::default()
+                },
+                FieldDescriptorProto {
+                    name: Some("message".to_string()),
+                    number: Some(2),
+                    r#type: Some(field_descriptor_proto::Type::String as i32),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        })
+        .recovery(false)
+        .build()
+        .await?;
+    let record = vec![
+        0x08, 0x01, 0x12, 0x07, b'u', b'n', b'a', b'c', b'k', b'e', b'd',
+    ];
+
+    stream.ingest_record_offset(record.clone()).await?;
+
+    let handle = NativeStreamHandle::new(stream, String::new(), String::new());
+    assert!(close_native_stream(&handle).await.is_err());
+
+    let guard = handle.stream.lock().await;
+    let closed_stream = guard
+        .as_ref()
+        .expect("native close must retain the Rust stream until Java retrieves unacked data");
+    let unacked: Vec<_> = closed_stream.get_unacked_records().await?.collect();
+    assert_eq!(unacked.len(), 1);
+    assert!(matches!(&unacked[0], EncodedRecord::Proto(payload) if payload == &record));
+
+    Ok(())
+}

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -3,11 +3,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub mod databricks {
-    pub mod zerobus {
-        tonic::include_proto!("databricks.zerobus");
-    }
-}
 use databricks::zerobus::{
     ephemeral_stream_request::Payload as RequestPayload,
     ephemeral_stream_response::Payload as ResponsePayload,
@@ -15,6 +10,7 @@ use databricks::zerobus::{
     CloseStreamSignal, CreateIngestStreamResponse, EphemeralStreamRequest, EphemeralStreamResponse,
     IngestRecordResponse,
 };
+use databricks_zerobus_ingest_sdk::databricks;
 use prost_types::Duration as ProtobufDuration;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use tokio::sync::{mpsc, Mutex, Notify, Semaphore};


### PR DESCRIPTION
## Summary
- retain closed Rust streams until Java caches unacknowledged recovery data
- propagate recovery failures instead of silently replacing recovery data with empty lists
- preserve recovery data even when stream close reports a flush failure

## Testing
Added a test, verified it fails before the changes and passes after