### PR TITLE
[Rust] Test persistent stream resume

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -53,6 +53,8 @@
 - Added the feature-gated persistent gRPC transport, durable wire offsets,
   resume-watermark reconciliation after a lost acknowledgment, and validation
   for setup responses, acknowledgment bounds, and offset overflow.
+- Added a stateful persistent-stream mock and integration coverage for create,
+  flush, resume offset continuity, and unknown stream IDs.
 
 ### Breaking Changes
 

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -21,6 +21,10 @@ name = "multiplexed_stream_tests"
 path = "src/multiplexed_stream_tests.rs"
 
 [[test]]
+name = "persistent_stream_tests"
+path = "src/persistent_stream_tests.rs"
+
+[[test]]
 name = "arrow_tests"
 path = "src/arrow_tests.rs"
 
@@ -40,7 +44,7 @@ tonic-prost.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "test-hooks", "arrow-flight", "internal-arrow-c-data", "zeroparser"] }
+databricks-zerobus-ingest-sdk = { path = "../sdk", features = ["testing", "test-hooks", "arrow-flight", "internal-arrow-c-data", "zeroparser", "eos"] }
 zerobus-ffi = { path = "../ffi" }
 
 # Arrow Flight test dependencies

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -1,15 +1,19 @@
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use databricks::zerobus::{
     ephemeral_stream_request::Payload as RequestPayload,
     ephemeral_stream_response::Payload as ResponsePayload,
+    persistent_stream_request::Payload as PersistentRequestPayload,
+    persistent_stream_response::Payload as PersistentResponsePayload,
+    resume_ingest_stream_request::Identifier as ResumeIdentifier,
     zerobus_server::{Zerobus, ZerobusServer},
     CloseStreamSignal, CreateIngestStreamResponse, EphemeralStreamRequest, EphemeralStreamResponse,
-    IngestRecordResponse, PersistentStreamRequest, PersistentStreamResponse, RetireStreamRequest,
-    RetireStreamResponse,
+    IngestRecordResponse, PersistentStreamRequest, PersistentStreamResponse,
+    ResumeIngestStreamResponse, RetireStreamRequest, RetireStreamResponse,
 };
 use databricks_zerobus_ingest_sdk::databricks;
 use prost_types::Duration as ProtobufDuration;
@@ -75,6 +79,18 @@ pub enum MockResponse {
     Error { status: Status, delay_ms: u64 },
 }
 
+#[derive(Debug)]
+enum PersistentOpenFault {
+    MissingStreamId,
+    UnexpectedResponse,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PersistentStreamConfig {
+    record_type: Option<i32>,
+    descriptor_proto: Option<Vec<u8>>,
+}
+
 /// Mock gRPC server for testing the Rust SDK
 pub struct MockZerobusServer {
     /// Responses to inject for each stream
@@ -89,6 +105,14 @@ pub struct MockZerobusServer {
     response_indices: Arc<Mutex<HashMap<String, usize>>>,
     /// Observation that a delayed setup response registered its timer.
     delayed_setup_armed: Arc<Notify>,
+    /// Durable offset retained across persistent-stream connections.
+    persistent_offsets: Arc<Mutex<HashMap<String, Option<i64>>>>,
+    /// Record configuration retained and validated when a stream resumes.
+    persistent_configs: Arc<Mutex<HashMap<String, PersistentStreamConfig>>>,
+    /// One-shot malformed response returned while opening a persistent stream.
+    persistent_open_fault: Arc<Mutex<Option<PersistentOpenFault>>>,
+    /// One-shot disconnect after committing a persistent write but before ACKing it.
+    fail_persistent_ack_once: Arc<AtomicBool>,
 }
 
 impl MockZerobusServer {
@@ -100,6 +124,10 @@ impl MockZerobusServer {
             write_count: Arc::new(Mutex::new(0)),
             response_indices: Arc::new(Mutex::new(HashMap::new())),
             delayed_setup_armed: Arc::new(Notify::new()),
+            persistent_offsets: Arc::new(Mutex::new(HashMap::new())),
+            persistent_configs: Arc::new(Mutex::new(HashMap::new())),
+            persistent_open_fault: Arc::new(Mutex::new(None)),
+            fail_persistent_ack_once: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -131,6 +159,27 @@ impl MockZerobusServer {
         *self.write_count.lock().await
     }
 
+    pub async fn persistent_committed_offset(&self, stream_id: &str) -> Option<i64> {
+        self.persistent_offsets
+            .lock()
+            .await
+            .get(stream_id)
+            .copied()
+            .flatten()
+    }
+
+    pub async fn omit_next_persistent_stream_id(&self) {
+        *self.persistent_open_fault.lock().await = Some(PersistentOpenFault::MissingStreamId);
+    }
+
+    pub async fn send_unexpected_next_persistent_open_response(&self) {
+        *self.persistent_open_fault.lock().await = Some(PersistentOpenFault::UnexpectedResponse);
+    }
+
+    pub fn fail_next_persistent_ack_after_commit(&self) {
+        self.fail_persistent_ack_once.store(true, Ordering::SeqCst);
+    }
+
     /// Reset the server state
     #[allow(dead_code)]
     pub async fn reset(&self) {
@@ -141,6 +190,10 @@ impl MockZerobusServer {
         *self.max_offset_sent.lock().await = -1;
         *self.write_count.lock().await = 0;
         *self.stream_counter.lock().await = 0;
+        self.persistent_offsets.lock().await.clear();
+        self.persistent_configs.lock().await.clear();
+        *self.persistent_open_fault.lock().await = None;
+        self.fail_persistent_ack_once.store(false, Ordering::SeqCst);
     }
 }
 
@@ -148,27 +201,6 @@ impl MockZerobusServer {
 impl Zerobus for MockZerobusServer {
     type EphemeralStreamStream =
         Pin<Box<dyn Stream<Item = Result<EphemeralStreamResponse, Status>> + Send>>;
-    type PersistentStreamStream =
-        Pin<Box<dyn Stream<Item = Result<PersistentStreamResponse, Status>> + Send>>;
-
-    async fn persistent_stream(
-        &self,
-        _request: Request<Streaming<PersistentStreamRequest>>,
-    ) -> Result<Response<Self::PersistentStreamStream>, Status> {
-        Err(Status::unimplemented(
-            "persistent streams are not supported by this mock",
-        ))
-    }
-
-    async fn retire_stream(
-        &self,
-        _request: Request<RetireStreamRequest>,
-    ) -> Result<Response<RetireStreamResponse>, Status> {
-        Err(Status::unimplemented(
-            "retiring streams is not supported by this mock",
-        ))
-    }
-
     async fn ephemeral_stream(
         &self,
         request: Request<Streaming<EphemeralStreamRequest>>,
@@ -433,6 +465,173 @@ impl Zerobus for MockZerobusServer {
         let output_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(Response::new(Box::pin(output_stream)))
     }
+
+    type PersistentStreamStream =
+        Pin<Box<dyn Stream<Item = Result<PersistentStreamResponse, Status>> + Send>>;
+
+    async fn persistent_stream(
+        &self,
+        request: Request<Streaming<PersistentStreamRequest>>,
+    ) -> Result<Response<Self::PersistentStreamStream>, Status> {
+        let mut inbound = request.into_inner();
+        let (tx, rx) = mpsc::channel(100);
+        let offsets = Arc::clone(&self.persistent_offsets);
+        let configs = Arc::clone(&self.persistent_configs);
+        let counter = Arc::clone(&self.stream_counter);
+        let write_count = Arc::clone(&self.write_count);
+        let open_fault = Arc::clone(&self.persistent_open_fault);
+        let fail_ack_once = Arc::clone(&self.fail_persistent_ack_once);
+
+        tokio::spawn(async move {
+            let first = match inbound.message().await {
+                Ok(Some(message)) => message.payload,
+                Ok(None) => return,
+                Err(status) => {
+                    let _ = tx.send(Err(status)).await;
+                    return;
+                }
+            };
+
+            let stream_id = match first {
+                Some(PersistentRequestPayload::CreateStream(create)) => {
+                    let id = {
+                        let mut counter = counter.lock().await;
+                        *counter += 1;
+                        format!("persistent_stream_{}", *counter)
+                    };
+                    offsets.lock().await.insert(id.clone(), None);
+                    let create = create.create_stream.unwrap_or_default();
+                    configs.lock().await.insert(
+                        id.clone(),
+                        PersistentStreamConfig {
+                            record_type: create.record_type,
+                            descriptor_proto: create.descriptor_proto,
+                        },
+                    );
+                    let payload = match open_fault.lock().await.take() {
+                        Some(PersistentOpenFault::MissingStreamId) => {
+                            PersistentResponsePayload::CreateStreamResponse(
+                                CreateIngestStreamResponse { stream_id: None },
+                            )
+                        }
+                        Some(PersistentOpenFault::UnexpectedResponse) => {
+                            PersistentResponsePayload::IngestRecordResponse(IngestRecordResponse {
+                                durability_ack_up_to_offset: Some(0),
+                            })
+                        }
+                        None => PersistentResponsePayload::CreateStreamResponse(
+                            CreateIngestStreamResponse {
+                                stream_id: Some(id.clone()),
+                            },
+                        ),
+                    };
+                    let response = PersistentStreamResponse {
+                        payload: Some(payload),
+                    };
+                    if tx.send(Ok(response)).await.is_err() {
+                        return;
+                    }
+                    id
+                }
+                Some(PersistentRequestPayload::ResumeStream(resume)) => {
+                    let Some(ResumeIdentifier::StreamId(id)) = resume.identifier else {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument("missing stream_id")))
+                            .await;
+                        return;
+                    };
+                    let committed = match offsets.lock().await.get(&id).copied() {
+                        Some(offset) => offset,
+                        None => {
+                            let _ = tx.send(Err(Status::not_found("unknown stream_id"))).await;
+                            return;
+                        }
+                    };
+                    let resume_config = PersistentStreamConfig {
+                        record_type: resume.record_type,
+                        descriptor_proto: resume.descriptor_proto,
+                    };
+                    if configs.lock().await.get(&id) != Some(&resume_config) {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument(
+                                "record configuration does not match persistent stream",
+                            )))
+                            .await;
+                        return;
+                    }
+                    let response = PersistentStreamResponse {
+                        payload: Some(PersistentResponsePayload::ResumeStreamResponse(
+                            ResumeIngestStreamResponse {
+                                last_committed_offset: committed,
+                            },
+                        )),
+                    };
+                    if tx.send(Ok(response)).await.is_err() {
+                        return;
+                    }
+                    id
+                }
+                _ => {
+                    let _ = tx
+                        .send(Err(Status::invalid_argument(
+                            "first persistent message must create or resume",
+                        )))
+                        .await;
+                    return;
+                }
+            };
+
+            while let Ok(Some(message)) = inbound.message().await {
+                let (offset, records) = match message.payload {
+                    Some(PersistentRequestPayload::IngestRecord(record)) => (record.offset_id, 1),
+                    Some(PersistentRequestPayload::IngestRecordBatch(batch)) => {
+                        let records = batch.batch.as_ref().map_or(0, |batch| match batch {
+                            databricks::zerobus::ingest_record_batch_request::Batch::ProtoEncodedBatch(batch) => batch.records.len(),
+                            databricks::zerobus::ingest_record_batch_request::Batch::JsonBatch(batch) => batch.records.len(),
+                        });
+                        (batch.offset_id, records)
+                    }
+                    _ => continue,
+                };
+                if let Some(offset) = offset {
+                    offsets.lock().await.insert(stream_id.clone(), Some(offset));
+                    *write_count.lock().await += records as u64;
+                    if fail_ack_once.swap(false, Ordering::SeqCst) {
+                        let _ = tx
+                            .send(Err(Status::unavailable(
+                                "injected disconnect after persistent commit",
+                            )))
+                            .await;
+                        return;
+                    }
+                    let response = PersistentStreamResponse {
+                        payload: Some(PersistentResponsePayload::IngestRecordResponse(
+                            IngestRecordResponse {
+                                durability_ack_up_to_offset: Some(offset),
+                            },
+                        )),
+                    };
+                    if tx.send(Ok(response)).await.is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
+    }
+
+    /// Not exercised by the existing tests; returns `Unimplemented`.
+    async fn retire_stream(
+        &self,
+        _request: Request<RetireStreamRequest>,
+    ) -> Result<Response<RetireStreamResponse>, Status> {
+        Err(Status::unimplemented(
+            "RetireStream is not implemented in the mock server",
+        ))
+    }
 }
 
 /// Helper function to create a mock server and return its address
@@ -468,6 +667,10 @@ async fn start_mock_server_inner(
         write_count: Arc::clone(&mock_server.write_count),
         response_indices: Arc::clone(&mock_server.response_indices),
         delayed_setup_armed: Arc::clone(&mock_server.delayed_setup_armed),
+        persistent_offsets: Arc::clone(&mock_server.persistent_offsets),
+        persistent_configs: Arc::clone(&mock_server.persistent_configs),
+        persistent_open_fault: Arc::clone(&mock_server.persistent_open_fault),
+        fail_persistent_ack_once: Arc::clone(&mock_server.fail_persistent_ack_once),
     };
 
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;

--- a/rust/tests/src/persistent_stream_tests.rs
+++ b/rust/tests/src/persistent_stream_tests.rs
@@ -1,0 +1,363 @@
+mod mock_grpc;
+mod utils;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use databricks_zerobus_ingest_sdk::{NoTlsConfig, ZerobusSdk};
+use mock_grpc::start_mock_server;
+use prost_types::DescriptorProto;
+use tokio::time::timeout;
+use utils::TestHeadersProvider;
+
+const TABLE_NAME: &str = "test_catalog.test_schema.test_table";
+
+fn sdk(endpoint: String) -> ZerobusSdk {
+    ZerobusSdk::builder()
+        .endpoint(endpoint)
+        .unity_catalog_url("https://mock-uc.com")
+        .tls_config(Arc::new(NoTlsConfig))
+        .build()
+        .expect("build SDK")
+}
+
+#[tokio::test]
+async fn create_ingest_flush_and_resume_continues_offsets() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    let sdk = sdk(endpoint);
+
+    let mut stream = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create persistent stream");
+    let stream_id = stream.stream_id().expect("stream id").to_owned();
+
+    assert_eq!(
+        stream
+            .ingest_record_offset(r#"{"id":1}"#.to_string())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        stream
+            .ingest_record_offset(r#"{"id":2}"#.to_string())
+            .await
+            .unwrap(),
+        1
+    );
+    stream.flush().await.expect("flush");
+    assert_eq!(
+        server.persistent_committed_offset(&stream_id).await,
+        Some(1)
+    );
+    stream.close().await.expect("close");
+
+    let mut resumed = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .resume(stream_id.clone())
+        .await
+        .expect("resume persistent stream");
+    assert_eq!(resumed.last_committed_offset(), Some(1));
+    assert_eq!(
+        resumed
+            .ingest_record_offset(r#"{"id":3}"#.to_string())
+            .await
+            .unwrap(),
+        2
+    );
+    resumed.flush().await.expect("flush resumed stream");
+    resumed.close().await.expect("close resumed stream");
+    assert_eq!(
+        server.persistent_committed_offset(&stream_id).await,
+        Some(2)
+    );
+}
+
+#[tokio::test]
+async fn resume_unknown_stream_fails() {
+    let (_server, endpoint) = start_mock_server().await.expect("start mock");
+    let result = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .resume("missing-stream")
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn resume_without_committed_records_starts_at_offset_zero() {
+    let (_server, endpoint) = start_mock_server().await.expect("start mock");
+    let sdk = sdk(endpoint);
+
+    let mut created = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create persistent stream");
+    let stream_id = created.stream_id().expect("stream id").to_owned();
+    assert_eq!(created.last_committed_offset(), None);
+    created.close().await.expect("close created stream");
+
+    let mut resumed = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .resume(stream_id)
+        .await
+        .expect("resume empty persistent stream");
+    assert_eq!(resumed.last_committed_offset(), None);
+    assert_eq!(
+        resumed
+            .ingest_record_offset(r#"{"id":1}"#.to_string())
+            .await
+            .expect("ingest after resume"),
+        0
+    );
+    resumed.flush().await.expect("flush resumed stream");
+    resumed.close().await.expect("close resumed stream");
+}
+
+#[tokio::test]
+async fn batch_uses_one_offset_and_acknowledges_every_record() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    let mut stream = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create persistent stream");
+    let stream_id = stream.stream_id().expect("stream id").to_owned();
+
+    let offset = stream
+        .ingest_records_offset([
+            r#"{"id":1}"#.to_string(),
+            r#"{"id":2}"#.to_string(),
+            r#"{"id":3}"#.to_string(),
+        ])
+        .await
+        .expect("ingest batch")
+        .expect("non-empty batch offset");
+    assert_eq!(offset, 0);
+    stream
+        .wait_for_offset(offset)
+        .await
+        .expect("wait for batch");
+    assert_eq!(server.get_write_count().await, 3);
+    assert_eq!(
+        server.persistent_committed_offset(&stream_id).await,
+        Some(0)
+    );
+    stream.close().await.expect("close stream");
+}
+
+#[tokio::test]
+async fn persistent_stream_offsets_are_isolated_by_stream_id() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    let sdk = sdk(endpoint);
+
+    let mut first = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create first stream");
+    let mut second = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create second stream");
+    let first_id = first.stream_id().expect("first stream id").to_owned();
+    let second_id = second.stream_id().expect("second stream id").to_owned();
+    assert_ne!(first_id, second_id);
+
+    assert_eq!(
+        first
+            .ingest_record_offset(r#"{"id":1}"#.to_string())
+            .await
+            .expect("ingest first record"),
+        0
+    );
+    assert_eq!(
+        first
+            .ingest_record_offset(r#"{"id":2}"#.to_string())
+            .await
+            .expect("ingest second record"),
+        1
+    );
+    assert_eq!(
+        second
+            .ingest_record_offset(r#"{"id":3}"#.to_string())
+            .await
+            .expect("ingest other stream record"),
+        0
+    );
+    first.flush().await.expect("flush first stream");
+    second.flush().await.expect("flush second stream");
+
+    assert_eq!(server.persistent_committed_offset(&first_id).await, Some(1));
+    assert_eq!(
+        server.persistent_committed_offset(&second_id).await,
+        Some(0)
+    );
+    first.close().await.expect("close first stream");
+    second.close().await.expect("close second stream");
+}
+
+#[tokio::test]
+async fn create_without_stream_id_fails() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    server.omit_next_persistent_stream_id().await;
+
+    let result = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn unexpected_open_response_fails() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    server.send_unexpected_next_persistent_open_response().await;
+
+    let result = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn lost_ack_is_reconciled_from_resume_watermark() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    let mut stream = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(true)
+        .recovery_backoff_ms(0)
+        .recovery_timeout_ms(1_000)
+        .recovery_retries(2)
+        .flush_timeout_ms(5_000)
+        .build()
+        .await
+        .expect("create persistent stream");
+    let stream_id = stream.stream_id().expect("stream id").to_owned();
+    server.fail_next_persistent_ack_after_commit();
+
+    let offset = stream
+        .ingest_record_offset(r#"{"id":1}"#.to_string())
+        .await
+        .expect("queue record");
+    timeout(Duration::from_secs(5), stream.wait_for_offset(offset))
+        .await
+        .expect("recovery timed out")
+        .expect("lost ACK should reconcile during recovery");
+
+    assert_eq!(server.get_write_count().await, 1);
+    assert_eq!(
+        server.persistent_committed_offset(&stream_id).await,
+        Some(0)
+    );
+    assert_eq!(
+        stream
+            .ingest_record_offset(r#"{"id":2}"#.to_string())
+            .await
+            .expect("ingest after recovery"),
+        1
+    );
+    stream.flush().await.expect("flush after recovery");
+    stream.close().await.expect("close recovered stream");
+}
+
+#[tokio::test]
+async fn lost_ack_fails_when_recovery_is_disabled() {
+    let (server, endpoint) = start_mock_server().await.expect("start mock");
+    let mut stream = sdk(endpoint)
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .flush_timeout_ms(5_000)
+        .build()
+        .await
+        .expect("create persistent stream");
+    server.fail_next_persistent_ack_after_commit();
+
+    let offset = stream
+        .ingest_record_offset(r#"{"id":1}"#.to_string())
+        .await
+        .expect("queue record");
+    let result = timeout(Duration::from_secs(5), stream.wait_for_offset(offset))
+        .await
+        .expect("failure propagation timed out");
+    assert!(result.is_err());
+    assert!(stream.is_closed());
+    stream.close().await.expect("close remains idempotent");
+}
+
+#[tokio::test]
+async fn resume_with_mismatched_record_type_fails() {
+    let (_server, endpoint) = start_mock_server().await.expect("start mock");
+    let sdk = sdk(endpoint);
+    let mut created = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .json()
+        .recovery(false)
+        .build()
+        .await
+        .expect("create JSON persistent stream");
+    let stream_id = created.stream_id().expect("stream id").to_owned();
+    created.close().await.expect("close created stream");
+
+    let result = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .headers_provider(Arc::new(TestHeadersProvider::default()))
+        .compiled_proto(DescriptorProto::default())
+        .recovery(false)
+        .resume(stream_id)
+        .await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds stateful mock-server support and integration coverage for persistent streams.

The mock models durable state across connections:

- Create mints a unique `stream_id`.
- Acknowledged offsets remain stored by `stream_id` after disconnect.
- Resume returns the last committed offset.
- Unknown stream IDs return `NOT_FOUND`.
- Ingestion uses the persistent response envelope.

The lifecycle test creates a stream, queues multiple records, flushes once, closes, resumes at offset 1, ingests offset 2, flushes, and verifies the durable watermark. A second test covers an unknown stream ID. This infrastructure addition is recorded in `rust/NEXT_CHANGELOG.md`.

### Stack

1. #761 — protobuf contract
2. #762 — gRPC transport and recovery engine
3. #763 — public Rust API
4. **#764 — stateful mock and integration tests**
5. #765 — documentation and runnable example

## How is this tested?

- `cargo test -p tests --test persistent_stream_tests` — 2 tests passed
- `cargo test -p databricks-zerobus-ingest-sdk --features eos --lib` — 156 tests passed
- `cargo fmt --all -- --check`
- `git diff --check`