### PR TITLE
[Rust] Backoff before gRPC reconnect

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bug Fixes
 
+- After a mid-stream gRPC failure, recovery now waits `recovery_backoff_ms`
+  before the first reconnect attempt, matching Arrow. Previously only retries
+  *within* an episode were delayed, so a flapping server was reconnected in a
+  tight loop.
 - The OAuth `expires_in` field is now parsed from a quoted integer (`"3600"`) in
   addition to a plain JSON integer. A value that is missing or does not represent
   a positive integer still yields no token lifetime, as before.

--- a/rust/sdk/src/stream/grpc/supervisor.rs
+++ b/rust/sdk/src/stream/grpc/supervisor.rs
@@ -66,8 +66,18 @@ impl ZerobusStream {
                 info!(
                     pending_batches = landing_zone.len(),
                     pending_records = landing_zone.total_count(),
+                    backoff_ms = options.recovery_backoff_ms,
                     "Stream lost; starting recovery"
                 );
+                // FixedInterval only delays between retries in this episode; the first
+                // attempt is immediate. Sleep first so a flapping server is not hot-looped.
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        debug!("Supervisor task cancelled during recovery backoff");
+                        return Ok(());
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(options.recovery_backoff_ms)) => {}
+                }
             }
 
             let landing_zone_sender = Arc::clone(&landing_zone);

--- a/rust/sdk/src/stream/grpc/supervisor.rs
+++ b/rust/sdk/src/stream/grpc/supervisor.rs
@@ -62,24 +62,6 @@ impl ZerobusStream {
                 return Ok(());
             }
 
-            if !initial_stream_creation {
-                info!(
-                    pending_batches = landing_zone.len(),
-                    pending_records = landing_zone.total_count(),
-                    backoff_ms = options.recovery_backoff_ms,
-                    "Stream lost; starting recovery"
-                );
-                // FixedInterval only delays between retries in this episode; the first
-                // attempt is immediate. Sleep first so a flapping server is not hot-looped.
-                tokio::select! {
-                    _ = cancellation_token.cancelled() => {
-                        debug!("Supervisor task cancelled during recovery backoff");
-                        return Ok(());
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(options.recovery_backoff_ms)) => {}
-                }
-            }
-
             let landing_zone_sender = Arc::clone(&landing_zone);
             let landing_zone_receiver = Arc::clone(&landing_zone);
             let landing_zone_recovery = Arc::clone(&landing_zone);
@@ -312,6 +294,23 @@ impl ZerobusStream {
                     )
                     .await;
                     return Err(error);
+                }
+
+                info!(
+                    pending_batches = landing_zone.len(),
+                    pending_records = landing_zone.total_count(),
+                    backoff_ms = options.recovery_backoff_ms,
+                    "Stream lost; starting recovery"
+                );
+                // FixedInterval only delays between retries in this episode; the first
+                // attempt is immediate. Sleep first so a flapping server is not hot-looped.
+                // A graceful close returns Ok and deliberately bypasses this backoff.
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        debug!("Supervisor task cancelled during recovery backoff");
+                        return Ok(());
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(options.recovery_backoff_ms)) => {}
                 }
             }
         }

--- a/rust/tests/src/rust_tests.rs
+++ b/rust/tests/src/rust_tests.rs
@@ -3414,6 +3414,66 @@ mod failure_scenarios_tests {
         }
 
         #[tokio::test]
+        async fn test_recovery_waits_backoff_before_first_reconnect(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            setup_tracing();
+
+            const BACKOFF_MS: u64 = 300;
+
+            let (mock_server, server_url) = start_mock_server().await?;
+            mock_server
+                .inject_responses(
+                    TABLE_NAME,
+                    vec![
+                        MockResponse::CreateStream {
+                            stream_id: "test_stream_before_backoff".to_string(),
+                            delay_ms: 0,
+                        },
+                        MockResponse::Error {
+                            status: tonic::Status::unavailable("flapping server"),
+                            delay_ms: 0,
+                        },
+                        MockResponse::CreateStream {
+                            stream_id: "test_stream_after_backoff".to_string(),
+                            delay_ms: 0,
+                        },
+                        MockResponse::RecordAck {
+                            ack_up_to_offset: 0,
+                            delay_ms: 0,
+                        },
+                    ],
+                )
+                .await;
+
+            let sdk = ZerobusSdk::builder()
+                .endpoint(server_url.clone())
+                .unity_catalog_url("https://mock-uc.com")
+                .tls_config(Arc::new(NoTlsConfig))
+                .build()?;
+            let stream = sdk
+                .stream_builder()
+                .table(TABLE_NAME)
+                .headers_provider(Arc::new(TestHeadersProvider::default()))
+                .compiled_proto(create_test_descriptor_proto().unwrap_or_default())
+                .recovery(true)
+                .recovery_timeout_ms(5000)
+                .recovery_backoff_ms(BACKOFF_MS)
+                .build()
+                .await?;
+
+            let started = std::time::Instant::now();
+            let offset = stream.ingest_record_offset(b"pending".to_vec()).await?;
+            stream.wait_for_offset(offset).await?;
+            let elapsed = started.elapsed();
+            assert!(
+                elapsed >= std::time::Duration::from_millis(BACKOFF_MS),
+                "first reconnect skipped recovery_backoff_ms: elapsed {elapsed:?}"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
         async fn test_recovery_after_server_unresponsiveness(
         ) -> Result<(), Box<dyn std::error::Error>> {
             setup_tracing();


### PR DESCRIPTION
## Summary
- After a retryable mid-stream gRPC failure, wait `recovery_backoff_ms` before the first reconnect. `RetryIf` + `FixedInterval` only delay *between* retries, so a flapping server was otherwise hot-looped.
- Graceful `CloseStreamSignal` reconnects are unchanged (no extra backoff).
- Fixes #641

## Test plan
- [ ] `test_recovery_waits_backoff_before_first_reconnect`
- [ ] `failure_scenarios_tests::recovery`
- [ ] `graceful_close_tests` (immediate / server-duration reconnect timing)
- [ ] `cargo clippy -p databricks-zerobus-ingest-sdk --all-targets -- -D warnings`