### PR TITLE
[Rust] Simplify Arrow lifecycle transitions

### DIFF
--- a/rust/sdk/src/stream/arrow/acks.rs
+++ b/rust/sdk/src/stream/arrow/acks.rs
@@ -69,6 +69,61 @@ struct CloseDrain {
     selected: Option<ZerobusResult<()>>,
 }
 
+impl CloseDrain {
+    fn new(request: CloseRequest, selected: Option<ZerobusResult<()>>) -> Self {
+        Self { request, selected }
+    }
+
+    fn selected(request: CloseRequest, outcome: ZerobusResult<()>) -> Self {
+        Self::new(request, Some(outcome))
+    }
+
+    fn empty_target(request: CloseRequest) -> Self {
+        Self::new(request, None)
+    }
+
+    fn flush_timeout(request: CloseRequest) -> Self {
+        Self::selected(request, Err(CloseCoordinator::flush_timeout_error()))
+    }
+
+    fn rotation_interrupted(request: CloseRequest) -> Self {
+        Self::selected(request, Err(AckProcessor::rotation_error()))
+    }
+}
+
+impl DrainState {
+    fn explicit_close(deadline: Instant, response_finished: bool, close: CloseDrain) -> Self {
+        Self {
+            deadline,
+            response_finished,
+            terminal_error: None,
+            close: Some(close),
+        }
+    }
+
+    fn rotation_drain(
+        deadline: Instant,
+        response_finished: bool,
+        terminal_error: Option<ZerobusError>,
+    ) -> Self {
+        Self {
+            deadline,
+            response_finished,
+            terminal_error,
+            close: None,
+        }
+    }
+
+    fn close_during_rotation(deadline: Instant, close: CloseDrain) -> Self {
+        Self {
+            deadline,
+            response_finished: false,
+            terminal_error: None,
+            close: Some(close),
+        }
+    }
+}
+
 pub(super) enum AckProcessOutcome {
     Stopped,
     Recovery {
@@ -94,6 +149,26 @@ enum ConnectionState {
     Active,
     Waiting(WaitState),
     Draining(DrainState),
+}
+
+/// Connection context for mapping a terminal event into transport drain.
+enum TerminalDrainTarget {
+    Active,
+    Rotation {
+        deadline: Instant,
+    },
+    Close {
+        request: CloseRequest,
+        deadline: Instant,
+    },
+}
+
+/// Terminal condition observed before transport drain begins.
+enum TerminalEvent {
+    RequestSendFailed,
+    AckApplyFailed,
+    ResponseError,
+    ResponseEof,
 }
 
 /// Deadlines for the ACK-wait and transport-drain phases of rotation.
@@ -421,6 +496,26 @@ impl AckProcessor {
         })
     }
 
+    fn acknowledged_close_outcome(&self) -> ZerobusResult<()> {
+        if self.close.target_reached_timely() {
+            Ok(())
+        } else {
+            Err(CloseCoordinator::flush_timeout_error())
+        }
+    }
+
+    fn drain_for_acknowledged_close(
+        request: CloseRequest,
+        outcome: ZerobusResult<()>,
+        deadline: Instant,
+    ) -> ConnectionState {
+        ConnectionState::Draining(DrainState::explicit_close(
+            deadline,
+            false,
+            CloseDrain::selected(request, outcome),
+        ))
+    }
+
     fn begin_close(
         &self,
         connection: &ConnectionState,
@@ -428,46 +523,64 @@ impl AckProcessor {
     ) -> ConnectionState {
         match connection {
             ConnectionState::Active if self.close_target_is_acknowledged(close_request) => {
-                let outcome = if self.close.target_reached_timely() {
-                    Ok(())
-                } else {
-                    Err(CloseCoordinator::flush_timeout_error())
-                };
-                ConnectionState::Draining(DrainState {
-                    deadline: Self::explicit_close_drain_deadline(),
-                    response_finished: false,
-                    terminal_error: None,
-                    close: Some(CloseDrain {
-                        request: close_request,
-                        selected: Some(outcome),
-                    }),
-                })
+                let outcome = self.acknowledged_close_outcome();
+                let deadline = Self::explicit_close_drain_deadline();
+                Self::drain_for_acknowledged_close(close_request, outcome, deadline)
             }
             ConnectionState::Active if close_request.target_offset.is_none() => {
-                ConnectionState::Draining(DrainState {
-                    deadline: Self::explicit_close_drain_deadline(),
-                    response_finished: false,
-                    terminal_error: None,
-                    close: Some(CloseDrain {
-                        request: close_request,
-                        selected: None,
-                    }),
-                })
+                let deadline = Self::explicit_close_drain_deadline();
+                ConnectionState::Draining(DrainState::explicit_close(
+                    deadline,
+                    false,
+                    CloseDrain::empty_target(close_request),
+                ))
             }
             ConnectionState::Active => ConnectionState::Waiting(WaitState::Close(close_request)),
             ConnectionState::Waiting(WaitState::Rotation { deadlines, .. }) => {
-                ConnectionState::Draining(DrainState {
-                    deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
-                    response_finished: false,
-                    terminal_error: None,
-                    close: Some(CloseDrain {
-                        request: close_request,
-                        selected: Some(Err(Self::rotation_error())),
-                    }),
-                })
+                let deadline = Self::bounded_rotation_drain_deadline(deadlines.drain);
+                ConnectionState::Draining(DrainState::close_during_rotation(
+                    deadline,
+                    CloseDrain::rotation_interrupted(close_request),
+                ))
             }
             ConnectionState::Waiting(WaitState::Close(_)) | ConnectionState::Draining(_) => {
                 unreachable!()
+            }
+        }
+    }
+
+    fn drain_from_waiting(
+        target: TerminalDrainTarget,
+        event: TerminalEvent,
+        error: ZerobusError,
+    ) -> ZerobusResult<ConnectionState> {
+        match target {
+            TerminalDrainTarget::Active => Err(error),
+            TerminalDrainTarget::Rotation { deadline } => {
+                let (response_finished, terminal_error) = match event {
+                    TerminalEvent::RequestSendFailed | TerminalEvent::AckApplyFailed => {
+                        (false, Some(error))
+                    }
+                    TerminalEvent::ResponseError => (true, Some(error)),
+                    // Rotation already has its trigger; EOF only marks the response complete.
+                    TerminalEvent::ResponseEof => (true, None),
+                };
+                Ok(ConnectionState::Draining(DrainState::rotation_drain(
+                    deadline,
+                    response_finished,
+                    terminal_error,
+                )))
+            }
+            TerminalDrainTarget::Close { request, deadline } => {
+                let response_finished = matches!(
+                    event,
+                    TerminalEvent::ResponseError | TerminalEvent::ResponseEof
+                );
+                Ok(ConnectionState::Draining(DrainState::explicit_close(
+                    deadline,
+                    response_finished,
+                    CloseDrain::selected(request, Err(error)),
+                )))
             }
         }
     }
@@ -520,10 +633,7 @@ impl AckProcessor {
             // A continuously ready response must not starve close publication.
             if observe_close {
                 if let Some(close_request) = self.close.request() {
-                    close = Some(CloseDrain {
-                        request: close_request,
-                        selected: Some(Err(Self::rotation_error())),
-                    });
+                    close = Some(CloseDrain::rotation_interrupted(close_request));
                     observe_close = false;
                 }
             }
@@ -571,10 +681,7 @@ impl AckProcessor {
                 published = self.close.wait_for_request(close_rx), if observe_close => {
                     match published {
                         Some(request) => {
-                            close = Some(CloseDrain {
-                                request,
-                                selected: Some(Err(Self::rotation_error())),
-                            });
+                            close = Some(CloseDrain::rotation_interrupted(request));
                             observe_close = false;
                         }
                         None => return Ok(AckProcessOutcome::Stopped),
@@ -744,12 +851,11 @@ impl AckProcessor {
             self.ack_progress(),
             close_rx,
             false,
-            DrainState {
-                deadline: Self::explicit_close_drain_deadline(),
-                response_finished: false,
-                terminal_error: None,
-                close: Some(CloseDrain { request, selected }),
-            },
+            DrainState::explicit_close(
+                Self::explicit_close_drain_deadline(),
+                false,
+                CloseDrain::new(request, selected),
+            ),
         )
         .await
     }
@@ -835,15 +941,12 @@ impl AckProcessor {
 
             if let ConnectionState::Waiting(WaitState::Close(close_request)) = &connection {
                 if Instant::now() >= close_request.deadline {
-                    connection = ConnectionState::Draining(DrainState {
-                        deadline: Self::explicit_close_drain_deadline(),
-                        response_finished: false,
-                        terminal_error: None,
-                        close: Some(CloseDrain {
-                            request: *close_request,
-                            selected: Some(Err(CloseCoordinator::flush_timeout_error())),
-                        }),
-                    });
+                    let deadline = Self::explicit_close_drain_deadline();
+                    connection = ConnectionState::Draining(DrainState::explicit_close(
+                        deadline,
+                        false,
+                        CloseDrain::flush_timeout(*close_request),
+                    ));
                     continue;
                 }
             }
@@ -856,12 +959,10 @@ impl AckProcessor {
                 if self.last_acked_records.load(Ordering::Acquire) >= *target_records
                     || Instant::now() >= deadlines.ack
                 {
-                    connection = ConnectionState::Draining(DrainState {
-                        deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
-                        response_finished: false,
-                        terminal_error: None,
-                        close: None,
-                    });
+                    let deadline = Self::bounded_rotation_drain_deadline(deadlines.drain);
+                    connection = ConnectionState::Draining(DrainState::rotation_drain(
+                        deadline, false, None,
+                    ));
                     continue;
                 }
             }
@@ -955,44 +1056,35 @@ impl AckProcessor {
                 AckEvent::CloseDeadline => {
                     let close_request =
                         close_wait.expect("close deadline requires a close request");
-                    connection = ConnectionState::Draining(DrainState {
-                        deadline: Self::explicit_close_drain_deadline(),
-                        response_finished: false,
-                        terminal_error: None,
-                        close: Some(CloseDrain {
-                            request: close_request,
-                            selected: Some(Err(CloseCoordinator::flush_timeout_error())),
-                        }),
-                    });
+                    let deadline = Self::explicit_close_drain_deadline();
+                    connection = ConnectionState::Draining(DrainState::explicit_close(
+                        deadline,
+                        false,
+                        CloseDrain::flush_timeout(close_request),
+                    ));
                 }
                 AckEvent::RequestSendFailed => {
                     if !self.request_send_failure.take() {
                         continue;
                     }
                     let error = Self::request_send_error();
-                    connection = match &connection {
+                    let target = match &connection {
                         ConnectionState::Waiting(WaitState::Rotation { deadlines, .. }) => {
-                            ConnectionState::Draining(DrainState {
+                            TerminalDrainTarget::Rotation {
                                 deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
-                                response_finished: false,
-                                terminal_error: Some(error),
-                                close: None,
-                            })
+                            }
                         }
-                        ConnectionState::Waiting(WaitState::Close(close_request)) => {
-                            ConnectionState::Draining(DrainState {
+                        ConnectionState::Waiting(WaitState::Close(request)) => {
+                            TerminalDrainTarget::Close {
+                                request: *request,
                                 deadline: Self::explicit_close_drain_deadline(),
-                                response_finished: false,
-                                terminal_error: None,
-                                close: Some(CloseDrain {
-                                    request: *close_request,
-                                    selected: Some(Err(error)),
-                                }),
-                            })
+                            }
                         }
-                        ConnectionState::Active => return Err(error),
+                        ConnectionState::Active => TerminalDrainTarget::Active,
                         ConnectionState::Draining(_) => unreachable!(),
                     };
+                    connection =
+                        Self::drain_from_waiting(target, TerminalEvent::RequestSendFailed, error)?;
                 }
                 AckEvent::AckDeadline(expected) => {
                     if let Some(pending_count) =
@@ -1038,111 +1130,89 @@ impl AckProcessor {
 
                     if ack.ack_up_to_records > 0 {
                         if let Err(error) = acknowledgments.apply(&ack).await {
-                            connection = match &connection {
+                            let target = match &connection {
                                 ConnectionState::Waiting(WaitState::Rotation {
                                     deadlines, ..
-                                }) => ConnectionState::Draining(DrainState {
+                                }) => TerminalDrainTarget::Rotation {
                                     deadline: Self::bounded_rotation_drain_deadline(
                                         deadlines.drain,
                                     ),
-                                    response_finished: false,
-                                    terminal_error: Some(error),
-                                    close: None,
-                                }),
-                                ConnectionState::Waiting(WaitState::Close(close_request)) => {
-                                    ConnectionState::Draining(DrainState {
+                                },
+                                ConnectionState::Waiting(WaitState::Close(request)) => {
+                                    TerminalDrainTarget::Close {
+                                        request: *request,
                                         deadline: Self::explicit_close_drain_deadline(),
-                                        response_finished: false,
-                                        terminal_error: None,
-                                        close: Some(CloseDrain {
-                                            request: *close_request,
-                                            selected: Some(Err(error)),
-                                        }),
-                                    })
+                                    }
                                 }
-                                ConnectionState::Active => return Err(error),
+                                ConnectionState::Active => TerminalDrainTarget::Active,
                                 ConnectionState::Draining(_) => unreachable!(),
                             };
+                            connection = Self::drain_from_waiting(
+                                target,
+                                TerminalEvent::AckApplyFailed,
+                                error,
+                            )?;
                             continue;
                         }
                     }
 
                     if let ConnectionState::Waiting(WaitState::Close(close_request)) = &connection {
                         if self.close_target_is_acknowledged(*close_request) {
-                            let outcome = if self.close.target_reached_timely() {
-                                Ok(())
-                            } else {
-                                Err(CloseCoordinator::flush_timeout_error())
-                            };
-                            connection = ConnectionState::Draining(DrainState {
-                                deadline: Self::explicit_close_drain_deadline(),
-                                response_finished: false,
-                                terminal_error: None,
-                                close: Some(CloseDrain {
-                                    request: *close_request,
-                                    selected: Some(outcome),
-                                }),
-                            });
+                            let outcome = self.acknowledged_close_outcome();
+                            let deadline = Self::explicit_close_drain_deadline();
+                            connection = Self::drain_for_acknowledged_close(
+                                *close_request,
+                                outcome,
+                                deadline,
+                            );
                         }
                     }
                 }
                 AckEvent::Response(Some(Err(error))) => {
                     let status: tonic::Status = error.into();
                     let error = ZerobusError::StreamClosedError(status);
-                    connection = match &connection {
+                    if matches!(&connection, ConnectionState::Active) {
+                        let _ = self.server_error_tx.send(Some(error.clone()));
+                    }
+                    let target = match &connection {
                         ConnectionState::Waiting(WaitState::Rotation { deadlines, .. }) => {
-                            ConnectionState::Draining(DrainState {
+                            TerminalDrainTarget::Rotation {
                                 deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
-                                response_finished: true,
-                                terminal_error: Some(error),
-                                close: None,
-                            })
+                            }
                         }
-                        ConnectionState::Waiting(WaitState::Close(close_request)) => {
-                            ConnectionState::Draining(DrainState {
+                        ConnectionState::Waiting(WaitState::Close(request)) => {
+                            TerminalDrainTarget::Close {
+                                request: *request,
                                 deadline: Self::explicit_close_drain_deadline(),
-                                response_finished: true,
-                                terminal_error: None,
-                                close: Some(CloseDrain {
-                                    request: *close_request,
-                                    selected: Some(Err(error)),
-                                }),
-                            })
+                            }
                         }
-                        ConnectionState::Active => {
-                            let _ = self.server_error_tx.send(Some(error.clone()));
-                            return Err(error);
-                        }
+                        ConnectionState::Active => TerminalDrainTarget::Active,
                         ConnectionState::Draining(_) => unreachable!(),
                     };
+                    connection =
+                        Self::drain_from_waiting(target, TerminalEvent::ResponseError, error)?;
                 }
                 AckEvent::Response(None) => {
                     let error = ZerobusError::StreamClosedError(tonic::Status::unknown(
                         "Server closed the stream",
                     ));
-                    connection = match &connection {
+                    let target = match &connection {
                         ConnectionState::Waiting(WaitState::Rotation { deadlines, .. }) => {
-                            ConnectionState::Draining(DrainState {
+                            TerminalDrainTarget::Rotation {
                                 deadline: Self::bounded_rotation_drain_deadline(deadlines.drain),
-                                response_finished: true,
-                                terminal_error: None,
-                                close: None,
-                            })
+                            }
                         }
-                        ConnectionState::Waiting(WaitState::Close(close_request)) => {
-                            ConnectionState::Draining(DrainState {
+                        ConnectionState::Waiting(WaitState::Close(request)) => {
+                            TerminalDrainTarget::Close {
+                                request: *request,
                                 deadline: Self::explicit_close_drain_deadline(),
-                                response_finished: true,
-                                terminal_error: None,
-                                close: Some(CloseDrain {
-                                    request: *close_request,
-                                    selected: Some(Err(error)),
-                                }),
-                            })
+                            }
                         }
-                        ConnectionState::Active => return Err(error),
+                        ConnectionState::Active => TerminalDrainTarget::Active,
                         ConnectionState::Draining(_) => unreachable!(),
                     };
+                    connection =
+                        Self::drain_from_waiting(target, TerminalEvent::ResponseEof, error)?;
                 }
             }
         }

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -427,13 +427,8 @@ impl ZerobusArrowStream {
     /// ```
     #[instrument(level = "debug", skip_all, fields(table_name = %self.table_properties.table_name))]
     pub async fn ingest_batch(&self, batch: RecordBatch) -> ZerobusResult<OffsetId> {
-        if self.admission_closed.load(Ordering::Acquire)
-            || self.is_closed.load(Ordering::Relaxed)
-            || self.close.has_started()
-        {
-            return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                "Stream is closing or closed",
-            )));
+        if self.is_ingest_admission_closed() {
+            return Err(Self::stream_closing_or_closed_error());
         }
 
         if batch.schema() != self.table_properties.schema {
@@ -468,13 +463,8 @@ impl ZerobusArrowStream {
         let _guard = self.ingest_mutex.lock().await;
 
         // May have closed while we blocked on the permit; returning drops it.
-        if self.admission_closed.load(Ordering::Acquire)
-            || self.is_closed.load(Ordering::Relaxed)
-            || self.close.has_started()
-        {
-            return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                "Stream is closing or closed",
-            )));
+        if self.is_ingest_admission_closed() {
+            return Err(Self::stream_closing_or_closed_error());
         }
 
         let offset_id = self.offset_generator.next();
@@ -513,12 +503,9 @@ impl ZerobusArrowStream {
                 // close teardown, and recovery detaches under ingest_mutex. Retain this
                 // fallback for unsupported concurrent close/ingest across foreign
                 // boundaries, preferring a known terminal cause.
-                if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                    return Err(server_error);
-                }
-                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                    "Stream sender is closed",
-                )));
+                return Err(Self::terminal_error_or(&self.server_error_rx, || {
+                    "Stream sender is closed".to_string()
+                }));
             }
         };
 
@@ -544,12 +531,9 @@ impl ZerobusArrowStream {
                     self.server_error_rx.clone().changed(),
                 )
                 .await;
-                if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                    return Err(server_error);
-                }
-                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                    "Failed to send batch",
-                )));
+                return Err(Self::terminal_error_or(&self.server_error_rx, || {
+                    "Failed to send batch".to_string()
+                }));
             }
         };
 
@@ -581,13 +565,8 @@ impl ZerobusArrowStream {
     /// marker after `finish()`) is allowed after that batch.
     #[instrument(level = "debug", skip_all, fields(table_name = %self.table_properties.table_name))]
     pub async fn ingest_ipc_batch(&self, ipc_bytes: Bytes) -> ZerobusResult<OffsetId> {
-        if self.admission_closed.load(Ordering::Acquire)
-            || self.is_closed.load(Ordering::Relaxed)
-            || self.close.has_started()
-        {
-            return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                "Stream is closing or closed",
-            )));
+        if self.is_ingest_admission_closed() {
+            return Err(Self::stream_closing_or_closed_error());
         }
 
         // Deserialise IPC bytes into a RecordBatch.
@@ -648,15 +627,12 @@ impl ZerobusArrowStream {
                             return Ok(());
                         }
                     }
-                    if let Some(server_error) = error_rx.borrow().clone() {
-                        return Err(server_error);
-                    }
-                    return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
+                    return Err(Self::terminal_error_or(&error_rx, || {
                         format!(
                             "Stream closing or closed during {}",
                             operation_name.to_lowercase()
-                        ),
-                    )));
+                        )
+                    }));
                 }
 
                 // Neither arm returns directly. After either watch changes, loop so the
@@ -697,9 +673,7 @@ impl ZerobusArrowStream {
             }
 
             if close_rx.changed().await.is_err() {
-                return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                    "Close coordinator stopped unexpectedly",
-                )));
+                return Err(Self::close_coordinator_stopped_error());
             }
         }
     }
@@ -749,12 +723,9 @@ impl ZerobusArrowStream {
                 // Nothing was ingested: report closure if closed, otherwise nothing to do.
                 // Prefer the real terminal error over a generic closed message.
                 if self.is_closed.load(Ordering::Relaxed) || self.close.has_started() {
-                    if let Some(server_error) = self.server_error_rx.borrow().clone() {
-                        return Err(server_error);
-                    }
-                    return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                        "Cannot flush: stream is closing or closed",
-                    )));
+                    return Err(Self::terminal_error_or(&self.server_error_rx, || {
+                        "Cannot flush: stream is closing or closed".to_string()
+                    }));
                 }
                 debug!("No batches to flush");
                 return Ok(());
@@ -880,11 +851,7 @@ impl ZerobusArrowStream {
                             // only after the retained-batch snapshot is complete.
                             drop(guard);
                             if close_rx.changed().await.is_err() {
-                                return Err(ZerobusError::StreamClosedError(
-                                    tonic::Status::internal(
-                                        "Close coordinator stopped unexpectedly",
-                                    ),
-                                ));
+                                return Err(Self::close_coordinator_stopped_error());
                             }
                         }
                         CloseState::Requested(_) => {}
@@ -893,9 +860,7 @@ impl ZerobusArrowStream {
                 }
                 CloseState::Requested(_) => {
                     if close_rx.changed().await.is_err() {
-                        return Err(ZerobusError::StreamClosedError(tonic::Status::internal(
-                            "Close coordinator stopped unexpectedly",
-                        )));
+                        return Err(Self::close_coordinator_stopped_error());
                     }
                 }
                 CloseState::Finalized(result) => return result,
@@ -1063,6 +1028,32 @@ impl ZerobusArrowStream {
 
     pub(crate) fn headers_provider(&self) -> Arc<dyn HeadersProvider> {
         Arc::clone(&self.headers_provider)
+    }
+
+    fn is_ingest_admission_closed(&self) -> bool {
+        self.admission_closed.load(Ordering::Acquire)
+            || self.is_closed.load(Ordering::Relaxed)
+            || self.close.has_started()
+    }
+
+    fn stream_closing_or_closed_error() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::internal("Stream is closing or closed"))
+    }
+
+    fn close_coordinator_stopped_error() -> ZerobusError {
+        ZerobusError::StreamClosedError(tonic::Status::internal(
+            "Close coordinator stopped unexpectedly",
+        ))
+    }
+
+    fn terminal_error_or(
+        error_rx: &watch::Receiver<Option<ZerobusError>>,
+        fallback_message: impl FnOnce() -> String,
+    ) -> ZerobusError {
+        let terminal_error = error_rx.borrow().clone();
+        terminal_error.unwrap_or_else(|| {
+            ZerobusError::StreamClosedError(tonic::Status::internal(fallback_message()))
+        })
     }
 }
 

--- a/rust/tests/src/arrow_tests.rs
+++ b/rust/tests/src/arrow_tests.rs
@@ -3297,7 +3297,60 @@ mod arrow_flight_tests {
     }
 
     mod recovery_tests {
+        use databricks_zerobus_ingest_sdk::ZerobusArrowStream;
+
         use super::*;
+
+        fn partial_ack_then_unavailable(message: &'static str) -> Vec<MockFlightResponse> {
+            vec![
+                MockFlightResponse::BatchAck {
+                    ack_up_to_offset: 0,
+                    delay_ms: 0,
+                    ack_up_to_records: 1,
+                },
+                MockFlightResponse::Error {
+                    status: tonic::Status::unavailable(message),
+                    delay_ms: 0,
+                },
+            ]
+        }
+
+        async fn close_expecting_error_containing(
+            stream: &mut ZerobusArrowStream,
+            timeout: std::time::Duration,
+            completion_message: &str,
+            close_error_message: &str,
+            expected: &str,
+        ) {
+            let error = tokio::time::timeout(timeout, stream.close())
+                .await
+                .expect(completion_message)
+                .expect_err(close_error_message);
+            assert!(
+                error.to_string().contains(expected),
+                "expected the active recovery trigger, got: {error}"
+            );
+        }
+
+        async fn assert_unacked_ids(
+            stream: &ZerobusArrowStream,
+            expected: &[&[i64]],
+            assertion_message: Option<&str>,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let actual: Vec<Vec<i64>> = stream
+                .get_unacked_batches()
+                .await?
+                .iter()
+                .map(batch_ids)
+                .collect();
+            let expected: Vec<Vec<i64>> = expected.iter().map(|ids| ids.to_vec()).collect();
+            if let Some(assertion_message) = assertion_message {
+                assert_eq!(actual, expected, "{assertion_message}");
+            } else {
+                assert_eq!(actual, expected);
+            }
+            Ok(())
+        }
 
         /// The supervisor must surface a non-retryable configuration error if a timeout
         /// that was representable at construction can no longer form a runtime deadline.
@@ -3410,14 +3463,14 @@ mod arrow_flight_tests {
                 .await
                 .expect("reconnect must enter replacement setup");
 
-            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
-                .await
-                .expect("close must cancel replacement setup")
-                .expect_err("close during recovery must preserve the recovery trigger");
-            assert!(
-                error.to_string().contains("active transport failed"),
-                "expected the active recovery trigger, got: {error}"
-            );
+            close_expecting_error_containing(
+                &mut stream,
+                std::time::Duration::from_secs(1),
+                "close must cancel replacement setup",
+                "close during recovery must preserve the recovery trigger",
+                "active transport failed",
+            )
+            .await;
             assert_eq!(stream.get_unacked_batches().await?.len(), 1);
             Ok(())
         }
@@ -3500,21 +3553,15 @@ mod arrow_flight_tests {
             .await
             .expect("reconnect must wait for the proxy CONNECT response");
 
-            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
-                .await
-                .expect("close must cancel the replacement transport handshake")
-                .expect_err("close during recovery must preserve the recovery trigger");
-            assert!(
-                error.to_string().contains("active transport failed"),
-                "expected the active recovery trigger, got: {error}"
-            );
-            let unacked: Vec<Vec<i64>> = stream
-                .get_unacked_batches()
-                .await?
-                .iter()
-                .map(batch_ids)
-                .collect();
-            assert_eq!(unacked, vec![vec![7, 8]]);
+            close_expecting_error_containing(
+                &mut stream,
+                std::time::Duration::from_secs(1),
+                "close must cancel the replacement transport handshake",
+                "close during recovery must preserve the recovery trigger",
+                "active transport failed",
+            )
+            .await;
+            assert_unacked_ids(&stream, &[&[7, 8]], None).await?;
 
             proxy_task.abort();
             let _ = proxy_task.await;
@@ -3616,20 +3663,7 @@ mod arrow_flight_tests {
             // Partially ack A (1 of 3 records), then a retriable error on B triggers the
             // reconnect we park at the rebuild barrier.
             mock_server
-                .inject_responses(
-                    TABLE_NAME,
-                    vec![
-                        MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 0,
-                            delay_ms: 0,
-                            ack_up_to_records: 1,
-                        },
-                        MockFlightResponse::Error {
-                            status: tonic::Status::unavailable("Connection lost"),
-                            delay_ms: 0,
-                        },
-                    ],
-                )
+                .inject_responses(TABLE_NAME, partial_ack_then_unavailable("Connection lost"))
                 .await;
 
             let sdk = ZerobusSdk::builder()
@@ -3678,14 +3712,14 @@ mod arrow_flight_tests {
                 .await
                 .expect("reconnect should reach the rebuild barrier");
 
-            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
-                .await
-                .expect("close must interrupt recovery after READY")
-                .expect_err("close during recovery must preserve the recovery trigger");
-            assert!(
-                error.to_string().contains("Connection lost"),
-                "expected the active recovery trigger, got: {error}"
-            );
+            close_expecting_error_containing(
+                &mut stream,
+                std::time::Duration::from_secs(1),
+                "close must interrupt recovery after READY",
+                "close during recovery must preserve the recovery trigger",
+                "Connection lost",
+            )
+            .await;
 
             let unacked = stream.get_unacked_batches().await?;
             assert_eq!(unacked.len(), 2, "expected sliced A suffix + full B");
@@ -3709,17 +3743,7 @@ mod arrow_flight_tests {
             mock_server
                 .inject_responses(
                     TABLE_NAME,
-                    vec![
-                        MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 0,
-                            delay_ms: 0,
-                            ack_up_to_records: 1,
-                        },
-                        MockFlightResponse::Error {
-                            status: tonic::Status::unavailable("active transport failed"),
-                            delay_ms: 0,
-                        },
-                    ],
+                    partial_ack_then_unavailable("active transport failed"),
                 )
                 .await;
 
@@ -3757,21 +3781,15 @@ mod arrow_flight_tests {
                 .await
                 .expect("recovery must hand off the first replay batch");
 
-            let error = tokio::time::timeout(std::time::Duration::from_secs(1), stream.close())
-                .await
-                .expect("close must interrupt partial replay")
-                .expect_err("close during recovery must preserve the recovery trigger");
-            assert!(
-                error.to_string().contains("active transport failed"),
-                "expected the active recovery trigger, got: {error}"
-            );
-            let unacked: Vec<Vec<i64>> = stream
-                .get_unacked_batches()
-                .await?
-                .iter()
-                .map(batch_ids)
-                .collect();
-            assert_eq!(unacked, vec![vec![2, 3], vec![4]]);
+            close_expecting_error_containing(
+                &mut stream,
+                std::time::Duration::from_secs(1),
+                "close must interrupt partial replay",
+                "close during recovery must preserve the recovery trigger",
+                "active transport failed",
+            )
+            .await;
+            assert_unacked_ids(&stream, &[&[2, 3], &[4]], None).await?;
             Ok(())
         }
 
@@ -3874,20 +3892,7 @@ mod arrow_flight_tests {
             // alone would instead reconnect via the slow ack timeout and let the scripted
             // error fire on a later connection.
             mock_server
-                .inject_responses(
-                    TABLE_NAME,
-                    vec![
-                        MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 0,
-                            delay_ms: 0,
-                            ack_up_to_records: 1,
-                        },
-                        MockFlightResponse::Error {
-                            status: tonic::Status::unavailable("Connection lost"),
-                            delay_ms: 0,
-                        },
-                    ],
-                )
+                .inject_responses(TABLE_NAME, partial_ack_then_unavailable("Connection lost"))
                 .await;
 
             let sdk = ZerobusSdk::builder()
@@ -3971,17 +3976,7 @@ mod arrow_flight_tests {
             mock_server
                 .inject_responses(
                     TABLE_NAME,
-                    vec![
-                        MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 0,
-                            delay_ms: 0,
-                            ack_up_to_records: 1,
-                        },
-                        MockFlightResponse::Error {
-                            status: tonic::Status::unavailable("active transport failed"),
-                            delay_ms: 0,
-                        },
-                    ],
+                    partial_ack_then_unavailable("active transport failed"),
                 )
                 .await;
 
@@ -4037,17 +4032,12 @@ mod arrow_flight_tests {
                 close_error.to_string().contains("active transport failed"),
                 "expected the active recovery trigger, got: {close_error}"
             );
-            let unacked: Vec<Vec<i64>> = stream
-                .get_unacked_batches()
-                .await?
-                .iter()
-                .map(batch_ids)
-                .collect();
-            assert_eq!(
-                unacked,
-                vec![vec![2, 3], vec![4]],
-                "close during backoff must retain only the exact unacknowledged suffix"
-            );
+            assert_unacked_ids(
+                &stream,
+                &[&[2, 3], &[4]],
+                Some("close during backoff must retain only the exact unacknowledged suffix"),
+            )
+            .await?;
             Ok(())
         }
 
@@ -4058,29 +4048,17 @@ mod arrow_flight_tests {
 
             let (mock_server, server_url) = start_mock_flight_server().await?;
             let schema = create_test_arrow_schema();
-            mock_server
-                .inject_responses(
-                    TABLE_NAME,
-                    vec![
-                        MockFlightResponse::BatchAck {
-                            ack_up_to_offset: 0,
-                            delay_ms: 0,
-                            ack_up_to_records: 1,
-                        },
-                        MockFlightResponse::Error {
-                            status: tonic::Status::unavailable("active transport failed"),
-                            delay_ms: 0,
-                        },
-                        MockFlightResponse::FailSetup {
-                            status: tonic::Status::unavailable("first reconnect failed"),
-                        },
-                        MockFlightResponse::FailSetupAfter {
-                            status: tonic::Status::unavailable("second reconnect failed"),
-                            delay_ms: 60_000,
-                        },
-                    ],
-                )
-                .await;
+            let mut responses = partial_ack_then_unavailable("active transport failed");
+            responses.extend([
+                MockFlightResponse::FailSetup {
+                    status: tonic::Status::unavailable("first reconnect failed"),
+                },
+                MockFlightResponse::FailSetupAfter {
+                    status: tonic::Status::unavailable("second reconnect failed"),
+                    delay_ms: 60_000,
+                },
+            ]);
+            mock_server.inject_responses(TABLE_NAME, responses).await;
 
             let delayed_setup_armed = mock_server.delayed_setup_armed();
             let sdk = ZerobusSdk::builder()
@@ -4131,13 +4109,7 @@ mod arrow_flight_tests {
                 }
                 other => panic!("expected the first attempt's reconnect error, got: {other:?}"),
             }
-            let unacked: Vec<Vec<i64>> = stream
-                .get_unacked_batches()
-                .await?
-                .iter()
-                .map(batch_ids)
-                .collect();
-            assert_eq!(unacked, vec![vec![2, 3], vec![4]]);
+            assert_unacked_ids(&stream, &[&[2, 3], &[4]], None).await?;
 
             Ok(())
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Centralize Arrow close/drain state construction and terminal-event mapping.
- Consolidate repeated admission and terminal-error handling.
- Deduplicate close-during-recovery test setup and assertions while preserving race coverage and timing.

## How is this tested?

Pure refactor, no functional changes. Existing tests.