### PR TITLE
[PureGo] Speed up JSON conversion

### DIFF
--- a/purego/NEXT_CHANGELOG.md
+++ b/purego/NEXT_CHANGELOG.md
@@ -15,6 +15,9 @@
   descriptor declares, so callers can inspect a table's columns without parsing
   the descriptor themselves. It accepts the bytes returned by
   `FetchProtoDescriptorFromUC` or passed to `WithProto`.
+- Speed up JSON-to-protobuf conversion, especially for wide tables, by using the
+  descriptor's indexed field lookup and skipping collection validation for
+  schemas that contain only scalar fields or records that contain no `null`.
 
 ### Bug Fixes
 

--- a/purego/internal/dynamicproto/converter.go
+++ b/purego/internal/dynamicproto/converter.go
@@ -16,7 +16,8 @@ import (
 
 // Converter encodes JSON payloads into protobuf bytes using a runtime descriptor.
 type Converter struct {
-	message protoreflect.MessageDescriptor
+	message                 protoreflect.MessageDescriptor
+	validateNullCollections bool
 }
 
 // NewFromDescriptorProtoBytes creates a converter from a serialized DescriptorProto.
@@ -44,7 +45,10 @@ func NewFromDescriptorProtoBytes(descBytes []byte) (*Converter, error) {
 	if message == nil {
 		return nil, fmt.Errorf("dynamicproto: missing top-level message descriptor")
 	}
-	return &Converter{message: message}, nil
+	return &Converter{
+		message:                 message,
+		validateNullCollections: hasCollectionFields(message),
+	}, nil
 }
 
 // MessageDescriptor returns the converter's runtime message descriptor.
@@ -68,8 +72,12 @@ func (c *Converter) EncodeJSONBytes(record []byte) ([]byte, error) {
 	if err := unmarshal.Unmarshal(record, msg); err != nil {
 		return nil, fmt.Errorf("dynamicproto: parse JSON payload: %w", err)
 	}
-	if err := rejectNullCollections(record, c.message); err != nil {
-		return nil, err
+	// A JSON null token always contains these exact bytes. Matches inside strings
+	// are harmless false positives that only trigger the validation pass.
+	if c.validateNullCollections && bytes.Contains(record, []byte("null")) {
+		if err := rejectNullCollections(record, c.message); err != nil {
+			return nil, err
+		}
 	}
 	out, err := proto.Marshal(msg)
 	if err != nil {
@@ -196,11 +204,32 @@ func fieldByJSONName(
 	fields protoreflect.FieldDescriptors,
 	name string,
 ) protoreflect.FieldDescriptor {
-	for i := 0; i < fields.Len(); i++ {
-		field := fields.Get(i)
-		if name == field.JSONName() || name == string(field.Name()) {
-			return field
-		}
+	if field := fields.ByJSONName(name); field != nil {
+		return field
 	}
-	return nil
+	return fields.ByTextName(name)
+}
+
+func hasCollectionFields(message protoreflect.MessageDescriptor) bool {
+	visited := make(map[protoreflect.FullName]struct{})
+	var visit func(protoreflect.MessageDescriptor) bool
+	visit = func(current protoreflect.MessageDescriptor) bool {
+		if current == nil {
+			return false
+		}
+		if _, ok := visited[current.FullName()]; ok {
+			return false
+		}
+		visited[current.FullName()] = struct{}{}
+
+		fields := current.Fields()
+		for i := 0; i < fields.Len(); i++ {
+			field := fields.Get(i)
+			if field.Cardinality() == protoreflect.Repeated || visit(field.Message()) {
+				return true
+			}
+		}
+		return false
+	}
+	return visit(message)
 }

--- a/purego/internal/dynamicproto/converter_test.go
+++ b/purego/internal/dynamicproto/converter_test.go
@@ -1,6 +1,7 @@
 package dynamicproto
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func testDescriptorBytes(t *testing.T) []byte {
 	return b
 }
 
-func collectionDescriptorBytes(t *testing.T) []byte {
+func collectionDescriptorBytes(t testing.TB) []byte {
 	t.Helper()
 	desc, err := schema.DescriptorFromUCColumns([]schema.UcColumn{
 		{
@@ -68,6 +69,9 @@ func TestConverter_EncodeJSONBytes(t *testing.T) {
 	c, err := NewFromDescriptorProtoBytes(testDescriptorBytes(t))
 	if err != nil {
 		t.Fatalf("NewFromDescriptorProtoBytes() error = %v", err)
+	}
+	if c.validateNullCollections {
+		t.Fatal("scalar descriptor unexpectedly requires collection validation")
 	}
 	out, err := c.EncodeJSONBytes([]byte(`{"id": 123, "customer":"alice"}`))
 	if err != nil {
@@ -206,9 +210,13 @@ func TestConverter_RejectsNullCollections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFromDescriptorProtoBytes() error = %v", err)
 	}
+	if !converter.validateNullCollections {
+		t.Fatal("collection descriptor does not require collection validation")
+	}
 	for _, record := range []string{
 		`{}`,
 		`{"items":[],"lookup":{}}`,
+		`{"items":[],"lookup":{"null-key":1}}`,
 	} {
 		if _, err := converter.EncodeJSONBytes([]byte(record)); err != nil {
 			t.Fatalf("valid record %s rejected: %v", record, err)
@@ -232,6 +240,33 @@ func TestConverter_RejectsNullCollections(t *testing.T) {
 	}
 }
 
+func TestConverter_DetectsNestedCollections(t *testing.T) {
+	desc, err := schema.DescriptorFromUCColumns([]schema.UcColumn{{
+		Name:     "payload",
+		TypeName: "STRUCT",
+		TypeJSON: `{"type":"struct","fields":[{"name":"items","type":` +
+			`{"type":"array","elementType":"long","containsNull":false},"nullable":false}]}`,
+		Position: 0,
+	}}, "NestedCollections")
+	if err != nil {
+		t.Fatalf("DescriptorFromUCColumns() error = %v", err)
+	}
+	encoded, err := proto.Marshal(desc)
+	if err != nil {
+		t.Fatalf("marshal descriptor: %v", err)
+	}
+	converter, err := NewFromDescriptorProtoBytes(encoded)
+	if err != nil {
+		t.Fatalf("NewFromDescriptorProtoBytes() error = %v", err)
+	}
+	if !converter.validateNullCollections {
+		t.Fatal("nested collection descriptor does not require collection validation")
+	}
+	if _, err := converter.EncodeJSONBytes([]byte(`{"payload":{"items":[null]}}`)); err == nil {
+		t.Fatal("null nested collection element was accepted")
+	}
+}
+
 func TestConverter_RejectsMalformedDescriptor(t *testing.T) {
 	_, err := NewFromDescriptorProtoBytes([]byte{0x0a, 0x01})
 	if err == nil {
@@ -239,5 +274,64 @@ func TestConverter_RejectsMalformedDescriptor(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parse descriptor bytes") {
 		t.Fatalf("error = %v, want descriptor parse error", err)
+	}
+}
+
+func BenchmarkConverter_EncodeJSONBytes_WideScalarRecord(b *testing.B) {
+	const columns = 105
+	desc := &descriptorpb.DescriptorProto{Name: proto.String("WideRecord")}
+	var record strings.Builder
+	record.WriteByte('{')
+	for i := 0; i < columns; i++ {
+		name := "field_" + strconv.Itoa(i)
+		desc.Field = append(desc.Field, &descriptorpb.FieldDescriptorProto{
+			Name:     proto.String(name),
+			Number:   proto.Int32(int32(i + 1)),
+			Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			Type:     descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+			JsonName: proto.String(name),
+		})
+		if i > 0 {
+			record.WriteByte(',')
+		}
+		record.WriteByte('"')
+		record.WriteString(name)
+		record.WriteString(`":`)
+		record.WriteString(strconv.Itoa(i))
+	}
+	record.WriteByte('}')
+
+	encoded, err := proto.Marshal(desc)
+	if err != nil {
+		b.Fatalf("marshal descriptor: %v", err)
+	}
+	converter, err := NewFromDescriptorProtoBytes(encoded)
+	if err != nil {
+		b.Fatalf("NewFromDescriptorProtoBytes() error = %v", err)
+	}
+	payload := []byte(record.String())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := converter.EncodeJSONBytes(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConverter_EncodeJSONBytes_CollectionsWithoutNull(b *testing.B) {
+	converter, err := NewFromDescriptorProtoBytes(collectionDescriptorBytes(b))
+	if err != nil {
+		b.Fatalf("NewFromDescriptorProtoBytes() error = %v", err)
+	}
+	payload := []byte(`{"items":[1,2,3],"lookup":{"a":1,"b":2}}`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := converter.EncodeJSONBytes(payload); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

The dynamic JSON-to-protobuf path did unnecessary work for every record:

1. `protojson.Unmarshal` parsed the JSON and populated the dynamic protobuf message.
2. `encoding/json` parsed the same record again so `rejectNullCollections` could detect `null` collection fields, array elements, and map values.
3. During that validation pass, every JSON key scanned every protobuf field to resolve its descriptor. This made field lookup quadratic in the column count and especially expensive for wide tables.

The two passes cannot simply be merged while using `protojson.Unmarshal`: its decoder loop is internal and has no validation callback. After conversion, the protobuf message no longer preserves every distinction needed by the validator, such as a missing collection versus one explicitly set to `null`. A true single-pass implementation would therefore require replacing and maintaining much of `protojson`'s decoding behavior.

## Solution

This PR keeps `protojson` and removes the avoidable work in two steps:

1. **Use descriptor indexes.** Resolve fields with `ByJSONName` and `ByTextName` instead of scanning the complete field list for every key.
2. **Skip validation when it cannot reject the record.** Inspect the descriptor once to determine whether any collection exists, including inside nested messages. At ingestion time, run the second parse only when the schema has collections and the payload contains `null`. The quick check may also find the word `null` inside a normal JSON string and run validation unnecessarily. That only costs extra work; it does not change the result. Every actual JSON `null` is written with those same bytes, so the check never skips a record that needs validation.

Collection-null behavior is unchanged, while scalar schemas and normal collection records now use only the `protojson` parse.

## Test plan

- [x] `cd purego && go test ./...`
- [x] `go test ./internal/dynamicproto -run '^$' -bench 'BenchmarkConverter_EncodeJSONBytes_(WideScalarRecord|CollectionsWithoutNull)$' -benchmem -benchtime=1s`

Closes #777
