### PR TITLE
[Arrow] Bump arrow dep to 59.2

### DIFF
--- a/python/rust/Cargo.lock
+++ b/python/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrow-array"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -83,7 +83,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "half",
  "lexical-core",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "59.1.0"
+version = "59.2.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -114,7 +114,7 @@ dependencies = [
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "futures",
  "prost",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -154,15 +154,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 
 [[package]]
 name = "arrow-select"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -252,6 +252,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -712,7 +718,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -856,7 +862,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1162,9 +1168,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -1224,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.8"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1743,7 +1749,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2285,7 +2291,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",

--- a/python/rust/Cargo.toml
+++ b/python/rust/Cargo.toml
@@ -19,6 +19,6 @@ async-trait = "0.1"
 prost = "0.14"
 prost-types = "0.14"
 tonic = "0.14"
-arrow-ipc = { version = "59.1", default-features = false }
-arrow-schema = { version = "59.1", default-features = false }
-arrow-array = { version = "59.1", default-features = false }
+arrow-ipc = { version = "59.2", default-features = false }
+arrow-schema = { version = "59.2", default-features = false }
+arrow-array = { version = "59.2", default-features = false }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -104,9 +104,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow-arith"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -130,6 +130,7 @@ dependencies = [
  "chrono-tz",
  "half",
  "hashbrown 0.17.0",
+ "libc",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -137,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
@@ -149,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -160,7 +161,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "comfy-table",
  "half",
@@ -171,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -184,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "59.1.0"
+version = "59.2.0"
 dependencies = [
  "anyhow",
  "arrow-arith",
@@ -199,7 +200,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "assert_cmd",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "clap",
  "futures",
@@ -207,7 +208,6 @@ dependencies = [
  "http-body",
  "hyper-util",
  "once_cell",
- "paste",
  "pin-project-lite",
  "prost",
  "prost-types",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -266,18 +266,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -421,6 +421,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -1135,7 +1141,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -1293,7 +1299,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1660,9 +1666,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -1732,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1808,18 +1814,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2053,7 +2053,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "prost",
  "prost-types",
  "serde",
@@ -2342,7 +2342,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -3123,7 +3123,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "flate2",
  "h2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,10 +57,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Arrow
 # arrow-flight is vendored locally with a slice-aware batch-split fix (arrow-rs#9388 / #5352).
-arrow-flight = { path = "third_party/arrow-flight", version = "59.1", default-features = false }
-arrow-array = { version = "59.1", default-features = false }
-arrow-schema = { version = "59.1", default-features = false }
-arrow-ipc = { version = "59.1", default-features = false }
+arrow-flight = { path = "third_party/arrow-flight", version = "59.2", default-features = false }
+arrow-array = { version = "59.2", default-features = false }
+arrow-schema = { version = "59.2", default-features = false }
+arrow-ipc = { version = "59.2", default-features = false }
 
 # Misc
 futures = "0.3"

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### Internal Changes
 
+- Updated Arrow crates and the vendored `arrow-flight` fork from `59.1` to
+  `59.2` while retaining the slice-aware batch-splitting patch.
 - Added Arrow C Data `RecordBatch` conversion behind a disabled-by-default
   wrapper-only SDK feature so current and future native bindings can share one
   ownership implementation. No supported Rust SDK or Flight behavior changed.

--- a/rust/third_party/arrow-flight/Cargo.toml
+++ b/rust/third_party/arrow-flight/Cargo.toml
@@ -13,7 +13,7 @@
 edition = "2024"
 rust-version = "1.85"
 name = "arrow-flight"
-version = "59.1.0"
+version = "59.2.0"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 build = false
 autolib = false
@@ -53,7 +53,6 @@ flight-sql = [
     "dep:arrow-select",
     "dep:arrow-string",
     "dep:once_cell",
-    "dep:paste",
 ]
 flight-sql-experimental = ["flight-sql"]
 tls-aws-lc = ["tonic/tls-aws-lc"]
@@ -70,45 +69,45 @@ version = "1.0"
 optional = true
 
 [dependencies.arrow-arith]
-version = "59.1.0"
+version = "59.2.0"
 optional = true
 
 [dependencies.arrow-array]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-buffer]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-cast]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-data]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-ipc]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-ord]
-version = "59.1.0"
+version = "59.2.0"
 optional = true
 
 [dependencies.arrow-row]
-version = "59.1.0"
+version = "59.2.0"
 optional = true
 
 [dependencies.arrow-schema]
-version = "59.1.0"
+version = "59.2.0"
 
 [dependencies.arrow-select]
-version = "59.1.0"
+version = "59.2.0"
 optional = true
 
 [dependencies.arrow-string]
-version = "59.1.0"
+version = "59.2.0"
 optional = true
 
 [dependencies.base64]
-version = "0.22"
+version = "0.23"
 features = ["std"]
 default-features = false
 
@@ -139,10 +138,6 @@ default-features = false
 
 [dependencies.once_cell]
 version = "1"
-optional = true
-
-[dependencies.paste]
-version = "1.0"
 optional = true
 
 [dependencies.prost]
@@ -192,11 +187,11 @@ optional = true
 default-features = false
 
 [dev-dependencies.arrow-cast]
-version = "59.1.0"
+version = "59.2.0"
 features = ["prettyprint"]
 
 [dev-dependencies.arrow-ipc]
-version = "59.1.0"
+version = "59.2.0"
 features = [
     "lz4",
     "zstd",

--- a/rust/third_party/arrow-flight/src/decode.rs
+++ b/rust/third_party/arrow-flight/src/decode.rs
@@ -308,12 +308,14 @@ impl FlightDataDecoder {
                     )
                 })?;
 
-                arrow_ipc::reader::read_dictionary(
+                arrow_ipc::reader::read_dictionary_impl(
                     &buffer,
                     dictionary_batch,
                     &state.schema,
                     &mut state.dictionaries_by_field,
                     &message.version(),
+                    false,
+                    self.skip_validation.clone(),
                 )
                 .map_err(|e| {
                     FlightError::DecodeError(format!("Error decoding ipc dictionary: {e}"))
@@ -336,8 +338,17 @@ impl FlightDataDecoder {
                         "Unable to convert flight data header to a record batch".to_string(),
                     )
                 })?;
+                let buffer = {
+                    // see https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
+                    // reuse the allocation if already aligned, otherwise copy into a fresh aligned buffer.
+                    if data.data_body.as_ptr() as usize % 64 == 0 {
+                        &Buffer::from(data.data_body.clone())
+                    } else {
+                        &Buffer::from(data.data_body.as_ref())
+                    }
+                };
                 let batch = arrow_ipc::reader::RecordBatchDecoder::try_new(
-                    &Buffer::from(data.data_body.as_ref()),
+                    buffer,
                     record_batch,
                     Arc::clone(&state.schema),
                     &state.dictionaries_by_field,

--- a/rust/third_party/arrow-flight/src/encode.rs
+++ b/rust/third_party/arrow-flight/src/encode.rs
@@ -373,7 +373,12 @@ impl FlightDataEncoder {
             DictionaryHandling::Hydrate => hydrate_dictionaries(&batch, schema)?,
         };
 
-        for batch in split_batch_for_grpc_response(batch, self.max_flight_data_size) {
+        let batches = split_batch_for_grpc_response(batch, self.max_flight_data_size);
+        let last = batches.len().saturating_sub(1); // handle empty batches
+        for (i, batch) in batches.into_iter().enumerate() {
+            self.encoder
+                .ipc_write_context
+                .set_reserve_scratch(i != last);
             let (flight_dictionaries, flight_batch) = self.encoder.encode_batch(&batch)?;
             for dict in flight_dictionaries {
                 self.queue_message(dict);
@@ -666,7 +671,7 @@ fn prepare_schema_for_flight(
 fn split_batch_for_grpc_response(
     batch: RecordBatch,
     max_flight_data_size: usize,
-) -> impl Iterator<Item = RecordBatch> {
+) -> Vec<RecordBatch> {
     // DATABRICKS PATCH (arrow-rs#9388 / #5352): use a slice-aware memory size.
     // `get_buffer_memory_size` reports each buffer's full allocation capacity, so a
     // batch decoded zero-copy from Arrow IPC (every column slicing one shared
@@ -688,17 +693,15 @@ fn split_batch_for_grpc_response(
     let num_rows = batch.num_rows();
     let rows_per_batch = (num_rows / n_batches).max(1);
     let mut offset = 0;
+    let mut batches = Vec::with_capacity(n_batches);
 
-    std::iter::from_fn(move || {
-        if offset < num_rows {
-            let length = rows_per_batch.min(num_rows - offset);
-            let slice = batch.slice(offset, length);
-            offset += length;
-            Some(slice)
-        } else {
-            None
-        }
-    })
+    while offset < num_rows {
+        let length = rows_per_batch.min(num_rows - offset);
+        batches.push(batch.slice(offset, length));
+        offset += length;
+    }
+
+    batches
 }
 
 /// The data needed to encode a stream of flight data, holding on to
@@ -1868,8 +1871,7 @@ mod tests {
         let c = UInt32Array::from(vec![1, 2, 3, 4, 5, 6]);
         let batch = RecordBatch::try_from_iter(vec![("a", Arc::new(c) as ArrayRef)])
             .expect("cannot create record batch");
-        let split: Vec<_> =
-            split_batch_for_grpc_response(batch.clone(), max_flight_data_size).collect();
+        let split: Vec<_> = split_batch_for_grpc_response(batch.clone(), max_flight_data_size);
         assert_eq!(split.len(), 1);
         assert_eq!(batch, split[0]);
 
@@ -1879,8 +1881,7 @@ mod tests {
         let c = UInt8Array::from((0..n_rows).map(|i| (i % 256) as u8).collect::<Vec<_>>());
         let batch = RecordBatch::try_from_iter(vec![("a", Arc::new(c) as ArrayRef)])
             .expect("cannot create record batch");
-        let split: Vec<_> =
-            split_batch_for_grpc_response(batch.clone(), max_flight_data_size).collect();
+        let split: Vec<_> = split_batch_for_grpc_response(batch.clone(), max_flight_data_size);
         assert_eq!(split.len(), 3);
         assert_eq!(
             split.iter().map(|batch| batch.num_rows()).sum::<usize>(),
@@ -1925,7 +1926,7 @@ mod tests {
         let input_rows = batch.num_rows();
 
         let split: Vec<_> =
-            split_batch_for_grpc_response(batch.clone(), max_flight_data_size_bytes).collect();
+            split_batch_for_grpc_response(batch.clone(), max_flight_data_size_bytes);
         let sizes: Vec<_> = split.iter().map(RecordBatch::num_rows).collect();
         let output_rows: usize = sizes.iter().sum();
 

--- a/rust/third_party/arrow-flight/src/sql/mod.rs
+++ b/rust/third_party/arrow-flight/src/sql/mod.rs
@@ -40,7 +40,6 @@
 //! [`metadata`]: crate::sql::metadata
 use arrow_schema::ArrowError;
 use bytes::Bytes;
-use paste::paste;
 use prost::Message;
 
 #[allow(clippy::all)]
@@ -124,113 +123,95 @@ pub trait ProstMessageExt: prost::Message + Default {
     fn as_any(&self) -> Any;
 }
 
-/// Macro to coerce a token to an item, specifically
-/// to build the `Commands` enum.
-///
-/// See: <https://danielkeep.github.io/tlborm/book/blk-ast-coercion.html>
-macro_rules! as_item {
-    ($i:item) => {
-        $i
-    };
-}
-
 macro_rules! prost_message_ext {
     ($($name:tt,)*) => {
-        paste! {
+        /// Helper to convert to/from protobuf [`Any`] message
+        /// to a specific FlightSQL command message.
+        ///
+        /// # Example
+        /// ```rust
+        /// # use arrow_flight::sql::{Any, CommandStatementQuery, Command};
+        /// let flightsql_message = CommandStatementQuery {
+        ///   query: "SELECT * FROM foo".to_string(),
+        ///   transaction_id: None,
+        /// };
+        ///
+        /// // Given a packed FlightSQL Any message
+        /// let any_message = Any::pack(&flightsql_message).unwrap();
+        ///
+        /// // decode it to Command:
+        /// match Command::try_from(any_message).unwrap() {
+        ///   Command::CommandStatementQuery(decoded) => {
+        ///    assert_eq!(flightsql_message, decoded);
+        ///   }
+        ///   _ => panic!("Unexpected decoded message"),
+        /// }
+        /// ```
+        #[derive(Clone, Debug, PartialEq)]
+        pub enum Command {
             $(
-            const [<$name:snake:upper _TYPE_URL>]: &'static str = concat!("type.googleapis.com/arrow.flight.protocol.sql.", stringify!($name));
-            )*
+                #[doc = concat!(stringify!($name), "variant")]
+                $name($name),)*
 
-                as_item! {
-                /// Helper to convert to/from protobuf [`Any`] message
-                /// to a specific FlightSQL command message.
-                ///
-                /// # Example
-                /// ```rust
-                /// # use arrow_flight::sql::{Any, CommandStatementQuery, Command};
-                /// let flightsql_message = CommandStatementQuery {
-                ///   query: "SELECT * FROM foo".to_string(),
-                ///   transaction_id: None,
-                /// };
-                ///
-                /// // Given a packed FlightSQL Any message
-                /// let any_message = Any::pack(&flightsql_message).unwrap();
-                ///
-                /// // decode it to Command:
-                /// match Command::try_from(any_message).unwrap() {
-                ///   Command::CommandStatementQuery(decoded) => {
-                ///    assert_eq!(flightsql_message, decoded);
-                ///   }
-                ///   _ => panic!("Unexpected decoded message"),
-                /// }
-                /// ```
-                #[derive(Clone, Debug, PartialEq)]
-                pub enum Command {
-                    $(
-                        #[doc = concat!(stringify!($name), "variant")]
-                        $name($name),)*
-
-                    /// Any message that is not any FlightSQL command.
-                    Unknown(Any),
-                }
-            }
-
-            impl Command {
-                /// Convert the command to [`Any`].
-                pub fn into_any(self) -> Any {
-                    match self {
-                        $(
-                        Self::$name(cmd) => cmd.as_any(),
-                        )*
-                        Self::Unknown(any) => any,
-                    }
-                }
-
-                /// Get the URL for the command.
-                pub fn type_url(&self) -> &str {
-                    match self {
-                        $(
-                        Self::$name(_) => [<$name:snake:upper _TYPE_URL>],
-                        )*
-                        Self::Unknown(any) => any.type_url.as_str(),
-                    }
-                }
-            }
-
-            impl TryFrom<Any> for Command {
-                type Error = ArrowError;
-
-                fn try_from(any: Any) -> Result<Self, Self::Error> {
-                    match any.type_url.as_str() {
-                        $(
-                        [<$name:snake:upper _TYPE_URL>]
-                            => {
-                                let m: $name = Message::decode(&*any.value).map_err(|err| {
-                                    ArrowError::ParseError(format!("Unable to decode Any value: {err}"))
-                                })?;
-                                Ok(Self::$name(m))
-                            }
-                        )*
-                        _ => Ok(Self::Unknown(any)),
-                    }
-                }
-            }
-
-            $(
-                impl ProstMessageExt for $name {
-                    fn type_url() -> &'static str {
-                        [<$name:snake:upper _TYPE_URL>]
-                    }
-
-                    fn as_any(&self) -> Any {
-                        Any {
-                            type_url: <$name>::type_url().to_string(),
-                            value: self.encode_to_vec().into(),
-                        }
-                    }
-                }
-            )*
+            /// Any message that is not any FlightSQL command.
+            Unknown(Any),
         }
+
+        impl Command {
+            /// Convert the command to [`Any`].
+            pub fn into_any(self) -> Any {
+                match self {
+                    $(
+                    Self::$name(cmd) => cmd.as_any(),
+                    )*
+                    Self::Unknown(any) => any,
+                }
+            }
+
+            /// Get the URL for the command.
+            pub fn type_url(&self) -> &str {
+                match self {
+                    $(
+                    Self::$name(_) => <$name as ProstMessageExt>::type_url(),
+                    )*
+                    Self::Unknown(any) => any.type_url.as_str(),
+                }
+            }
+        }
+
+        impl TryFrom<Any> for Command {
+            type Error = ArrowError;
+
+            fn try_from(any: Any) -> Result<Self, Self::Error> {
+                match any.type_url.as_str() {
+                    $(
+                    concat!("type.googleapis.com/arrow.flight.protocol.sql.", stringify!($name))
+                        => {
+                            let m: $name = Message::decode(&*any.value).map_err(|err| {
+                                ArrowError::ParseError(format!("Unable to decode Any value: {err}"))
+                            })?;
+                            Ok(Self::$name(m))
+                        }
+                    )*
+                    _ => Ok(Self::Unknown(any)),
+                }
+            }
+        }
+
+        $(
+            impl ProstMessageExt for $name {
+                fn type_url() -> &'static str {
+                    concat!("type.googleapis.com/arrow.flight.protocol.sql.", stringify!($name))
+                }
+
+                fn as_any(&self) -> Any {
+                    Any {
+                        type_url: <$name>::type_url().to_string(),
+                        value: self.encode_to_vec().into(),
+                    }
+                }
+            }
+        )*
     };
 }
 
@@ -361,7 +342,7 @@ mod tests {
         let cmd: Command = any.try_into().unwrap();
 
         assert!(matches!(cmd, Command::CommandStatementQuery(_)));
-        assert_eq!(cmd.type_url(), COMMAND_STATEMENT_QUERY_TYPE_URL);
+        assert_eq!(cmd.type_url(), CommandStatementQuery::type_url());
 
         // Unknown variant
 

--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow-array"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -83,7 +83,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "half",
  "lexical-core",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42115e09dbb694b5955da998912121451c6910b338228cb80a5701370dba43ff"
+checksum = "2bebfacc9d71f0728f6774164e4d4254b5e504d2b46812d0512d8290ec119a64"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -116,7 +116,7 @@ dependencies = [
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures",
  "prost",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -156,15 +156,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 
 [[package]]
 name = "arrow-select"
-version = "59.1.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -260,6 +260,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -1197,9 +1203,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -1301,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -32,9 +32,9 @@ async-trait = "0.1"
 # `Bytes` is the input type for the Rust SDK's `ingest_ipc_batch` entry.
 bytes = "1"
 
-arrow-array = { version = "59.1", optional = true }
-arrow-schema = { version = "59.1", optional = true }
-arrow-ipc = { version = "59.1", features = ["lz4", "zstd"], optional = true }
+arrow-array = { version = "59.2", optional = true }
+arrow-schema = { version = "59.2", optional = true }
+arrow-ipc = { version = "59.2", features = ["lz4", "zstd"], optional = true }
 
 [build-dependencies]
 napi-build = "2"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bump arrow rs to 59.2 while preserving patch in flight for batch size calc.

## How is this tested?

Existing tests, dep bump.