### PR TITLE
[Python] Wire NonRetriable exceptions

### DIFF
--- a/python/NEXT_CHANGELOG.md
+++ b/python/NEXT_CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bug Fixes
 
+- Map non-retryable Rust errors to `NonRetriableException` instead of always
+  raising `ZerobusException`. Retryability follows `ZerobusError::is_retryable()`
+  (invalid credentials, missing table, schema/argument errors, and other fatal
+  conditions). `NonRetriableException` remains a subclass of `ZerobusException`.
+
 ### Documentation
 
 - Corrected README, example, and docstring snippets for record-format selection,

--- a/python/README.md
+++ b/python/README.md
@@ -332,25 +332,35 @@ compatibility but does not select the format.
 
 ## Error Handling
 
-SDK operation failures currently surface as `ZerobusException`. The
-`NonRetriableException` class is exported for compatibility, but the current native binding does
-not construct it. Do not use the Python exception class to decide whether an operation is safe to
-retry.
+The SDK raises two categories of exception. Handle them differently:
+
+- **Retriable** (`ZerobusException`): transient conditions such as network issues or
+  temporary server errors. Safe to retry, ideally with backoff. The SDK's built-in
+  recovery already handles many of these for you.
+- **Non-retriable** (`NonRetriableException`): fatal conditions such as invalid
+  credentials or a missing table. Retrying won't help. Fix the underlying problem.
+
+`NonRetriableException` is a subclass of `ZerobusException`, so a bare
+`except ZerobusException` still catches both.
 
 ```python
-from zerobus.sdk.shared import ZerobusException
+from zerobus.sdk.shared import ZerobusException, NonRetriableException
 
 try:
     stream.ingest_record_offset(record)
+except NonRetriableException as e:
+    # Fatal: do not retry; fix the cause (credentials, table, schema)
+    raise
 except ZerobusException as e:
-    print(f"Ingestion failed: {e}")
+    # Transient: retry with backoff
+    ...
 ```
 
 ## Handling Stream Failures
 
 The SDK automatically handles retries for transient errors. Enqueue, flush, and close
-failures all surface as `ZerobusException`. `get_unacked_records()` and
-`recreate_stream()` succeed only after the stream has already closed, which a terminal
+failures surface as `ZerobusException` or `NonRetriableException`. `get_unacked_records()`
+and `recreate_stream()` succeed only after the stream has already closed, which a terminal
 failure does. An enqueue failure leaves the stream active, so those calls fail; raise
 the original error and keep the stream. `recreate_stream()` re-queues records that were
 already accepted; it does not retry a payload that failed to enqueue.
@@ -573,9 +583,8 @@ ack.is_done() -> bool
 
 ### Exceptions
 
-- `ZerobusException(message, cause=None)` - Base exception raised by current SDK operations
-- `NonRetriableException(message, cause=None)` - Exported subclass reserved for non-retriable errors;
-  the current native binding does not construct it
+- `ZerobusException(message, cause=None)` - Base exception; retryable SDK failures are raised as this type
+- `NonRetriableException(message, cause=None)` - Subclass for fatal errors (`ZerobusError::is_retryable()` is false)
 
 ## Debugging
 

--- a/python/rust/src/common.rs
+++ b/python/rust/src/common.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 
 use databricks_zerobus_ingest_sdk::{
-    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder,
+    AckCallback as RustAckCallback, EncodedRecord, OffsetId, StreamBuilder, ZerobusError,
 };
 
 /// User-agent prefix emitted by this wrapper SDK. Combined with the wrapper
@@ -563,10 +563,12 @@ pyo3::create_exception!(
     "Indicates a non-retriable error has occurred"
 );
 
-/// Map Rust SDK errors to Python exceptions
-pub fn map_error(err: impl std::fmt::Display) -> PyErr {
+/// Map Rust SDK errors to Python exceptions using `ZerobusError::is_retryable()`.
+pub fn map_error(err: ZerobusError) -> PyErr {
     let msg = err.to_string();
-    // For now, treat all errors as retriable ZerobusException
-    // We can make this more sophisticated later by examining error messages/types
-    ZerobusException::new_err(msg)
+    if err.is_retryable() {
+        ZerobusException::new_err(msg)
+    } else {
+        NonRetriableException::new_err(msg)
+    }
 }

--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -1,0 +1,105 @@
+"""Exception mapping: ZerobusException vs NonRetriableException.
+
+These tests hit native `map_error` without a live Zerobus server. Fatal Rust
+errors (`is_retryable() == false`) must raise NonRetriableException; retryable
+ones must raise the base ZerobusException, not the subclass.
+"""
+
+import asyncio
+import unittest
+
+from zerobus import (
+    HeadersProvider,
+    NonRetriableException,
+    StreamConfigurationOptions,
+    TableProperties,
+    ZerobusException,
+)
+from zerobus import _zerobus_core as core
+from zerobus.sdk import ZerobusSdk as SyncSdk
+from zerobus.sdk.aio import ZerobusSdk as AsyncSdk
+
+HOST = "https://workspace.zerobus.cloud.databricks.com"
+UC = "https://workspace.cloud.databricks.com"
+# Connection refused without hanging on recovery retries.
+LOCAL_REFUSED = "http://127.0.0.1:1"
+NO_RECOVERY = StreamConfigurationOptions(recovery=False)
+
+
+def _sync_sdk():
+    return SyncSdk(HOST, UC)
+
+
+class DummyHeaders(HeadersProvider):
+    def get_headers(self):
+        return [("authorization", "Bearer test")]
+
+
+class TestExceptionHierarchy(unittest.TestCase):
+    def test_non_retriable_is_subclass(self):
+        self.assertTrue(issubclass(NonRetriableException, ZerobusException))
+
+    def test_bare_zerobus_exception_catches_non_retriable(self):
+        try:
+            raise NonRetriableException("fatal")
+        except ZerobusException as e:
+            self.assertIsInstance(e, NonRetriableException)
+        else:
+            self.fail("NonRetriableException must be caught by except ZerobusException")
+
+
+class TestNonRetriableMapping(unittest.TestCase):
+    def _assert_non_retriable(self, fn):
+        with self.assertRaises(NonRetriableException) as ctx:
+            fn()
+        self.assertIsInstance(ctx.exception, ZerobusException)
+
+    def test_invalid_application_name_sync(self):
+        self._assert_non_retriable(lambda: SyncSdk(HOST, UC, application_name="bad\nname"))
+
+    def test_invalid_application_name_async(self):
+        self._assert_non_retriable(lambda: AsyncSdk(HOST, UC, application_name="bad\nname"))
+
+    def test_empty_table_name_on_create_stream(self):
+        sdk = _sync_sdk()
+        self._assert_non_retriable(lambda: sdk.create_stream("id", "secret", TableProperties(""), NO_RECOVERY))
+
+    def test_invalid_table_name_on_create_stream(self):
+        sdk = _sync_sdk()
+        self._assert_non_retriable(
+            lambda: sdk.create_stream("id", "secret", TableProperties("not-three-parts"), NO_RECOVERY)
+        )
+
+    def test_invalid_arrow_ipc_schema(self):
+        sdk = core.sync.ZerobusSdk(HOST, UC)
+        self._assert_non_retriable(lambda: sdk.create_arrow_stream("catalog.schema.table", b"not-ipc", "id", "secret"))
+
+    def test_async_empty_table_name(self):
+        sdk = AsyncSdk(HOST, UC)
+
+        async def _create():
+            await sdk.create_stream("id", "secret", TableProperties(""), NO_RECOVERY)
+
+        with self.assertRaises(NonRetriableException) as ctx:
+            asyncio.run(_create())
+        self.assertIsInstance(ctx.exception, ZerobusException)
+
+
+class TestRetriableMapping(unittest.TestCase):
+    def test_connection_refused_is_base_zerobus_exception(self):
+        sdk = SyncSdk(LOCAL_REFUSED, LOCAL_REFUSED)
+        with self.assertRaises(ZerobusException) as ctx:
+            sdk.create_stream(
+                "id",
+                "secret",
+                TableProperties("catalog.schema.table"),
+                NO_RECOVERY,
+                headers_provider=DummyHeaders(),
+            )
+        self.assertNotIsInstance(ctx.exception, NonRetriableException)
+
+    def test_oauth_token_fetch_network_error_is_base_zerobus_exception(self):
+        sdk = SyncSdk(HOST, LOCAL_REFUSED)
+        with self.assertRaises(ZerobusException) as ctx:
+            sdk.create_stream("id", "secret", TableProperties("catalog.schema.table"), NO_RECOVERY)
+        self.assertNotIsInstance(ctx.exception, NonRetriableException)

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -27,7 +27,7 @@ class TestImports(unittest.TestCase):
     def test_import_exceptions(self):
         """Test exception classes are available."""
         self.assertTrue(issubclass(ZerobusException, Exception))
-        self.assertTrue(issubclass(NonRetriableException, Exception))
+        self.assertTrue(issubclass(NonRetriableException, ZerobusException))
 
     def test_import_record_type(self):
         """Test RecordType enum is available."""

--- a/python/zerobus/_zerobus_core.pyi
+++ b/python/zerobus/_zerobus_core.pyi
@@ -162,7 +162,10 @@ class StreamConfigurationOptions:
 # =============================================================================
 
 class ZerobusException(Exception):
-    """Base class for all exceptions in the Zerobus SDK."""
+    """Base class for all exceptions in the Zerobus SDK.
+
+    Retryable failures (network issues, temporary server errors) are raised as this type.
+    """
 
     ...
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Map non-retryable Rust errors to `NonRetriableException` instead of always
  raising `ZerobusException`. Retryability follows `ZerobusError::is_retryable()`
  (invalid credentials, missing table, schema/argument errors, and other fatal
  conditions). `NonRetriableException` remains a subclass of `ZerobusException`.
## How is this tested?
added new test file and manual testing