### PR TITLE
[TypeScript ] Use local Rust SDK for builds

### DIFF
--- a/typescript/Cargo.lock
+++ b/typescript/Cargo.lock
@@ -107,8 +107,6 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bebfacc9d71f0728f6774164e4d4254b5e504d2b46812d0512d8290ec119a64"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -411,9 +409,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c2574a4e2fbcf3ee98afced16bcdf1673f8918c993790914c1801a46e242cc"
+version = "2.7.1"
 dependencies = [
  "arrow-array",
  "arrow-flight",

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 napi = { version = "2", features = ["async", "tokio_rt", "serde-json", "napi6"] }
 napi-derive = "2"
 
-databricks-zerobus-ingest-sdk = "2.6.0"
+databricks-zerobus-ingest-sdk = { path = "../rust/sdk", version = "2.6.0" }
 
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This updates the TypeScript native crate to resolve the Zerobus Rust SDK from the local repository source while retaining the published version compatibility constraint. The lockfile now records both the local Rust SDK and its local Arrow Flight dependency.

This makes TypeScript builds and cross-SDK CI validate the current Rust source directly, so integration issues can be caught before either SDK is released.

## How is this tested?

- `cargo check --manifest-path typescript/Cargo.toml`
- `cargo check --manifest-path typescript/Cargo.toml --features arrow-flight`