### PR TITLE
[Rust] Document persistent streams

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -48,6 +48,8 @@
 
 ### Documentation
 
+- Added a persistent JSON example demonstrating durable stream creation,
+  pipelined ingestion followed by one `flush()`, and resume by `stream_id`.
 ### Internal Changes
 
 - Added the feature-gated persistent gRPC transport, durable wire offsets,

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -38,6 +38,7 @@ The SDK supports two serialization formats and two ingestion methods:
 |---------|--------|--------|----------|
 | [JSON Single](json/README.md#single-record-example) | JSON | Single-record | `cargo run -p rust-examples-json --example json_single` |
 | [JSON Batch](json/README.md#batch-example) | JSON | Batch | `cargo run -p rust-examples-json --example json_batch` |
+| [JSON Persistent](json/README.md#persistent-stream-example) | JSON | Persistent create/resume | `cargo run -p rust-examples-json --example json_persistent` |
 | [Proto Compiled Single](proto/README.md#compiled-single-record-example) | Protocol Buffers | Single-record | `cargo run -p rust-examples-proto --example proto_compiled_single` |
 | [Proto Compiled Batch](proto/README.md#compiled-batch-example) | Protocol Buffers | Batch | `cargo run -p rust-examples-proto --example proto_compiled_batch` |
 | [Proto Dynamic](proto/README.md#dynamic-schema-example) | Protocol Buffers | Single-record (runtime schema) | `cargo run -p rust-examples-proto --example proto_dynamic_single` |

--- a/rust/examples/json/Cargo.toml
+++ b/rust/examples/json/Cargo.toml
@@ -12,8 +12,12 @@ path = "batch.rs"
 name = "json_single"
 path = "single.rs"
 
+[[example]]
+name = "json_persistent"
+path = "persistent.rs"
+
 [dependencies]
-databricks-zerobus-ingest-sdk = { path = "../../sdk" }
+databricks-zerobus-ingest-sdk = { path = "../../sdk", features = ["eos"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 chrono.workspace = true
 serde.workspace = true

--- a/rust/examples/json/README.md
+++ b/rust/examples/json/README.md
@@ -12,6 +12,7 @@ This directory contains examples demonstrating JSON-based data ingestion into Da
 - [Batch Example](#batch-example)
   - [Running the Example](#running-the-example-1)
   - [Code Highlights](#code-highlights-1)
+- [Persistent Stream Example](#persistent-stream-example)
 - [Adapting for Your Custom Table](#adapting-for-your-custom-table)
 
 ## Overview
@@ -26,6 +27,7 @@ JSON examples are recommended for getting started - they're simpler and don't re
 **Available examples:**
 - **`single.rs`** - Ingest records one at a time using `ingest_record_offset()`
 - **`batch.rs`** - Ingest multiple records at once using `ingest_records_offset()`
+- **`persistent.rs`** - Create a durable stream or resume it by `stream_id`
 
 ## Three Ways to Pass Data
 
@@ -159,6 +161,29 @@ stream.flush().await?;
 - **All-or-nothing**: The entire batch succeeds or fails as a unit
 - **Single acknowledgment**: One offset ID for the whole batch
 - **Empty batches**: Returns `None` (no-op)
+
+## Persistent Stream Example
+
+Persistent streams retain their identity and committed offset on the server,
+allowing a later process to resume ingestion without restarting offsets.
+
+On the first run, leave `ZEROBUS_PERSISTENT_STREAM_ID` unset:
+
+```bash
+cargo run -p rust-examples-json --example json_persistent
+```
+
+The example prints the newly assigned stream ID. Save it, then resume on a
+later run:
+
+```bash
+ZEROBUS_PERSISTENT_STREAM_ID=<stream-id> \
+  cargo run -p rust-examples-json --example json_persistent
+```
+
+The example queues records in a loop and calls `flush()` once afterward. Its
+final `close()` ends only the current connection; the durable stream remains
+available for another resume.
 
 ## Adapting for Your Custom Table
 

--- a/rust/examples/json/persistent.rs
+++ b/rust/examples/json/persistent.rs
@@ -1,0 +1,74 @@
+//! Persistent JSON ingestion with create and resume support.
+//!
+//! On the first run, leave `ZEROBUS_PERSISTENT_STREAM_ID` unset. The server
+//! creates a durable stream and this example prints its ID. Persist that ID and
+//! provide it through `ZEROBUS_PERSISTENT_STREAM_ID` on later runs to resume
+//! from the server's last committed offset.
+//!
+//! Records are queued without waiting for individual acknowledgements. A
+//! single `flush()` after the loop confirms the complete run.
+
+use std::env;
+use std::error::Error;
+
+use databricks_zerobus_ingest_sdk::ZerobusSdk;
+
+// Change these constants to match your workspace and table.
+const TABLE_NAME: &str = "<your_table_name>";
+const DATABRICKS_CLIENT_ID: &str = "<your_databricks_client_id>";
+const DATABRICKS_CLIENT_SECRET: &str = "<your_databricks_client_secret>";
+const DATABRICKS_WORKSPACE_URL: &str = "https://<your-workspace>.cloud.databricks.com";
+const SERVER_ENDPOINT: &str = "https://<your-shard-id>.zerobus.<region>.cloud.databricks.com";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let sdk = ZerobusSdk::builder()
+        .endpoint(SERVER_ENDPOINT)
+        .unity_catalog_url(DATABRICKS_WORKSPACE_URL)
+        .build()?;
+
+    let builder = sdk
+        .persistent_stream_builder()
+        .table(TABLE_NAME)
+        .oauth(DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET)
+        .json()
+        .max_inflight_requests(100);
+
+    let mut stream = match env::var("ZEROBUS_PERSISTENT_STREAM_ID") {
+        Ok(stream_id) => {
+            println!("Resuming persistent stream {stream_id}");
+            builder.resume(stream_id).await?
+        }
+        Err(env::VarError::NotPresent) => {
+            let stream = builder.build().await?;
+            println!(
+                "Created persistent stream {}. Save this ID to resume later.",
+                stream.stream_id().unwrap_or("<missing stream ID>")
+            );
+            stream
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let records = [
+        format!(
+            r#"{{"id":1,"customer_name":"Alice","product_name":"Mouse","quantity":1,"price":25.99,"status":"pending","created_at":{now},"updated_at":{now}}}"#
+        ),
+        format!(
+            r#"{{"id":2,"customer_name":"Bob","product_name":"Keyboard","quantity":1,"price":89.99,"status":"pending","created_at":{now},"updated_at":{now}}}"#
+        ),
+    ];
+
+    for record in records {
+        let offset = stream.ingest_record_offset(record).await?;
+        println!("Queued record at offset {offset}");
+    }
+    stream.flush().await?;
+    println!("All queued records are durable");
+
+    // Closing ends this connection but does not retire the durable stream. It
+    // can be resumed later with the same stream ID.
+    stream.close().await?;
+    Ok(())
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds the user-facing documentation for the feature-gated persistent-stream API introduced by the preceding stack.

It adds a runnable JSON example that:

- Creates a new durable stream when `ZEROBUS_PERSISTENT_STREAM_ID` is unset.
- Prints the server-assigned `stream_id` so applications can persist it externally.
- Resumes an existing stream when `ZEROBUS_PERSISTENT_STREAM_ID` is set.
- Queues records in a loop and calls `flush()` once afterward, preserving the SDK ingestion pipeline.
- Explains that `close()` ends the current connection without retiring the durable stream.

The Rust examples index and JSON README document how to run both the create and resume paths. This PR also adds the documentation entry to `rust/NEXT_CHANGELOG.md`.

### Stack

1. #761 — protobuf contract
2. #762 — gRPC transport and recovery engine
3. #763 — public Rust API
4. #764 — stateful mock and integration tests
5. **Documentation and runnable example**

## How is this tested?

- `cargo check -p rust-examples-json --example json_persistent`
- `cargo test -p tests --test persistent_stream_tests` — 2 tests passed
- `cargo fmt --all -- --check`
- `git diff --check`