### PR TITLE
[CI] Simplify cross-SDK Rust testing

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -1,10 +1,6 @@
 name: C++ CI
 
 on:
-  # No use_local_sdk input: the C++ build always compiles the Rust core from
-  # local source (BuildRustFfi.cmake runs `cargo build` in ../rust/ffi, which
-  # depends on ../rust/sdk by path), so there is no released-vs-local mode to
-  # toggle and no crates.io dependency to patch.
   workflow_call:
 
 env:

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -3,10 +3,10 @@ name: .NET CI
 on:
   workflow_call:
     inputs:
-      use_local_sdk:
-        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
+      run_published_artifact_tests:
+        description: 'Run smoke tests that download and consume published FFI artifacts'
         type: boolean
-        default: false
+        default: true
 
 jobs:
   fmt:
@@ -76,10 +76,6 @@ jobs:
         shell: bash
         run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-cargo.sh"
 
-      - name: Patch Rust workspace to use local SDK
-        if: inputs.use_local_sdk
-        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "sdk" }\n' >> ../rust/Cargo.toml
-
       - name: Build Rust FFI
         run: make build-rust
 
@@ -93,8 +89,7 @@ jobs:
         run: make examples
 
   user-experience:
-    # Skip when testing local SDK — this job tests the published release download flow
-    if: ${{ !inputs.use_local_sdk }}
+    if: inputs.run_published_artifact_tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -3,10 +3,10 @@ name: Go CI
 on:
   workflow_call:
     inputs:
-      use_local_sdk:
-        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
+      run_published_artifact_tests:
+        description: 'Run smoke tests that download and consume published FFI artifacts'
         type: boolean
-        default: false
+        default: true
 
 jobs:
   fmt:
@@ -139,10 +139,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Patch Rust workspace to use local SDK
-        if: inputs.use_local_sdk
-        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "sdk" }\n' >> ../rust/Cargo.toml
-
       - name: Build Rust FFI
         run: make build-rust
 
@@ -156,8 +152,7 @@ jobs:
         run: make examples
 
   user-experience:
-    # Skip when testing local SDK — this job tests the published release download flow
-    if: ${{ !inputs.use_local_sdk }}
+    if: inputs.run_published_artifact_tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -2,15 +2,6 @@ name: Java CI
 
 on:
   workflow_call:
-    inputs:
-      use_local_sdk:
-        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
-        type: boolean
-        default: false
-      artifact_suffix:
-        description: 'Suffix to append to artifact names to avoid conflicts when called multiple times in one workflow run'
-        type: string
-        default: ''
 
 jobs:
   fmt:
@@ -85,10 +76,6 @@ jobs:
       - name: Configure Maven registry
         shell: bash
         run: bash "$GITHUB_WORKSPACE/.github/scripts/configure-maven.sh"
-      - name: Patch Rust workspace to use local SDK
-        if: inputs.use_local_sdk
-        shell: bash
-        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "sdk" }\n' >> ../rust/Cargo.toml
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Build JNI native library
@@ -129,7 +116,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: test-results-${{ matrix.os }}-java-${{ matrix.javaVersion }}${{ inputs.artifact_suffix }}
+          name: test-results-${{ matrix.os }}-java-${{ matrix.javaVersion }}
           path: |
             java/target/surefire-reports/
             java/target/test-classes/

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -2,11 +2,6 @@ name: Python CI
 
 on:
   workflow_call:
-    inputs:
-      use_local_sdk:
-        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
-        type: boolean
-        default: false
 
 jobs:
   test:
@@ -68,13 +63,6 @@ jobs:
       - name: Copy root LICENSE for maturin
         shell: bash
         run: cp ../LICENSE LICENSE
-
-      # - name: Patch Cargo.toml to use local Rust SDK
-      #   if: inputs.use_local_sdk
-      #   working-directory: python/rust
-      #   shell: bash
-      #   run: |
-      #     printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "../../rust/sdk" }\n' >> Cargo.toml
 
       - name: Run tests (Linux)
         if: runner.os != 'Windows'

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -2,16 +2,6 @@ name: TypeScript CI
 
 on:
   workflow_call:
-    inputs:
-      use_local_sdk:
-        description: 'Override databricks-zerobus-ingest-sdk with the local path dep (for integration testing unreleased Rust changes)'
-        type: boolean
-        default: false
-      artifact_suffix:
-        description: 'Suffix to append to artifact names to avoid conflicts when called multiple times in one workflow run'
-        type: string
-        default: ''
-
 
 jobs:
   build:
@@ -71,15 +61,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-      - name: Patch Cargo.toml to use local Rust SDK (Unix)
-        if: inputs.use_local_sdk && runner.os != 'Windows'
-        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "../rust/sdk" }\n' >> Cargo.toml
-
-      - name: Patch Cargo.toml to use local Rust SDK (Windows)
-        if: inputs.use_local_sdk && runner.os == 'Windows'
-        run: Add-Content -Path Cargo.toml -Value "`n[patch.crates-io]`ndatabricks-zerobus-ingest-sdk = { path = `"../rust/sdk`" }`n"
-        shell: powershell
-
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
@@ -91,7 +72,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: bindings-${{ matrix.target }}${{ inputs.artifact_suffix }}
+          name: bindings-${{ matrix.target }}
           path: 'typescript/*.node'
           if-no-files-found: error
 
@@ -140,15 +121,6 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-
-      - name: Patch Cargo.toml to use local Rust SDK (Unix)
-        if: inputs.use_local_sdk && runner.os != 'Windows'
-        run: printf '\n[patch.crates-io]\ndatabricks-zerobus-ingest-sdk = { path = "../rust/sdk" }\n' >> Cargo.toml
-
-      - name: Patch Cargo.toml to use local Rust SDK (Windows)
-        if: inputs.use_local_sdk && runner.os == 'Windows'
-        run: Add-Content -Path Cargo.toml -Value "`n[patch.crates-io]`ndatabricks-zerobus-ingest-sdk = { path = `"../rust/sdk`" }`n"
-        shell: powershell
 
       - name: Install dependencies
         run: npm install --no-audit --no-fund

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -142,22 +142,22 @@ jobs:
       contents: read
     uses: ./.github/workflows/ci-dotnet.yml
 
-  # Non-blocking cross-SDK jobs — run all SDK tests against the local Rust
-  # source when rust/** changes, to catch breakage before a new FFI release.
-  # These are intentionally excluded from `gate` so they don't block merging.
+  # Non-blocking cross-SDK jobs — run wrapper tests against the local Rust
+  # source when rust/** changes. Skip wrappers already selected by their own
+  # path filter to avoid running the same workflow twice.
   cross-sdk-go:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.go != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-go.yml
     with:
-      use_local_sdk: true
+      run_published_artifact_tests: false
 
   cross-sdk-cpp:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.cpp != 'true'
     permissions:
       id-token: write
       contents: read
@@ -165,42 +165,34 @@ jobs:
 
   cross-sdk-dotnet:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.dotnet != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-dotnet.yml
     with:
-      use_local_sdk: true
+      run_published_artifact_tests: false
 
   cross-sdk-python:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.python != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-python.yml
-    with:
-      use_local_sdk: true
 
   cross-sdk-typescript:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.typescript != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-typescript.yml
-    with:
-      use_local_sdk: true
-      artifact_suffix: '-local-sdk'
 
   cross-sdk-java:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.java != 'true'
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/ci-java.yml
-    with:
-      use_local_sdk: true
-      artifact_suffix: '-local-sdk'

--- a/python/rust/Cargo.lock
+++ b/python/rust/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "arrow-array",
  "arrow-flight",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This simplifies cross-SDK CI around a single dependency model: wrapper source builds consume the Rust SDK from the repository path.

The workflows no longer patch Cargo manifests at runtime or expose a `use_local_sdk` mode. Cross-SDK jobs also skip wrappers already selected by their own path filters, avoiding duplicate test matrices when a pull request changes both Rust and a wrapper. Go and .NET retain a narrowly scoped input controlling their published-FFI-artifact smoke tests.

This PR should merge after #780, which makes the TypeScript path dependency permanent. The branches modify separate files and can merge without a textual conflict.

## How is this tested?

- Parsed all seven modified workflow files as YAML.
- Verified reusable-workflow callers use only declared inputs.
- Verified the diff has no whitespace errors.

Each edited reusable workflow is selected by its workflow path filter in this PR, so the pull request CI run will exercise the affected SDK job matrices.