### PR TITLE
[Rust] Reset ack timeout on progress

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- The gRPC lack-of-ack timeout now resets only when the durability watermark
+  advances. Duplicate or stale acknowledgments no longer postpone recovery.
 - The OAuth `expires_in` field is now parsed from a quoted integer (`"3600"`) in
   addition to a plain JSON integer. A value that is missing or does not represent
   a positive integer still yields no token lifetime, as before.

--- a/rust/sdk/src/stream/grpc/receiver.rs
+++ b/rust/sdk/src/stream/grpc/receiver.rs
@@ -8,7 +8,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use tokio::time::Duration;
+use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument, span, Level};
 
@@ -42,6 +42,9 @@ impl ZerobusStream {
             let _guard = span.enter();
             let mut last_acked_offset = -1;
             let mut pause_deadline: Option<tokio::time::Instant> = None;
+            let ack_timeout = Duration::from_millis(options.server_lack_of_ack_timeout_ms);
+            // Inbound frames do not move this deadline; only a newer durability ACK does.
+            let mut ack_deadline = Instant::now() + ack_timeout;
             // Set when we exit because the supervisor signalled close (`recv_drain_token`).
             // On that path we drain the response stream inline so the server sees END_STREAM
             // instead of RST_STREAM. On all other exits (recovery / errors) the runtime is
@@ -72,10 +75,7 @@ impl ZerobusStream {
                         _ = tokio::time::sleep_until(deadline) => {
                             continue;
                         }
-                        res = tokio::time::timeout(
-                            Duration::from_millis(options.server_lack_of_ack_timeout_ms),
-                            response_grpc_stream.message(),
-                        ) => res,
+                        res = response_grpc_stream.message() => Ok(res),
                     }
                 } else {
                     tokio::select! {
@@ -84,8 +84,8 @@ impl ZerobusStream {
                             close_initiated = true;
                             break 'recv_loop;
                         }
-                        res = tokio::time::timeout(
-                            Duration::from_millis(options.server_lack_of_ack_timeout_ms),
+                        res = tokio::time::timeout_at(
+                            ack_deadline,
                             response_grpc_stream.message(),
                         ) => res,
                     }
@@ -108,29 +108,32 @@ impl ZerobusStream {
                                     return Err(error);
                                 }
                             };
-                            let mut last_logical_acked_offset = -2;
-                            let mut map = oneshot_map.lock().await;
-                            for _offset_to_ack in
-                                (last_acked_offset + 1)..=durability_ack_up_to_offset
-                            {
-                                if let Ok(record) = landing_zone.remove_observed() {
-                                    let logical_offset = record.offset_id;
-                                    last_logical_acked_offset = logical_offset;
+                            if durability_ack_up_to_offset > last_acked_offset {
+                                let mut last_logical_acked_offset = None;
+                                let mut map = oneshot_map.lock().await;
+                                for _offset_to_ack in
+                                    (last_acked_offset + 1)..=durability_ack_up_to_offset
+                                {
+                                    if let Ok(record) = landing_zone.remove_observed() {
+                                        let logical_offset = record.offset_id;
+                                        last_logical_acked_offset = Some(logical_offset);
 
-                                    if let Some(sender) = map.remove(&logical_offset) {
-                                        let _ = sender.send(Ok(logical_offset));
-                                    }
+                                        if let Some(sender) = map.remove(&logical_offset) {
+                                            let _ = sender.send(Ok(logical_offset));
+                                        }
 
-                                    if let Some(ref tx) = callback_tx {
-                                        let _ = tx.send(CallbackMessage::Ack(logical_offset));
+                                        if let Some(ref tx) = callback_tx {
+                                            let _ = tx.send(CallbackMessage::Ack(logical_offset));
+                                        }
                                     }
                                 }
-                            }
-                            drop(map);
-                            last_acked_offset = durability_ack_up_to_offset;
-                            if last_logical_acked_offset != -2 {
-                                let _ignore_on_channel_break = last_received_offset_id_tx
-                                    .send(Some(last_logical_acked_offset));
+                                drop(map);
+                                last_acked_offset = durability_ack_up_to_offset;
+                                ack_deadline = Instant::now() + ack_timeout;
+                                if let Some(logical_offset) = last_logical_acked_offset {
+                                    let _ignore_on_channel_break =
+                                        last_received_offset_id_tx.send(Some(logical_offset));
+                                }
                             }
                         }
                         Some(ResponsePayload::CloseStreamSignal(CloseStreamSignal {
@@ -193,10 +196,9 @@ impl ZerobusStream {
                         return Err(error);
                     }
                     Err(_timeout) => {
-                        // No message received for server_lack_of_ack_timeout_ms.
-                        if pause_deadline.is_none() && !landing_zone.is_observed_empty() {
+                        if !landing_zone.is_observed_empty() {
                             error!(
-                                "Server ack timeout: no response for {}ms",
+                                "Server ack timeout: no durable progress for {}ms",
                                 options.server_lack_of_ack_timeout_ms
                             );
                             let error = ZerobusError::StreamClosedError(
@@ -205,6 +207,7 @@ impl ZerobusStream {
                             let _ = server_error_tx.send(Some(error.clone()));
                             return Err(error);
                         }
+                        ack_deadline = Instant::now() + ack_timeout;
                     }
                 }
             }

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -58,6 +58,12 @@ pub enum MockResponse {
         ack_up_to_offset: i64,
         delay_ms: u64,
     },
+    /// Record acknowledgment sent regardless of the triggering request offset.
+    #[allow(dead_code)]
+    RecordAckForAnyRequest {
+        ack_up_to_offset: i64,
+        delay_ms: u64,
+    },
     /// Successful record acknowledgment released explicitly by a test
     #[allow(dead_code)]
     GatedRecordAck {
@@ -532,6 +538,25 @@ async fn handle_mock_response(
             } else {
                 (true, current_index)
             }
+        }
+        MockResponse::RecordAckForAnyRequest {
+            ack_up_to_offset,
+            delay_ms,
+        } => {
+            if *delay_ms > 0 {
+                sleep(Duration::from_millis(*delay_ms)).await;
+            }
+            let response = EphemeralStreamResponse {
+                payload: Some(ResponsePayload::IngestRecordResponse(
+                    IngestRecordResponse {
+                        durability_ack_up_to_offset: Some(*ack_up_to_offset),
+                    },
+                )),
+            };
+            if tx.send(Ok(response)).await.is_err() {
+                return (false, current_index);
+            }
+            (true, current_index + 1)
         }
         MockResponse::GatedRecordAck {
             ack_up_to_offset,

--- a/rust/tests/src/rust_tests.rs
+++ b/rust/tests/src/rust_tests.rs
@@ -2930,6 +2930,71 @@ mod failure_scenarios_tests {
         }
 
         #[tokio::test]
+        async fn test_duplicate_acks_do_not_reset_server_ack_timeout(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            const ACK_TIMEOUT_MS: u64 = 200;
+            const STALE_ACK_INTERVAL_MS: u64 = 50;
+
+            let (mock_server, server_url) = start_mock_server().await?;
+            let mut responses = vec![
+                MockResponse::CreateStream {
+                    stream_id: "test_stream_duplicate_acks".to_string(),
+                    delay_ms: 0,
+                },
+                MockResponse::RecordAck {
+                    ack_up_to_offset: 0,
+                    delay_ms: 0,
+                },
+            ];
+            responses.extend((0..20).map(|_| MockResponse::RecordAckForAnyRequest {
+                ack_up_to_offset: 0,
+                delay_ms: STALE_ACK_INTERVAL_MS,
+            }));
+            mock_server.inject_responses(TABLE_NAME, responses).await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .compiled_proto(create_test_descriptor_proto().unwrap_or_default())
+                .recovery(false)
+                .server_lack_of_ack_timeout_ms(ACK_TIMEOUT_MS)
+                .build()
+                .await?;
+
+            let first = stream.ingest_record_offset(b"acked".to_vec()).await?;
+            stream.wait_for_offset(first).await?;
+
+            let pending = stream.ingest_record_offset(b"pending".to_vec()).await?;
+            for i in 0..20 {
+                stream
+                    .ingest_record_offset(format!("more-{i}").into_bytes())
+                    .await?;
+            }
+
+            let result = tokio::time::timeout(
+                std::time::Duration::from_millis(ACK_TIMEOUT_MS * 3),
+                stream.wait_for_offset(pending),
+            )
+            .await
+            .expect("duplicate acknowledgments kept the lack-of-ack timeout alive");
+            let error = result.expect_err("pending record was unexpectedly acknowledged");
+            assert!(
+                error.to_string().contains("Server ack timeout"),
+                "expected server ack timeout, got: {error}"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
         async fn test_get_unacked_records_after_failure() -> Result<(), Box<dyn std::error::Error>>
         {
             setup_tracing();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #639.

The gRPC receiver used a per-read timeout around every inbound frame. Any message reset the lack-of-ack clock, including a stale or duplicate `durability_ack_up_to_offset` that did not advance durability. A server repeating the same ack could postpone recovery indefinitely while later offsets stayed unacknowledged.

This PR keeps one deadline and moves it only when the ack watermark advances. Duplicate/stale acks and other frames no longer extend the budget.

## How is this tested?

- `cargo test -p databricks-zerobus-ingest-sdk`
- `cargo test -p tests --test rust_tests`
- New regression: `test_duplicate_acks_do_not_reset_server_ack_timeout` dribbles duplicate acks every 50ms and asserts the stream still fails with `Server ack timeout` within one timeout window.