### PR TITLE
[Rust] Expose persistent stream API

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### New Features and Improvements
 
+- Added the feature-gated `PersistentStream` API for creating durable ingestion
+  streams and resuming them by `stream_id` from the last committed offset.
+
 ### Bug Fixes
 
 - The OAuth `expires_in` field is now parsed from a quoted integer (`"3600"`) in

--- a/rust/sdk/src/builder/mod.rs
+++ b/rust/sdk/src/builder/mod.rs
@@ -29,8 +29,12 @@
 //!     .await?;
 //! ```
 
+#[cfg(feature = "eos")]
+mod persistent_stream_builder;
 mod sdk_builder;
 mod stream_builder;
 
+#[cfg(feature = "eos")]
+pub use persistent_stream_builder::PersistentStreamBuilder;
 pub use sdk_builder::ZerobusSdkBuilder;
 pub use stream_builder::StreamBuilder;

--- a/rust/sdk/src/builder/persistent_stream_builder.rs
+++ b/rust/sdk/src/builder/persistent_stream_builder.rs
@@ -1,0 +1,207 @@
+//! Fluent builder for creating or resuming persistent (Eos) streams.
+//!
+//! Reached via [`ZerobusSdk::persistent_stream_builder`](crate::ZerobusSdk::persistent_stream_builder).
+//! It reuses the ephemeral [`StreamBuilder`] for configuration — table, auth,
+//! format, and the gRPC tuning knobs — and adds two terminals that open a
+//! persistent stream:
+//!
+//! - [`build`](PersistentStreamBuilder::build) opens a brand-new persistent
+//!   stream; the server mints its durable identity.
+//! - [`resume`](PersistentStreamBuilder::resume) reconnects to an existing one
+//!   by `stream_id`, continuing offset generation past the committed offset.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! // Create a new persistent stream.
+//! let stream = sdk
+//!     .persistent_stream_builder()
+//!     .table("catalog.schema.events")
+//!     .oauth("client-id", "client-secret")
+//!     .json()
+//!     .build()
+//!     .await?;
+//! let id = stream.stream_id().unwrap().to_string();
+//!
+//! // Later, after a restart, resume it by id.
+//! let stream = sdk
+//!     .persistent_stream_builder()
+//!     .table("catalog.schema.events")
+//!     .oauth("client-id", "client-secret")
+//!     .json()
+//!     .resume(id)
+//!     .await?;
+//! ```
+
+use std::sync::Arc;
+
+use crate::builder::StreamBuilder;
+use crate::callbacks::AckCallback;
+use crate::headers_provider::HeadersProvider;
+use crate::{PersistentStream, ZerobusResult, ZerobusStream};
+
+/// A fluent builder for creating or resuming persistent (Eos) streams.
+///
+/// Configuration setters mirror [`StreamBuilder`] (they delegate to it); the
+/// terminals [`build`](Self::build) and [`resume`](Self::resume) open the
+/// stream. Arrow format is not supported for persistent streams.
+#[must_use = "a PersistentStreamBuilder does nothing until `.build()` or `.resume()` is called"]
+pub struct PersistentStreamBuilder<'a> {
+    inner: StreamBuilder<'a>,
+}
+
+#[allow(clippy::result_large_err)]
+impl<'a> PersistentStreamBuilder<'a> {
+    pub(crate) fn new(inner: StreamBuilder<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Set the fully-qualified Unity Catalog table name (e.g., `"catalog.schema.table"`).
+    pub fn table(mut self, table_name: impl Into<String>) -> Self {
+        self.inner = self.inner.table(table_name);
+        self
+    }
+
+    /// Authenticate with OAuth client credentials.
+    pub fn oauth(mut self, client_id: impl Into<String>, client_secret: impl Into<String>) -> Self {
+        self.inner = self.inner.oauth(client_id, client_secret);
+        self
+    }
+
+    /// Authenticate with a custom headers provider.
+    pub fn headers_provider(mut self, provider: Arc<dyn HeadersProvider>) -> Self {
+        self.inner = self.inner.headers_provider(provider);
+        self
+    }
+
+    /// Use a no-op headers provider that sends no authentication credentials.
+    ///
+    /// Intended only for local testing. Available behind the `testing` feature.
+    #[cfg(feature = "testing")]
+    pub fn no_auth(mut self) -> Self {
+        self.inner = self.inner.no_auth();
+        self
+    }
+
+    /// Select JSON record format.
+    pub fn json(mut self) -> Self {
+        self.inner = self.inner.json();
+        self
+    }
+
+    /// Select compiled protobuf record format.
+    pub fn compiled_proto(mut self, descriptor: prost_types::DescriptorProto) -> Self {
+        self.inner = self.inner.compiled_proto(descriptor);
+        self
+    }
+
+    /// Enable or disable automatic stream recovery.
+    pub fn recovery(mut self, enabled: bool) -> Self {
+        self.inner = self.inner.recovery(enabled);
+        self
+    }
+
+    /// Set the timeout in milliseconds for each recovery attempt.
+    pub fn recovery_timeout_ms(mut self, ms: u64) -> Self {
+        self.inner = self.inner.recovery_timeout_ms(ms);
+        self
+    }
+
+    /// Set the backoff time in milliseconds between recovery retries.
+    pub fn recovery_backoff_ms(mut self, ms: u64) -> Self {
+        self.inner = self.inner.recovery_backoff_ms(ms);
+        self
+    }
+
+    /// Set the maximum number of recovery retry attempts.
+    pub fn recovery_retries(mut self, n: u32) -> Self {
+        self.inner = self.inner.recovery_retries(n);
+        self
+    }
+
+    /// Set the timeout in milliseconds for server acknowledgement.
+    pub fn server_lack_of_ack_timeout_ms(mut self, ms: u64) -> Self {
+        self.inner = self.inner.server_lack_of_ack_timeout_ms(ms);
+        self
+    }
+
+    /// Set the timeout in milliseconds for flush operations.
+    pub fn flush_timeout_ms(mut self, ms: u64) -> Self {
+        self.inner = self.inner.flush_timeout_ms(ms);
+        self
+    }
+
+    /// Set the maximum number of in-flight requests.
+    pub fn max_inflight_requests(mut self, n: usize) -> Self {
+        self.inner = self.inner.max_inflight_requests(n);
+        self
+    }
+
+    /// Set the maximum total encoded record byte size allowed per ingest call.
+    pub fn max_ingest_payload_bytes(mut self, bytes: usize) -> Self {
+        self.inner = self.inner.max_ingest_payload_bytes(bytes);
+        self
+    }
+
+    /// Set the maximum wait time during graceful stream pause.
+    pub fn stream_paused_max_wait_time_ms(mut self, ms: Option<u64>) -> Self {
+        self.inner = self.inner.stream_paused_max_wait_time_ms(ms);
+        self
+    }
+
+    /// Set the acknowledgment callback.
+    pub fn ack_callback(mut self, callback: Arc<dyn AckCallback>) -> Self {
+        self.inner = self.inner.ack_callback(callback);
+        self
+    }
+
+    /// Set the maximum wait time for callbacks after stream close.
+    pub fn callback_max_wait_time_ms(mut self, ms: Option<u64>) -> Self {
+        self.inner = self.inner.callback_max_wait_time_ms(ms);
+        self
+    }
+
+    /// Validate that the builder has all required fields configured.
+    ///
+    /// Returns `Ok(())` if table name, authentication, and format are set.
+    pub fn validate(&self) -> ZerobusResult<()> {
+        self.inner.validate()
+    }
+
+    /// Build and open a new persistent (Eos) stream.
+    ///
+    /// The server mints a durable stream identity, available via
+    /// [`PersistentStream::stream_id`]; persist it to reconnect later with
+    /// [`resume`](Self::resume). Delivery into Delta is exactly-once.
+    ///
+    /// Returns an error if table name, authentication, or format has not been set.
+    pub async fn build(self) -> ZerobusResult<PersistentStream> {
+        self.open(None).await
+    }
+
+    /// Resume an existing persistent (Eos) stream by its `stream_id`.
+    ///
+    /// Reconnects to the stream created earlier by [`build`](Self::build),
+    /// continuing offset generation past the server's committed offset. The
+    /// table and record format must match those the stream was created with.
+    ///
+    /// Returns an error if table name, authentication, or format has not been set.
+    pub async fn resume(self, stream_id: impl Into<String>) -> ZerobusResult<PersistentStream> {
+        self.open(Some(stream_id.into())).await
+    }
+
+    async fn open(self, resume_stream_id: Option<String>) -> ZerobusResult<PersistentStream> {
+        let (channel, table_properties, headers_provider, config) =
+            self.inner.prepare_grpc().await?;
+        let stream = ZerobusStream::new_persistent_stream(
+            channel,
+            table_properties,
+            headers_provider,
+            config,
+            resume_stream_id,
+        )
+        .await?;
+        crate::client_warnings::record_stream_creation(stream.table_properties.table_name.as_str());
+        Ok(PersistentStream::new(stream))
+    }
+}

--- a/rust/sdk/src/builder/stream_builder.rs
+++ b/rust/sdk/src/builder/stream_builder.rs
@@ -429,7 +429,27 @@ impl<'a> StreamBuilder<'a> {
     ///
     /// Returns an error if table name, authentication, or format has not been set,
     /// or if an Arrow format was selected (use `build_arrow()` instead).
-    pub async fn build(mut self) -> ZerobusResult<ZerobusStream> {
+    pub async fn build(self) -> ZerobusResult<ZerobusStream> {
+        let (channel, table_properties, headers_provider, config) = self.prepare_grpc().await?;
+        let stream =
+            ZerobusStream::new_stream(channel, table_properties, headers_provider, config).await?;
+        crate::client_warnings::record_stream_creation(stream.table_properties.table_name.as_str());
+        Ok(stream)
+    }
+
+    /// Validates the builder and resolves the pieces shared by the gRPC
+    /// terminals (`build`, and the persistent builder's `build` / `resume`):
+    /// the channel, table properties, headers provider, and finalized config
+    /// with the record type set. Rejects the Arrow format (which needs
+    /// `build_arrow()`).
+    pub(crate) async fn prepare_grpc(
+        mut self,
+    ) -> ZerobusResult<(
+        crate::databricks::zerobus::zerobus_client::ZerobusClient<tonic::transport::Channel>,
+        TableProperties,
+        Arc<dyn HeadersProvider>,
+        StreamConfigurationOptions,
+    )> {
         self.validate()?;
         let headers_provider = self.resolve_headers_provider()?;
 
@@ -464,15 +484,12 @@ impl<'a> StreamBuilder<'a> {
         };
 
         let channel = self.sdk.get_or_create_channel_zerobus_client().await?;
-        let stream = ZerobusStream::new_stream(
+        Ok((
             channel,
             table_properties,
             headers_provider,
             self.grpc_config,
-        )
-        .await?;
-        crate::client_warnings::record_stream_creation(stream.table_properties.table_name.as_str());
-        Ok(stream)
+        ))
     }
 
     /// Build and open an Arrow Flight ingestion stream.

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -48,6 +48,8 @@ mod landing_zone;
 #[cfg(feature = "testing")]
 mod multiplexed_stream;
 mod offset_generator;
+#[cfg(feature = "eos")]
+mod persistent_stream;
 mod proxy;
 mod record_types;
 pub mod schema;
@@ -58,6 +60,8 @@ pub mod stream_options;
 mod tls_config;
 mod token_cache;
 
+#[cfg(feature = "eos")]
+pub use builder::PersistentStreamBuilder;
 pub use builder::{StreamBuilder, ZerobusSdkBuilder};
 pub use callbacks::AckCallback;
 pub use default_token_factory::DefaultTokenFactory;
@@ -72,6 +76,8 @@ pub use headers_provider::{HeadersProvider, OAuthHeadersProvider};
 #[cfg(feature = "testing")]
 pub use multiplexed_stream::{MessageId, MultiplexedStream};
 pub use offset_generator::{OffsetId, OffsetIdGenerator};
+#[cfg(feature = "eos")]
+pub use persistent_stream::PersistentStream;
 pub use proxy::{ConnectorFactory, ProxyConnector};
 pub use record_types::{
     EncodedBatch, EncodedBatchIter, EncodedRecord, JsonEncodedRecord, JsonString, JsonValue,
@@ -99,14 +105,16 @@ pub mod zeroparser;
 pub mod internal;
 
 /// The type of the stream connection created with the server.
-/// Currently we only support ephemeral streams on the server side, so we support only that in the SDK as well.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StreamType {
     /// Ephemeral streams exist only for the duration of the connection.
     /// They are not persisted and are not recoverable.
     Ephemeral,
-    /// UNSUPPORTED: Persistent streams are durable and recoverable.
+    /// Persistent (Eos) streams are durable and recoverable: the server records
+    /// the stream identity and its committed offset, so a client can reconnect
+    /// after a crash and resume with exactly-once delivery into Delta. Created
+    /// via `ZerobusSdk::persistent_stream_builder` behind the `eos` feature.
     Persistent,
 }
 

--- a/rust/sdk/src/persistent_stream.rs
+++ b/rust/sdk/src/persistent_stream.rs
@@ -1,0 +1,127 @@
+//! Persistent (Eos) ingestion stream — the public, durable-stream type.
+//!
+//! `PersistentStream` is a thin wrapper over the shared gRPC stream engine
+//! (`ZerobusStream`). It exists so the persistent contract is visible in the
+//! type: the durable [`stream_id`](PersistentStream::stream_id) resume handle
+//! and the [`last_committed_offset`](PersistentStream::last_committed_offset)
+//! resume watermark are surfaced here rather than on the ephemeral stream. All
+//! ingestion, flushing, and teardown delegate to the underlying engine, so
+//! there is no duplicated stream machinery.
+//!
+//! Create or resume one via
+//! [`ZerobusSdk::persistent_stream_builder`](crate::ZerobusSdk::persistent_stream_builder).
+
+use crate::{EncodedBatch, EncodedRecord, OffsetId, ZerobusResult, ZerobusStream};
+
+/// A durable, recoverable ingestion stream (Eos).
+///
+/// Unlike an ephemeral [`ZerobusStream`], a persistent stream's identity and
+/// committed offset are recorded server-side, so it can be resumed after a
+/// restart with exactly-once delivery into Delta. Persist
+/// [`stream_id`](Self::stream_id) to reconnect later via
+/// [`resume`](crate::PersistentStreamBuilder::resume).
+///
+/// # Examples
+///
+/// ```no_run
+/// # use databricks_zerobus_ingest_sdk::*;
+/// # async fn example(stream: PersistentStream, records: Vec<Vec<u8>>) -> Result<(), ZerobusError> {
+/// // Idiomatic flow: ingest in a loop, then flush() once to confirm the batch.
+/// for record in records {
+///     stream.ingest_record_offset(record).await?;
+/// }
+/// stream.flush().await?;
+/// # Ok(())
+/// # }
+/// ```
+#[non_exhaustive]
+pub struct PersistentStream {
+    inner: ZerobusStream,
+}
+
+impl PersistentStream {
+    /// Wraps a persistent-mode engine stream. Constructed by the persistent
+    /// stream builder.
+    pub(crate) fn new(inner: ZerobusStream) -> Self {
+        Self { inner }
+    }
+
+    /// The durable stream identity — the resume handle.
+    ///
+    /// Persist this to reconnect to the same stream after a restart via
+    /// [`resume`](crate::PersistentStreamBuilder::resume). Present once the
+    /// stream has been opened.
+    pub fn stream_id(&self) -> Option<&str> {
+        self.inner.stream_id.as_deref()
+    }
+
+    /// The offset the server had durably committed at resume time.
+    ///
+    /// Records ingested after a resume are assigned offsets starting at
+    /// `last_committed_offset + 1`. Returns `None` for a freshly created stream
+    /// (nothing committed yet).
+    pub fn last_committed_offset(&self) -> Option<OffsetId> {
+        self.inner.last_committed_offset
+    }
+
+    /// Ingests a single record and returns its logical offset once queued.
+    ///
+    /// See [`ZerobusStream::ingest_record_offset`].
+    pub async fn ingest_record_offset(
+        &self,
+        payload: impl Into<EncodedRecord>,
+    ) -> ZerobusResult<OffsetId> {
+        self.inner.ingest_record_offset(payload).await
+    }
+
+    /// Ingests a batch of records and returns the logical offset once queued.
+    ///
+    /// See [`ZerobusStream::ingest_records_offset`].
+    pub async fn ingest_records_offset<I, T>(&self, payload: I) -> ZerobusResult<Option<OffsetId>>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<EncodedRecord>,
+    {
+        self.inner.ingest_records_offset(payload).await
+    }
+
+    /// Flushes all currently pending records and waits for their acknowledgments.
+    ///
+    /// See [`ZerobusStream::flush`].
+    pub async fn flush(&self) -> ZerobusResult<()> {
+        self.inner.flush().await
+    }
+
+    /// Waits for server acknowledgment of a specific logical offset.
+    ///
+    /// See [`ZerobusStream::wait_for_offset`].
+    pub async fn wait_for_offset(&self, offset: OffsetId) -> ZerobusResult<()> {
+        self.inner.wait_for_offset(offset).await
+    }
+
+    /// Returns whether the stream has been closed.
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Closes the stream gracefully after flushing all pending records.
+    ///
+    /// See [`ZerobusStream::close`].
+    pub async fn close(&mut self) -> ZerobusResult<()> {
+        self.inner.close().await
+    }
+
+    /// Returns all records that were ingested but not acknowledged by the server.
+    ///
+    /// See [`ZerobusStream::get_unacked_records`].
+    pub async fn get_unacked_records(&self) -> ZerobusResult<impl Iterator<Item = EncodedRecord>> {
+        self.inner.get_unacked_records().await
+    }
+
+    /// Returns unacknowledged records grouped by batch.
+    ///
+    /// See [`ZerobusStream::get_unacked_batches`].
+    pub async fn get_unacked_batches(&self) -> ZerobusResult<Vec<EncodedBatch>> {
+        self.inner.get_unacked_batches().await
+    }
+}

--- a/rust/sdk/src/sdk.rs
+++ b/rust/sdk/src/sdk.rs
@@ -115,6 +115,33 @@ impl ZerobusSdk {
         StreamBuilder::new(self)
     }
 
+    /// Creates a new builder for a persistent (Eos) ingestion stream.
+    ///
+    /// Persistent streams are durable and recoverable: the server records the
+    /// stream identity and its committed offset, so a client can reconnect after
+    /// a restart and resume with exactly-once delivery into Delta. Configure the
+    /// builder like [`stream_builder`](Self::stream_builder), then call
+    /// [`build`](crate::PersistentStreamBuilder::build) to open a new stream or
+    /// [`resume`](crate::PersistentStreamBuilder::resume) to reconnect to one by
+    /// its `stream_id`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let stream = sdk
+    ///     .persistent_stream_builder()
+    ///     .table("catalog.schema.events")
+    ///     .oauth("client-id", "client-secret")
+    ///     .json()
+    ///     .build()
+    ///     .await?;
+    /// let id = stream.stream_id().unwrap().to_string(); // persist to resume later
+    /// ```
+    #[cfg(feature = "eos")]
+    pub fn persistent_stream_builder(&self) -> crate::PersistentStreamBuilder<'_> {
+        crate::PersistentStreamBuilder::new(StreamBuilder::new(self))
+    }
+
     /// Creates a new SDK instance with explicit configuration.
     ///
     /// This is used internally by the builder pattern. `sdk_identifier` is the


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR exposes the feature-gated Rust API for creating and resuming persistent streams on top of #762.

It adds:

- `ZerobusSdk::persistent_stream_builder()`.
- `PersistentStreamBuilder` with the existing table, authentication, format, recovery, timeout, backpressure, and callback configuration.
- `build()` for a new durable stream and `resume(stream_id)` for reconnecting.
- `PersistentStream`, exposing `stream_id`, the resume watermark, ingestion, batch ingestion, flush, offset waiting, close, and unacknowledged-record retrieval.
- Shared builder preparation so ephemeral and persistent streams resolve identical gRPC configuration.

JSON and protobuf are supported; Arrow Flight and a public retirement API are intentionally deferred. Documentation follows the pipelined loop-then-`flush()` pattern. The new public feature is recorded in `rust/NEXT_CHANGELOG.md`.

### Stack

1. #761 — protobuf contract
2. #762 — gRPC transport and recovery engine
3. **#763 — public Rust API**
4. #764 — stateful mock and integration tests
5. #765 — documentation and runnable example

## How is this tested?

- `cargo check -p databricks-zerobus-ingest-sdk --features eos`
- `cargo test -p databricks-zerobus-ingest-sdk --features eos --lib` — 156 tests passed
- `cargo fmt --all -- --check`
- Public create/resume behavior is exercised in #764.