### PR TITLE
[Java][Python][TypeScript] Optional macOS release binaries

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -8,6 +8,11 @@ on:
         description: "Run ID of the release-jni.yml build containing JNI artifacts."
         required: true
         type: string
+      macos-binaries-release:
+        description: "Optional GitHub Release tag holding laptop-built libzerobus_jni-osx-*.dylib files. Leave empty to skip extra macOS import (jni-osx-* artifacts from the JNI run are still packed)."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-jar:
@@ -45,6 +50,25 @@ jobs:
             cp "$dir"/* src/main/resources/native/"$platform"/
           done
 
+      - name: Import macOS dylibs from release
+        if: inputs.macos-binaries-release != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ inputs.macos-binaries-release }}
+        working-directory: java
+        run: |
+          set -euo pipefail
+          for arch in x86_64 aarch64; do
+            dest="src/main/resources/native/osx-$arch"
+            mkdir -p "$dest"
+            gh release download "$REF" \
+              --repo "${{ github.repository }}" \
+              --pattern "libzerobus_jni-osx-$arch.dylib" \
+              --dir "$dest"
+            test -f "$dest/libzerobus_jni-osx-$arch.dylib"
+            mv "$dest/libzerobus_jni-osx-$arch.dylib" "$dest/libzerobus_jni.dylib"
+          done
+
       - name: Set up Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
@@ -69,6 +93,12 @@ jobs:
             native/linux-musl-aarch64/libzerobus_jni.so
             native/windows-x86_64/zerobus_jni.dll
           )
+          if [[ -f src/main/resources/native/osx-x86_64/libzerobus_jni.dylib ]]; then
+            required_entries+=(
+              native/osx-x86_64/libzerobus_jni.dylib
+              native/osx-aarch64/libzerobus_jni.dylib
+            )
+          fi
 
           shopt -s nullglob
           jars=(target/zerobus-ingest-sdk-*.jar)

--- a/.github/workflows/release-jni.yml
+++ b/.github/workflows/release-jni.yml
@@ -3,8 +3,53 @@ run-name: "Build JNI ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      macos-binaries-release:
+        description: "Optional GitHub Release tag holding laptop-built libzerobus_jni-osx-*.dylib files. Leave empty to skip macOS."
+        required: false
+        type: string
+        default: ""
 
 jobs:
+  import-macos:
+    if: inputs.macos-binaries-release != ''
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download macOS dylibs from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ inputs.macos-binaries-release }}
+        run: |
+          set -euo pipefail
+          for arch in x86_64 aarch64; do
+            mkdir -p "jni-osx-$arch"
+            gh release download "$REF" \
+              --repo "${{ github.repository }}" \
+              --pattern "libzerobus_jni-osx-$arch.dylib" \
+              --dir "jni-osx-$arch"
+            test -f "jni-osx-$arch/libzerobus_jni-osx-$arch.dylib"
+            mv "jni-osx-$arch/libzerobus_jni-osx-$arch.dylib" \
+               "jni-osx-$arch/libzerobus_jni.dylib"
+          done
+
+      - name: Upload osx-x86_64
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jni-osx-x86_64
+          path: jni-osx-x86_64/libzerobus_jni.dylib
+          if-no-files-found: error
+
+      - name: Upload osx-aarch64
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jni-osx-aarch64
+          path: jni-osx-aarch64/libzerobus_jni.dylib
+          if-no-files-found: error
+
   build-jni:
     strategy:
       fail-fast: false

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -3,6 +3,12 @@ run-name: "Build Python SDK ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      macos-binaries-release:
+        description: "Optional GitHub Release tag holding laptop-built *macosx*.whl files. Leave empty to skip macOS."
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -168,4 +174,47 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
+          if-no-files-found: error
+
+  import-macos:
+    if: inputs.macos-binaries-release != ''
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download macOS wheels from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ inputs.macos-binaries-release }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$REF" \
+            --repo "${{ github.repository }}" \
+            --pattern '*macosx*.whl' \
+            --dir dist/
+          version="${REF##*/v}"
+          version="${version#python/v}"
+          arm64="dist/databricks_zerobus_ingest_sdk-${version}-cp39-abi3-macosx_11_0_arm64.whl"
+          x86_64="dist/databricks_zerobus_ingest_sdk-${version}-cp39-abi3-macosx_10_12_x86_64.whl"
+          # Version tag may be a staging tag; accept any two macosx wheels if the
+          # conventional names are absent.
+          if [[ ! -f "$arm64" || ! -f "$x86_64" ]]; then
+            shopt -s nullglob
+            wheels=(dist/*macosx*.whl)
+            if [[ "${#wheels[@]}" -lt 2 ]]; then
+              echo "ERROR: expected two macOS wheels in $REF"
+              ls -lh dist/ || true
+              exit 1
+            fi
+          fi
+          ls -lh dist/*macosx*.whl
+
+      - name: Upload macOS wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wheels-macos
+          path: dist/*macosx*.whl
           if-no-files-found: error

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -3,6 +3,12 @@ run-name: "Build TypeScript SDK ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      macos-binaries-release:
+        description: "Optional GitHub Release tag holding laptop-built zerobus-ingest-sdk.darwin-*.node files. Leave empty to skip macOS."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -82,4 +88,34 @@ jobs:
           path: |
             typescript/index.js
             typescript/index.d.ts
+          if-no-files-found: error
+
+  import-macos:
+    if: inputs.macos-binaries-release != ''
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download darwin .node binaries from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ inputs.macos-binaries-release }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$REF" \
+            --repo "${{ github.repository }}" \
+            --pattern 'zerobus-ingest-sdk.darwin-*.node' \
+            --dir dist/
+          test -f dist/zerobus-ingest-sdk.darwin-x64.node
+          test -f dist/zerobus-ingest-sdk.darwin-arm64.node
+          ls -lh dist/zerobus-ingest-sdk.darwin-*.node
+
+      - name: Upload darwin bindings
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bindings-macos
+          path: dist/zerobus-ingest-sdk.darwin-*.node
           if-no-files-found: error

--- a/java/NEXT_CHANGELOG.md
+++ b/java/NEXT_CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ### Internal Changes
 
+- Bumped `central-publishing-maven-plugin` from 0.5.0 to 0.11.0 so Maven Central
+  deploy can parse the Portal status response that now includes a `warnings` field.
+  0.5.0 crashed after a successful upload, which made the publisher job look failed
+  even when the bundle was already in the Portal.
+- The JNI and Java release workflows can optionally import laptop-built macOS
+  dylibs from a GitHub Release when CI has no macOS runners.
+
 ### Breaking Changes
 
 ### Deprecations

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -304,7 +304,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>0.11.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>

--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Internal Changes
 
+- The Python release workflow can optionally import laptop-built macOS wheels from
+  a GitHub Release when CI has no macOS runners.
+
 ### Breaking Changes
 
 ### Deprecations

--- a/typescript/NEXT_CHANGELOG.md
+++ b/typescript/NEXT_CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### Internal Changes
 
+- The TypeScript release workflow can optionally import laptop-built darwin `.node`
+  binaries from a GitHub Release when CI has no macOS runners.
 - Updated TypeScript SDK development dependencies and the NAPI Cargo lockfile to
   resolve Dependabot security alerts without changing the public SDK API.
 - Updated the wrapped Rust SDK dependency from v2.0.1 to v2.6.0 and aligned


### PR DESCRIPTION
## What changes are proposed in this pull request?

WHAT: Two related release-tooling changes.

- Bump `central-publishing-maven-plugin` from 0.5.0 to 0.11.0 in `java/pom.xml`. 0.5.0 crashes while polling Maven Central Portal after a successful upload because the Portal status response now includes a `warnings` field the old plugin cannot parse.
- Add an optional `macos-binaries-release` input to the Java, JNI, Python, and TypeScript builder workflows. When set, the workflow downloads laptop-built macOS artifacts from that GitHub Release and uploads them alongside the CI-built linux/windows artifacts. Leave the input empty to skip macOS, which is the default.

WHY: There are no macOS CI runners, so Apple binaries have to be built on a laptop and attached to a (draft) GitHub Release before the builder runs. The Java publisher job has also been going red on every recent release after the bundle was already uploaded, because of the 0.5.0 plugin parse error.

## How is this tested?

Not tested. The plugin bump is a version pin; the new workflow jobs only run when `macos-binaries-release` is set, which is not exercised by pull-request CI.