### PR TITLE
[PureGo] Accept Arrow IPC bytes as ingest input

### DIFF
--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -50,9 +50,18 @@
   values spanning the whole parent, and a batch's custom metadata is charged
   separately because it is written into the IPC message header rather than into
   any column buffer. Nothing is exposed through a public API yet.
+- Accept caller-owned Arrow IPC bytes as an ingestion input, canonicalized into
+  the same self-contained payload the typed path produces. A compressed stream is
+  measured before Arrow sees it: the IPC metadata is walked directly and the
+  uncompressed size each buffer declares is charged at admission, so a stream
+  that expands far past its wire length is refused instead of being allowed
+  through on its compressed size and then allocated for. Nothing is exposed
+  through a public API yet.
 - Add the `github.com/apache/arrow-go/v18` dependency. arrow-go requires
   `google.golang.org/grpc` v1.82.0, which raises this module's grpc minimum from
-  v1.81.1.
+  v1.81.1. `github.com/google/flatbuffers` becomes a direct dependency, having
+  been an indirect one through arrow-go, because Arrow IPC metadata is read
+  without materializing the batch it describes.
 
 ### Breaking Changes
 

--- a/purego/go.mod
+++ b/purego/go.mod
@@ -4,13 +4,13 @@ go 1.25.0
 
 require (
 	github.com/apache/arrow-go/v18 v18.7.0
+	github.com/google/flatbuffers v25.12.19+incompatible
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect

--- a/purego/internal/arrowproto/encoder.go
+++ b/purego/internal/arrowproto/encoder.go
@@ -130,6 +130,26 @@ func (p *Protocol) EncodeRecordBatch(batch arrow.RecordBatch) (*Payload, error) 
 	return p.payloadFromCanonicalIPC(serialized, uint64(batch.NumRows()))
 }
 
+// EncodeIPC canonicalizes one caller-owned Arrow IPC stream. The batch is read
+// back and reserialized rather than forwarded, so the payload carries its own
+// schema and dictionary state instead of depending on frames the caller sent
+// earlier and will not send again after a reconnect.
+func (p *Protocol) EncodeIPC(data []byte) (*Payload, error) {
+	batch, err := p.decodeOne(data)
+	if err != nil {
+		return nil, err
+	}
+	defer batch.Release()
+	serialized, err := p.serialize(batch)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"arrow protocol: canonicalize IPC RecordBatch: %w",
+			err,
+		)
+	}
+	return p.payloadFromCanonicalIPC(serialized, uint64(batch.NumRows()))
+}
+
 // EstimateRecordBatchRetainedSize returns a conservative pre-materialization
 // reservation: the batch sized from the rows it covers plus its custom
 // metadata, doubled to cover framing, compression, and buffer growth, plus the
@@ -148,6 +168,26 @@ func (p *Protocol) EstimateRecordBatchRetainedSize(
 		totalRecordBufferSize(batch),
 		recordBatchMetadataSize(batch),
 	)
+	if err != nil {
+		return math.MaxInt64, nil
+	}
+	return p.admissionEstimate(inputBytes), nil
+}
+
+// EstimateIPCRetainedSize reserves for canonicalizing one caller-owned IPC
+// stream. A compressed batch declares the uncompressed size of every buffer, so
+// those declarations are read straight out of the IPC metadata and charged here:
+// Arrow allocates against them the moment it materializes the input, and by then
+// admission has already let the stream through.
+func (p *Protocol) EstimateIPCRetainedSize(data []byte) (int64, error) {
+	expandedBytes, err := preflightIPCExpansion(data)
+	if err != nil {
+		return 0, err
+	}
+	// The wire bytes and the expansion they declare are both held while the
+	// payload is rebuilt, and both scale the same way, so they are charged as one
+	// input rather than as separate terms.
+	inputBytes, err := addInt64Saturating(int64(len(data)), expandedBytes)
 	if err != nil {
 		return math.MaxInt64, nil
 	}

--- a/purego/internal/arrowproto/encoder_test.go
+++ b/purego/internal/arrowproto/encoder_test.go
@@ -2,6 +2,8 @@ package arrowproto
 
 import (
 	"bytes"
+	"encoding/binary"
+	"math"
 	"strings"
 	"testing"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 func idSchema(metadata *arrow.Metadata) *arrow.Schema {
@@ -133,6 +136,67 @@ func structBatch(
 	record := array.NewRecordBatch(schema, []arrow.Array{column}, int64(rows))
 	column.Release()
 	return schema, record
+}
+
+func dictionaryBatch(
+	t *testing.T,
+	allocator memory.Allocator,
+	rows int,
+	distinct int,
+	valueBytes int,
+) (*arrow.Schema, arrow.RecordBatch) {
+	t.Helper()
+	dictionaryType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int32,
+		ValueType: arrow.BinaryTypes.String,
+	}
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "value", Type: dictionaryType, Nullable: false,
+	}}, nil)
+	builder, ok := array.NewBuilder(allocator, dictionaryType).(*array.BinaryDictionaryBuilder)
+	if !ok {
+		t.Fatal("dictionary builder is not a *array.BinaryDictionaryBuilder")
+	}
+	for i := range rows {
+		value := strings.Repeat(string(rune('a'+i%distinct)), valueBytes)
+		if err := builder.AppendString(value); err != nil {
+			t.Fatalf("append dictionary value: %v", err)
+		}
+	}
+	column := builder.NewArray()
+	builder.Release()
+	record := array.NewRecordBatch(schema, []arrow.Array{column}, int64(rows))
+	column.Release()
+	return schema, record
+}
+
+func serializeRecords(
+	t *testing.T,
+	schema *arrow.Schema,
+	records ...arrow.RecordBatch,
+) []byte {
+	return serializeRecordsWithOptions(t, schema, nil, records...)
+}
+
+func serializeRecordsWithOptions(
+	t *testing.T,
+	schema *arrow.Schema,
+	options []ipc.Option,
+	records ...arrow.RecordBatch,
+) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	writerOptions := append([]ipc.Option{ipc.WithSchema(schema)}, options...)
+	writer := ipc.NewWriter(&output, writerOptions...)
+	for _, record := range records {
+		if err := writer.Write(record); err != nil {
+			t.Fatalf("write IPC record: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close IPC writer: %v", err)
+	}
+	return bytes.Clone(output.Bytes())
 }
 
 func readIDs(t *testing.T, data []byte) []int32 {
@@ -539,5 +603,298 @@ func TestTypedAdmissionChargesRecordBatchMetadata(t *testing.T) {
 			estimate,
 			payload.RetainedSize(),
 		)
+	}
+}
+
+func TestEncodeIPCCanonicalizesAndCopiesInput(t *testing.T) {
+	schema := idSchema(nil)
+	protocol, err := New(schema, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	record := idBatch(t, memory.DefaultAllocator, schema, []int32{1, 2})
+	defer record.Release()
+
+	input := serializeRecords(t, schema, record)
+	payload, err := protocol.EncodeIPC(input)
+	if err != nil {
+		t.Fatalf("EncodeIPC: %v", err)
+	}
+	// The caller may reuse its buffer the moment EncodeIPC returns.
+	for i := range input {
+		input[i] = 0
+	}
+	if got := readIDs(t, payload.IPCBytes()); !equalInt32(got, []int32{1, 2}) {
+		t.Fatalf("canonical ids = %v", got)
+	}
+
+	if _, err := protocol.EncodeIPC([]byte("not IPC")); err == nil {
+		t.Fatal("invalid IPC accepted")
+	}
+}
+
+func TestEncodeIPCRejectsNoEmptyAndMultipleBatches(t *testing.T) {
+	schema := idSchema(nil)
+	protocol, err := New(schema, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	empty := idBatch(t, memory.DefaultAllocator, schema, nil)
+	defer empty.Release()
+	one := idBatch(t, memory.DefaultAllocator, schema, []int32{1})
+	defer one.Release()
+
+	for _, test := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "no batch", data: serializeRecords(t, schema)},
+		{name: "empty batch", data: serializeRecords(t, schema, empty)},
+		{name: "multiple batches", data: serializeRecords(t, schema, one, one)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := protocol.EncodeIPC(test.data); err == nil {
+				t.Fatalf("EncodeIPC accepted %s", test.name)
+			}
+		})
+	}
+}
+
+// A caller supplying its own IPC bytes is the first place a payload's exactly-one-batch
+// contract can be violated from outside, so anything past the single batch is rejected
+// rather than silently dropped.
+func TestEncodeIPCRejectsTrailingBytesAndConcatenatedStreams(t *testing.T) {
+	schema := idSchema(nil)
+	protocol, err := New(schema, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	record := idBatch(t, memory.DefaultAllocator, schema, []int32{1})
+	defer record.Release()
+	batchStream := serializeRecords(t, schema, record)
+
+	for _, test := range []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "trailing bytes",
+			input: append(bytes.Clone(batchStream), []byte("trailing")...),
+		},
+		{
+			name:  "concatenated stream",
+			input: append(bytes.Clone(batchStream), batchStream...),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := protocol.EncodeIPC(test.input); err == nil {
+				t.Fatalf("EncodeIPC accepted %s", test.name)
+			}
+			if _, err := protocol.EstimateIPCRetainedSize(test.input); err == nil {
+				t.Fatalf("EstimateIPCRetainedSize accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestUncompressedIPCAdmissionCoversCanonicalPayload(t *testing.T) {
+	schema, record := binaryBatch(t, memory.DefaultAllocator, 512, 64)
+	defer record.Release()
+	protocol, err := New(schema, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	input := serializeRecords(t, schema, record)
+	estimate, err := protocol.EstimateIPCRetainedSize(input)
+	if err != nil {
+		t.Fatalf("EstimateIPCRetainedSize: %v", err)
+	}
+	payload, err := protocol.EncodeIPC(input)
+	if err != nil {
+		t.Fatalf("EncodeIPC: %v", err)
+	}
+	if estimate < payload.RetainedSize() {
+		t.Fatalf(
+			"estimate %d under-reserves the %d-byte canonical payload",
+			estimate,
+			payload.RetainedSize(),
+		)
+	}
+}
+
+// A compressed stream weighs a fraction of what Arrow allocates for it, so the
+// estimate has to follow the sizes the buffers declare rather than the wire
+// length — that is what lets a buffer limit below the expanded size refuse the
+// stream. Reaching that number must not materialize anything.
+func TestCompressedIPCAdmissionUsesDeclaredUncompressedSizes(t *testing.T) {
+	const (
+		rows       = 4_096
+		valueBytes = 2_048
+		valueTotal = int64(rows) * valueBytes
+	)
+	schema, record := binaryBatch(t, memory.DefaultAllocator, rows, valueBytes)
+	defer record.Release()
+
+	for _, test := range []struct {
+		name   string
+		option ipc.Option
+	}{
+		{name: "LZ4", option: ipc.WithLZ4()},
+		{name: "Zstd", option: ipc.WithZstd()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := serializeRecordsWithOptions(
+				t,
+				schema,
+				[]ipc.Option{test.option},
+				record,
+			)
+			if int64(len(input)) >= valueTotal/4 {
+				t.Fatalf(
+					"compressed IPC size = %d, input is not highly compressible",
+					len(input),
+				)
+			}
+
+			allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			protocol, err := New(schema, Options{Allocator: allocator})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			estimate, err := protocol.EstimateIPCRetainedSize(input)
+			if err != nil {
+				t.Fatalf("EstimateIPCRetainedSize: %v", err)
+			}
+			// Doubling the compressed length cannot reach this, so only the
+			// declared uncompressed sizes can account for the estimate.
+			if estimate < valueTotal {
+				t.Fatalf(
+					"compressed IPC estimate = %d, below the %d bytes its buffers declare",
+					estimate,
+					valueTotal,
+				)
+			}
+			allocator.AssertSize(t, 0)
+		})
+	}
+}
+
+// A dictionary arrives as its own IPC message, and its values — not the indices
+// in the record batch — are the large buffers, so the preflight has to charge
+// that message too or the bulk of a dictionary-encoded stream goes unmeasured.
+func TestCompressedDictionaryIPCChargesDictionaryBatch(t *testing.T) {
+	const (
+		rows       = 4_096
+		distinct   = 64
+		valueBytes = 16 * 1024
+		valueTotal = int64(distinct) * valueBytes
+	)
+	schema, record := dictionaryBatch(
+		t,
+		memory.DefaultAllocator,
+		rows,
+		distinct,
+		valueBytes,
+	)
+	defer record.Release()
+	protocol, err := New(schema, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	input := serializeRecordsWithOptions(
+		t,
+		schema,
+		[]ipc.Option{ipc.WithLZ4()},
+		record,
+	)
+	estimate, err := protocol.EstimateIPCRetainedSize(input)
+	if err != nil {
+		t.Fatalf("EstimateIPCRetainedSize: %v", err)
+	}
+	// The record batch holds only 4-byte indices, so nothing but the dictionary
+	// message can account for this much.
+	if estimate < valueTotal {
+		t.Fatalf(
+			"dictionary IPC estimate = %d, below the %d bytes its values declare",
+			estimate,
+			valueTotal,
+		)
+	}
+	payload, err := protocol.EncodeIPC(input)
+	if err != nil {
+		t.Fatalf("EncodeIPC: %v", err)
+	}
+	if estimate < payload.RetainedSize() {
+		t.Fatalf(
+			"estimate %d under-reserves the %d-byte canonical payload",
+			estimate,
+			payload.RetainedSize(),
+		)
+	}
+}
+
+func TestCompressedIPCDeclaredSizeOverflowIsRejected(t *testing.T) {
+	builder := flatbuffers.NewBuilder(128)
+
+	builder.StartObject(2)
+	compression := builder.EndObject()
+
+	builder.StartVector(16, 2, 8)
+	for index := 1; index >= 0; index-- {
+		builder.Prep(8, 16)
+		builder.PrependInt64(8)
+		builder.PrependInt64(int64(index * 8))
+	}
+	buffers := builder.EndVector(2)
+
+	builder.StartObject(5)
+	builder.PrependUOffsetTSlot(2, buffers, 0)
+	builder.PrependUOffsetTSlot(3, compression, 0)
+	recordBatch := builder.EndObject()
+	builder.Finish(recordBatch)
+
+	body := make([]byte, 16)
+	binary.LittleEndian.PutUint64(body[:8], math.MaxInt64)
+	binary.LittleEndian.PutUint64(body[8:], 1)
+	if _, err := ipcCompressedExpansion(
+		ipcRootTable(builder.FinishedBytes()),
+		body,
+	); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("ipcCompressedExpansion overflow error = %v", err)
+	}
+}
+
+// The preflight walks flatbuffer metadata by hand, so every malformed shape has
+// to come back as an error rather than as a panic or a usable size.
+func TestPreflightRejectsMalformedIPC(t *testing.T) {
+	schema := idSchema(nil)
+	record := idBatch(t, memory.DefaultAllocator, schema, []int32{1})
+	defer record.Release()
+	batchStream := serializeRecords(t, schema, record)
+
+	for _, test := range []struct {
+		name  string
+		input []byte
+	}{
+		{name: "empty", input: nil},
+		{name: "garbage", input: []byte("not IPC at all")},
+		{name: "truncated", input: batchStream[:len(batchStream)/2]},
+		{
+			name:  "trailing bytes",
+			input: append(bytes.Clone(batchStream), 'x'),
+		},
+		{name: "schema only", input: serializeRecords(t, schema)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			expanded, err := preflightIPCExpansion(test.input)
+			if err == nil {
+				t.Fatalf("preflight accepted %s", test.name)
+			}
+			if expanded != 0 {
+				t.Fatalf("rejected input reported %d expanded bytes", expanded)
+			}
+		})
 	}
 }

--- a/purego/internal/arrowproto/encoder_test.go
+++ b/purego/internal/arrowproto/encoder_test.go
@@ -157,9 +157,16 @@ func dictionaryBatch(
 	if !ok {
 		t.Fatal("dictionary builder is not a *array.BinaryDictionaryBuilder")
 	}
+	// Single-byte runes only, so each value is exactly valueBytes on the wire and
+	// the caller can predict the dictionary's total size.
+	const alphabet = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/"
+	if distinct > len(alphabet) {
+		t.Fatalf("distinct = %d, want at most %d", distinct, len(alphabet))
+	}
 	for i := range rows {
-		value := strings.Repeat(string(rune('a'+i%distinct)), valueBytes)
-		if err := builder.AppendString(value); err != nil {
+		letter := alphabet[i%distinct : i%distinct+1]
+		if err := builder.AppendString(strings.Repeat(letter, valueBytes)); err != nil {
 			t.Fatalf("append dictionary value: %v", err)
 		}
 	}

--- a/purego/internal/arrowproto/ipc_preflight.go
+++ b/purego/internal/arrowproto/ipc_preflight.go
@@ -1,0 +1,281 @@
+package arrowproto
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+
+const (
+	ipcContinuationToken = uint32(0xffffffff)
+
+	ipcHeaderSchema          = byte(1)
+	ipcHeaderDictionaryBatch = byte(2)
+	ipcHeaderRecordBatch     = byte(3)
+)
+
+// preflightIPCExpansion walks IPC message metadata without building Arrow arrays.
+// For compressed batches it sums the per-buffer uncompressed-size prefixes that
+// Arrow would otherwise allocate against unchecked.
+func preflightIPCExpansion(data []byte) (expandedBytes int64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			expandedBytes = 0
+			err = fmt.Errorf("arrow protocol: invalid IPC metadata: %v", recovered)
+		}
+	}()
+	if len(data) == 0 {
+		return 0, fmt.Errorf("arrow protocol: IPC input is empty")
+	}
+
+	position := int64(0)
+	sawSchema := false
+	sawRecordBatch := false
+	for position < int64(len(data)) {
+		first, next, takeErr := takeIPCBytes(data, position, 4)
+		if takeErr != nil {
+			return 0, takeErr
+		}
+		position = next
+		indicator := binary.LittleEndian.Uint32(first)
+
+		var metadataLength uint32
+		switch indicator {
+		case 0:
+			if position != int64(len(data)) {
+				return 0, fmt.Errorf(
+					"arrow protocol: IPC stream contains %d trailing bytes",
+					int64(len(data))-position,
+				)
+			}
+			position = int64(len(data))
+			continue
+		case ipcContinuationToken:
+			lengthBytes, next, lengthErr := takeIPCBytes(data, position, 4)
+			if lengthErr != nil {
+				return 0, lengthErr
+			}
+			position = next
+			metadataLength = binary.LittleEndian.Uint32(lengthBytes)
+			if metadataLength == 0 {
+				if position != int64(len(data)) {
+					return 0, fmt.Errorf(
+						"arrow protocol: IPC stream contains %d trailing bytes",
+						int64(len(data))-position,
+					)
+				}
+				position = int64(len(data))
+				continue
+			}
+		default:
+			metadataLength = indicator
+		}
+		if metadataLength < 4 {
+			return 0, fmt.Errorf(
+				"arrow protocol: invalid IPC message metadata length %d",
+				metadataLength,
+			)
+		}
+		metadata, next, metadataErr := takeIPCBytes(
+			data,
+			position,
+			int64(metadataLength),
+		)
+		if metadataErr != nil {
+			return 0, metadataErr
+		}
+		position = next
+
+		message := ipcRootTable(metadata)
+		headerType := message.GetByteSlot(6, 0)
+		bodyLength := message.GetInt64Slot(10, 0)
+		if bodyLength < 0 {
+			return 0, fmt.Errorf(
+				"arrow protocol: invalid IPC message body length %d",
+				bodyLength,
+			)
+		}
+		body, next, bodyErr := takeIPCBytes(data, position, bodyLength)
+		if bodyErr != nil {
+			return 0, bodyErr
+		}
+		position = next
+
+		switch headerType {
+		case ipcHeaderSchema:
+			if sawSchema || sawRecordBatch {
+				return 0, fmt.Errorf("arrow protocol: IPC stream contains an unexpected schema message")
+			}
+			sawSchema = true
+		case ipcHeaderDictionaryBatch:
+			if !sawSchema || sawRecordBatch {
+				return 0, fmt.Errorf("arrow protocol: IPC dictionary message is out of order")
+			}
+			header, headerErr := ipcMessageHeader(message)
+			if headerErr != nil {
+				return 0, headerErr
+			}
+			recordBatch, recordErr := ipcDictionaryRecordBatch(header)
+			if recordErr != nil {
+				return 0, recordErr
+			}
+			expanded, expansionErr := ipcCompressedExpansion(recordBatch, body)
+			if expansionErr != nil {
+				return 0, expansionErr
+			}
+			expandedBytes, err = addInt64Saturating(expandedBytes, expanded)
+			if err != nil {
+				return math.MaxInt64, err
+			}
+		case ipcHeaderRecordBatch:
+			if !sawSchema || sawRecordBatch {
+				return 0, fmt.Errorf(
+					"arrow protocol: IPC stream must contain exactly one RecordBatch",
+				)
+			}
+			sawRecordBatch = true
+			recordBatch, headerErr := ipcMessageHeader(message)
+			if headerErr != nil {
+				return 0, headerErr
+			}
+			expanded, expansionErr := ipcCompressedExpansion(recordBatch, body)
+			if expansionErr != nil {
+				return 0, expansionErr
+			}
+			expandedBytes, err = addInt64Saturating(expandedBytes, expanded)
+			if err != nil {
+				return math.MaxInt64, err
+			}
+		default:
+			return 0, fmt.Errorf(
+				"arrow protocol: unsupported IPC message header type %d",
+				headerType,
+			)
+		}
+	}
+	if !sawSchema {
+		return 0, fmt.Errorf("arrow protocol: IPC stream contains no schema")
+	}
+	if !sawRecordBatch {
+		return 0, fmt.Errorf("arrow protocol: IPC stream contains no RecordBatch")
+	}
+	return expandedBytes, nil
+}
+
+func takeIPCBytes(data []byte, position, length int64) ([]byte, int64, error) {
+	if position < 0 || length < 0 ||
+		position > int64(len(data)) ||
+		length > int64(len(data))-position {
+		return nil, position, fmt.Errorf(
+			"arrow protocol: IPC message extends beyond %d-byte input",
+			len(data),
+		)
+	}
+	end := position + length
+	return data[int(position):int(end)], end, nil
+}
+
+func ipcRootTable(metadata []byte) flatbuffers.Table {
+	root := flatbuffers.GetUOffsetT(metadata)
+	return flatbuffers.Table{Bytes: metadata, Pos: root}
+}
+
+func ipcMessageHeader(message flatbuffers.Table) (flatbuffers.Table, error) {
+	offset := flatbuffers.UOffsetT(message.Offset(8))
+	if offset == 0 {
+		return flatbuffers.Table{}, fmt.Errorf("arrow protocol: IPC message has no header")
+	}
+	var header flatbuffers.Table
+	message.Union(&header, offset)
+	return header, nil
+}
+
+func ipcDictionaryRecordBatch(
+	dictionary flatbuffers.Table,
+) (flatbuffers.Table, error) {
+	offset := flatbuffers.UOffsetT(dictionary.Offset(6))
+	if offset == 0 {
+		return flatbuffers.Table{}, fmt.Errorf(
+			"arrow protocol: IPC dictionary message has no RecordBatch header",
+		)
+	}
+	position := dictionary.Indirect(offset + dictionary.Pos)
+	return flatbuffers.Table{Bytes: dictionary.Bytes, Pos: position}, nil
+}
+
+func ipcCompressedExpansion(recordBatch flatbuffers.Table, body []byte) (int64, error) {
+	compressionOffset := flatbuffers.UOffsetT(recordBatch.Offset(10))
+	if compressionOffset == 0 {
+		return 0, nil
+	}
+	compressionPosition := recordBatch.Indirect(compressionOffset + recordBatch.Pos)
+	compression := flatbuffers.Table{
+		Bytes: recordBatch.Bytes,
+		Pos:   compressionPosition,
+	}
+	codec := compression.GetInt8Slot(4, 0)
+	method := compression.GetInt8Slot(6, 0)
+	if codec != 0 && codec != 1 {
+		return 0, fmt.Errorf("arrow protocol: unsupported IPC compression codec %d", codec)
+	}
+	if method != 0 {
+		return 0, fmt.Errorf("arrow protocol: unsupported IPC compression method %d", method)
+	}
+
+	buffersOffset := flatbuffers.UOffsetT(recordBatch.Offset(8))
+	if buffersOffset == 0 {
+		return 0, nil
+	}
+	buffersLength := recordBatch.VectorLen(buffersOffset)
+	buffersStart := recordBatch.Vector(buffersOffset)
+	var total int64
+	for index := range buffersLength {
+		bufferPosition := buffersStart + flatbuffers.UOffsetT(index*16)
+		offset := recordBatch.GetInt64(bufferPosition)
+		length := recordBatch.GetInt64(bufferPosition + 8)
+		if offset < 0 || length < 0 || offset > int64(len(body)) ||
+			length > int64(len(body))-offset {
+			return 0, fmt.Errorf(
+				"arrow protocol: compressed IPC buffer %d range [%d,%d) exceeds %d-byte body",
+				index,
+				offset,
+				offset+length,
+				len(body),
+			)
+		}
+		if length == 0 {
+			continue
+		}
+		if length < 8 {
+			return 0, fmt.Errorf(
+				"arrow protocol: compressed IPC buffer %d is %d bytes, smaller than its size prefix",
+				index,
+				length,
+			)
+		}
+		prefix := int64(binary.LittleEndian.Uint64(
+			body[int(offset) : int(offset)+8],
+		))
+		if prefix == -1 {
+			continue
+		}
+		if prefix < 0 {
+			return 0, fmt.Errorf(
+				"arrow protocol: compressed IPC buffer %d declares invalid uncompressed size %d",
+				index,
+				prefix,
+			)
+		}
+		var err error
+		total, err = addInt64Saturating(total, prefix)
+		if err != nil {
+			return math.MaxInt64, fmt.Errorf(
+				"arrow protocol: declared uncompressed IPC buffer sizes overflow: %w",
+				err,
+			)
+		}
+	}
+	return total, nil
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Accepts caller-owned Arrow IPC bytes as an ingestion input, alongside the live
`RecordBatch` that #758 added. Nothing in the package is reachable from a public API yet.

A caller that already holds IPC bytes — read from a file, forwarded from another
Arrow producer, or received over Flight — previously had no way in. `EncodeIPC`
takes those bytes and produces the same canonical payload the typed path
produces, so everything downstream is unchanged.

The two pieces worth review attention:

- **The input is reserialized, not forwarded.** The batch is read back and
  written out again so the payload carries its own schema and dictionary state.
  A caller's stream may reference dictionaries declared in frames it sent
  earlier and will not send again, and a payload has to survive a reconnect on
  its own. Reserializing also puts the input through the same exactly-one-batch
  validation as the typed path, which matters more here because this is the
  first input a caller supplies in wire form: a stream with trailing bytes, two
  batches, or none is rejected rather than silently truncated.
- **Admission cannot use the wire length.** A compressed batch weighs a fraction
  of what Arrow allocates when it materializes, and the core admits before
  encoding, so charging the compressed size would let a stream through and then
  expand past the buffer limit while Arrow allocates for it. Every compressed
  buffer declares its uncompressed size in the IPC metadata, so
  `preflightIPCExpansion` walks the message headers directly — without building
  a single Arrow array — and charges what those declarations add up to. On the
  4,096-row string batch in the tests that number is 41x the doubled wire
  length.

The walk is hand-rolled flatbuffer parsing rather than a call into arrow-go,
because arrow-go's own readers reach these fields only while materializing the
batch, which is the allocation this is trying to get ahead of. It validates as
it goes — message order, header type, body bounds, per-buffer ranges, negative
and overflowing declared sizes — and a `recover()` converts a malformed shape
into an error rather than a panic escaping into the caller's goroutine.

The dictionary message is charged on the same path. A dictionary-encoded stream
keeps its values in a separate IPC message while the record batch holds only
indices, so measuring the record batch alone would miss the bulk of it.

**Dependencies.** `github.com/google/flatbuffers` becomes a direct dependency.
It was already in the module graph as an indirect dependency through arrow-go,
so this adds no new code to the build — only an explicit `require`.

**Deliberately not here**, each following as its own change:

1. Flight frame encoding: the 2 MiB chunk plan measured by binary searching
   actual encoded protobuf size, and the frame emitter.
2. Flight acknowledgment and batch metadata parsing in `internal/transport`.
3. `stream.EncoderHooks` and the stream-core wiring.

#732 also carries `DecodeIPCRecordBatch` and exported `EncodeSchemaIPC` /
`DecodeSchemaIPC`. Nothing outside their own tests consumes them even there, so
as with #758 they ride with the change that gives them a caller. #732's version
of `EncodeIPC` additionally computes a Flight chunk plan; that arrives with the
frame encoder.

## How is this tested?

18 unit tests in `internal/arrowproto` (33 cases counting subtests), none of
which need a server or a network. `go test -race ./...` passes across the module
(586 cases, 10 packages), as does `CGO_ENABLED=0 go test ./...`, and `gofmt`,
`go vet`, and `go mod tidy -diff` are clean.

Coverage worth calling out:

- The compressed-admission case asserts the estimate reaches at least the
  uncompressed footprint the buffers declare, which doubling the compressed
  length cannot reach — so it fails if the preflight stops reading declarations
  rather than merely looking conservative. It runs on a
  `memory.NewCheckedAllocator` and asserts zero allocations, which is the other
  half of the claim: the expansion is measured without ever being performed. Both
  LZ4 and Zstd are covered.
- A dictionary-encoded compressed stream is charged for its dictionary values,
  the case that distinguishes walking every message from walking only the record
  batch.
- Declared sizes that overflow `int64` are rejected, driven through a
  hand-built flatbuffer rather than a real Arrow stream, since arrow-go will not
  produce one.
- Malformed inputs — empty, garbage, truncated mid-message, trailing bytes,
  schema with no batch — all return an error and report zero expanded bytes, so
  a rejected stream cannot leave a usable-looking size behind.
- `EncodeIPC` canonicalizes and copies: the caller's buffer is zeroed
  immediately after the call and the payload still decodes to the original rows.
- Admission covers the materialized payload for both an uncompressed and a
  dictionary-encoded input.

Not covered here because it needs the changes that follow: the core rejecting an
oversized compressed stream with `ErrPayloadTooLarge` before the decoder runs
(#732 tests this through `EncoderHooks`, which arrives with the wiring), Flight
frame chunking, and anything end-to-end against a Flight server.
