### PR TITLE
[PureGo] Add ColumnsFromDescriptor

### DIFF
--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -11,6 +11,10 @@
   request still being sent is allowed to finish, so an acknowledgment already
   received for it makes the record durable instead of replaying the record on
   the new connection. Teardown stays bounded by the drain budget.
+- `ColumnsFromDescriptor` returns the set of column names a serialized protobuf
+  descriptor declares, so callers can inspect a table's columns without parsing
+  the descriptor themselves. It accepts the bytes returned by
+  `FetchProtoDescriptorFromUC` or passed to `WithProto`.
 
 ### Bug Fixes
 
@@ -21,6 +25,8 @@
   replays them on a fresh stream. The JSON batch example demonstrates that a
   batch produces a single ack callback event and waits for that callback before
   exit.
+- Corrected the README's dynamic JSON rules: a payload carrying a field the
+  descriptor does not declare fails conversion; unknown fields are not ignored.
 
 ### Internal Changes
 

--- a/purego/README.md
+++ b/purego/README.md
@@ -135,6 +135,22 @@ if err := stream.Flush(); err != nil { // wait once at the end
 
 See `examples/dynamic/single/main.go` for a complete example.
 
+`ColumnsFromDescriptor` reports which columns a descriptor declares, without
+parsing the protobuf yourself:
+
+```go
+columns, err := zerobus.ColumnsFromDescriptor(descriptor)
+if err != nil {
+    log.Fatal(err)
+}
+if _, ok := columns["event_id"]; !ok {
+    log.Fatal("table has no event_id column")
+}
+```
+
+Only top-level fields are columns; the fields of a nested `STRUCT` belong to
+that column's value.
+
 To skip JSON conversion while retaining UC schema discovery, build dynamic
 protobuf messages from the stream descriptor:
 
@@ -172,7 +188,8 @@ Dynamic JSON follows protobuf JSON value rules:
 - `BIGINT` values above 2^53 should be strings to avoid JSON-number precision
   loss.
 - `STRUCT`, `ARRAY`, and `MAP` use JSON objects, arrays, and objects.
-- Unknown JSON fields are ignored.
+- Unknown JSON fields are rejected; conversion fails the ingest call rather
+  than dropping them.
 
 ## Error handling
 

--- a/purego/zerobus/columns_test.go
+++ b/purego/zerobus/columns_test.go
@@ -1,0 +1,135 @@
+package zerobus_test
+
+import (
+	"errors"
+	"maps"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/databricks/zerobus-sdk/purego/internal/schema"
+	"github.com/databricks/zerobus-sdk/purego/zerobus"
+)
+
+func TestColumnsFromDescriptorMatchesUCColumns(t *testing.T) {
+	descriptor, err := schema.DescriptorFromUCColumns([]schema.UcColumn{
+		{Name: "id", TypeName: "BIGINT", Position: 0},
+		{Name: "payload", TypeName: "STRING", Position: 1, Nullable: true},
+	}, "events")
+	if err != nil {
+		t.Fatalf("DescriptorFromUCColumns: %v", err)
+	}
+	raw, err := proto.Marshal(descriptor)
+	if err != nil {
+		t.Fatalf("marshal descriptor: %v", err)
+	}
+
+	got, err := zerobus.ColumnsFromDescriptor(raw)
+	if err != nil {
+		t.Fatalf("ColumnsFromDescriptor: %v", err)
+	}
+	want := map[string]struct{}{"id": {}, "payload": {}}
+	if !maps.Equal(got, want) {
+		t.Fatalf("columns = %v, want %v", got, want)
+	}
+}
+
+func TestColumnsFromDescriptorSkipsNestedAndUnnamedFields(t *testing.T) {
+	raw := mustMarshalDescriptor(t, &descriptorpb.DescriptorProto{
+		Name: proto.String("events"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			descriptorField("id", 1, descriptorpb.FieldDescriptorProto_TYPE_INT64),
+			{
+				Name:     proto.String("address"),
+				Number:   proto.Int32(2),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String("address"),
+			},
+			{Number: proto.Int32(3), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},
+		},
+		NestedType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("address"),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				descriptorField("city", 1, descriptorpb.FieldDescriptorProto_TYPE_STRING),
+			},
+		}},
+	})
+
+	got, err := zerobus.ColumnsFromDescriptor(raw)
+	if err != nil {
+		t.Fatalf("ColumnsFromDescriptor: %v", err)
+	}
+	want := map[string]struct{}{"id": {}, "address": {}}
+	if !maps.Equal(got, want) {
+		t.Fatalf("columns = %v, want %v", got, want)
+	}
+}
+
+func TestColumnsFromDescriptorErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     []byte
+		wantErr string
+	}{
+		{
+			name:    "truncated bytes",
+			raw:     []byte{0x0a, 0x05, 'e'},
+			wantErr: "parse descriptor",
+		},
+		{
+			name:    "empty bytes",
+			raw:     nil,
+			wantErr: "has no columns",
+		},
+		{
+			name:    "descriptor without fields",
+			raw:     mustMarshalDescriptor(t, &descriptorpb.DescriptorProto{Name: proto.String("events")}),
+			wantErr: "has no columns",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := zerobus.ColumnsFromDescriptor(tc.raw)
+			if err == nil {
+				t.Fatalf("ColumnsFromDescriptor returned %v, want error", got)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+			var sdkErr *zerobus.Error
+			if !errors.As(err, &sdkErr) {
+				t.Fatalf("error %v is not a *zerobus.Error", err)
+			}
+			if sdkErr.Op != "ColumnsFromDescriptor" {
+				t.Fatalf("Op = %q, want %q", sdkErr.Op, "ColumnsFromDescriptor")
+			}
+			if zerobus.Retryable(err) {
+				t.Fatal("a malformed descriptor must not be retryable")
+			}
+		})
+	}
+}
+
+func descriptorField(
+	name string,
+	number int32,
+	typ descriptorpb.FieldDescriptorProto_Type,
+) *descriptorpb.FieldDescriptorProto {
+	return &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(number),
+		Type:   typ.Enum(),
+	}
+}
+
+func mustMarshalDescriptor(t *testing.T, descriptor *descriptorpb.DescriptorProto) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(descriptor)
+	if err != nil {
+		t.Fatalf("marshal descriptor: %v", err)
+	}
+	return raw
+}

--- a/purego/zerobus/example_test.go
+++ b/purego/zerobus/example_test.go
@@ -99,6 +99,17 @@ func ExampleStream_proto() {
 	}
 }
 
+// Check which columns a descriptor declares before ingesting into the table.
+func ExampleColumnsFromDescriptor() {
+	columns, err := zerobus.ColumnsFromDescriptor(descriptorProto())
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, ok := columns["event_id"]; !ok {
+		log.Fatal("table has no event_id column")
+	}
+}
+
 // logAckCallback logs each acknowledged offset and any per-record error.
 type logAckCallback struct{}
 

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -1,5 +1,4 @@
-// Package zerobus is a pure-Go client for Zerobus ingestion. It speaks gRPC
-// directly, so it needs no cgo and no prebuilt native libraries.
+// Package zerobus is a pure-Go client for Zerobus ingestion.
 //
 // Create an SDK with New and a stream with CreateStream. Ingestion is
 // asynchronous: IngestRecordOffset returns as soon as the record is queued, so

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -209,12 +209,8 @@ func (s *SDK) CreateStreamWithProvider(
 }
 
 // FetchProtoDescriptorFromUC returns a protobuf descriptor built from a Unity
-// Catalog table schema.
-//
-// Every call performs a fresh Unity Catalog request; the SDK does not cache the
-// result. Fetch once per table and reuse the bytes for every stream on it —
-// calling this per stream, or worse per record, puts a UC round-trip on the
-// ingestion path. Fetch again only when the table schema changes.
+// Catalog table schema. Every call performs a fresh Unity Catalog request; the
+// SDK does not cache the result.
 func (s *SDK) FetchProtoDescriptorFromUC(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -1,13 +1,5 @@
-// Package zerobus is a pure-Go client for Zerobus ingestion.
-//
-// Create an SDK with New and a stream with CreateStream. Ingestion is
-// asynchronous: IngestRecordOffset returns as soon as the record is queued, so
-// queue in a loop and call Flush once at the end. Waiting on every record
-// instead costs a server round-trip apiece. For continuous streams, flush
-// periodically or register an ack callback with WithAckCallback.
-//
-// See the README for authentication, record types, error handling, and
-// recovery.
+// Package zerobus is a pure-Go client for Zerobus ingestion. Create an SDK with
+// New and a stream with CreateStream.
 package zerobus
 
 import (

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -1,57 +1,14 @@
-// Package zerobus is a pure-Go client for Zerobus ingestion.
+// Package zerobus is a pure-Go client for Zerobus ingestion. It speaks gRPC
+// directly, so it needs no cgo and no prebuilt native libraries.
 //
-// # Quick start
+// Create an SDK with New and a stream with CreateStream. Ingestion is
+// asynchronous: IngestRecordOffset returns as soon as the record is queued, so
+// queue in a loop and call Flush once at the end. Waiting on every record
+// instead costs a server round-trip apiece. For continuous streams, flush
+// periodically or register an ack callback with WithAckCallback.
 //
-//	sdk, err := zerobus.New(
-//	    "https://your-workspace.zerobus.region.cloud.databricks.com",
-//	    "https://your-workspace.cloud.databricks.com",
-//	)
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
-//	defer sdk.Close()
-//
-//	stream, err := sdk.CreateStream(ctx, "catalog.schema.table",
-//	    clientID, clientSecret, zerobus.WithJSON())
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
-//	defer stream.Close()
-//
-// # Ingesting data
-//
-// Ingestion is asynchronous. Queue records in a loop and call Flush once.
-//
-//	for _, rec := range records {
-//	    if _, err := stream.IngestRecordOffset(rec); err != nil {
-//	        log.Fatal(err)
-//	    }
-//	}
-//	if err := stream.Flush(); err != nil { // wait once for all pending acks
-//	    log.Fatal(err)
-//	}
-//
-// For continuous streams call Flush periodically (every N records) or register
-// an ack callback with WithAckCallback. Reserve per-record WaitForOffset for
-// genuinely low-volume cases where each record must be confirmed before
-// continuing.
-//
-// Stream creation is asynchronous by default: CreateStream returns after local
-// validation while first-open runs in the background. Pass WithWaitForReady to
-// make CreateStream block until first-open succeeds or fails terminally.
-//
-// # Proto descriptors from Unity Catalog
-//
-// FetchProtoDescriptorFromUC builds a descriptor from a Unity Catalog table
-// schema. It is a plain remote call with no caching, so fetch the descriptor
-// once and reuse the bytes for every stream on that table; fetch again only
-// after the table schema changes.
-//
-// # Authentication
-//
-// CreateStream uses the Unity Catalog OAuth 2.0 client-credentials flow. For
-// custom authentication, implement HeadersProvider and use
-// CreateStreamWithProvider.
+// See the README for authentication, record types, error handling, and
+// recovery.
 package zerobus
 
 import (
@@ -68,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/auth"
 	"github.com/databricks/zerobus-sdk/purego/internal/dynamicproto"
@@ -254,21 +212,9 @@ func (s *SDK) CreateStreamWithProvider(
 // Catalog table schema.
 //
 // Every call performs a fresh Unity Catalog request; the SDK does not cache the
-// result. Fetch the descriptor once and reuse the returned bytes for every
-// stream on that table:
-//
-//	descriptor, err := sdk.FetchProtoDescriptorFromUC(ctx, table, clientID, clientSecret)
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
-//	for range streamCount {
-//	    stream, err := sdk.CreateStream(ctx, table, clientID, clientSecret,
-//	        zerobus.WithProto(descriptor))
-//	    // ...
-//	}
-//
-// Calling it per stream, or worse per record, adds a Unity Catalog round-trip
-// to the hot path. Fetch again only when the table schema changes.
+// result. Fetch once per table and reuse the bytes for every stream on it —
+// calling this per stream, or worse per record, puts a UC round-trip on the
+// ingestion path. Fetch again only when the table schema changes.
 func (s *SDK) FetchProtoDescriptorFromUC(
 	ctx context.Context,
 	tableName, clientID, clientSecret string,
@@ -291,6 +237,18 @@ func (s *SDK) FetchProtoDescriptorFromUC(
 		}
 	}
 	return descBytes, nil
+}
+
+// ColumnsFromDescriptor returns the column names declared by a serialized
+// protobuf descriptor, such as the bytes from FetchProtoDescriptorFromUC or
+// WithProto. Only top-level fields are columns; the fields of a nested message
+// belong to that column's value.
+func ColumnsFromDescriptor(raw []byte) (map[string]struct{}, error) {
+	columns, err := columnsFromDescriptor(raw)
+	if err != nil {
+		return nil, &Error{Op: "ColumnsFromDescriptor", cause: err, retryable: false}
+	}
+	return columns, nil
 }
 
 func (s *SDK) createStream(
@@ -416,6 +374,23 @@ func (s *SDK) fetchProtoDescriptor(
 		return nil, fmt.Errorf("serialize descriptor: %w", err)
 	}
 	return descBytes, nil
+}
+
+func columnsFromDescriptor(raw []byte) (map[string]struct{}, error) {
+	var descriptor descriptorpb.DescriptorProto
+	if err := proto.Unmarshal(raw, &descriptor); err != nil {
+		return nil, fmt.Errorf("parse descriptor: %w", err)
+	}
+	columns := make(map[string]struct{}, len(descriptor.GetField()))
+	for _, field := range descriptor.GetField() {
+		if name := field.GetName(); name != "" {
+			columns[name] = struct{}{}
+		}
+	}
+	if len(columns) == 0 {
+		return nil, errors.New("table schema descriptor has no columns")
+	}
+	return columns, nil
 }
 
 func dynamicSchemaErrorRetryable(err error) bool {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `ColumnsFromDescriptor` to the pure-Go public API. It returns the set of
*column names* a serialized protobuf descriptor declares — the bytes returned by
`FetchProtoDescriptorFromUC` or passed to `WithProto`:

```go
columns, err := zerobus.ColumnsFromDescriptor(descriptor)
if err != nil {
    log.Fatal(err)
}
if _, ok := columns["event_id"]; !ok {
    log.Fatal("table has no event_id column")
}
```

**Why:** a caller who fetches a descriptor from Unity Catalog currently has no
way to see which columns it declares without unmarshalling
`descriptorpb.DescriptorProto` themselves — importing protobuf internals to
answer a question the SDK already holds the data for.

Only top-level fields are columns; the fields of a nested message belong to that
column's value. The exported function is a thin wrapper over a private helper,
mirroring `FetchProtoDescriptorFromUC`, so failures surface as `*zerobus.Error`
with `Op: "ColumnsFromDescriptor"` and non-retryable — consistent with every
other public entry point.

Two documentation fixes ride along:

- The README claimed "Unknown JSON fields are ignored." They are rejected:
  `internal/dynamicproto` runs `protojson` with `DiscardUnknown` false, and
  `TestConverter_UnknownFieldRejected` has been asserting that rejection all
  along. Anyone reading that line would have planned around the wrong behavior.
- The package doc comment (54 lines) and `FetchProtoDescriptorFromUC`'s doc
  comment (19 lines) were long yet partial — the package doc documented four
  topics out of the README's eleven, and every section it did cover was already
  documented by symbol godoc on the same page (`WithWaitForReady` covers async
  creation in more detail, `HeadersProvider` covers auth, and the Quick start
  block was `ExampleStream_ingestThenFlush` verbatim). Both are now short and
  point at the README, which keeps the queue-then-`Flush` rule up front.

## How is this tested?

New `purego/zerobus/columns_test.go`, in the external `zerobus_test` package so
it exercises the public surface:

- Round-trip through the SDK's own `schema.DescriptorFromUCColumns` builder, so
  the result is checked against the descriptor the SDK itself produces from a UC
  schema.
- Nested-message and unnamed fields are excluded.
- Error paths (truncated bytes, empty bytes, a descriptor with no fields) return
  `*zerobus.Error` with the right `Op` and are classified non-retryable.

`ExampleColumnsFromDescriptor` was added to `example_test.go` and compiles as
part of the suite. Full purego suite passes under `-race` (553 tests), with
`go vet` and `gofmt` clean.