### PR TITLE
[Rust] Expose Arrow batch encoded byte sizes

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ### New Features and Improvements
 
+- Added `ZerobusArrowStream::take_offset_details`, which returns
+  `Some(OffsetDetails)` with, for the batch at a given offset, both `wire_byte_size`
+  (actual bytes on the wire, after IPC compression) and `uncompressed_byte_size`
+  (encoded size before compression), plus a running total for each. Call it after
+  `wait_for_offset` to report "bytes sent" metrics (e.g. network bytes vs. component
+  bytes) without re-serialising the `RecordBatch` yourself. All sizes accumulate every
+  transmission, so a batch re-sent during connection recovery counts each send. Sizes
+  are best-effort instrumentation captured as the SDK encodes each batch and are
+  consumed on read; it returns `None` when no size is recorded (not yet encoded, or
+  evicted from the bounded cache). The uncompressed size is codec-independent (measured
+  from the Arrow buffers, excluding IPC framing), so a batch reports the same value with
+  or without compression. `OffsetDetails` is a new public type. (Beta Arrow API.)
+
 ### Bug Fixes
 
 - The OAuth `expires_in` field is now parsed from a quoted integer (`"3600"`) in

--- a/rust/README.md
+++ b/rust/README.md
@@ -317,6 +317,18 @@ Each input `RecordBatch` receives one logical SDK offset even if Flight splits i
 into several wire messages. Durability is tracked through the cumulative
 `ack_up_to_records` watermark. Arrow Flight does not support `ack_callback`.
 
+For "bytes sent" metrics, call `take_offset_details(offset)` after `wait_for_offset(offset)`:
+it returns `Some(OffsetDetails)` carrying the batch's `wire_byte_size` (actual bytes on
+the wire, after IPC compression) and `uncompressed_byte_size` (encoded size before
+compression), plus a running total for each — so you don't re-serialise the `RecordBatch`
+to measure it. All sizes accumulate every transmission, so a batch re-sent during
+connection recovery counts each send. The read consumes the entry; it returns `None`
+when no size is recorded (not yet encoded, or evicted from the bounded cache). The
+uncompressed size is codec-independent (measured from the Arrow buffers, excluding IPC
+framing), so a batch reports the same value with or without compression. As with
+`wait_for_offset`, don't wait after *every* batch in a hot loop — reserve per-batch
+waiting for low-volume or instrumentation paths.
+
 Recovery reconnects and replays only unacknowledged batch suffixes. After a failed
 `close()`, call `get_unacked_batches()` to inspect the retained work; the returned
 set can be empty when every record was already durable.

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -83,8 +83,8 @@ pub use stream::CallbackHandlerHarness;
 pub use stream::ZerobusStream;
 #[cfg(feature = "arrow-flight")]
 pub use stream::{
-    ArrowSchema, ArrowStreamConfigurationOptions, DataType, Field, RecordBatch, TimeUnit,
-    ZerobusArrowStream,
+    ArrowSchema, ArrowStreamConfigurationOptions, DataType, Field, OffsetDetails, RecordBatch,
+    TimeUnit, ZerobusArrowStream,
 };
 pub use stream_configuration::StreamConfigurationOptions;
 #[cfg(feature = "testing")]

--- a/rust/sdk/src/stream/arrow/batch.rs
+++ b/rust/sdk/src/stream/arrow/batch.rs
@@ -199,7 +199,7 @@ pub(super) fn refresh_pending_ack_deadlines(
 pub(super) fn rebuild_pending_for_replay(
     pending: &mut Vec<PendingBatch>,
     acked_before_disconnect: u64,
-) -> (Vec<RecordBatch>, u64) {
+) -> (Vec<(OffsetId, RecordBatch)>, u64) {
     let mut rebuilt = Vec::with_capacity(pending.len());
     let mut replay = Vec::with_capacity(pending.len());
     let mut cumulative_records = 0;
@@ -215,7 +215,7 @@ pub(super) fn rebuild_pending_for_replay(
         let end_record = cumulative_records + record_count;
         cumulative_records = end_record;
 
-        replay.push(batch.clone());
+        replay.push((pending_batch.offset_id, batch.clone()));
         rebuilt.push(PendingBatch::new_at(
             batch,
             pending_batch.offset_id,

--- a/rust/sdk/src/stream/arrow/batch_stats.rs
+++ b/rust/sdk/src/stream/arrow/batch_stats.rs
@@ -1,0 +1,189 @@
+//! Bounded per-offset encoded byte-size accounting for the Arrow stream.
+//!
+//! The Flight encoder captures each batch's sizes as it runs. [`BatchStatsTracker`]
+//! records them, bounded to a fixed number of recent offsets, so
+//! [`ZerobusArrowStream::take_offset_details`] can report them without
+//! re-serialising the `RecordBatch`.
+//!
+//! [`ZerobusArrowStream::take_offset_details`]: super::ZerobusArrowStream::take_offset_details
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use crate::offset_generator::OffsetId;
+
+/// Encoded byte sizes reported by
+/// [`ZerobusArrowStream::take_offset_details`](super::ZerobusArrowStream::take_offset_details).
+///
+/// **Beta**: part of the Beta Arrow API and may change before GA. Sizes are
+/// best-effort instrumentation captured as the SDK encodes each batch, and
+/// accumulate across every transmission (a batch re-sent during recovery counts
+/// each send).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OffsetDetails {
+    /// Full FlightData frame placed on the wire for this offset's batch (Arrow IPC
+    /// header + body + app metadata, **after** IPC compression when enabled), including
+    /// IPC framing overhead. The actual bytes sent over the network.
+    pub wire_byte_size: u64,
+    /// Uncompressed Arrow data payload size of this offset's batch, measured from the
+    /// batch buffers and **independent of the wire compression codec** — the same batch
+    /// reports the same value whether or not compression is on. Best-effort: it is the
+    /// Arrow buffer bytes and excludes IPC framing (header + inter-buffer padding), so
+    /// with compression off it is somewhat below `wire_byte_size`. Dictionary-encoded
+    /// columns over-count: this counts the full dictionary each batch, while IPC sends
+    /// the dictionary once and only the keys per batch.
+    pub uncompressed_byte_size: u64,
+    /// Running total of [`wire_byte_size`](Self::wire_byte_size) across the stream
+    /// at the moment this offset's batch was last encoded. Counts retransmits, so a
+    /// resend refreshes it to the later, larger total — values are not ordered by
+    /// offset. The stream's monotonic running total, not a per-offset prefix sum.
+    pub cumulative_wire_byte_size: u64,
+    /// Running total of [`uncompressed_byte_size`](Self::uncompressed_byte_size)
+    /// across the stream at the moment this offset's batch was last encoded. Counts
+    /// retransmits, so a resend refreshes it to the later, larger total — values are
+    /// not ordered by offset. The stream's monotonic running total, not a per-offset
+    /// prefix sum.
+    pub cumulative_uncompressed_byte_size: u64,
+}
+
+/// Bounded, self-contained byte-size accounting shared with the Flight encoder.
+///
+/// The stream holds one `Arc<BatchStatsTracker>`; the encoder closure gets a
+/// clone and calls [`record`](Self::record), while `take_offset_details` calls
+/// [`take`](Self::take).
+pub(super) struct BatchStatsTracker {
+    /// Per-offset details, bounded to `cap` entries; the smallest offset is
+    /// evicted first.
+    details: Mutex<BTreeMap<OffsetId, OffsetDetails>>,
+    /// Monotonic total wire bytes sent on this stream.
+    cumulative_wire: AtomicU64,
+    /// Monotonic total uncompressed (pre-compression) bytes sent on this stream.
+    cumulative_uncompressed: AtomicU64,
+    cap: usize,
+}
+
+impl BatchStatsTracker {
+    pub(super) fn new(cap: usize) -> Self {
+        Self {
+            details: Mutex::new(BTreeMap::new()),
+            cumulative_wire: AtomicU64::new(0),
+            cumulative_uncompressed: AtomicU64::new(0),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Adds `wire` (post-compression on-the-wire) and `uncompressed`
+    /// (pre-compression encoded) bytes against `offset`, bumping both monotonic
+    /// running totals. Either may be `0` when only one is known at the call site.
+    /// Accumulates across retransmits. A single call keeps this off the hot path
+    /// cheap — one lock, one map entry.
+    pub(super) fn record(&self, offset: OffsetId, wire: u64, uncompressed: u64) {
+        let cumulative_wire = self.cumulative_wire.fetch_add(wire, Ordering::Relaxed) + wire;
+        let cumulative_uncompressed = self
+            .cumulative_uncompressed
+            .fetch_add(uncompressed, Ordering::Relaxed)
+            + uncompressed;
+        let mut details = self.details.lock().unwrap();
+        let entry = details.entry(offset).or_default();
+        entry.wire_byte_size += wire;
+        entry.uncompressed_byte_size += uncompressed;
+        entry.cumulative_wire_byte_size = cumulative_wire;
+        entry.cumulative_uncompressed_byte_size = cumulative_uncompressed;
+        // Bound the map by evicting the smallest offset once over the cap. Consumers
+        // drain entries they wait on, so steady state stays near the in-flight count.
+        while details.len() > self.cap {
+            details.pop_first();
+        }
+    }
+
+    /// Removes and returns the details for `offset`, or `None` on miss.
+    pub(super) fn take(&self, offset: OffsetId) -> Option<OffsetDetails> {
+        self.details.lock().unwrap().remove(&offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BatchStatsTracker, OffsetDetails};
+
+    #[test]
+    fn accumulates_both_totals_and_take_consumes() {
+        let tracker = BatchStatsTracker::new(16);
+        tracker.record(0, 100, 120);
+        tracker.record(1, 40, 50);
+
+        assert_eq!(
+            tracker.take(0),
+            Some(OffsetDetails {
+                wire_byte_size: 100,
+                uncompressed_byte_size: 120,
+                cumulative_wire_byte_size: 100,
+                cumulative_uncompressed_byte_size: 120,
+            })
+        );
+        assert_eq!(
+            tracker.take(1),
+            Some(OffsetDetails {
+                wire_byte_size: 40,
+                uncompressed_byte_size: 50,
+                cumulative_wire_byte_size: 140,
+                cumulative_uncompressed_byte_size: 170,
+            })
+        );
+        // Consumed on read: a second take misses and returns None.
+        assert_eq!(tracker.take(0), None);
+    }
+
+    #[test]
+    fn split_calls_accumulate_into_one_entry() {
+        // Wire and uncompressed can be recorded in separate calls (as the compressed
+        // path does: uncompressed on batch pull, wire on frame emit); both land on
+        // the same offset entry with independent running totals.
+        let tracker = BatchStatsTracker::new(16);
+        tracker.record(3, 0, 200); // uncompressed only (input side)
+        tracker.record(3, 90, 0); // wire only (output side)
+
+        assert_eq!(
+            tracker.take(3),
+            Some(OffsetDetails {
+                wire_byte_size: 90,
+                uncompressed_byte_size: 200,
+                cumulative_wire_byte_size: 90,
+                cumulative_uncompressed_byte_size: 200,
+            })
+        );
+    }
+
+    #[test]
+    fn resend_accumulates_per_offset_and_cumulative() {
+        // A batch re-sent during recovery is recorded again at the same offset;
+        // both the per-offset sizes and the running totals count every transmission.
+        let tracker = BatchStatsTracker::new(16);
+        tracker.record(6, 100, 100);
+        tracker.record(6, 60, 60); // recovery replay (e.g. a partial suffix)
+
+        assert_eq!(
+            tracker.take(6),
+            Some(OffsetDetails {
+                wire_byte_size: 160,
+                uncompressed_byte_size: 160,
+                cumulative_wire_byte_size: 160,
+                cumulative_uncompressed_byte_size: 160,
+            })
+        );
+    }
+
+    #[test]
+    fn cap_evicts_smallest_offset() {
+        let tracker = BatchStatsTracker::new(2);
+        tracker.record(0, 10, 10);
+        tracker.record(1, 10, 10);
+        tracker.record(2, 10, 10); // overflows: offset 0 evicted
+
+        assert_eq!(tracker.take(0), None);
+        assert_eq!(tracker.take(1).unwrap().wire_byte_size, 10);
+        assert_eq!(tracker.take(2).unwrap().wire_byte_size, 10);
+    }
+}

--- a/rust/sdk/src/stream/arrow/connection.rs
+++ b/rust/sdk/src/stream/arrow/connection.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
 
+use arrow_array::{Array, RecordBatch};
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
 use arrow_flight::{FlightClient, FlightData, PutResult};
@@ -21,16 +22,32 @@ use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 use super::batch::make_ipc_write_options;
+use super::batch_stats::BatchStatsTracker;
 use super::metadata::{FlightAckMetadata, FlightBatchMetadata};
 use super::{
-    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties,
-    FlightConnectionParameters, RecordBatch, ZerobusArrowStream,
+    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchItem,
+    FlightConnectionParameters, ZerobusArrowStream,
 };
 use crate::errors::ZerobusError;
 use crate::headers_provider::HeadersProvider;
 use crate::proxy::{self, ConnectorFactory};
 use crate::tls_config::TlsConfig;
 use crate::ZerobusResult;
+
+/// Best-effort uncompressed payload size of `batch`: the Arrow data bytes of its
+/// columns for the sliced rows (via `ArrayData::get_slice_memory_size`). Cheap — no
+/// re-encode, and codec-independent (an in-memory `RecordBatch` is never LZ4/ZSTD
+/// compressed; that applies only to the IPC wire form). Excludes IPC 8-byte buffer
+/// padding and the flatbuffer header, so it slightly under-estimates the true
+/// pre-compression IPC message size. Dictionary-encoded columns over-count: this
+/// counts the full dictionary each batch, while IPC sends it once plus per-batch keys.
+fn uncompressed_ipc_bytes(batch: &RecordBatch) -> u64 {
+    batch
+        .columns()
+        .iter()
+        .map(|col| col.to_data().get_slice_memory_size().unwrap_or(0) as u64)
+        .sum()
+}
 
 pub(super) type FlightResponseStream =
     Pin<Box<dyn Stream<Item = Result<PutResult, FlightError>> + Send>>;
@@ -213,12 +230,12 @@ impl Drop for RequestBodyStreamState {
 /// State owned by a single active DoPut connection.
 pub(super) struct FlightConnection {
     response_stream: FlightResponseStream,
-    batch_tx: mpsc::Sender<Result<RecordBatch, FlightError>>,
+    batch_tx: mpsc::Sender<BatchItem>,
     request_body: RequestBodyControl,
 }
 
 impl FlightConnection {
-    pub(super) fn sender(&self) -> mpsc::Sender<Result<RecordBatch, FlightError>> {
+    pub(super) fn sender(&self) -> mpsc::Sender<BatchItem> {
         self.batch_tx.clone()
     }
 
@@ -226,7 +243,7 @@ impl FlightConnection {
         self,
     ) -> (
         FlightResponseStream,
-        mpsc::Sender<Result<RecordBatch, FlightError>>,
+        mpsc::Sender<BatchItem>,
         RequestBodyControl,
     ) {
         (self.response_stream, self.batch_tx, self.request_body)
@@ -270,6 +287,7 @@ impl ZerobusArrowStream {
                 parameters.table_properties,
                 parameters.options,
                 parameters.request_bodies,
+                Some(Arc::clone(parameters.batch_stats)),
                 #[cfg(feature = "test-hooks")]
                 Arc::clone(parameters.test_hooks),
             )
@@ -377,14 +395,31 @@ impl ZerobusArrowStream {
     /// Builds a request body that can be stopped at a FlightData boundary and observed
     /// reaching EOF without dropping the surrounding HTTP/2 stream.
     fn make_request_stream(
-        batch_rx: mpsc::Receiver<Result<RecordBatch, FlightError>>,
+        batch_rx: mpsc::Receiver<BatchItem>,
         table_properties: &ArrowTableProperties,
         options: &ArrowStreamConfigurationOptions,
+        tracker: Option<Arc<BatchStatsTracker>>,
         #[cfg(feature = "test-hooks")] test_hooks: Arc<super::TestHooks>,
     ) -> ZerobusResult<(FlightRequestStream, RequestBodyControl)> {
         let ipc_write_options = make_ipc_write_options(options.ipc_compression)?;
         let schema = Arc::clone(&table_properties.schema);
-        let batch_stream = tokio_stream::wrappers::ReceiverStream::new(batch_rx);
+        // Stash each batch's OffsetId on pull, read it back when its FlightData emits
+        // (the encoder drains one batch before pulling the next). Uncompressed payload
+        // is measured from the batch here (codec-independent); wire size is read from
+        // the emitted frame below (compressed when compression is on).
+        let current_offset = Arc::new(AtomicI64::new(-1));
+        let current_offset_in = Arc::clone(&current_offset);
+        let tracker_in = tracker.clone();
+        let batch_stream =
+            tokio_stream::wrappers::ReceiverStream::new(batch_rx).map(move |result| {
+                result.map(|(offset, batch)| {
+                    current_offset_in.store(offset, Ordering::Relaxed);
+                    if let Some(tracker) = &tracker_in {
+                        tracker.record(offset, 0, uncompressed_ipc_bytes(&batch));
+                    }
+                    batch
+                })
+            });
         let offset_counter = Arc::new(AtomicI64::new(0));
         let offset_counter_clone = Arc::clone(&offset_counter);
         let encoded: FlightRequestStream = Box::pin(
@@ -400,6 +435,19 @@ impl ZerobusArrowStream {
                             let metadata = FlightBatchMetadata::new(offset);
                             if let Ok(bytes) = metadata.to_bytes() {
                                 flight_data.app_metadata = bytes.into();
+                            }
+                            if let Some(tracker) = &tracker {
+                                let offset_id = current_offset.load(Ordering::Relaxed);
+                                if offset_id >= 0 {
+                                    // Full FlightData frame actually placed on the wire
+                                    // (compressed body when compression is on). The
+                                    // uncompressed size was recorded on batch pull.
+                                    let wire = (flight_data.data_header.len()
+                                        + flight_data.data_body.len()
+                                        + flight_data.app_metadata.len())
+                                        as u64;
+                                    tracker.record(offset_id, wire, 0);
+                                }
                             }
                         }
                         flight_data
@@ -463,16 +511,17 @@ impl ZerobusArrowStream {
         table_properties: &ArrowTableProperties,
         options: &ArrowStreamConfigurationOptions,
         request_bodies: &RequestBodyRegistry,
+        tracker: Option<Arc<BatchStatsTracker>>,
         #[cfg(feature = "test-hooks")] test_hooks: Arc<super::TestHooks>,
     ) -> ZerobusResult<FlightConnection> {
         // Create channel for sending RecordBatches.
-        let (batch_tx, batch_rx) =
-            mpsc::channel::<Result<RecordBatch, FlightError>>(options.max_inflight_batches);
+        let (batch_tx, batch_rx) = mpsc::channel::<BatchItem>(options.max_inflight_batches);
 
         let (flight_data_stream, request_body) = Self::make_request_stream(
             batch_rx,
             table_properties,
             options,
+            tracker,
             #[cfg(feature = "test-hooks")]
             test_hooks,
         )?;
@@ -569,13 +618,13 @@ impl ZerobusArrowStream {
         )
         .await?;
 
-        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(
-            parameters.options.max_inflight_batches,
-        );
+        let (batch_tx, batch_rx) =
+            mpsc::channel::<BatchItem>(parameters.options.max_inflight_batches);
         let (flight_data_stream, request_body) = Self::make_request_stream(
             batch_rx,
             parameters.table_properties,
             parameters.options,
+            Some(Arc::clone(parameters.batch_stats)),
             #[cfg(feature = "test-hooks")]
             Arc::clone(parameters.test_hooks),
         )?;
@@ -652,7 +701,6 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use arrow_flight::error::FlightError;
     use async_trait::async_trait;
     use futures::StreamExt;
     use tokio::sync::mpsc;
@@ -660,9 +708,9 @@ mod tests {
 
     use super::super::{ArrowSchema, RecordBatch};
     use super::{
-        ArrowStreamConfigurationOptions, ArrowTableProperties, FlightClient, FlightConnection,
-        FlightResponseStream, HeadersProvider, RequestBodyControl, RequestBodyRegistry, TlsConfig,
-        ZerobusArrowStream, ZerobusResult,
+        ArrowStreamConfigurationOptions, ArrowTableProperties, BatchItem, FlightClient,
+        FlightConnection, FlightResponseStream, HeadersProvider, RequestBodyControl,
+        RequestBodyRegistry, TlsConfig, ZerobusArrowStream, ZerobusResult,
     };
 
     struct PassthroughTlsConfig;
@@ -690,7 +738,7 @@ mod tests {
 
     #[tokio::test]
     async fn supervisor_handoff_does_not_retain_redundant_sender() {
-        let (batch_tx, mut batch_rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(1);
+        let (batch_tx, mut batch_rx) = mpsc::channel::<BatchItem>(1);
         let response_stream: FlightResponseStream = Box::pin(futures::stream::pending());
         let connection = FlightConnection {
             response_stream,
@@ -719,6 +767,7 @@ mod tests {
             batch_rx,
             &table_properties,
             &ArrowStreamConfigurationOptions::default(),
+            None,
             #[cfg(feature = "test-hooks")]
             Arc::new(super::super::TestHooks::default()),
         )
@@ -743,6 +792,7 @@ mod tests {
             batch_rx,
             &table_properties,
             &ArrowStreamConfigurationOptions::default(),
+            None,
             #[cfg(feature = "test-hooks")]
             Arc::new(super::super::TestHooks::default()),
         )
@@ -752,6 +802,189 @@ mod tests {
         while request_body.next().await.is_some() {}
         assert!(request_body.next().await.is_none());
         assert!(control.is_finished());
+    }
+
+    #[tokio::test]
+    async fn make_request_stream_records_encoded_byte_sizes() {
+        use arrow_array::Int32Array;
+        use arrow_ipc::writer::StreamWriter;
+        use arrow_schema::{DataType, Field};
+
+        use super::super::batch_stats::BatchStatsTracker;
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let table_properties = ArrowTableProperties {
+            table_name: "catalog.schema.table".to_string(),
+            schema: Arc::clone(&schema),
+        };
+        let make_batch = |values: Vec<i32>| {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(values))],
+            )
+            .unwrap()
+        };
+
+        let (batch_tx, batch_rx) = mpsc::channel::<BatchItem>(4);
+        let tracker = Arc::new(BatchStatsTracker::new(16));
+        let (mut request_body, _control) = ZerobusArrowStream::make_request_stream(
+            batch_rx,
+            &table_properties,
+            &ArrowStreamConfigurationOptions::default(),
+            Some(Arc::clone(&tracker)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(super::super::TestHooks::default()),
+        )
+        .unwrap();
+
+        // The larger batch must clear IPC buffer alignment/padding so its encoded
+        // size is unambiguously bigger than the small batch's.
+        let large = make_batch((0..400).collect());
+        batch_tx
+            .send(Ok((0, make_batch(vec![1, 2, 3]))))
+            .await
+            .unwrap();
+        batch_tx.send(Ok((1, large.clone()))).await.unwrap();
+        drop(batch_tx);
+        // Drain every encoded FlightData so the encoder records each batch.
+        while request_body.next().await.is_some() {}
+
+        // The first data message is offset 0 and the second is offset 1; idx 0 is the
+        // schema message and carries no offset.
+        let d0 = tracker.take(0).expect("offset 0 recorded");
+        let d1 = tracker.take(1).expect("offset 1 recorded");
+        assert!(d0.wire_byte_size > 0, "small batch size should be recorded");
+        assert!(
+            d1.wire_byte_size > d0.wire_byte_size,
+            "the larger batch must encode to more bytes"
+        );
+        // Uncompressed (Arrow payload buffer bytes) is populated too; with compression
+        // off the wire frame carries IPC framing on top, so wire >= uncompressed.
+        assert!(d0.uncompressed_byte_size > 0);
+        assert!(d0.wire_byte_size >= d0.uncompressed_byte_size);
+        // Cumulative wire total is monotonic and additive.
+        assert_eq!(d0.cumulative_wire_byte_size, d0.wire_byte_size);
+        assert_eq!(
+            d1.cumulative_wire_byte_size,
+            d0.wire_byte_size + d1.wire_byte_size
+        );
+
+        // Tie to a real IPC encode: the tracked per-batch size stays below a full
+        // standalone stream (schema + batch + markers) of the same batch.
+        let mut buf = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
+            writer.write(&large).unwrap();
+            writer.finish().unwrap();
+        }
+        assert!(d1.wire_byte_size <= buf.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn make_request_stream_keys_bytes_by_channel_offset() {
+        use arrow_array::Int32Array;
+        use arrow_schema::{DataType, Field};
+
+        use super::super::batch_stats::BatchStatsTracker;
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let table_properties = ArrowTableProperties {
+            table_name: "catalog.schema.table".to_string(),
+            schema: Arc::clone(&schema),
+        };
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap();
+
+        let (batch_tx, batch_rx) = mpsc::channel::<BatchItem>(4);
+        let tracker = Arc::new(BatchStatsTracker::new(16));
+        let (mut request_body, _control) = ZerobusArrowStream::make_request_stream(
+            batch_rx,
+            &table_properties,
+            &ArrowStreamConfigurationOptions::default(),
+            Some(Arc::clone(&tracker)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(super::super::TestHooks::default()),
+        )
+        .unwrap();
+
+        // Non-contiguous offsets carried on the channel: bytes must be keyed by the
+        // offset itself, not by wire position, and a re-sent offset accumulates.
+        batch_tx.send(Ok((5, batch.clone()))).await.unwrap();
+        batch_tx.send(Ok((9, batch.clone()))).await.unwrap();
+        batch_tx.send(Ok((5, batch))).await.unwrap(); // resend of offset 5
+        drop(batch_tx);
+        while request_body.next().await.is_some() {}
+
+        let d5 = tracker.take(5).expect("offset 5 recorded");
+        let d9 = tracker.take(9).expect("offset 9 recorded");
+        // Offset 5 was sent twice, so its per-offset size is double offset 9's single send.
+        assert_eq!(d5.wire_byte_size, 2 * d9.wire_byte_size);
+        // Wire position 0/1/2 never leak in as keys.
+        assert_eq!(tracker.take(0), None);
+        assert_eq!(tracker.take(1), None);
+    }
+
+    #[tokio::test]
+    async fn make_request_stream_uncompressed_size_independent_of_compression() {
+        use arrow_array::Int32Array;
+        use arrow_ipc::CompressionType;
+        use arrow_schema::{DataType, Field};
+
+        use super::super::batch_stats::BatchStatsTracker;
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let table_properties = ArrowTableProperties {
+            table_name: "catalog.schema.table".to_string(),
+            schema: Arc::clone(&schema),
+        };
+        // Highly compressible payload so the compressed wire body is clearly smaller.
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![7; 4000]))]).unwrap();
+
+        let options = ArrowStreamConfigurationOptions {
+            ipc_compression: Some(CompressionType::ZSTD),
+            ..Default::default()
+        };
+        let (batch_tx, batch_rx) = mpsc::channel::<BatchItem>(4);
+        let tracker = Arc::new(BatchStatsTracker::new(16));
+        let (mut request_body, _control) = ZerobusArrowStream::make_request_stream(
+            batch_rx,
+            &table_properties,
+            &options,
+            Some(Arc::clone(&tracker)),
+            #[cfg(feature = "test-hooks")]
+            Arc::new(super::super::TestHooks::default()),
+        )
+        .unwrap();
+
+        batch_tx.send(Ok((0, batch))).await.unwrap();
+        drop(batch_tx);
+        while request_body.next().await.is_some() {}
+
+        let d0 = tracker.take(0).expect("offset 0 recorded");
+        // Uncompressed comes from the batch (buffer sum), wire from the compressed
+        // frame; both populated, and compression shrinks the wire size well below the
+        // uncompressed encoded size for this repetitive payload.
+        assert!(d0.uncompressed_byte_size > 0);
+        assert!(d0.wire_byte_size > 0);
+        assert!(
+            d0.wire_byte_size < d0.uncompressed_byte_size,
+            "compressed wire ({}) should be smaller than uncompressed ({})",
+            d0.wire_byte_size,
+            d0.uncompressed_byte_size
+        );
     }
 
     #[cfg(feature = "test-hooks")]
@@ -767,6 +1000,7 @@ mod tests {
             batch_rx,
             &table_properties,
             &ArrowStreamConfigurationOptions::default(),
+            None,
             Arc::clone(&test_hooks),
         )
         .unwrap();
@@ -813,6 +1047,7 @@ mod tests {
             batch_rx,
             &table_properties,
             &ArrowStreamConfigurationOptions::default(),
+            None,
             #[cfg(feature = "test-hooks")]
             Arc::new(super::super::TestHooks::default()),
         )
@@ -844,6 +1079,7 @@ mod tests {
                 &table_properties,
                 &options,
                 &registry,
+                None,
                 #[cfg(feature = "test-hooks")]
                 Arc::new(super::super::TestHooks::default()),
             );

--- a/rust/sdk/src/stream/arrow/mod.rs
+++ b/rust/sdk/src/stream/arrow/mod.rs
@@ -29,6 +29,8 @@ pub use arrow_array::RecordBatch;
 pub use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
 
 use self::batch::{materialize_ipc, PendingBatch};
+use self::batch_stats::BatchStatsTracker;
+pub use self::batch_stats::OffsetDetails;
 use self::close::{CloseCoordinator, CloseFinalizer, CloseRequest, CloseState};
 use self::connection::RequestBodyRegistry;
 pub use self::options::ArrowStreamConfigurationOptions;
@@ -45,6 +47,7 @@ pub(crate) mod c_data;
 
 mod acks;
 mod batch;
+mod batch_stats;
 mod close;
 mod connection;
 mod metadata;
@@ -53,7 +56,8 @@ mod supervisor;
 
 const LOG_TARGET: &str = module_path!();
 
-type BatchSender = Arc<Mutex<Option<mpsc::Sender<Result<RecordBatch, FlightError>>>>>;
+type BatchItem = Result<(OffsetId, RecordBatch), FlightError>;
+type BatchSender = Arc<Mutex<Option<mpsc::Sender<BatchItem>>>>;
 
 struct FlightConnectionParameters<'a> {
     endpoint: &'a str,
@@ -64,6 +68,8 @@ struct FlightConnectionParameters<'a> {
     headers_provider: &'a Arc<dyn HeadersProvider>,
     sdk_identifier: &'a str,
     request_bodies: &'a RequestBodyRegistry,
+    /// Shared byte-size accounting; the encoder records into it on every connection.
+    batch_stats: &'a Arc<BatchStatsTracker>,
     #[cfg(feature = "test-hooks")]
     test_hooks: &'a Arc<TestHooks>,
 }
@@ -238,6 +244,9 @@ pub struct ZerobusArrowStream {
     /// Pause gate used while draining a close signal or rebuilding after failure; accepted
     /// ingests remain pending until recovery replays or finalizes them.
     is_paused: Arc<AtomicBool>,
+    /// Bounded per-offset encoded byte-size accounting for
+    /// `take_offset_details`, populated by the Flight encoder.
+    batch_stats: Arc<BatchStatsTracker>,
     /// Final value sent as the HTTP `user-agent` header on every request.
     /// Either `"zerobus-sdk-rs/<version>"` or `"zerobus-sdk-rs/<version> <application_name>"`.
     /// Re-applied to each fresh Channel built during recovery.
@@ -304,6 +313,11 @@ impl ZerobusArrowStream {
         let is_paused = Arc::new(AtomicBool::new(false));
         // Capacity mirrors the batch_tx channel so a permit holder always has a slot.
         let inflight = Arc::new(Semaphore::new(options.max_inflight_batches));
+        // Retain a few multiples of the in-flight window of recent byte sizes so a
+        // consumer that reads them per acknowledged batch never misses its own.
+        let batch_stats = Arc::new(BatchStatsTracker::new(
+            options.max_inflight_batches.saturating_mul(4),
+        ));
 
         let (server_error_tx, server_error_rx) = watch::channel(None);
         let close = CloseCoordinator::new();
@@ -342,6 +356,7 @@ impl ZerobusArrowStream {
             sdk_identifier,
             #[cfg(feature = "test-hooks")]
             test_hooks: Arc::new(TestHooks::default()),
+            batch_stats,
         };
 
         // Initialize the connection with retry logic.
@@ -366,6 +381,7 @@ impl ZerobusArrowStream {
             let request_bodies = request_bodies.clone();
             #[cfg(feature = "test-hooks")]
             let test_hooks = Arc::clone(&stream.test_hooks);
+            let batch_stats = Arc::clone(&stream.batch_stats);
 
             async move {
                 let parameters = FlightConnectionParameters {
@@ -377,6 +393,7 @@ impl ZerobusArrowStream {
                     headers_provider: &headers_provider,
                     sdk_identifier: &sdk_identifier,
                     request_bodies: &request_bodies,
+                    batch_stats: &batch_stats,
                     #[cfg(feature = "test-hooks")]
                     test_hooks: &test_hooks,
                 };
@@ -596,7 +613,7 @@ impl ZerobusArrowStream {
         {
             let _pending = self.pending_batches.lock().await;
             self.submitted_records.store(end_record, Ordering::Release);
-            send_permit.send(Ok(batch));
+            send_permit.send(Ok((offset_id, batch)));
         }
         // Notify after publishing `submitted_records`: waking earlier could let the ACK
         // processor observe the batch as buffered-but-unsent and go idle again.
@@ -836,6 +853,49 @@ impl ZerobusArrowStream {
     pub async fn wait_for_offset(&self, offset: OffsetId) -> ZerobusResult<()> {
         self.wait_for_offset_internal(offset, "Waiting for acknowledgement")
             .await
+    }
+
+    /// Consumes and returns the encoded byte sizes recorded for `offset`.
+    ///
+    /// Returns [`OffsetDetails`] with both the on-the-wire size (post-compression)
+    /// and the uncompressed encoded size of the batch at `offset`, plus running
+    /// totals for each — useful for "bytes sent" metrics without re-serialising the
+    /// `RecordBatch` yourself. Sizes are captured as the SDK encodes each batch and
+    /// accumulate every transmission, so a batch re-sent during connection recovery
+    /// counts each send.
+    ///
+    /// Call this after the batch has been sent — typically once
+    /// [`wait_for_offset`](Self::wait_for_offset) has acknowledged it. The reading
+    /// consumes the entry, so a second call for the same `offset` returns `None`.
+    /// `None` is also returned when no size is recorded — the batch has not been
+    /// encoded yet, or its entry was evicted from the bounded cache.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use databricks_zerobus_ingest_sdk::*;
+    /// # use arrow_array::RecordBatch;
+    /// # async fn example(stream: ZerobusArrowStream, batches: Vec<RecordBatch>) -> Result<(), ZerobusError> {
+    /// // High throughput: queue in a loop, then flush() once — do NOT wait per batch.
+    /// for batch in &batches {
+    ///     stream.ingest_batch(batch.clone()).await?;
+    /// }
+    /// stream.flush().await?;
+    ///
+    /// // Low-volume / per-batch instrumentation only: wait on one batch, then read its size.
+    /// let offset = stream.ingest_batch(batches[0].clone()).await?;
+    /// stream.wait_for_offset(offset).await?;
+    /// if let Some(details) = stream.take_offset_details(offset) {
+    ///     println!(
+    ///         "wire {} bytes, uncompressed {} bytes",
+    ///         details.wire_byte_size, details.uncompressed_byte_size
+    ///     );
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn take_offset_details(&self, offset: OffsetId) -> Option<OffsetDetails> {
+        self.batch_stats.take(offset)
     }
 
     /// Flushes pending work, stops background I/O, and retains unacknowledged batches for

--- a/rust/sdk/src/stream/arrow/supervisor.rs
+++ b/rust/sdk/src/stream/arrow/supervisor.rs
@@ -6,7 +6,6 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
-use arrow_flight::error::FlightError;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::{spawn, AbortHandle, JoinError, JoinHandle};
 use tokio::time::{sleep, sleep_until, timeout_at, Duration, Instant};
@@ -14,16 +13,18 @@ use tracing::{debug, error, info, warn};
 
 use super::acks::{pause_and_detach_sender, AckProcessOutcome, AckProcessor};
 use super::batch::{rebuild_pending_for_replay, refresh_pending_ack_deadlines, PendingBatch};
+use super::batch_stats::BatchStatsTracker;
 use super::close::{CloseCoordinator, CloseFinalizer, CloseState};
 use super::connection::{
     FlightConnection, FlightResponseStream, RequestBodyControl, RequestBodyRegistry,
 };
 use super::{
-    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchSender,
-    FlightConnectionParameters, RecordBatch, ZerobusArrowStream,
+    configured_deadline, ArrowStreamConfigurationOptions, ArrowTableProperties, BatchItem,
+    BatchSender, FlightConnectionParameters, RecordBatch, ZerobusArrowStream,
 };
 use crate::errors::ZerobusError;
 use crate::headers_provider::HeadersProvider;
+use crate::offset_generator::OffsetId;
 use crate::proxy::ConnectorFactory;
 use crate::tls_config::TlsConfig;
 use crate::ZerobusResult;
@@ -50,6 +51,7 @@ pub(super) struct Supervisor {
     is_paused: Arc<AtomicBool>,
     ingest_mutex: Arc<Mutex<()>>,
     sdk_identifier: Arc<str>,
+    batch_stats: Arc<BatchStatsTracker>,
     #[cfg(feature = "test-hooks")]
     test_hooks: Arc<super::TestHooks>,
 }
@@ -99,6 +101,7 @@ impl Supervisor {
             is_paused: Arc::clone(&stream.is_paused),
             ingest_mutex: Arc::clone(&stream.ingest_mutex),
             sdk_identifier: Arc::clone(&stream.sdk_identifier),
+            batch_stats: Arc::clone(&stream.batch_stats),
             #[cfg(feature = "test-hooks")]
             test_hooks: Arc::clone(&stream.test_hooks),
         }
@@ -425,6 +428,7 @@ impl Supervisor {
             headers_provider: &self.headers_provider,
             sdk_identifier: &self.sdk_identifier,
             request_bodies: &self.request_bodies,
+            batch_stats: &self.batch_stats,
             #[cfg(feature = "test-hooks")]
             test_hooks: &self.test_hooks,
         };
@@ -441,7 +445,7 @@ impl Supervisor {
 
     async fn replay_and_commit(
         &self,
-        tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
+        tx: &mpsc::Sender<BatchItem>,
         acked_before_disconnect: u64,
     ) -> ZerobusResult<bool> {
         #[cfg(feature = "test-hooks")]
@@ -489,12 +493,11 @@ impl Supervisor {
                     return Ok(false);
                 }
                 let submitted = self.submitted_records.load(Ordering::Acquire);
-                let buffered = self
-                    .pending_batches
-                    .lock()
-                    .await
-                    .iter()
-                    .find_map(|batch| batch.unacknowledged_suffix(submitted));
+                let buffered = self.pending_batches.lock().await.iter().find_map(|batch| {
+                    batch
+                        .unacknowledged_suffix(submitted)
+                        .map(|suffix| (batch.offset_id(), suffix))
+                });
                 if buffered.is_none() {
                     return Ok(Self::commit_reconnect(
                         tx.clone(),
@@ -509,9 +512,11 @@ impl Supervisor {
                 buffered
             };
 
+            let (offset, batch) = buffered.expect("buffered batch was selected");
             if !Self::send_replay_batch(
                 tx,
-                buffered.expect("buffered batch was selected"),
+                offset,
+                batch,
                 &self.submitted_records,
                 &self.ingest_mutex,
                 &self.close,
@@ -525,7 +530,7 @@ impl Supervisor {
     }
 
     async fn commit_reconnect(
-        tx: mpsc::Sender<Result<RecordBatch, FlightError>>,
+        tx: mpsc::Sender<BatchItem>,
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
         batch_tx: &BatchSender,
         is_paused: &AtomicBool,
@@ -549,7 +554,7 @@ impl Supervisor {
         submitted_records: &Arc<AtomicU64>,
         last_acked_records: &Arc<AtomicU64>,
         acked_before_disconnect: u64,
-    ) -> Vec<RecordBatch> {
+    ) -> Vec<(OffsetId, RecordBatch)> {
         let mut pending = pending_batches.lock().await;
         if !pending.is_empty() {
             info!(target: super::LOG_TARGET,
@@ -567,16 +572,17 @@ impl Supervisor {
     }
 
     async fn send_replay_batches(
-        tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
-        replay_batches: Vec<RecordBatch>,
+        tx: &mpsc::Sender<BatchItem>,
+        replay_batches: Vec<(OffsetId, RecordBatch)>,
         submitted_records: &Arc<AtomicU64>,
         ingest_mutex: &Arc<Mutex<()>>,
         close: &CloseCoordinator,
         #[cfg(feature = "test-hooks")] replay_send_gate: Option<&super::TestBarrierGate>,
     ) -> ZerobusResult<bool> {
-        for batch in replay_batches {
+        for (offset, batch) in replay_batches {
             if !Self::send_replay_batch(
                 tx,
+                offset,
                 batch,
                 submitted_records,
                 ingest_mutex,
@@ -604,7 +610,8 @@ impl Supervisor {
     }
 
     async fn send_replay_batch(
-        tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
+        tx: &mpsc::Sender<BatchItem>,
+        offset: OffsetId,
         batch: RecordBatch,
         submitted_records: &Arc<AtomicU64>,
         ingest_mutex: &Arc<Mutex<()>>,
@@ -621,7 +628,7 @@ impl Supervisor {
             return Ok(false);
         }
         submitted_records.fetch_add(batch.num_rows() as u64, Ordering::Release);
-        permit.send(Ok(batch));
+        permit.send(Ok((offset, batch)));
         Ok(true)
     }
 }
@@ -631,7 +638,6 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::Int32Array;
-    use arrow_flight::error::FlightError;
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use tokio::sync::{mpsc, Mutex, Semaphore};
     use tokio::task::JoinHandle;
@@ -641,7 +647,8 @@ mod tests {
     #[cfg(feature = "internal-arrow-c-data")]
     use super::SupervisorTaskHandle;
     use super::{
-        pause_and_detach_sender, BatchSender, PendingBatch, RecordBatch, Supervisor, ZerobusError,
+        pause_and_detach_sender, BatchItem, BatchSender, PendingBatch, RecordBatch, Supervisor,
+        ZerobusError,
     };
     use crate::offset_generator::OffsetId;
 
@@ -738,7 +745,7 @@ mod tests {
         let ingest_mutex = Arc::new(Mutex::new(()));
         let close = CloseCoordinator::new();
         let submitted = Arc::new(AtomicU64::new(0));
-        let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(1);
+        let (tx, mut rx) = mpsc::channel::<BatchItem>(1);
         let request = CloseRequest {
             target_offset: Some(0),
             deadline: Instant::now() + Duration::from_secs(30),
@@ -754,6 +761,7 @@ mod tests {
 
         let send = Supervisor::send_replay_batch(
             &tx,
+            0,
             batch_with_rows(&schema, 1),
             &submitted,
             &ingest_mutex,
@@ -784,7 +792,7 @@ mod tests {
     }
 
     async fn replay_pending_batches(
-        tx: &mpsc::Sender<Result<RecordBatch, FlightError>>,
+        tx: &mpsc::Sender<BatchItem>,
         pending_batches: &Arc<Mutex<Vec<PendingBatch>>>,
         cumulative_records_assigned: &Arc<AtomicU64>,
         submitted_records: &Arc<AtomicU64>,
@@ -842,7 +850,7 @@ mod tests {
         let last_acked = Arc::new(AtomicU64::new(7));
 
         // Receiver dropped -> every send fails.
-        let (tx, rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
+        let (tx, rx) = mpsc::channel::<BatchItem>(4);
         drop(rx);
 
         let res =
@@ -903,7 +911,7 @@ mod tests {
         let cumulative = Arc::new(AtomicU64::new(0));
         let submitted = Arc::new(AtomicU64::new(0));
         let last_acked = Arc::new(AtomicU64::new(4));
-        let (tx, mut rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(4);
+        let (tx, mut rx) = mpsc::channel::<BatchItem>(4);
 
         let res =
             replay_pending_batches(&tx, &pending, &cumulative, &submitted, &last_acked, 4).await;
@@ -921,8 +929,12 @@ mod tests {
         // Fully-acked batch's permit was released; one remains.
         assert_eq!(sem.available_permits(), 3);
 
-        let replayed = rx.try_recv().expect("suffix replay batch");
-        assert_eq!(replayed.unwrap().num_rows(), 2);
+        let (offset, replayed) = rx.try_recv().expect("suffix replay batch").unwrap();
+        assert_eq!(
+            offset, 1,
+            "the partially-acked batch keeps its offset on replay"
+        );
+        assert_eq!(replayed.num_rows(), 2);
         assert!(rx.try_recv().is_err(), "only one batch should be replayed");
     }
 
@@ -932,7 +944,7 @@ mod tests {
     async fn pause_and_detach_waits_for_in_flight_ingest() {
         let ingest_mutex = Arc::new(Mutex::new(()));
         let is_paused = Arc::new(AtomicBool::new(false));
-        let (tx, _rx) = mpsc::channel::<Result<RecordBatch, FlightError>>(1);
+        let (tx, _rx) = mpsc::channel::<BatchItem>(1);
         let batch_tx: BatchSender = Arc::new(Mutex::new(Some(tx)));
 
         // Deterministic sync point: hold ingest_mutex to represent an ingest in its

--- a/rust/sdk/src/stream/mod.rs
+++ b/rust/sdk/src/stream/mod.rs
@@ -17,8 +17,8 @@ pub(crate) use arrow::c_data as arrow_c_data;
 pub(crate) use arrow::ArrowTableProperties;
 #[cfg(feature = "arrow-flight")]
 pub use arrow::{
-    ArrowSchema, ArrowStreamConfigurationOptions, DataType, Field, RecordBatch, TimeUnit,
-    ZerobusArrowStream,
+    ArrowSchema, ArrowStreamConfigurationOptions, DataType, Field, OffsetDetails, RecordBatch,
+    TimeUnit, ZerobusArrowStream,
 };
 
 pub use grpc::ZerobusStream;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `ZerobusArrowStream::take_offset_details`, returning `Some(OffsetDetails)` with the encoded wire byte size of the batch at an offset and the cumulative wire bytes sent through it. Callers report an accurate bytes-sent metric without re-serialising the RecordBatch (issue [#779](https://github.com/databricks/zerobus-sdk/issues/779)); None when no size is recorded.

To make this happen, we carry the OffsetId alongside the RecordBatch so that we can encode the size. The stats recorder keeps only a certain amount of stats so if they are not consumed, the user won't be able to recover them, so they have to be consumed after waiting for the offset.

This change will be used to track the vector's `databricks_zerobus` bytes sent which is helpful to debug what is happening.

An alternative design that was considered was to introduce a separate `wait_for_offset` called `wait_for_offset_with_details` which waits for the offset and then immediately returns the stats. The downside is that we end up with multiple similar functions but can do that if you feel that's better.

## How is this tested?
Added several unit tests.