### PR TITLE
[Rust] Document Arrow Flight architecture

### DIFF
--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -32,7 +32,8 @@ This is a Cargo workspace. The workspace root is `rust/Cargo.toml`.
 - `headers_provider.rs` — `HeadersProvider` trait + OAuth implementation
 - `landing_zone.rs` — Batches records before sending over gRPC
 - `record_types.rs` — `EncodedRecord`, `ProtoMessage`, `JsonString`
-- `stream/arrow/` — Arrow Flight ingestion, ACK rotation, connection, and recovery modules (Beta; behind `arrow-flight`)
+- `stream/arrow/` — Arrow Flight ingestion, ACK rotation, connection, and recovery modules
+  (Beta; behind `arrow-flight`); see `stream/arrow/README.md` for architecture and invariants
 
 ## Build commands
 

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -24,6 +24,10 @@
 - Example READMEs and `get_unacked_*` rustdoc now name `ingest_record_offset()` /
   `ingest_records_offset()`. The generate-files tool README quoting is valid shell.
   Arrow example docs place schema validation at stream creation, not the first batch.
+- Updated the Arrow example to use application-sized batches and queue them before
+  one `flush()`, clarified logical versus wire offsets and partial acknowledgments,
+  and added an Arrow Flight architecture guide covering lifecycle, recovery, close,
+  and concurrency invariants.
 
 ### Internal Changes
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -49,7 +49,7 @@ The Zerobus Rust SDK provides a robust, async-first interface for ingesting larg
 - **Flexible Configuration** - Fine-tune timeouts, retries, and recovery behavior
 - **Graceful Stream Management** - Proper flushing and acknowledgment tracking
 - **Acknowledgment Callbacks** - Receive notifications when records are acknowledged or encounter errors
-- **Arrow Flight Ingestion** *(Beta, opt-in)* — Stream Apache Arrow `RecordBatch` data directly to Zerobus over the Arrow Flight protocol on the same gRPC connection. Enable with `features = ["arrow-flight"]`; see [`examples/arrow/`](https://github.com/databricks/zerobus-sdk/tree/main/rust/examples/arrow).
+- **Arrow Flight Ingestion** *(Beta, opt-in)* — Stream Apache Arrow `RecordBatch` data directly to Zerobus using Arrow Flight's gRPC transport. Enable with `features = ["arrow-flight"]`; see [`examples/arrow/`](https://github.com/databricks/zerobus-sdk/tree/main/rust/examples/arrow).
 - **Zeroparser** *(opt-in)* — Zero-copy, single-pass protobuf parser for runtime-known schemas. Enable with `features = ["zeroparser"]`; see [`sdk/src/zeroparser/README.md`](https://github.com/databricks/zerobus-sdk/blob/main/rust/sdk/src/zeroparser/README.md).
 
 ## Installation
@@ -133,7 +133,9 @@ zerobus_rust_sdk/
 │   │   │       ├── supervisor.rs       # Recovery, replay, and finalization
 │   │   │       ├── batch.rs            # Pending batches and IPC helpers
 │   │   │       ├── metadata.rs         # Flight request/ack metadata
-│   │   │       └── options.rs          # Arrow Flight stream options
+│   │   │       ├── options.rs          # Arrow Flight stream options
+│   │   │       ├── close.rs            # Close coordination and terminal finalization
+│   │   │       └── README.md           # Arrow Flight internal architecture
 │   │   ├── multiplexed_stream.rs       # Multiplexed stream implementation
 │   │   ├── default_token_factory.rs    # OAuth 2.0 token handling
 │   │   ├── token_cache.rs              # OAuth token caching
@@ -245,7 +247,10 @@ zerobus_rust_sdk/
 
 ## How It Works
 
-### Architecture Overview
+### JSON / Protocol Buffers Architecture Overview
+
+The following diagram describes the standard JSON/protobuf stream. Arrow Flight uses a
+separate Flight request/response exchange and lifecycle state machine.
 
 ```
 +-----------------+
@@ -287,13 +292,37 @@ zerobus_rust_sdk/
 +-----------------------+
 ```
 
-### Data Flow
+### JSON / Protocol Buffers Data Flow
 
 1. **Ingestion** - Your app calls `stream.ingest_record_offset(data)` or `stream.ingest_records_offset(batch)`
 2. **Buffering** - Records are placed in the landing zone with logical offsets
 3. **Sending** - Sender task sends records over gRPC with physical offsets
 4. **Acknowledgment** - Receiver task gets server ack; callers wait via `stream.wait_for_offset(offset)`
 5. **Recovery** - If connection fails, supervisor reconnects and resends unacked records
+
+### Arrow Flight Lifecycle *(Beta)*
+
+Arrow Flight uses a dedicated DoPut request/response exchange:
+
+```text
+ingest_batch -> Flight encoder -> DoPut -> ack_up_to_records
+```
+
+1. Build the stream with `.arrow(schema).build_arrow()`.
+2. Queue application-sized `RecordBatch`es with `ingest_batch()`.
+3. Call `flush()` once at a durability boundary.
+4. Call `close()` to half-close and drain the active Flight exchange.
+
+Each input `RecordBatch` receives one logical SDK offset even if Flight splits it
+into several wire messages. Durability is tracked through the cumulative
+`ack_up_to_records` watermark. Arrow Flight does not support `ack_callback`.
+
+Recovery reconnects and replays only unacknowledged batch suffixes. After a failed
+`close()`, call `get_unacked_batches()` to inspect the retained work; the returned
+set can be empty when every record was already durable.
+
+For state ownership, replay, rotation, and concurrency invariants, see the
+[Arrow Flight maintainer architecture guide](https://github.com/databricks/zerobus-sdk/blob/main/rust/sdk/src/stream/arrow/README.md).
 
 ### Authentication Flow
 
@@ -811,13 +840,42 @@ Also accepts `0` or `no`.
 | `ack_callback` | `Option<Arc<dyn AckCallback>>` | `None` | **gRPC JSON/proto streams only.** Optional callback for acknowledgment notifications. Not supported for Arrow Flight streams. |
 | `callback_max_wait_time_ms` | `Option<u64>` | `Some(5_000)` | **gRPC JSON/proto streams only.** Maximum time to wait for callback processing to complete after closing the stream (`None` = wait indefinitely, `Some(x)` = wait up to `x` ms) |
 
+### ArrowStreamConfigurationOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_inflight_batches` | `usize` | 1,000 | Maximum accepted batches awaiting acknowledgment; bounds memory and applies backpressure |
+| `recovery` | `bool` | true | Reconnect and replay unacknowledged batch suffixes after retryable failures |
+| `recovery_timeout_ms` | `u64` | 15,000 | Timeout for one recovery attempt (ms) |
+| `recovery_backoff_ms` | `u64` | 2,000 | Delay between recovery attempts (ms) |
+| `recovery_retries` | `u32` | 4 | Maximum recovery attempts |
+| `server_lack_of_ack_timeout_ms` | `u64` | 60,000 | Maximum pending lifetime for the oldest submitted batch on an active connection |
+| `flush_timeout_ms` | `u64` | 300,000 | Timeout for `flush()`, `wait_for_offset()`, and the explicit-close acknowledgment wait |
+| `connection_timeout_ms` | `u64` | 30,000 | Timeout for Flight connection establishment |
+| `ipc_compression` | `Option<CompressionType>` | `None` | Optional `LZ4_FRAME` or `ZSTD` Arrow IPC compression |
+| `stream_paused_max_wait_time_ms` | `Option<u64>` | `None` | ACK-wait cap during server rotation; `None` uses the available server grace, while `Some(0)` skips ACK waiting but not bounded transport cleanup |
+
+```rust
+let stream = sdk
+    .stream_builder()
+    .table("catalog.schema.orders")
+    .oauth(client_id, client_secret)
+    .arrow(schema)
+    .max_inflight_batches(1_000)
+    .connection_timeout_ms(30_000)
+    .ipc_compression(Some(arrow_ipc::CompressionType::ZSTD))
+    .build_arrow()
+    .await?;
+```
+
 For Arrow Flight streams *(Beta)*, `server_lack_of_ack_timeout_ms` is an
 absolute limit on how long the oldest batch may remain pending during normal
 stream operation, not an inactivity timeout. No timer runs while the stream is
-idle. A batch's deadline starts when it becomes pending; responses and partial
-acknowledgments do not pause or extend it. Replayed batches receive a fresh
-deadline after the full replay completes and acknowledgment processing can
-resume on the recovered connection. Configure this timeout together with
+idle or while a batch is buffered but not submitted. For the oldest submitted
+pending batch, the deadline is based on when it became pending; responses and
+partial acknowledgments do not pause or extend it. Replayed batches receive a
+fresh deadline after the full replay completes and acknowledgment processing
+can resume on the recovered connection. Configure this timeout together with
 `max_inflight_batches` so the server can acknowledge a full allowed backlog
 within the timeout.
 
@@ -828,7 +886,10 @@ capped at one year. If `ack_callback` was configured on the builder,
 `build_arrow()` returns `ZerobusError::InvalidArgument` instead of silently
 ignoring the callback.
 
-**Example:**
+For internal lifecycle, offset, recovery, and concurrency details, see the
+[Arrow Flight maintainer architecture guide](https://github.com/databricks/zerobus-sdk/blob/main/rust/sdk/src/stream/arrow/README.md).
+
+**JSON / protobuf example:**
 
 ```rust
 let stream = sdk

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -145,7 +145,8 @@ use std::sync::Arc;
 use databricks_zerobus_ingest_sdk::{ArrowSchema, DataType, Field};
 
 let schema = Arc::new(ArrowSchema::new(vec![
-    Field::new("id", DataType::Int32, false),
+    // Delta columns are nullable unless declared NOT NULL.
+    Field::new("id", DataType::Int32, true),
     // ... other fields matching your table
 ]));
 
@@ -161,12 +162,24 @@ let mut stream = sdk
 
 ### 3. Ingest and Acknowledge
 
+**JSON / Protocol Buffers:**
+
 ```rust
 for record in records {
     // Returns once queued — do NOT wait on this offset inside the loop.
     let _offset = stream.ingest_record_offset(record).await?;
 }
 stream.flush().await?; // Confirm all pending records at once.
+```
+
+**Arrow Flight:**
+
+```rust
+for batch in record_batches {
+    // Returns once the logical batch is queued.
+    stream.ingest_batch(batch).await?;
+}
+stream.flush().await?; // Confirm every queued batch at once.
 ```
 
 ### 4. Close Stream

--- a/rust/examples/arrow/README.md
+++ b/rust/examples/arrow/README.md
@@ -14,11 +14,11 @@ This directory contains an example demonstrating Arrow Flight-based data ingesti
 
 ## Overview
 
-Arrow Flight is a third record format option alongside JSON and Protocol Buffers: it sends Apache Arrow `RecordBatch` data directly to Zerobus over the Arrow Flight protocol, on the same gRPC connection. It is the best fit when your workload is naturally columnar or batched — analytics pipelines, gateways aggregating short windows of rows, wide/numeric schemas where row-by-row serialization adds noticeable CPU overhead — or when your application already produces Arrow data via pyarrow, the [arrow-rs](https://github.com/apache/arrow-rs) crates, DataFusion, Polars, or similar libraries.
+Arrow Flight is a third record format option alongside JSON and Protocol Buffers: it sends Apache Arrow `RecordBatch` data directly to Zerobus using Arrow Flight's gRPC transport. It is the best fit when your workload is naturally columnar or batched — analytics pipelines, gateways aggregating short windows of rows, wide/numeric schemas where row-by-row serialization adds noticeable CPU overhead — or when your application already produces Arrow data via pyarrow, the [arrow-rs](https://github.com/apache/arrow-rs) crates, DataFusion, Polars, or similar libraries.
 
 **Features:**
 - Columnar Arrow data sent over the Arrow Flight protocol
-- Per-batch acknowledgments with the same recovery semantics as the standard streams
+- Logical batch offsets, cumulative durability acknowledgments, and automatic recovery
 
 > **Feature flag.** The Arrow Flight API is behind the `arrow-flight` Cargo feature. The example's `Cargo.toml` enables it for you.
 
@@ -33,15 +33,11 @@ Send multiple rows per `RecordBatch`. Start with natural application-sized batch
    cargo run -p example_arrow
    ```
 
-The example ingests 100 `RecordBatch`es (3 rows each), waits for an acknowledgment every 10th batch, then calls `flush()` and `close()` at the end.
+The example queues 10 `RecordBatch`es of 10,000 rows each, calls `flush()` once
+to confirm all pending data, then closes the stream.
 
 **Expected output:**
 ```
-Acknowledged through batch 10 (offset ID 9)
-Acknowledged through batch 20 (offset ID 19)
-Acknowledged through batch 30 (offset ID 29)
-...
-Acknowledged through batch 100 (offset ID 99)
 Flushed all in-flight batches
 Stream closed successfully
 ```
@@ -55,12 +51,12 @@ use std::sync::Arc;
 use databricks_zerobus_ingest_sdk::{ArrowSchema, DataType, Field, ZerobusSdk};
 
 let schema = Arc::new(ArrowSchema::new(vec![
-    Field::new("id", DataType::Int32, false),
-    Field::new("customer_name", DataType::Utf8, false),
+    Field::new("id", DataType::Int32, true),
+    Field::new("customer_name", DataType::LargeUtf8, true),
     // ... other fields
 ]));
 
-let stream = sdk
+let mut stream = sdk
     .stream_builder()
     .table(TABLE_NAME)
     .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
@@ -69,26 +65,23 @@ let stream = sdk
     .await?;
 ```
 
-**Ingest many `RecordBatch`es and wait periodically:**
+**Queue many `RecordBatch`es, then flush once:**
 
 ```rust
-use arrow_array::{Int32Array, RecordBatch, StringArray};
+use arrow_array::{Int32Array, LargeStringArray, RecordBatch};
 
-for i in 0..100 {
+const ROWS_PER_BATCH: usize = 10_000;
+
+for _ in 0..10 {
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
-            Arc::new(Int32Array::from(vec![/* ... */])),
-            Arc::new(StringArray::from(vec![/* ... */])),
+            Arc::new(Int32Array::from(vec![0; ROWS_PER_BATCH])),
+            Arc::new(LargeStringArray::from(vec!["Customer"; ROWS_PER_BATCH])),
             // ... other columns
         ],
     )?;
-    let offset = stream.ingest_batch(batch).await?;
-
-    // Apply backpressure every 10 batches by waiting for an ack.
-    if (i + 1) % 10 == 0 {
-        stream.wait_for_offset(offset).await?;
-    }
+    stream.ingest_batch(batch).await?;
 }
 
 // Drain any in-flight batches before closing.
@@ -97,9 +90,14 @@ stream.close().await?;
 ```
 
 **Batch semantics:**
-- **All-or-nothing per `RecordBatch`**: A batch is acknowledged as a unit
-- **Single acknowledgment**: One offset ID for the whole `RecordBatch`
-- **Schema validation**: The `RecordBatch` schema must exactly match the schema configured on the stream
+- **One logical offset per input batch**: `ingest_batch` returns one SDK offset even when
+  Flight splits a large batch into multiple wire messages
+- **Cumulative durability**: `wait_for_offset` completes after every record in that logical
+  batch is durable; after a partial failure, recovery/retrieval keeps only the unacknowledged suffix
+- **Non-empty batches**: zero-row batches are rejected with `InvalidArgument` because
+  they produce no Flight data message to acknowledge
+- **Schema validation**: Each `RecordBatch` must exactly match the client schema
+  configured on the stream; the server validates that schema against the target
 
 ## IPC compression
 
@@ -129,15 +127,20 @@ To disable compression, drop the `.ipc_compression(...)` call (default is `None`
 
 To ingest into your own table, change the Arrow schema and the array values to match its columns.
 
-**1. Update the Arrow schema** (must match the Delta table column types exactly):
+**1. Update the Arrow schema** (use the target table's canonical Arrow types):
 
 ```rust
 let schema = Arc::new(ArrowSchema::new(vec![
-    Field::new("your_field_1", DataType::Utf8, false),
-    Field::new("your_field_2", DataType::Int32, false),
+    Field::new("your_field_1", DataType::LargeUtf8, true),
+    Field::new("your_field_2", DataType::Int32, true),
     Field::new("your_field_3", DataType::Boolean, true),
 ]));
 ```
+
+The runnable example's `orders_schema()` shows the canonical mappings for strings
+and timestamps. If you already have Unity Catalog columns, prefer
+`arrow_schema_from_uc_columns()` or `arrow_schema_from_uc_schema()` to construct
+the schema. Every `RecordBatch` must exactly match the schema passed to `.arrow(...)`.
 
 **2. Update the arrays in `RecordBatch::try_new`** to match the schema:
 
@@ -145,7 +148,7 @@ let schema = Arc::new(ArrowSchema::new(vec![
 let batch = RecordBatch::try_new(
     schema.clone(),
     vec![
-        Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        Arc::new(LargeStringArray::from(vec!["a", "b", "c"])),
         Arc::new(Int32Array::from(vec![1, 2, 3])),
         Arc::new(BooleanArray::from(vec![Some(true), Some(false), None])),
     ],

--- a/rust/examples/arrow/src/main.rs
+++ b/rust/examples/arrow/src/main.rs
@@ -103,9 +103,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build_arrow()
         .await?;
 
-    const NUM_BATCHES: usize = 100;
-    const ROWS_PER_BATCH: usize = 3;
-    const WAIT_EVERY: usize = 10;
+    // Use application-sized batches to amortize Arrow encoding and Flight RPC overhead.
+    const NUM_BATCHES: usize = 10;
+    const ROWS_PER_BATCH: usize = 10_000;
 
     let now = chrono::Utc::now().timestamp_micros();
 
@@ -124,16 +124,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .collect();
 
         let batch = build_orders_batch(&schema, &orders);
-        let offset_id = stream.ingest_batch(batch).await?;
-
-        if (i + 1) % WAIT_EVERY == 0 {
-            stream.wait_for_offset(offset_id).await?;
-            println!(
-                "Acknowledged through batch {} (offset ID {})",
-                i + 1,
-                offset_id
-            );
-        }
+        stream.ingest_batch(batch).await?;
     }
 
     stream.flush().await?;

--- a/rust/sdk/src/stream/arrow/README.md
+++ b/rust/sdk/src/stream/arrow/README.md
@@ -1,0 +1,281 @@
+# Arrow Flight SDK Architecture
+
+This document describes the internal architecture and correctness invariants of the
+Rust Arrow Flight ingestion stream. For public API usage, see the
+[Rust SDK README](https://github.com/databricks/zerobus-sdk/blob/main/rust/README.md)
+and the
+[Arrow example](https://github.com/databricks/zerobus-sdk/blob/main/rust/examples/arrow/README.md).
+
+Arrow Flight support is currently behind the `arrow-flight` Cargo feature.
+
+## Data flow
+
+```text
+RecordBatch
+    |
+    v
+ZerobusArrowStream::ingest_batch
+    |
+    +-- logical offset + pending record range
+    +-- backpressure permit
+    |
+    v
+FlightDataEncoder
+    |
+    +-- schema message
+    +-- one or more physical RecordBatch messages
+    |
+    v
+Arrow Flight DoPut request
+    |
+    v
+PutResult acknowledgments
+    |
+    +-- cumulative durable record count
+    +-- optional server-rotation signal
+    |
+    v
+pending-range removal / recovery suffix
+```
+
+The caller task queues each batch onto the active request channel, and tonic
+drives the encoded request body. The supervisor owns acknowledgment processing,
+rotation, recovery, and terminal finalization.
+
+## Module responsibilities
+
+- [`mod.rs`](mod.rs) owns the public stream API, admission checks, logical offsets,
+  shared state, and stream construction.
+- [`connection.rs`](connection.rs) creates Flight clients and DoPut exchanges,
+  encodes request bodies, observes request EOF, and tracks request-body ownership.
+- [`acks.rs`](acks.rs) validates and applies acknowledgments, enforces pending
+  deadlines, and runs active/rotation/close transport states.
+- [`supervisor.rs`](supervisor.rs) owns the background lifecycle, retry policy,
+  reconnect, replay, sender publication, and terminal error selection.
+- [`close.rs`](close.rs) publishes the close request/result and performs the
+  idempotent terminal pending-to-failed transition.
+- [`batch.rs`](batch.rs) owns pending batch ranges, unacknowledged suffixes, replay
+  rebuilding, and IPC materialization.
+- [`metadata.rs`](metadata.rs) defines request and acknowledgment metadata.
+- [`options.rs`](options.rs) defines Arrow-specific configuration and contracts.
+- `c_data.rs`, when enabled internally, imports canonical Arrow C Data into a
+  Rust-owned `RecordBatch`.
+
+## Logical offsets and wire offsets
+
+The SDK has two intentionally different offset domains.
+
+### Logical SDK offsets
+
+`ingest_batch()` assigns one logical `OffsetId` to each input `RecordBatch`. This
+is the offset returned to callers and used by `wait_for_offset()` and `flush()`.
+The corresponding `PendingBatch` also stores a cumulative record range:
+`[start_record, end_record)`.
+
+Logical offsets are monotonic for the stream lifetime. Record ranges,
+`submitted_records`, and `last_acked_records` are connection-relative and are
+renumbered from zero when pending work is rebuilt for replay.
+
+### Physical Flight offsets
+
+`FlightDataEncoder` may split a large input batch into multiple physical
+`FlightData` record-batch messages. Each physical message receives a sequential,
+connection-local wire offset in `FlightBatchMetadata`.
+
+The first Flight message is the schema and carries no batch offset. Dictionary
+arrays use Arrow Flight's default `DictionaryHandling::Hydrate`, so dictionary
+values are expanded and do not introduce dictionary side messages.
+
+The server's `ack_up_to_offset` describes the physical Flight sequence. The SDK
+does not use that value to complete caller offsets. Completion is derived from
+`ack_up_to_records` and local pending ranges, which preserves correct behavior
+when one logical batch is split into several wire messages.
+
+## Ingestion and backpressure
+
+`max_inflight_batches` is represented by a semaphore. A `PendingBatch` owns one
+permit until it is acknowledged, removed during replay rebuilding, or moved into
+the terminal failed set.
+
+The ingestion sequence is:
+
+1. Acquire an inflight permit before `ingest_mutex`.
+2. Under `ingest_mutex`, re-check terminal admission.
+3. Assign the logical offset and cumulative record range.
+4. Insert the `PendingBatch`.
+5. If paused, return the logical offset and leave the batch buffered.
+6. Otherwise reserve a request-channel slot, publish `submitted_records`, and send.
+
+The semaphore and request channel use the same capacity. A task that owns an
+inflight permit therefore has a request-channel slot available while the active
+sender is attached.
+
+If reservation fails with recovery enabled, the batch remains pending and the
+send-failure notification starts recovery. With recovery disabled, ingestion
+withdraws the pending batch, rolls back its logical offset and record range,
+claims terminal admission, wakes the supervisor, and waits for the shared
+terminal result.
+
+`flush()` snapshots the latest logical offset under `ingest_mutex`, so it cannot
+observe an offset while a failed enqueue is rolling that offset back.
+
+## Admission, pause, and closure
+
+Three flags represent different lifecycle facts:
+
+- `is_paused` is a reversible transport gate. New batches are accepted and
+  buffered, but not sent. Successful reconnect clears it.
+- `admission_closed` is a one-way API gate. New batches are permanently rejected
+  once terminal finalization or an unrecoverable enqueue failure owns admission.
+- `is_closed` indicates that terminal failed-batch retrieval is available.
+
+`CloseState` separately publishes the explicit-close protocol:
+
+```text
+Open -> Requested(target, deadline) -> Finalized(result)
+  \----------------------------------> Finalized(result)
+```
+
+The direct `Open -> Finalized` edge is used by background terminal failures that
+occur without an explicit close request. The first request and final result are
+sticky. Cancelling a caller's `close()` future does not cancel supervisor-owned
+teardown; calling `close()` again waits for the same result.
+
+## Acknowledgment processing
+
+The authoritative durable watermark is `ack_up_to_records`.
+
+Applying an acknowledgment:
+
+1. Rejects a watermark beyond `submitted_records`.
+2. Advances `last_acked_records` monotonically.
+3. Removes fully acknowledged pending ranges.
+4. Publishes the highest completed logical offset.
+5. Records when an explicit close target became durable.
+
+Partial acknowledgments leave a `PendingBatch` in place. Recovery or terminal
+retrieval slices that batch to its unacknowledged suffix rather than replaying
+the already-durable prefix.
+
+During normal active operation, the oldest submitted pending batch has an
+absolute ACK deadline. Responses and partial progress do not extend it. No ACK
+timer runs while there are no submitted pending batches. A completed replay
+refreshes pending deadlines before the replacement sender becomes active.
+
+## Server-initiated rotation
+
+A rotation signal pauses sends and snapshots the records submitted on the
+current connection. Batches accepted after that snapshot remain pending for the
+next connection and do not extend the old connection's target.
+
+The ACK-wait period is capped by both the server-advertised grace and
+`stream_paused_max_wait_time_ms`. The client reserves transport-cleanup time,
+half-closes the request, and drains responses for a bounded interval. Setting
+the option to `Some(0)` skips ACK waiting but does not skip transport cleanup.
+
+When recovery is disabled, the same half-close/drain still runs, but the stream
+then terminates instead of reconnecting.
+
+## Recovery and replay
+
+Only the supervisor reconnects or publishes a replacement sender.
+
+On a retryable active failure:
+
+1. Pause ingestion sends and detach the failed sender under `ingest_mutex`.
+2. Wait the configured backoff unless explicit close interrupts it.
+3. Establish a replacement DoPut exchange and wait for READY.
+4. Rebuild pending ranges from the durable record watermark.
+5. Replay every unacknowledged suffix and any batches buffered during replay.
+6. Under `ingest_mutex`, refresh ACK deadlines, publish the replacement sender,
+   and clear `is_paused`.
+
+The replacement sender is not visible until replay succeeds. A failed or
+cancelled attempt drops its private sender. Explicit close during an uncommitted
+recovery attempt cancels that attempt best-effort, retains pending suffixes, and
+returns the trigger for the interrupted attempt.
+
+Authentication rejection invalidates cached credentials under a bounded
+deadline. Invalidation runs independently of explicit close so a rejected token
+is not left cached merely because close won the recovery race.
+
+## Transport and wrapper ownership
+
+`FlightConnection` owns both halves of one DoPut exchange: the response stream,
+the request-body control, and a sender for logical `RecordBatch` values. Normal
+supervisor handoff drops the connection's redundant sender clone because the
+stream's shared sender slot owns the active ingest path.
+
+`RequestBodyControl` uses a cancellation token to stop the request at a
+`FlightData` boundary and a watch channel to confirm that tonic polled the body
+to EOF. Transport cleanup half-closes through that control before bounded
+response draining; dropping only the response side would instead reset the
+exchange and lose late acknowledgments.
+
+Language wrappers never own Rust stream internals. IPC inputs are materialized
+into Rust `RecordBatch` values before regular ingestion. The internal Arrow C
+Data path imports an owner whose lifetime follows the resulting batch, including
+pending, replay, and terminal-retention paths. Wrapper handles must remain valid
+until their asynchronous operation completes and must use the matching
+close/free operation.
+
+## Explicit close and terminal finalization
+
+The first `close()` call snapshots its target offset and deadline under
+`ingest_mutex`, atomically with ingest admission and replacement-sender
+publication.
+
+On an active connection, ACK processing waits for the target or deadline, then
+half-closes and drains the transport. A target whose durable watermark was
+applied before the deadline succeeds even if timeout observation races with it.
+
+Close during an existing server rotation or uncommitted recovery returns that
+attempt's trigger, even when every record is already durable. Callers should
+inspect `get_unacked_batches()` after an error; the returned set may be empty.
+
+`CloseFinalizer`:
+
+1. Closes admission and detaches the sender under `ingest_mutex`.
+2. Publishes the selected terminal error for waiters.
+3. Moves unacknowledged pending suffixes into `failed_batches`.
+4. Publishes the sticky `CloseState::Finalized` result.
+
+The supervisor worker has a detached reaper that owns its `JoinHandle`. If the
+worker panics or is aborted before finalization, the reaper performs terminal
+finalization and wakes close waiters.
+
+## Concurrency invariants
+
+`ingest_mutex` serializes:
+
+- logical offset and pending-range assignment or rollback;
+- pause and sender detachment;
+- replay rebuilding and replacement-sender publication;
+- explicit-close target publication;
+- terminal admission and finalization.
+
+Important invariants:
+
+- A batch is either ordered before close publication or rejected/buffered after
+  the relevant lifecycle transition; it is never half-admitted.
+- A replacement sender is published only after complete replay.
+- A recovery-disabled failed enqueue claims terminal admission before releasing
+  `ingest_mutex`, so concurrent close cannot replace its error with success.
+- On the normal ingest path, `submitted_records` advances in the same pending-lock
+  critical section as the infallible request-channel handoff. Replay advances it
+  under `ingest_mutex`; no ACK processor observes the replacement until publication.
+- `failed_batches` and `pending_batches` are always locked in that order during
+  terminal retrieval, so concurrent drains are idempotent.
+- `get_unacked_batches()` re-runs the pending-to-failed drain before returning,
+  ensuring a complete snapshot even if it races terminal finalization.
+
+Do not reorder `biased` `select!` arms, deadline reads, atomic stores, or lock
+acquisitions without adding a deterministic race test for the intended change.
+
+## Testing
+
+Unit tests beside the modules validate range rebuilding, ACK deadlines, close
+selection, and sender publication. Integration tests in
+[`rust/tests/src/arrow_tests.rs`](https://github.com/databricks/zerobus-sdk/blob/main/rust/tests/src/arrow_tests.rs)
+use a mock Flight server plus `test-hooks` barriers to reproduce recovery and
+close interleavings without relying on sleeps.


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add an Arrow Flight maintainer guide covering module ownership, logical and wire offsets, ACKs, recovery, close, transport ownership, and concurrency invariants.
- Add a user-level Arrow lifecycle and options section to the Rust README.
- Correct schema, offset, partial-acknowledgment, and task-ownership documentation.
- Update the runnable example to use application-sized batches and one final flush().

## How is this tested?

Doc change.