### PR TITLE
[Rust] Add persistent stream proto

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -36,3 +36,6 @@
 ### Deprecations
 
 ### API Changes
+
+- Added the in-development persistent-stream protobuf contract for creating,
+  resuming, ingesting into, and retiring durable streams.

--- a/rust/sdk/zerobus_service.proto
+++ b/rust/sdk/zerobus_service.proto
@@ -43,6 +43,20 @@ service Zerobus {
    * - Receive durability confirmations via IngestRecordResponse.
    */
   rpc EphemeralStream(stream EphemeralStreamRequest) returns (stream EphemeralStreamResponse);
+
+  // IN DEVELOPMENT: may change or be removed.
+  //
+  // Creates or resumes a durable (exactly-once) ingestion stream. The first
+  // message is a CreatePersistentStreamRequest (new stream) or a
+  // ResumeIngestStreamRequest (reconnect by stream_id); everything after is
+  // ingest_record / ingest_record_batch, as on EphemeralStream.
+  rpc PersistentStream(stream PersistentStreamRequest) returns (stream PersistentStreamResponse);
+
+  // IN DEVELOPMENT: may change or be removed.
+  //
+  // Permanently retires a persistent stream. Unary and idempotent; callable
+  // without an open connection. A retired stream can never be resumed.
+  rpc RetireStream(RetireStreamRequest) returns (RetireStreamResponse);
 }
 
 /*
@@ -230,4 +244,91 @@ message EphemeralStreamResponse {
     // Signal that the server will close the stream after the specified duration.
     CloseStreamSignal close_stream_signal = 3;
   }
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// First message on a PersistentStream RPC when creating a new stream.
+message CreatePersistentStreamRequest {
+  // Creation parameters shared with ephemeral streams.
+  optional CreateIngestStreamRequest create_stream = 1;
+
+  // Reserved for a future client-supplied stream name.
+  reserved "stream_name";
+  reserved 2;
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// First message on a PersistentStream RPC when resuming an existing stream.
+message ResumeIngestStreamRequest {
+  // How the stream to resume is identified. Only stream_id is supported by
+  // this SDK; stream_name is reserved for future server support.
+  oneof identifier {
+    // The durable stream identity returned by a prior create.
+    string stream_id = 1;
+  }
+
+  // Protocol buffer descriptor for record serialization/deserialization.
+  //
+  // Required when the stream was created with record_type PROTO. Must be
+  // compatible with the target table's schema. Not used for JSON or ARROW_IPC
+  // record types.
+  optional bytes descriptor_proto = 2;
+
+  // Record type accepted by the resumed stream. Must match the type used when
+  // the persistent stream was created.
+  optional RecordType record_type = 3;
+
+  reserved "stream_name";
+  reserved 4;
+}
+
+// IN DEVELOPMENT: may change or be removed.
+message ResumeIngestStreamResponse {
+  // Resume watermark: resume sending from last_committed_offset + 1.
+  // Absent means nothing has been committed yet (resume from 0).
+  optional int64 last_committed_offset = 1;
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// A message in the PersistentStream request stream. The first message is a
+// create_stream or resume_stream; the rest are ingest_record(_batch).
+message PersistentStreamRequest {
+  oneof payload {
+    CreatePersistentStreamRequest create_stream = 1;
+    ResumeIngestStreamRequest resume_stream = 2;
+    IngestRecordRequest ingest_record = 3;
+    IngestRecordBatchRequest ingest_record_batch = 4;
+  }
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// A message in the PersistentStream response stream.
+message PersistentStreamResponse {
+  oneof payload {
+    CreateIngestStreamResponse create_stream_response = 1;
+    ResumeIngestStreamResponse resume_stream_response = 2;
+    IngestRecordResponse ingest_record_response = 3;
+    CloseStreamSignal close_stream_signal = 4;
+  }
+}
+
+// IN DEVELOPMENT: may change or be removed.
+message RetireStreamRequest {
+  // Three part name of the table the stream belongs to.
+  optional string table_name = 1;
+
+  // How the stream to retire is identified. Only stream_id is currently
+  // supported; stream_name is reserved for future server support.
+  oneof identifier {
+    // The persistent stream to retire permanently.
+    string stream_id = 2;
+  }
+
+  reserved "stream_name";
+  reserved 3;
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// Empty: success or failure is carried by the gRPC status code.
+message RetireStreamResponse {
 }

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -8,7 +8,8 @@ use databricks::zerobus::{
     ephemeral_stream_response::Payload as ResponsePayload,
     zerobus_server::{Zerobus, ZerobusServer},
     CloseStreamSignal, CreateIngestStreamResponse, EphemeralStreamRequest, EphemeralStreamResponse,
-    IngestRecordResponse,
+    IngestRecordResponse, PersistentStreamRequest, PersistentStreamResponse, RetireStreamRequest,
+    RetireStreamResponse,
 };
 use databricks_zerobus_ingest_sdk::databricks;
 use prost_types::Duration as ProtobufDuration;
@@ -147,6 +148,26 @@ impl MockZerobusServer {
 impl Zerobus for MockZerobusServer {
     type EphemeralStreamStream =
         Pin<Box<dyn Stream<Item = Result<EphemeralStreamResponse, Status>> + Send>>;
+    type PersistentStreamStream =
+        Pin<Box<dyn Stream<Item = Result<PersistentStreamResponse, Status>> + Send>>;
+
+    async fn persistent_stream(
+        &self,
+        _request: Request<Streaming<PersistentStreamRequest>>,
+    ) -> Result<Response<Self::PersistentStreamStream>, Status> {
+        Err(Status::unimplemented(
+            "persistent streams are not supported by this mock",
+        ))
+    }
+
+    async fn retire_stream(
+        &self,
+        _request: Request<RetireStreamRequest>,
+    ) -> Result<Response<RetireStreamResponse>, Status> {
+        Err(Status::unimplemented(
+            "retiring streams is not supported by this mock",
+        ))
+    }
 
     async fn ephemeral_stream(
         &self,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds the in-development protobuf contract used by persistent Zerobus ingestion streams. It contains only the wire-level API.

The contract adds:

- `PersistentStream`, a bidirectional RPC whose first message creates a durable stream or resumes one by `stream_id`.
- `ResumeIngestStreamRequest`, including the protobuf descriptor and required `record_type` used to validate a resumed stream against its original configuration.
- `ResumeIngestStreamResponse.last_committed_offset`, the server watermark from which the client continues at `last_committed_offset + 1`.
- Persistent envelopes for create, resume, ingestion, acknowledgements, and server close signals.
- The server-side `RetireStream` contract; a public Rust retirement API is intentionally deferred.

The shapes and field numbers match the current Shinkansen server contract. The PR also records this API-contract addition in `rust/NEXT_CHANGELOG.md`.

### Stack

1. **#761 — protobuf contract**
2. #762 — gRPC transport and recovery engine
3. #763 — public Rust API
4. #764 — stateful mock and integration tests
5. #765 — documentation and runnable example

## How is this tested?

The protobuf is compiled by the Rust SDK build. The complete create, ingest, flush, and resume flow is exercised in #764.