### PR TITLE
[All] Add avro record type to proto surface

### DIFF
--- a/.github/workflows/ci-purego.yml
+++ b/.github/workflows/ci-purego.yml
@@ -33,6 +33,66 @@ jobs:
             exit 1
           fi
 
+  # Verify the committed protobuf bindings (internal/zerobuspb) are in sync with
+  # the canonical schema (rust/sdk/zerobus_service.proto). These files are
+  # committed, not generated at build time, so this gate catches a proto change
+  # that forgot to regenerate them. Tooling is pinned to the versions in
+  # internal/zerobuspb/gen.go so regeneration is byte-for-byte reproducible.
+  generate:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    defaults:
+      run:
+        working-directory: purego
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Get JFrog OIDC token
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/jfrog-oidc-token.sh"
+      - name: Configure Go registry
+        shell: bash
+        run: |
+          echo "GOPROXY=https://databricks.jfrog.io/artifactory/api/go/db-golang,direct" >> "$GITHUB_ENV"
+          echo "GONOSUMDB=*" >> "$GITHUB_ENV"
+          cat > ~/.netrc << EOF
+          machine databricks.jfrog.io
+          login gha-service-account
+          password ${JFROG_ACCESS_TOKEN}
+          EOF
+          chmod 600 ~/.netrc
+          echo "Go configured to use JFrog registry"
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.25'
+
+      # protoc pinned to match gen.go (renders as "protoc v6.33.0" in the output
+      # header). A version mismatch changes the embedded descriptor bytes and
+      # fails the diff below — bump this together with gen.go.
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          version: '33.0'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Plugin versions pinned to gen.go so the output is deterministic.
+      - name: Install protoc-gen-go plugins
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Regenerate bindings
+        run: go generate ./...
+
+      - name: Fail if committed bindings are stale
+        run: |
+          if ! git diff --exit-code -- internal/zerobuspb/; then
+            echo "internal/zerobuspb is out of date with the proto."
+            echo "Run 'go generate ./...' in purego/internal/zerobuspb and commit the result."
+            exit 1
+          fi
+
   vet:
     runs-on:
       group: databricks-protected-runner-group

--- a/purego/internal/zerobuspb/zerobus_service.pb.go
+++ b/purego/internal/zerobuspb/zerobus_service.pb.go
@@ -31,6 +31,7 @@ const (
 	RecordType_RECORD_TYPE_UNSPECIFIED RecordType = 0
 	RecordType_PROTO                   RecordType = 1
 	RecordType_JSON                    RecordType = 2
+	RecordType_AVRO                    RecordType = 4
 )
 
 // Enum value maps for RecordType.
@@ -39,11 +40,13 @@ var (
 		0: "RECORD_TYPE_UNSPECIFIED",
 		1: "PROTO",
 		2: "JSON",
+		4: "AVRO",
 	}
 	RecordType_value = map[string]int32{
 		"RECORD_TYPE_UNSPECIFIED": 0,
 		"PROTO":                   1,
 		"JSON":                    2,
+		"AVRO":                    4,
 	}
 )
 
@@ -183,6 +186,57 @@ func (x *ProtoEncodedRecordBatch) GetRecords() [][]byte {
 	return nil
 }
 
+// Batch of Avro-encoded records.
+//
+// Each element is a single raw Avro binary datum (no framing). The writer
+// schema is supplied once at stream creation via
+// CreateIngestStreamRequest.avro_schema_json.
+type AvroRecordBatch struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Array of raw Avro binary datums. Each datum must be encoded according to
+	// the writer schema provided in CreateIngestStreamRequest.avro_schema_json.
+	Records       [][]byte `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AvroRecordBatch) Reset() {
+	*x = AvroRecordBatch{}
+	mi := &file_zerobus_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AvroRecordBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AvroRecordBatch) ProtoMessage() {}
+
+func (x *AvroRecordBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AvroRecordBatch.ProtoReflect.Descriptor instead.
+func (*AvroRecordBatch) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *AvroRecordBatch) GetRecords() [][]byte {
+	if x != nil {
+		return x.Records
+	}
+	return nil
+}
+
 // Request to create a new ephemeral ingestion stream.
 //
 // This message initiates the streaming session and must be the first message
@@ -202,14 +256,19 @@ type CreateIngestStreamRequest struct {
 	DescriptorProto []byte `protobuf:"bytes,3,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
 	// Record type that will be accepted in the stream.
 	// Defaults to PROTO for backwards compatibility.
-	RecordType    *RecordType `protobuf:"varint,4,opt,name=record_type,json=recordType,enum=databricks.zerobus.RecordType" json:"record_type,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RecordType *RecordType `protobuf:"varint,4,opt,name=record_type,json=recordType,enum=databricks.zerobus.RecordType" json:"record_type,omitempty"`
+	// Avro writer schema as a JSON-encoded Avro schema string.
+	//
+	// Required when record_type is AVRO. Must be a valid Avro record schema.
+	// Ignored for all other record types.
+	AvroSchemaJson *string `protobuf:"bytes,5,opt,name=avro_schema_json,json=avroSchemaJson" json:"avro_schema_json,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CreateIngestStreamRequest) Reset() {
 	*x = CreateIngestStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[2]
+	mi := &file_zerobus_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -221,7 +280,7 @@ func (x *CreateIngestStreamRequest) String() string {
 func (*CreateIngestStreamRequest) ProtoMessage() {}
 
 func (x *CreateIngestStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[2]
+	mi := &file_zerobus_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +293,7 @@ func (x *CreateIngestStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateIngestStreamRequest.ProtoReflect.Descriptor instead.
 func (*CreateIngestStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{2}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CreateIngestStreamRequest) GetTableName() string {
@@ -258,6 +317,13 @@ func (x *CreateIngestStreamRequest) GetRecordType() RecordType {
 	return RecordType_RECORD_TYPE_UNSPECIFIED
 }
 
+func (x *CreateIngestStreamRequest) GetAvroSchemaJson() string {
+	if x != nil && x.AvroSchemaJson != nil {
+		return *x.AvroSchemaJson
+	}
+	return ""
+}
+
 // Response confirming the creation of an ephemeral ingestion stream.
 //
 // This message is sent by the server in response to a CreateIngestStreamRequest
@@ -272,7 +338,7 @@ type CreateIngestStreamResponse struct {
 
 func (x *CreateIngestStreamResponse) Reset() {
 	*x = CreateIngestStreamResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[3]
+	mi := &file_zerobus_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -284,7 +350,7 @@ func (x *CreateIngestStreamResponse) String() string {
 func (*CreateIngestStreamResponse) ProtoMessage() {}
 
 func (x *CreateIngestStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[3]
+	mi := &file_zerobus_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -297,7 +363,7 @@ func (x *CreateIngestStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateIngestStreamResponse.ProtoReflect.Descriptor instead.
 func (*CreateIngestStreamResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{3}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CreateIngestStreamResponse) GetStreamId() string {
@@ -321,6 +387,7 @@ type IngestRecordRequest struct {
 	//
 	//	*IngestRecordRequest_ProtoEncodedRecord
 	//	*IngestRecordRequest_JsonRecord
+	//	*IngestRecordRequest_AvroEncodedRecord
 	Record        isIngestRecordRequest_Record `protobuf_oneof:"record"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -328,7 +395,7 @@ type IngestRecordRequest struct {
 
 func (x *IngestRecordRequest) Reset() {
 	*x = IngestRecordRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[4]
+	mi := &file_zerobus_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -340,7 +407,7 @@ func (x *IngestRecordRequest) String() string {
 func (*IngestRecordRequest) ProtoMessage() {}
 
 func (x *IngestRecordRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[4]
+	mi := &file_zerobus_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -353,7 +420,7 @@ func (x *IngestRecordRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngestRecordRequest.ProtoReflect.Descriptor instead.
 func (*IngestRecordRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{4}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *IngestRecordRequest) GetOffsetId() int64 {
@@ -388,6 +455,15 @@ func (x *IngestRecordRequest) GetJsonRecord() string {
 	return ""
 }
 
+func (x *IngestRecordRequest) GetAvroEncodedRecord() []byte {
+	if x != nil {
+		if x, ok := x.Record.(*IngestRecordRequest_AvroEncodedRecord); ok {
+			return x.AvroEncodedRecord
+		}
+	}
+	return nil
+}
+
 type isIngestRecordRequest_Record interface {
 	isIngestRecordRequest_Record()
 }
@@ -402,9 +478,17 @@ type IngestRecordRequest_JsonRecord struct {
 	JsonRecord string `protobuf:"bytes,3,opt,name=json_record,json=jsonRecord,oneof"`
 }
 
+type IngestRecordRequest_AvroEncodedRecord struct {
+	// A single raw Avro binary datum (no framing). The writer schema is supplied
+	// once at stream creation via CreateIngestStreamRequest.avro_schema_json.
+	AvroEncodedRecord []byte `protobuf:"bytes,4,opt,name=avro_encoded_record,json=avroEncodedRecord,oneof"`
+}
+
 func (*IngestRecordRequest_ProtoEncodedRecord) isIngestRecordRequest_Record() {}
 
 func (*IngestRecordRequest_JsonRecord) isIngestRecordRequest_Record() {}
+
+func (*IngestRecordRequest_AvroEncodedRecord) isIngestRecordRequest_Record() {}
 
 // Request to ingest a batch of records into the stream.
 //
@@ -421,6 +505,7 @@ type IngestRecordBatchRequest struct {
 	//
 	//	*IngestRecordBatchRequest_ProtoEncodedBatch
 	//	*IngestRecordBatchRequest_JsonBatch
+	//	*IngestRecordBatchRequest_AvroBatch
 	Batch         isIngestRecordBatchRequest_Batch `protobuf_oneof:"batch"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -428,7 +513,7 @@ type IngestRecordBatchRequest struct {
 
 func (x *IngestRecordBatchRequest) Reset() {
 	*x = IngestRecordBatchRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[5]
+	mi := &file_zerobus_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +525,7 @@ func (x *IngestRecordBatchRequest) String() string {
 func (*IngestRecordBatchRequest) ProtoMessage() {}
 
 func (x *IngestRecordBatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[5]
+	mi := &file_zerobus_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +538,7 @@ func (x *IngestRecordBatchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngestRecordBatchRequest.ProtoReflect.Descriptor instead.
 func (*IngestRecordBatchRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{5}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *IngestRecordBatchRequest) GetOffsetId() int64 {
@@ -488,6 +573,15 @@ func (x *IngestRecordBatchRequest) GetJsonBatch() *JsonRecordBatch {
 	return nil
 }
 
+func (x *IngestRecordBatchRequest) GetAvroBatch() *AvroRecordBatch {
+	if x != nil {
+		if x, ok := x.Batch.(*IngestRecordBatchRequest_AvroBatch); ok {
+			return x.AvroBatch
+		}
+	}
+	return nil
+}
+
 type isIngestRecordBatchRequest_Batch interface {
 	isIngestRecordBatchRequest_Batch()
 }
@@ -503,9 +597,17 @@ type IngestRecordBatchRequest_JsonBatch struct {
 	JsonBatch *JsonRecordBatch `protobuf:"bytes,3,opt,name=json_batch,json=jsonBatch,oneof"`
 }
 
+type IngestRecordBatchRequest_AvroBatch struct {
+	// Batch of Avro-encoded records. The writer schema must be provided in
+	// CreateIngestStreamRequest.avro_schema_json.
+	AvroBatch *AvroRecordBatch `protobuf:"bytes,4,opt,name=avro_batch,json=avroBatch,oneof"`
+}
+
 func (*IngestRecordBatchRequest_ProtoEncodedBatch) isIngestRecordBatchRequest_Batch() {}
 
 func (*IngestRecordBatchRequest_JsonBatch) isIngestRecordBatchRequest_Batch() {}
+
+func (*IngestRecordBatchRequest_AvroBatch) isIngestRecordBatchRequest_Batch() {}
 
 // A message in the EphemeralStream bidirectional stream.
 //
@@ -525,7 +627,7 @@ type EphemeralStreamRequest struct {
 
 func (x *EphemeralStreamRequest) Reset() {
 	*x = EphemeralStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[6]
+	mi := &file_zerobus_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -537,7 +639,7 @@ func (x *EphemeralStreamRequest) String() string {
 func (*EphemeralStreamRequest) ProtoMessage() {}
 
 func (x *EphemeralStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[6]
+	mi := &file_zerobus_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -550,7 +652,7 @@ func (x *EphemeralStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EphemeralStreamRequest.ProtoReflect.Descriptor instead.
 func (*EphemeralStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{6}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *EphemeralStreamRequest) GetPayload() isEphemeralStreamRequest_Payload {
@@ -635,7 +737,7 @@ type IngestRecordResponse struct {
 
 func (x *IngestRecordResponse) Reset() {
 	*x = IngestRecordResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[7]
+	mi := &file_zerobus_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -647,7 +749,7 @@ func (x *IngestRecordResponse) String() string {
 func (*IngestRecordResponse) ProtoMessage() {}
 
 func (x *IngestRecordResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[7]
+	mi := &file_zerobus_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -660,7 +762,7 @@ func (x *IngestRecordResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngestRecordResponse.ProtoReflect.Descriptor instead.
 func (*IngestRecordResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{7}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *IngestRecordResponse) GetDurabilityAckUpToOffset() int64 {
@@ -681,7 +783,7 @@ type CloseStreamSignal struct {
 
 func (x *CloseStreamSignal) Reset() {
 	*x = CloseStreamSignal{}
-	mi := &file_zerobus_service_proto_msgTypes[8]
+	mi := &file_zerobus_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -693,7 +795,7 @@ func (x *CloseStreamSignal) String() string {
 func (*CloseStreamSignal) ProtoMessage() {}
 
 func (x *CloseStreamSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[8]
+	mi := &file_zerobus_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -706,7 +808,7 @@ func (x *CloseStreamSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseStreamSignal.ProtoReflect.Descriptor instead.
 func (*CloseStreamSignal) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{8}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CloseStreamSignal) GetDuration() *durationpb.Duration {
@@ -734,7 +836,7 @@ type EphemeralStreamResponse struct {
 
 func (x *EphemeralStreamResponse) Reset() {
 	*x = EphemeralStreamResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[9]
+	mi := &file_zerobus_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -746,7 +848,7 @@ func (x *EphemeralStreamResponse) String() string {
 func (*EphemeralStreamResponse) ProtoMessage() {}
 
 func (x *EphemeralStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[9]
+	mi := &file_zerobus_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -759,7 +861,7 @@ func (x *EphemeralStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EphemeralStreamResponse.ProtoReflect.Descriptor instead.
 func (*EphemeralStreamResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{9}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *EphemeralStreamResponse) GetPayload() isEphemeralStreamResponse_Payload {
@@ -833,7 +935,7 @@ type CreatePersistentStreamRequest struct {
 
 func (x *CreatePersistentStreamRequest) Reset() {
 	*x = CreatePersistentStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[10]
+	mi := &file_zerobus_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -845,7 +947,7 @@ func (x *CreatePersistentStreamRequest) String() string {
 func (*CreatePersistentStreamRequest) ProtoMessage() {}
 
 func (x *CreatePersistentStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[10]
+	mi := &file_zerobus_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -858,7 +960,7 @@ func (x *CreatePersistentStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePersistentStreamRequest.ProtoReflect.Descriptor instead.
 func (*CreatePersistentStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{10}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CreatePersistentStreamRequest) GetCreateStream() *CreateIngestStreamRequest {
@@ -882,7 +984,7 @@ type ResumeIngestStreamRequest struct {
 	// Protocol buffer descriptor for record serialization/deserialization.
 	//
 	// Required when the stream was created with record_type PROTO. Must be
-	// compatible with the target table's schema. Not used for JSON or ARROW_IPC
+	// compatible with the target table's schema. Not used for JSON or AVRO
 	// record types.
 	DescriptorProto []byte `protobuf:"bytes,2,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
 	// Record type accepted by the resumed stream. Must match the type used when
@@ -894,7 +996,7 @@ type ResumeIngestStreamRequest struct {
 
 func (x *ResumeIngestStreamRequest) Reset() {
 	*x = ResumeIngestStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[11]
+	mi := &file_zerobus_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -906,7 +1008,7 @@ func (x *ResumeIngestStreamRequest) String() string {
 func (*ResumeIngestStreamRequest) ProtoMessage() {}
 
 func (x *ResumeIngestStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[11]
+	mi := &file_zerobus_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -919,7 +1021,7 @@ func (x *ResumeIngestStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeIngestStreamRequest.ProtoReflect.Descriptor instead.
 func (*ResumeIngestStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{11}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ResumeIngestStreamRequest) GetIdentifier() isResumeIngestStreamRequest_Identifier {
@@ -975,7 +1077,7 @@ type ResumeIngestStreamResponse struct {
 
 func (x *ResumeIngestStreamResponse) Reset() {
 	*x = ResumeIngestStreamResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[12]
+	mi := &file_zerobus_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +1089,7 @@ func (x *ResumeIngestStreamResponse) String() string {
 func (*ResumeIngestStreamResponse) ProtoMessage() {}
 
 func (x *ResumeIngestStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[12]
+	mi := &file_zerobus_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +1102,7 @@ func (x *ResumeIngestStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeIngestStreamResponse.ProtoReflect.Descriptor instead.
 func (*ResumeIngestStreamResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{12}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ResumeIngestStreamResponse) GetLastCommittedOffset() int64 {
@@ -1028,7 +1130,7 @@ type PersistentStreamRequest struct {
 
 func (x *PersistentStreamRequest) Reset() {
 	*x = PersistentStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[13]
+	mi := &file_zerobus_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1142,7 @@ func (x *PersistentStreamRequest) String() string {
 func (*PersistentStreamRequest) ProtoMessage() {}
 
 func (x *PersistentStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[13]
+	mi := &file_zerobus_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1155,7 @@ func (x *PersistentStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistentStreamRequest.ProtoReflect.Descriptor instead.
 func (*PersistentStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{13}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PersistentStreamRequest) GetPayload() isPersistentStreamRequest_Payload {
@@ -1144,7 +1246,7 @@ type PersistentStreamResponse struct {
 
 func (x *PersistentStreamResponse) Reset() {
 	*x = PersistentStreamResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[14]
+	mi := &file_zerobus_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1156,7 +1258,7 @@ func (x *PersistentStreamResponse) String() string {
 func (*PersistentStreamResponse) ProtoMessage() {}
 
 func (x *PersistentStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[14]
+	mi := &file_zerobus_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1169,7 +1271,7 @@ func (x *PersistentStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistentStreamResponse.ProtoReflect.Descriptor instead.
 func (*PersistentStreamResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{14}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PersistentStreamResponse) GetPayload() isPersistentStreamResponse_Payload {
@@ -1261,7 +1363,7 @@ type RetireStreamRequest struct {
 
 func (x *RetireStreamRequest) Reset() {
 	*x = RetireStreamRequest{}
-	mi := &file_zerobus_service_proto_msgTypes[15]
+	mi := &file_zerobus_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1273,7 +1375,7 @@ func (x *RetireStreamRequest) String() string {
 func (*RetireStreamRequest) ProtoMessage() {}
 
 func (x *RetireStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[15]
+	mi := &file_zerobus_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1286,7 +1388,7 @@ func (x *RetireStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireStreamRequest.ProtoReflect.Descriptor instead.
 func (*RetireStreamRequest) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{15}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RetireStreamRequest) GetTableName() string {
@@ -1333,7 +1435,7 @@ type RetireStreamResponse struct {
 
 func (x *RetireStreamResponse) Reset() {
 	*x = RetireStreamResponse{}
-	mi := &file_zerobus_service_proto_msgTypes[16]
+	mi := &file_zerobus_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1345,7 +1447,7 @@ func (x *RetireStreamResponse) String() string {
 func (*RetireStreamResponse) ProtoMessage() {}
 
 func (x *RetireStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zerobus_service_proto_msgTypes[16]
+	mi := &file_zerobus_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1358,7 +1460,7 @@ func (x *RetireStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireStreamResponse.ProtoReflect.Descriptor instead.
 func (*RetireStreamResponse) Descriptor() ([]byte, []int) {
-	return file_zerobus_service_proto_rawDescGZIP(), []int{16}
+	return file_zerobus_service_proto_rawDescGZIP(), []int{17}
 }
 
 var File_zerobus_service_proto protoreflect.FileDescriptor
@@ -1369,26 +1471,32 @@ const file_zerobus_service_proto_rawDesc = "" +
 	"\x0fJsonRecordBatch\x12\x18\n" +
 	"\arecords\x18\x01 \x03(\tR\arecords\"3\n" +
 	"\x17ProtoEncodedRecordBatch\x12\x18\n" +
-	"\arecords\x18\x01 \x03(\fR\arecords\"\xb7\x01\n" +
+	"\arecords\x18\x01 \x03(\fR\arecords\"+\n" +
+	"\x0fAvroRecordBatch\x12\x18\n" +
+	"\arecords\x18\x01 \x03(\fR\arecords\"\xe1\x01\n" +
 	"\x19CreateIngestStreamRequest\x12\x1d\n" +
 	"\n" +
 	"table_name\x18\x01 \x01(\tR\ttableName\x12)\n" +
 	"\x10descriptor_proto\x18\x03 \x01(\fR\x0fdescriptorProto\x12?\n" +
 	"\vrecord_type\x18\x04 \x01(\x0e2\x1e.databricks.zerobus.RecordTypeR\n" +
-	"recordTypeJ\x04\b\x02\x10\x03R\tstream_id\"O\n" +
+	"recordType\x12(\n" +
+	"\x10avro_schema_json\x18\x05 \x01(\tR\x0eavroSchemaJsonJ\x04\b\x02\x10\x03R\tstream_id\"O\n" +
 	"\x1aCreateIngestStreamResponse\x12\x1b\n" +
-	"\tstream_id\x18\x01 \x01(\tR\bstreamIdJ\x04\b\x02\x10\x03R\x0elast_offset_id\"\x93\x01\n" +
+	"\tstream_id\x18\x01 \x01(\tR\bstreamIdJ\x04\b\x02\x10\x03R\x0elast_offset_id\"\xc5\x01\n" +
 	"\x13IngestRecordRequest\x12\x1b\n" +
 	"\toffset_id\x18\x01 \x01(\x03R\boffsetId\x122\n" +
 	"\x14proto_encoded_record\x18\x02 \x01(\fH\x00R\x12protoEncodedRecord\x12!\n" +
 	"\vjson_record\x18\x03 \x01(\tH\x00R\n" +
-	"jsonRecordB\b\n" +
-	"\x06record\"\xe5\x01\n" +
+	"jsonRecord\x120\n" +
+	"\x13avro_encoded_record\x18\x04 \x01(\fH\x00R\x11avroEncodedRecordB\b\n" +
+	"\x06record\"\xab\x02\n" +
 	"\x18IngestRecordBatchRequest\x12\x1b\n" +
 	"\toffset_id\x18\x01 \x01(\x03R\boffsetId\x12]\n" +
 	"\x13proto_encoded_batch\x18\x02 \x01(\v2+.databricks.zerobus.ProtoEncodedRecordBatchH\x00R\x11protoEncodedBatch\x12D\n" +
 	"\n" +
-	"json_batch\x18\x03 \x01(\v2#.databricks.zerobus.JsonRecordBatchH\x00R\tjsonBatchB\a\n" +
+	"json_batch\x18\x03 \x01(\v2#.databricks.zerobus.JsonRecordBatchH\x00R\tjsonBatch\x12D\n" +
+	"\n" +
+	"avro_batch\x18\x04 \x01(\v2#.databricks.zerobus.AvroRecordBatchH\x00R\tavroBatchB\a\n" +
 	"\x05batch\"\xa9\x02\n" +
 	"\x16EphemeralStreamRequest\x12T\n" +
 	"\rcreate_stream\x18\x01 \x01(\v2-.databricks.zerobus.CreateIngestStreamRequestH\x00R\fcreateStream\x12N\n" +
@@ -1433,12 +1541,13 @@ const file_zerobus_service_proto_rawDesc = "" +
 	"\tstream_id\x18\x02 \x01(\tH\x00R\bstreamIdB\f\n" +
 	"\n" +
 	"identifierJ\x04\b\x03\x10\x04R\vstream_name\"\x16\n" +
-	"\x14RetireStreamResponse*>\n" +
+	"\x14RetireStreamResponse*N\n" +
 	"\n" +
 	"RecordType\x12\x1b\n" +
 	"\x17RECORD_TYPE_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05PROTO\x10\x01\x12\b\n" +
-	"\x04JSON\x10\x022\xcf\x02\n" +
+	"\x04JSON\x10\x02\x12\b\n" +
+	"\x04AVRO\x10\x04\"\x04\b\x03\x10\x032\xcf\x02\n" +
 	"\aZerobus\x12n\n" +
 	"\x0fEphemeralStream\x12*.databricks.zerobus.EphemeralStreamRequest\x1a+.databricks.zerobus.EphemeralStreamResponse(\x010\x01\x12q\n" +
 	"\x10PersistentStream\x12+.databricks.zerobus.PersistentStreamRequest\x1a,.databricks.zerobus.PersistentStreamResponse(\x010\x01\x12a\n" +
@@ -1458,60 +1567,62 @@ func file_zerobus_service_proto_rawDescGZIP() []byte {
 }
 
 var file_zerobus_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_zerobus_service_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_zerobus_service_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_zerobus_service_proto_goTypes = []any{
 	(RecordType)(0),                       // 0: databricks.zerobus.RecordType
 	(*JsonRecordBatch)(nil),               // 1: databricks.zerobus.JsonRecordBatch
 	(*ProtoEncodedRecordBatch)(nil),       // 2: databricks.zerobus.ProtoEncodedRecordBatch
-	(*CreateIngestStreamRequest)(nil),     // 3: databricks.zerobus.CreateIngestStreamRequest
-	(*CreateIngestStreamResponse)(nil),    // 4: databricks.zerobus.CreateIngestStreamResponse
-	(*IngestRecordRequest)(nil),           // 5: databricks.zerobus.IngestRecordRequest
-	(*IngestRecordBatchRequest)(nil),      // 6: databricks.zerobus.IngestRecordBatchRequest
-	(*EphemeralStreamRequest)(nil),        // 7: databricks.zerobus.EphemeralStreamRequest
-	(*IngestRecordResponse)(nil),          // 8: databricks.zerobus.IngestRecordResponse
-	(*CloseStreamSignal)(nil),             // 9: databricks.zerobus.CloseStreamSignal
-	(*EphemeralStreamResponse)(nil),       // 10: databricks.zerobus.EphemeralStreamResponse
-	(*CreatePersistentStreamRequest)(nil), // 11: databricks.zerobus.CreatePersistentStreamRequest
-	(*ResumeIngestStreamRequest)(nil),     // 12: databricks.zerobus.ResumeIngestStreamRequest
-	(*ResumeIngestStreamResponse)(nil),    // 13: databricks.zerobus.ResumeIngestStreamResponse
-	(*PersistentStreamRequest)(nil),       // 14: databricks.zerobus.PersistentStreamRequest
-	(*PersistentStreamResponse)(nil),      // 15: databricks.zerobus.PersistentStreamResponse
-	(*RetireStreamRequest)(nil),           // 16: databricks.zerobus.RetireStreamRequest
-	(*RetireStreamResponse)(nil),          // 17: databricks.zerobus.RetireStreamResponse
-	(*durationpb.Duration)(nil),           // 18: google.protobuf.Duration
+	(*AvroRecordBatch)(nil),               // 3: databricks.zerobus.AvroRecordBatch
+	(*CreateIngestStreamRequest)(nil),     // 4: databricks.zerobus.CreateIngestStreamRequest
+	(*CreateIngestStreamResponse)(nil),    // 5: databricks.zerobus.CreateIngestStreamResponse
+	(*IngestRecordRequest)(nil),           // 6: databricks.zerobus.IngestRecordRequest
+	(*IngestRecordBatchRequest)(nil),      // 7: databricks.zerobus.IngestRecordBatchRequest
+	(*EphemeralStreamRequest)(nil),        // 8: databricks.zerobus.EphemeralStreamRequest
+	(*IngestRecordResponse)(nil),          // 9: databricks.zerobus.IngestRecordResponse
+	(*CloseStreamSignal)(nil),             // 10: databricks.zerobus.CloseStreamSignal
+	(*EphemeralStreamResponse)(nil),       // 11: databricks.zerobus.EphemeralStreamResponse
+	(*CreatePersistentStreamRequest)(nil), // 12: databricks.zerobus.CreatePersistentStreamRequest
+	(*ResumeIngestStreamRequest)(nil),     // 13: databricks.zerobus.ResumeIngestStreamRequest
+	(*ResumeIngestStreamResponse)(nil),    // 14: databricks.zerobus.ResumeIngestStreamResponse
+	(*PersistentStreamRequest)(nil),       // 15: databricks.zerobus.PersistentStreamRequest
+	(*PersistentStreamResponse)(nil),      // 16: databricks.zerobus.PersistentStreamResponse
+	(*RetireStreamRequest)(nil),           // 17: databricks.zerobus.RetireStreamRequest
+	(*RetireStreamResponse)(nil),          // 18: databricks.zerobus.RetireStreamResponse
+	(*durationpb.Duration)(nil),           // 19: google.protobuf.Duration
 }
 var file_zerobus_service_proto_depIdxs = []int32{
 	0,  // 0: databricks.zerobus.CreateIngestStreamRequest.record_type:type_name -> databricks.zerobus.RecordType
 	2,  // 1: databricks.zerobus.IngestRecordBatchRequest.proto_encoded_batch:type_name -> databricks.zerobus.ProtoEncodedRecordBatch
 	1,  // 2: databricks.zerobus.IngestRecordBatchRequest.json_batch:type_name -> databricks.zerobus.JsonRecordBatch
-	3,  // 3: databricks.zerobus.EphemeralStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
-	5,  // 4: databricks.zerobus.EphemeralStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
-	6,  // 5: databricks.zerobus.EphemeralStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
-	18, // 6: databricks.zerobus.CloseStreamSignal.duration:type_name -> google.protobuf.Duration
-	4,  // 7: databricks.zerobus.EphemeralStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
-	8,  // 8: databricks.zerobus.EphemeralStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
-	9,  // 9: databricks.zerobus.EphemeralStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
-	3,  // 10: databricks.zerobus.CreatePersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
-	0,  // 11: databricks.zerobus.ResumeIngestStreamRequest.record_type:type_name -> databricks.zerobus.RecordType
-	11, // 12: databricks.zerobus.PersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreatePersistentStreamRequest
-	12, // 13: databricks.zerobus.PersistentStreamRequest.resume_stream:type_name -> databricks.zerobus.ResumeIngestStreamRequest
-	5,  // 14: databricks.zerobus.PersistentStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
-	6,  // 15: databricks.zerobus.PersistentStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
-	4,  // 16: databricks.zerobus.PersistentStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
-	13, // 17: databricks.zerobus.PersistentStreamResponse.resume_stream_response:type_name -> databricks.zerobus.ResumeIngestStreamResponse
-	8,  // 18: databricks.zerobus.PersistentStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
-	9,  // 19: databricks.zerobus.PersistentStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
-	7,  // 20: databricks.zerobus.Zerobus.EphemeralStream:input_type -> databricks.zerobus.EphemeralStreamRequest
-	14, // 21: databricks.zerobus.Zerobus.PersistentStream:input_type -> databricks.zerobus.PersistentStreamRequest
-	16, // 22: databricks.zerobus.Zerobus.RetireStream:input_type -> databricks.zerobus.RetireStreamRequest
-	10, // 23: databricks.zerobus.Zerobus.EphemeralStream:output_type -> databricks.zerobus.EphemeralStreamResponse
-	15, // 24: databricks.zerobus.Zerobus.PersistentStream:output_type -> databricks.zerobus.PersistentStreamResponse
-	17, // 25: databricks.zerobus.Zerobus.RetireStream:output_type -> databricks.zerobus.RetireStreamResponse
-	23, // [23:26] is the sub-list for method output_type
-	20, // [20:23] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	3,  // 3: databricks.zerobus.IngestRecordBatchRequest.avro_batch:type_name -> databricks.zerobus.AvroRecordBatch
+	4,  // 4: databricks.zerobus.EphemeralStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
+	6,  // 5: databricks.zerobus.EphemeralStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
+	7,  // 6: databricks.zerobus.EphemeralStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
+	19, // 7: databricks.zerobus.CloseStreamSignal.duration:type_name -> google.protobuf.Duration
+	5,  // 8: databricks.zerobus.EphemeralStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
+	9,  // 9: databricks.zerobus.EphemeralStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
+	10, // 10: databricks.zerobus.EphemeralStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
+	4,  // 11: databricks.zerobus.CreatePersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
+	0,  // 12: databricks.zerobus.ResumeIngestStreamRequest.record_type:type_name -> databricks.zerobus.RecordType
+	12, // 13: databricks.zerobus.PersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreatePersistentStreamRequest
+	13, // 14: databricks.zerobus.PersistentStreamRequest.resume_stream:type_name -> databricks.zerobus.ResumeIngestStreamRequest
+	6,  // 15: databricks.zerobus.PersistentStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
+	7,  // 16: databricks.zerobus.PersistentStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
+	5,  // 17: databricks.zerobus.PersistentStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
+	14, // 18: databricks.zerobus.PersistentStreamResponse.resume_stream_response:type_name -> databricks.zerobus.ResumeIngestStreamResponse
+	9,  // 19: databricks.zerobus.PersistentStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
+	10, // 20: databricks.zerobus.PersistentStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
+	8,  // 21: databricks.zerobus.Zerobus.EphemeralStream:input_type -> databricks.zerobus.EphemeralStreamRequest
+	15, // 22: databricks.zerobus.Zerobus.PersistentStream:input_type -> databricks.zerobus.PersistentStreamRequest
+	17, // 23: databricks.zerobus.Zerobus.RetireStream:input_type -> databricks.zerobus.RetireStreamRequest
+	11, // 24: databricks.zerobus.Zerobus.EphemeralStream:output_type -> databricks.zerobus.EphemeralStreamResponse
+	16, // 25: databricks.zerobus.Zerobus.PersistentStream:output_type -> databricks.zerobus.PersistentStreamResponse
+	18, // 26: databricks.zerobus.Zerobus.RetireStream:output_type -> databricks.zerobus.RetireStreamResponse
+	24, // [24:27] is the sub-list for method output_type
+	21, // [21:24] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_zerobus_service_proto_init() }
@@ -1519,40 +1630,42 @@ func file_zerobus_service_proto_init() {
 	if File_zerobus_service_proto != nil {
 		return
 	}
-	file_zerobus_service_proto_msgTypes[4].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[5].OneofWrappers = []any{
 		(*IngestRecordRequest_ProtoEncodedRecord)(nil),
 		(*IngestRecordRequest_JsonRecord)(nil),
-	}
-	file_zerobus_service_proto_msgTypes[5].OneofWrappers = []any{
-		(*IngestRecordBatchRequest_ProtoEncodedBatch)(nil),
-		(*IngestRecordBatchRequest_JsonBatch)(nil),
+		(*IngestRecordRequest_AvroEncodedRecord)(nil),
 	}
 	file_zerobus_service_proto_msgTypes[6].OneofWrappers = []any{
+		(*IngestRecordBatchRequest_ProtoEncodedBatch)(nil),
+		(*IngestRecordBatchRequest_JsonBatch)(nil),
+		(*IngestRecordBatchRequest_AvroBatch)(nil),
+	}
+	file_zerobus_service_proto_msgTypes[7].OneofWrappers = []any{
 		(*EphemeralStreamRequest_CreateStream)(nil),
 		(*EphemeralStreamRequest_IngestRecord)(nil),
 		(*EphemeralStreamRequest_IngestRecordBatch)(nil),
 	}
-	file_zerobus_service_proto_msgTypes[9].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[10].OneofWrappers = []any{
 		(*EphemeralStreamResponse_CreateStreamResponse)(nil),
 		(*EphemeralStreamResponse_IngestRecordResponse)(nil),
 		(*EphemeralStreamResponse_CloseStreamSignal)(nil),
 	}
-	file_zerobus_service_proto_msgTypes[11].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[12].OneofWrappers = []any{
 		(*ResumeIngestStreamRequest_StreamId)(nil),
 	}
-	file_zerobus_service_proto_msgTypes[13].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[14].OneofWrappers = []any{
 		(*PersistentStreamRequest_CreateStream)(nil),
 		(*PersistentStreamRequest_ResumeStream)(nil),
 		(*PersistentStreamRequest_IngestRecord)(nil),
 		(*PersistentStreamRequest_IngestRecordBatch)(nil),
 	}
-	file_zerobus_service_proto_msgTypes[14].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[15].OneofWrappers = []any{
 		(*PersistentStreamResponse_CreateStreamResponse)(nil),
 		(*PersistentStreamResponse_ResumeStreamResponse)(nil),
 		(*PersistentStreamResponse_IngestRecordResponse)(nil),
 		(*PersistentStreamResponse_CloseStreamSignal)(nil),
 	}
-	file_zerobus_service_proto_msgTypes[15].OneofWrappers = []any{
+	file_zerobus_service_proto_msgTypes[16].OneofWrappers = []any{
 		(*RetireStreamRequest_StreamId)(nil),
 	}
 	type x struct{}
@@ -1561,7 +1674,7 @@ func file_zerobus_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_zerobus_service_proto_rawDesc), len(file_zerobus_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/purego/internal/zerobuspb/zerobus_service.pb.go
+++ b/purego/internal/zerobuspb/zerobus_service.pb.go
@@ -252,7 +252,7 @@ type CreateIngestStreamRequest struct {
 	// This descriptor defines the structure of the records being ingested.
 	// It must be compatible with the target table's schema.
 	//
-	// This is a required field for all stream creation requests.
+	// Required only for streams with record_type = PROTO; ignored otherwise.
 	DescriptorProto []byte `protobuf:"bytes,3,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
 	// Record type that will be accepted in the stream.
 	// Defaults to PROTO for backwards compatibility.
@@ -499,7 +499,7 @@ type IngestRecordBatchRequest struct {
 	// Unique identifier for this batch within the stream.
 	OffsetId *int64 `protobuf:"varint,1,opt,name=offset_id,json=offsetId" json:"offset_id,omitempty"`
 	// Batch of serialized records.
-	// The batch can contain multiple records encoded as either protobuf or JSON.
+	// The batch can contain multiple records encoded as protobuf, JSON, or Avro.
 	//
 	// Types that are valid to be assigned to Batch:
 	//

--- a/purego/internal/zerobuspb/zerobus_service.pb.go
+++ b/purego/internal/zerobuspb/zerobus_service.pb.go
@@ -22,6 +22,9 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Record type that will be accepted in the stream.
+//
+// Defaults to RECORD_TYPE_UNSPECIFIED, which returns an error on stream creation.
 type RecordType int32
 
 const (
@@ -81,9 +84,14 @@ func (RecordType) EnumDescriptor() ([]byte, []int) {
 	return file_zerobus_service_proto_rawDescGZIP(), []int{0}
 }
 
+// Batch of JSON-encoded records.
+//
+// This message contains multiple JSON records that will be ingested together.
+// Each string in the array represents a complete JSON object.
 type JsonRecordBatch struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Records       []string               `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Array of JSON-encoded records.
+	Records       []string `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -125,9 +133,15 @@ func (x *JsonRecordBatch) GetRecords() []string {
 	return nil
 }
 
+// Batch of protobuf-encoded records.
+//
+// This message contains multiple protobuf-encoded records that will be ingested together.
+// Each record must be serialized according to the protobuf descriptor provided in the
+// CreateIngestStreamRequest.
 type ProtoEncodedRecordBatch struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Records       [][]byte               `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Array of protobuf-encoded records.
+	Records       [][]byte `protobuf:"bytes,1,rep,name=records" json:"records,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -169,13 +183,28 @@ func (x *ProtoEncodedRecordBatch) GetRecords() [][]byte {
 	return nil
 }
 
+// Request to create a new ephemeral ingestion stream.
+//
+// This message initiates the streaming session and must be the first message
+// sent by the client in the EphemeralStream RPC.
 type CreateIngestStreamRequest struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	TableName       *string                `protobuf:"bytes,1,opt,name=table_name,json=tableName" json:"table_name,omitempty"`
-	DescriptorProto []byte                 `protobuf:"bytes,3,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
-	RecordType      *RecordType            `protobuf:"varint,4,opt,name=record_type,json=recordType,enum=databricks.zerobus.RecordType" json:"record_type,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Three part name of the target destination table for data ingestion.
+	//
+	// This is a required field for all stream creation requests.
+	TableName *string `protobuf:"bytes,1,opt,name=table_name,json=tableName" json:"table_name,omitempty"`
+	// Protocol buffer descriptor for record serialization/deserialization.
+	//
+	// This descriptor defines the structure of the records being ingested.
+	// It must be compatible with the target table's schema.
+	//
+	// This is a required field for all stream creation requests.
+	DescriptorProto []byte `protobuf:"bytes,3,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
+	// Record type that will be accepted in the stream.
+	// Defaults to PROTO for backwards compatibility.
+	RecordType    *RecordType `protobuf:"varint,4,opt,name=record_type,json=recordType,enum=databricks.zerobus.RecordType" json:"record_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateIngestStreamRequest) Reset() {
@@ -229,9 +258,14 @@ func (x *CreateIngestStreamRequest) GetRecordType() RecordType {
 	return RecordType_RECORD_TYPE_UNSPECIFIED
 }
 
+// Response confirming the creation of an ephemeral ingestion stream.
+//
+// This message is sent by the server in response to a CreateIngestStreamRequest
+// and contains the stream identifier and initial offset information.
 type CreateIngestStreamResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	StreamId      *string                `protobuf:"bytes,1,opt,name=stream_id,json=streamId" json:"stream_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique identifier assigned to this ephemeral ingestion stream.
+	StreamId      *string `protobuf:"bytes,1,opt,name=stream_id,json=streamId" json:"stream_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -273,9 +307,16 @@ func (x *CreateIngestStreamResponse) GetStreamId() string {
 	return ""
 }
 
+// Request to ingest a single record into the stream.
+//
+// This message is sent by the client after the initial CreateIngestStreamRequest
+// to stream individual records for ingestion.
 type IngestRecordRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	OffsetId *int64                 `protobuf:"varint,1,opt,name=offset_id,json=offsetId" json:"offset_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique identifier for this record within the stream.
+	OffsetId *int64 `protobuf:"varint,1,opt,name=offset_id,json=offsetId" json:"offset_id,omitempty"`
+	// Serialized record data.
+	//
 	// Types that are valid to be assigned to Record:
 	//
 	//	*IngestRecordRequest_ProtoEncodedRecord
@@ -352,6 +393,8 @@ type isIngestRecordRequest_Record interface {
 }
 
 type IngestRecordRequest_ProtoEncodedRecord struct {
+	// The proto encoded record must be serialized according to the protobuf descriptor
+	// provided in the CreateIngestStreamRequest.
 	ProtoEncodedRecord []byte `protobuf:"bytes,2,opt,name=proto_encoded_record,json=protoEncodedRecord,oneof"`
 }
 
@@ -363,9 +406,17 @@ func (*IngestRecordRequest_ProtoEncodedRecord) isIngestRecordRequest_Record() {}
 
 func (*IngestRecordRequest_JsonRecord) isIngestRecordRequest_Record() {}
 
+// Request to ingest a batch of records into the stream.
+//
+// This message is sent by the client after the initial CreateIngestStreamRequest
+// to stream batches of records for ingestion.
 type IngestRecordBatchRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	OffsetId *int64                 `protobuf:"varint,1,opt,name=offset_id,json=offsetId" json:"offset_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique identifier for this batch within the stream.
+	OffsetId *int64 `protobuf:"varint,1,opt,name=offset_id,json=offsetId" json:"offset_id,omitempty"`
+	// Batch of serialized records.
+	// The batch can contain multiple records encoded as either protobuf or JSON.
+	//
 	// Types that are valid to be assigned to Batch:
 	//
 	//	*IngestRecordBatchRequest_ProtoEncodedBatch
@@ -442,10 +493,13 @@ type isIngestRecordBatchRequest_Batch interface {
 }
 
 type IngestRecordBatchRequest_ProtoEncodedBatch struct {
+	// Batch of protobuf-encoded records. Each record must be serialized according to
+	// the protobuf descriptor provided in the CreateIngestStreamRequest.
 	ProtoEncodedBatch *ProtoEncodedRecordBatch `protobuf:"bytes,2,opt,name=proto_encoded_batch,json=protoEncodedBatch,oneof"`
 }
 
 type IngestRecordBatchRequest_JsonBatch struct {
+	// Batch of JSON-encoded records.
 	JsonBatch *JsonRecordBatch `protobuf:"bytes,3,opt,name=json_batch,json=jsonBatch,oneof"`
 }
 
@@ -453,6 +507,10 @@ func (*IngestRecordBatchRequest_ProtoEncodedBatch) isIngestRecordBatchRequest_Ba
 
 func (*IngestRecordBatchRequest_JsonBatch) isIngestRecordBatchRequest_Batch() {}
 
+// A message in the EphemeralStream bidirectional stream.
+//
+// This message type allows the client to send either stream creation requests
+// or record ingestion requests (individual or batched) through the same stream.
 type EphemeralStreamRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Payload:
@@ -534,14 +592,23 @@ type isEphemeralStreamRequest_Payload interface {
 }
 
 type EphemeralStreamRequest_CreateStream struct {
+	// Initial request to create an ephemeral stream.
+	// Must be the first message in the stream.
+	// All subsequent messages should be ingest_record or ingest_record_batch.
 	CreateStream *CreateIngestStreamRequest `protobuf:"bytes,1,opt,name=create_stream,json=createStream,oneof"`
 }
 
 type EphemeralStreamRequest_IngestRecord struct {
+	// Request to ingest a record.
+	// Can only be sent after a successful create_stream request.
+	// Multiple ingest_record messages can be sent in sequence.
 	IngestRecord *IngestRecordRequest `protobuf:"bytes,2,opt,name=ingest_record,json=ingestRecord,oneof"`
 }
 
 type EphemeralStreamRequest_IngestRecordBatch struct {
+	// Request to ingest a batch of records.
+	// Can only be sent after a successful create_stream request.
+	// Multiple ingest_record_batch messages can be sent in sequence.
 	IngestRecordBatch *IngestRecordBatchRequest `protobuf:"bytes,3,opt,name=ingest_record_batch,json=ingestRecordBatch,oneof"`
 }
 
@@ -551,9 +618,17 @@ func (*EphemeralStreamRequest_IngestRecord) isEphemeralStreamRequest_Payload() {
 
 func (*EphemeralStreamRequest_IngestRecordBatch) isEphemeralStreamRequest_Payload() {}
 
+// Acknowledgment for all records up to the specified offset.
+//
+// This message is sent by the server to confirm that records have been
+// successfully ingested and are durable.
 type IngestRecordResponse struct {
-	state                   protoimpl.MessageState `protogen:"open.v1"`
-	DurabilityAckUpToOffset *int64                 `protobuf:"varint,1,opt,name=durability_ack_up_to_offset,json=durabilityAckUpToOffset" json:"durability_ack_up_to_offset,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Highest offset that has been durably acknowledged.
+	//
+	// This offset indicates that all records with
+	// offset_id <= durability_ack_up_to_offset have been made durable.
+	DurabilityAckUpToOffset *int64 `protobuf:"varint,1,opt,name=durability_ack_up_to_offset,json=durabilityAckUpToOffset" json:"durability_ack_up_to_offset,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -595,9 +670,11 @@ func (x *IngestRecordResponse) GetDurabilityAckUpToOffset() int64 {
 	return 0
 }
 
+// Signal that the server will close the stream after the specified duration.
 type CloseStreamSignal struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Duration      *durationpb.Duration   `protobuf:"bytes,1,opt,name=duration" json:"duration,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Duration after which the server will close the stream.
+	Duration      *durationpb.Duration `protobuf:"bytes,1,opt,name=duration" json:"duration,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -639,6 +716,10 @@ func (x *CloseStreamSignal) GetDuration() *durationpb.Duration {
 	return nil
 }
 
+// A message in the EphemeralStream response stream.
+//
+// This message type allows the server to send either stream creation responses
+// or record ingestion responses through the same stream.
 type EphemeralStreamResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Payload:
@@ -720,14 +801,17 @@ type isEphemeralStreamResponse_Payload interface {
 }
 
 type EphemeralStreamResponse_CreateStreamResponse struct {
+	// Response to a create_stream request.
 	CreateStreamResponse *CreateIngestStreamResponse `protobuf:"bytes,1,opt,name=create_stream_response,json=createStreamResponse,oneof"`
 }
 
 type EphemeralStreamResponse_IngestRecordResponse struct {
+	// Response to ingest_record requests.
 	IngestRecordResponse *IngestRecordResponse `protobuf:"bytes,2,opt,name=ingest_record_response,json=ingestRecordResponse,oneof"`
 }
 
 type EphemeralStreamResponse_CloseStreamSignal struct {
+	// Signal that the server will close the stream after the specified duration.
 	CloseStreamSignal *CloseStreamSignal `protobuf:"bytes,3,opt,name=close_stream_signal,json=closeStreamSignal,oneof"`
 }
 
@@ -736,6 +820,546 @@ func (*EphemeralStreamResponse_CreateStreamResponse) isEphemeralStreamResponse_P
 func (*EphemeralStreamResponse_IngestRecordResponse) isEphemeralStreamResponse_Payload() {}
 
 func (*EphemeralStreamResponse_CloseStreamSignal) isEphemeralStreamResponse_Payload() {}
+
+// IN DEVELOPMENT: may change or be removed.
+// First message on a PersistentStream RPC when creating a new stream.
+type CreatePersistentStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Creation parameters shared with ephemeral streams.
+	CreateStream  *CreateIngestStreamRequest `protobuf:"bytes,1,opt,name=create_stream,json=createStream" json:"create_stream,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreatePersistentStreamRequest) Reset() {
+	*x = CreatePersistentStreamRequest{}
+	mi := &file_zerobus_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreatePersistentStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreatePersistentStreamRequest) ProtoMessage() {}
+
+func (x *CreatePersistentStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreatePersistentStreamRequest.ProtoReflect.Descriptor instead.
+func (*CreatePersistentStreamRequest) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CreatePersistentStreamRequest) GetCreateStream() *CreateIngestStreamRequest {
+	if x != nil {
+		return x.CreateStream
+	}
+	return nil
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// First message on a PersistentStream RPC when resuming an existing stream.
+type ResumeIngestStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// How the stream to resume is identified. Only stream_id is supported by
+	// this SDK; stream_name is reserved for future server support.
+	//
+	// Types that are valid to be assigned to Identifier:
+	//
+	//	*ResumeIngestStreamRequest_StreamId
+	Identifier isResumeIngestStreamRequest_Identifier `protobuf_oneof:"identifier"`
+	// Protocol buffer descriptor for record serialization/deserialization.
+	//
+	// Required when the stream was created with record_type PROTO. Must be
+	// compatible with the target table's schema. Not used for JSON or ARROW_IPC
+	// record types.
+	DescriptorProto []byte `protobuf:"bytes,2,opt,name=descriptor_proto,json=descriptorProto" json:"descriptor_proto,omitempty"`
+	// Record type accepted by the resumed stream. Must match the type used when
+	// the persistent stream was created.
+	RecordType    *RecordType `protobuf:"varint,3,opt,name=record_type,json=recordType,enum=databricks.zerobus.RecordType" json:"record_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeIngestStreamRequest) Reset() {
+	*x = ResumeIngestStreamRequest{}
+	mi := &file_zerobus_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeIngestStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeIngestStreamRequest) ProtoMessage() {}
+
+func (x *ResumeIngestStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeIngestStreamRequest.ProtoReflect.Descriptor instead.
+func (*ResumeIngestStreamRequest) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ResumeIngestStreamRequest) GetIdentifier() isResumeIngestStreamRequest_Identifier {
+	if x != nil {
+		return x.Identifier
+	}
+	return nil
+}
+
+func (x *ResumeIngestStreamRequest) GetStreamId() string {
+	if x != nil {
+		if x, ok := x.Identifier.(*ResumeIngestStreamRequest_StreamId); ok {
+			return x.StreamId
+		}
+	}
+	return ""
+}
+
+func (x *ResumeIngestStreamRequest) GetDescriptorProto() []byte {
+	if x != nil {
+		return x.DescriptorProto
+	}
+	return nil
+}
+
+func (x *ResumeIngestStreamRequest) GetRecordType() RecordType {
+	if x != nil && x.RecordType != nil {
+		return *x.RecordType
+	}
+	return RecordType_RECORD_TYPE_UNSPECIFIED
+}
+
+type isResumeIngestStreamRequest_Identifier interface {
+	isResumeIngestStreamRequest_Identifier()
+}
+
+type ResumeIngestStreamRequest_StreamId struct {
+	// The durable stream identity returned by a prior create.
+	StreamId string `protobuf:"bytes,1,opt,name=stream_id,json=streamId,oneof"`
+}
+
+func (*ResumeIngestStreamRequest_StreamId) isResumeIngestStreamRequest_Identifier() {}
+
+// IN DEVELOPMENT: may change or be removed.
+type ResumeIngestStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Resume watermark: resume sending from last_committed_offset + 1.
+	// Absent means nothing has been committed yet (resume from 0).
+	LastCommittedOffset *int64 `protobuf:"varint,1,opt,name=last_committed_offset,json=lastCommittedOffset" json:"last_committed_offset,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *ResumeIngestStreamResponse) Reset() {
+	*x = ResumeIngestStreamResponse{}
+	mi := &file_zerobus_service_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeIngestStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeIngestStreamResponse) ProtoMessage() {}
+
+func (x *ResumeIngestStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeIngestStreamResponse.ProtoReflect.Descriptor instead.
+func (*ResumeIngestStreamResponse) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ResumeIngestStreamResponse) GetLastCommittedOffset() int64 {
+	if x != nil && x.LastCommittedOffset != nil {
+		return *x.LastCommittedOffset
+	}
+	return 0
+}
+
+// IN DEVELOPMENT: may change or be removed.
+// A message in the PersistentStream request stream. The first message is a
+// create_stream or resume_stream; the rest are ingest_record(_batch).
+type PersistentStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*PersistentStreamRequest_CreateStream
+	//	*PersistentStreamRequest_ResumeStream
+	//	*PersistentStreamRequest_IngestRecord
+	//	*PersistentStreamRequest_IngestRecordBatch
+	Payload       isPersistentStreamRequest_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PersistentStreamRequest) Reset() {
+	*x = PersistentStreamRequest{}
+	mi := &file_zerobus_service_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PersistentStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PersistentStreamRequest) ProtoMessage() {}
+
+func (x *PersistentStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PersistentStreamRequest.ProtoReflect.Descriptor instead.
+func (*PersistentStreamRequest) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *PersistentStreamRequest) GetPayload() isPersistentStreamRequest_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *PersistentStreamRequest) GetCreateStream() *CreatePersistentStreamRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamRequest_CreateStream); ok {
+			return x.CreateStream
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamRequest) GetResumeStream() *ResumeIngestStreamRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamRequest_ResumeStream); ok {
+			return x.ResumeStream
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamRequest) GetIngestRecord() *IngestRecordRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamRequest_IngestRecord); ok {
+			return x.IngestRecord
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamRequest) GetIngestRecordBatch() *IngestRecordBatchRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamRequest_IngestRecordBatch); ok {
+			return x.IngestRecordBatch
+		}
+	}
+	return nil
+}
+
+type isPersistentStreamRequest_Payload interface {
+	isPersistentStreamRequest_Payload()
+}
+
+type PersistentStreamRequest_CreateStream struct {
+	CreateStream *CreatePersistentStreamRequest `protobuf:"bytes,1,opt,name=create_stream,json=createStream,oneof"`
+}
+
+type PersistentStreamRequest_ResumeStream struct {
+	ResumeStream *ResumeIngestStreamRequest `protobuf:"bytes,2,opt,name=resume_stream,json=resumeStream,oneof"`
+}
+
+type PersistentStreamRequest_IngestRecord struct {
+	IngestRecord *IngestRecordRequest `protobuf:"bytes,3,opt,name=ingest_record,json=ingestRecord,oneof"`
+}
+
+type PersistentStreamRequest_IngestRecordBatch struct {
+	IngestRecordBatch *IngestRecordBatchRequest `protobuf:"bytes,4,opt,name=ingest_record_batch,json=ingestRecordBatch,oneof"`
+}
+
+func (*PersistentStreamRequest_CreateStream) isPersistentStreamRequest_Payload() {}
+
+func (*PersistentStreamRequest_ResumeStream) isPersistentStreamRequest_Payload() {}
+
+func (*PersistentStreamRequest_IngestRecord) isPersistentStreamRequest_Payload() {}
+
+func (*PersistentStreamRequest_IngestRecordBatch) isPersistentStreamRequest_Payload() {}
+
+// IN DEVELOPMENT: may change or be removed.
+// A message in the PersistentStream response stream.
+type PersistentStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*PersistentStreamResponse_CreateStreamResponse
+	//	*PersistentStreamResponse_ResumeStreamResponse
+	//	*PersistentStreamResponse_IngestRecordResponse
+	//	*PersistentStreamResponse_CloseStreamSignal
+	Payload       isPersistentStreamResponse_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PersistentStreamResponse) Reset() {
+	*x = PersistentStreamResponse{}
+	mi := &file_zerobus_service_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PersistentStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PersistentStreamResponse) ProtoMessage() {}
+
+func (x *PersistentStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PersistentStreamResponse.ProtoReflect.Descriptor instead.
+func (*PersistentStreamResponse) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *PersistentStreamResponse) GetPayload() isPersistentStreamResponse_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *PersistentStreamResponse) GetCreateStreamResponse() *CreateIngestStreamResponse {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamResponse_CreateStreamResponse); ok {
+			return x.CreateStreamResponse
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamResponse) GetResumeStreamResponse() *ResumeIngestStreamResponse {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamResponse_ResumeStreamResponse); ok {
+			return x.ResumeStreamResponse
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamResponse) GetIngestRecordResponse() *IngestRecordResponse {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamResponse_IngestRecordResponse); ok {
+			return x.IngestRecordResponse
+		}
+	}
+	return nil
+}
+
+func (x *PersistentStreamResponse) GetCloseStreamSignal() *CloseStreamSignal {
+	if x != nil {
+		if x, ok := x.Payload.(*PersistentStreamResponse_CloseStreamSignal); ok {
+			return x.CloseStreamSignal
+		}
+	}
+	return nil
+}
+
+type isPersistentStreamResponse_Payload interface {
+	isPersistentStreamResponse_Payload()
+}
+
+type PersistentStreamResponse_CreateStreamResponse struct {
+	CreateStreamResponse *CreateIngestStreamResponse `protobuf:"bytes,1,opt,name=create_stream_response,json=createStreamResponse,oneof"`
+}
+
+type PersistentStreamResponse_ResumeStreamResponse struct {
+	ResumeStreamResponse *ResumeIngestStreamResponse `protobuf:"bytes,2,opt,name=resume_stream_response,json=resumeStreamResponse,oneof"`
+}
+
+type PersistentStreamResponse_IngestRecordResponse struct {
+	IngestRecordResponse *IngestRecordResponse `protobuf:"bytes,3,opt,name=ingest_record_response,json=ingestRecordResponse,oneof"`
+}
+
+type PersistentStreamResponse_CloseStreamSignal struct {
+	CloseStreamSignal *CloseStreamSignal `protobuf:"bytes,4,opt,name=close_stream_signal,json=closeStreamSignal,oneof"`
+}
+
+func (*PersistentStreamResponse_CreateStreamResponse) isPersistentStreamResponse_Payload() {}
+
+func (*PersistentStreamResponse_ResumeStreamResponse) isPersistentStreamResponse_Payload() {}
+
+func (*PersistentStreamResponse_IngestRecordResponse) isPersistentStreamResponse_Payload() {}
+
+func (*PersistentStreamResponse_CloseStreamSignal) isPersistentStreamResponse_Payload() {}
+
+// IN DEVELOPMENT: may change or be removed.
+type RetireStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Three part name of the table the stream belongs to.
+	TableName *string `protobuf:"bytes,1,opt,name=table_name,json=tableName" json:"table_name,omitempty"`
+	// How the stream to retire is identified. Only stream_id is currently
+	// supported; stream_name is reserved for future server support.
+	//
+	// Types that are valid to be assigned to Identifier:
+	//
+	//	*RetireStreamRequest_StreamId
+	Identifier    isRetireStreamRequest_Identifier `protobuf_oneof:"identifier"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetireStreamRequest) Reset() {
+	*x = RetireStreamRequest{}
+	mi := &file_zerobus_service_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetireStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetireStreamRequest) ProtoMessage() {}
+
+func (x *RetireStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetireStreamRequest.ProtoReflect.Descriptor instead.
+func (*RetireStreamRequest) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *RetireStreamRequest) GetTableName() string {
+	if x != nil && x.TableName != nil {
+		return *x.TableName
+	}
+	return ""
+}
+
+func (x *RetireStreamRequest) GetIdentifier() isRetireStreamRequest_Identifier {
+	if x != nil {
+		return x.Identifier
+	}
+	return nil
+}
+
+func (x *RetireStreamRequest) GetStreamId() string {
+	if x != nil {
+		if x, ok := x.Identifier.(*RetireStreamRequest_StreamId); ok {
+			return x.StreamId
+		}
+	}
+	return ""
+}
+
+type isRetireStreamRequest_Identifier interface {
+	isRetireStreamRequest_Identifier()
+}
+
+type RetireStreamRequest_StreamId struct {
+	// The persistent stream to retire permanently.
+	StreamId string `protobuf:"bytes,2,opt,name=stream_id,json=streamId,oneof"`
+}
+
+func (*RetireStreamRequest_StreamId) isRetireStreamRequest_Identifier() {}
+
+// IN DEVELOPMENT: may change or be removed.
+// Empty: success or failure is carried by the gRPC status code.
+type RetireStreamResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetireStreamResponse) Reset() {
+	*x = RetireStreamResponse{}
+	mi := &file_zerobus_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetireStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetireStreamResponse) ProtoMessage() {}
+
+func (x *RetireStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zerobus_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetireStreamResponse.ProtoReflect.Descriptor instead.
+func (*RetireStreamResponse) Descriptor() ([]byte, []int) {
+	return file_zerobus_service_proto_rawDescGZIP(), []int{16}
+}
 
 var File_zerobus_service_proto protoreflect.FileDescriptor
 
@@ -779,14 +1403,47 @@ const file_zerobus_service_proto_rawDesc = "" +
 	"\x16create_stream_response\x18\x01 \x01(\v2..databricks.zerobus.CreateIngestStreamResponseH\x00R\x14createStreamResponse\x12`\n" +
 	"\x16ingest_record_response\x18\x02 \x01(\v2(.databricks.zerobus.IngestRecordResponseH\x00R\x14ingestRecordResponse\x12W\n" +
 	"\x13close_stream_signal\x18\x03 \x01(\v2%.databricks.zerobus.CloseStreamSignalH\x00R\x11closeStreamSignalB\t\n" +
-	"\apayload*>\n" +
+	"\apayload\"\x86\x01\n" +
+	"\x1dCreatePersistentStreamRequest\x12R\n" +
+	"\rcreate_stream\x18\x01 \x01(\v2-.databricks.zerobus.CreateIngestStreamRequestR\fcreateStreamJ\x04\b\x02\x10\x03R\vstream_name\"\xc7\x01\n" +
+	"\x19ResumeIngestStreamRequest\x12\x1d\n" +
+	"\tstream_id\x18\x01 \x01(\tH\x00R\bstreamId\x12)\n" +
+	"\x10descriptor_proto\x18\x02 \x01(\fR\x0fdescriptorProto\x12?\n" +
+	"\vrecord_type\x18\x03 \x01(\x0e2\x1e.databricks.zerobus.RecordTypeR\n" +
+	"recordTypeB\f\n" +
+	"\n" +
+	"identifierJ\x04\b\x04\x10\x05R\vstream_name\"P\n" +
+	"\x1aResumeIngestStreamResponse\x122\n" +
+	"\x15last_committed_offset\x18\x01 \x01(\x03R\x13lastCommittedOffset\"\x84\x03\n" +
+	"\x17PersistentStreamRequest\x12X\n" +
+	"\rcreate_stream\x18\x01 \x01(\v21.databricks.zerobus.CreatePersistentStreamRequestH\x00R\fcreateStream\x12T\n" +
+	"\rresume_stream\x18\x02 \x01(\v2-.databricks.zerobus.ResumeIngestStreamRequestH\x00R\fresumeStream\x12N\n" +
+	"\ringest_record\x18\x03 \x01(\v2'.databricks.zerobus.IngestRecordRequestH\x00R\fingestRecord\x12^\n" +
+	"\x13ingest_record_batch\x18\x04 \x01(\v2,.databricks.zerobus.IngestRecordBatchRequestH\x00R\x11ingestRecordBatchB\t\n" +
+	"\apayload\"\xb0\x03\n" +
+	"\x18PersistentStreamResponse\x12f\n" +
+	"\x16create_stream_response\x18\x01 \x01(\v2..databricks.zerobus.CreateIngestStreamResponseH\x00R\x14createStreamResponse\x12f\n" +
+	"\x16resume_stream_response\x18\x02 \x01(\v2..databricks.zerobus.ResumeIngestStreamResponseH\x00R\x14resumeStreamResponse\x12`\n" +
+	"\x16ingest_record_response\x18\x03 \x01(\v2(.databricks.zerobus.IngestRecordResponseH\x00R\x14ingestRecordResponse\x12W\n" +
+	"\x13close_stream_signal\x18\x04 \x01(\v2%.databricks.zerobus.CloseStreamSignalH\x00R\x11closeStreamSignalB\t\n" +
+	"\apayload\"t\n" +
+	"\x13RetireStreamRequest\x12\x1d\n" +
+	"\n" +
+	"table_name\x18\x01 \x01(\tR\ttableName\x12\x1d\n" +
+	"\tstream_id\x18\x02 \x01(\tH\x00R\bstreamIdB\f\n" +
+	"\n" +
+	"identifierJ\x04\b\x03\x10\x04R\vstream_name\"\x16\n" +
+	"\x14RetireStreamResponse*>\n" +
 	"\n" +
 	"RecordType\x12\x1b\n" +
 	"\x17RECORD_TYPE_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05PROTO\x10\x01\x12\b\n" +
-	"\x04JSON\x10\x022y\n" +
+	"\x04JSON\x10\x022\xcf\x02\n" +
 	"\aZerobus\x12n\n" +
-	"\x0fEphemeralStream\x12*.databricks.zerobus.EphemeralStreamRequest\x1a+.databricks.zerobus.EphemeralStreamResponse(\x010\x01B=Z;github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
+	"\x0fEphemeralStream\x12*.databricks.zerobus.EphemeralStreamRequest\x1a+.databricks.zerobus.EphemeralStreamResponse(\x010\x01\x12q\n" +
+	"\x10PersistentStream\x12+.databricks.zerobus.PersistentStreamRequest\x1a,.databricks.zerobus.PersistentStreamResponse(\x010\x01\x12a\n" +
+	"\fRetireStream\x12'.databricks.zerobus.RetireStreamRequest\x1a(.databricks.zerobus.RetireStreamResponseB(\n" +
+	"\x16com.databricks.zerobusB\fZerobusProtoP\x01"
 
 var (
 	file_zerobus_service_proto_rawDescOnce sync.Once
@@ -801,20 +1458,27 @@ func file_zerobus_service_proto_rawDescGZIP() []byte {
 }
 
 var file_zerobus_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_zerobus_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_zerobus_service_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_zerobus_service_proto_goTypes = []any{
-	(RecordType)(0),                    // 0: databricks.zerobus.RecordType
-	(*JsonRecordBatch)(nil),            // 1: databricks.zerobus.JsonRecordBatch
-	(*ProtoEncodedRecordBatch)(nil),    // 2: databricks.zerobus.ProtoEncodedRecordBatch
-	(*CreateIngestStreamRequest)(nil),  // 3: databricks.zerobus.CreateIngestStreamRequest
-	(*CreateIngestStreamResponse)(nil), // 4: databricks.zerobus.CreateIngestStreamResponse
-	(*IngestRecordRequest)(nil),        // 5: databricks.zerobus.IngestRecordRequest
-	(*IngestRecordBatchRequest)(nil),   // 6: databricks.zerobus.IngestRecordBatchRequest
-	(*EphemeralStreamRequest)(nil),     // 7: databricks.zerobus.EphemeralStreamRequest
-	(*IngestRecordResponse)(nil),       // 8: databricks.zerobus.IngestRecordResponse
-	(*CloseStreamSignal)(nil),          // 9: databricks.zerobus.CloseStreamSignal
-	(*EphemeralStreamResponse)(nil),    // 10: databricks.zerobus.EphemeralStreamResponse
-	(*durationpb.Duration)(nil),        // 11: google.protobuf.Duration
+	(RecordType)(0),                       // 0: databricks.zerobus.RecordType
+	(*JsonRecordBatch)(nil),               // 1: databricks.zerobus.JsonRecordBatch
+	(*ProtoEncodedRecordBatch)(nil),       // 2: databricks.zerobus.ProtoEncodedRecordBatch
+	(*CreateIngestStreamRequest)(nil),     // 3: databricks.zerobus.CreateIngestStreamRequest
+	(*CreateIngestStreamResponse)(nil),    // 4: databricks.zerobus.CreateIngestStreamResponse
+	(*IngestRecordRequest)(nil),           // 5: databricks.zerobus.IngestRecordRequest
+	(*IngestRecordBatchRequest)(nil),      // 6: databricks.zerobus.IngestRecordBatchRequest
+	(*EphemeralStreamRequest)(nil),        // 7: databricks.zerobus.EphemeralStreamRequest
+	(*IngestRecordResponse)(nil),          // 8: databricks.zerobus.IngestRecordResponse
+	(*CloseStreamSignal)(nil),             // 9: databricks.zerobus.CloseStreamSignal
+	(*EphemeralStreamResponse)(nil),       // 10: databricks.zerobus.EphemeralStreamResponse
+	(*CreatePersistentStreamRequest)(nil), // 11: databricks.zerobus.CreatePersistentStreamRequest
+	(*ResumeIngestStreamRequest)(nil),     // 12: databricks.zerobus.ResumeIngestStreamRequest
+	(*ResumeIngestStreamResponse)(nil),    // 13: databricks.zerobus.ResumeIngestStreamResponse
+	(*PersistentStreamRequest)(nil),       // 14: databricks.zerobus.PersistentStreamRequest
+	(*PersistentStreamResponse)(nil),      // 15: databricks.zerobus.PersistentStreamResponse
+	(*RetireStreamRequest)(nil),           // 16: databricks.zerobus.RetireStreamRequest
+	(*RetireStreamResponse)(nil),          // 17: databricks.zerobus.RetireStreamResponse
+	(*durationpb.Duration)(nil),           // 18: google.protobuf.Duration
 }
 var file_zerobus_service_proto_depIdxs = []int32{
 	0,  // 0: databricks.zerobus.CreateIngestStreamRequest.record_type:type_name -> databricks.zerobus.RecordType
@@ -823,17 +1487,31 @@ var file_zerobus_service_proto_depIdxs = []int32{
 	3,  // 3: databricks.zerobus.EphemeralStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
 	5,  // 4: databricks.zerobus.EphemeralStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
 	6,  // 5: databricks.zerobus.EphemeralStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
-	11, // 6: databricks.zerobus.CloseStreamSignal.duration:type_name -> google.protobuf.Duration
+	18, // 6: databricks.zerobus.CloseStreamSignal.duration:type_name -> google.protobuf.Duration
 	4,  // 7: databricks.zerobus.EphemeralStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
 	8,  // 8: databricks.zerobus.EphemeralStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
 	9,  // 9: databricks.zerobus.EphemeralStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
-	7,  // 10: databricks.zerobus.Zerobus.EphemeralStream:input_type -> databricks.zerobus.EphemeralStreamRequest
-	10, // 11: databricks.zerobus.Zerobus.EphemeralStream:output_type -> databricks.zerobus.EphemeralStreamResponse
-	11, // [11:12] is the sub-list for method output_type
-	10, // [10:11] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	3,  // 10: databricks.zerobus.CreatePersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreateIngestStreamRequest
+	0,  // 11: databricks.zerobus.ResumeIngestStreamRequest.record_type:type_name -> databricks.zerobus.RecordType
+	11, // 12: databricks.zerobus.PersistentStreamRequest.create_stream:type_name -> databricks.zerobus.CreatePersistentStreamRequest
+	12, // 13: databricks.zerobus.PersistentStreamRequest.resume_stream:type_name -> databricks.zerobus.ResumeIngestStreamRequest
+	5,  // 14: databricks.zerobus.PersistentStreamRequest.ingest_record:type_name -> databricks.zerobus.IngestRecordRequest
+	6,  // 15: databricks.zerobus.PersistentStreamRequest.ingest_record_batch:type_name -> databricks.zerobus.IngestRecordBatchRequest
+	4,  // 16: databricks.zerobus.PersistentStreamResponse.create_stream_response:type_name -> databricks.zerobus.CreateIngestStreamResponse
+	13, // 17: databricks.zerobus.PersistentStreamResponse.resume_stream_response:type_name -> databricks.zerobus.ResumeIngestStreamResponse
+	8,  // 18: databricks.zerobus.PersistentStreamResponse.ingest_record_response:type_name -> databricks.zerobus.IngestRecordResponse
+	9,  // 19: databricks.zerobus.PersistentStreamResponse.close_stream_signal:type_name -> databricks.zerobus.CloseStreamSignal
+	7,  // 20: databricks.zerobus.Zerobus.EphemeralStream:input_type -> databricks.zerobus.EphemeralStreamRequest
+	14, // 21: databricks.zerobus.Zerobus.PersistentStream:input_type -> databricks.zerobus.PersistentStreamRequest
+	16, // 22: databricks.zerobus.Zerobus.RetireStream:input_type -> databricks.zerobus.RetireStreamRequest
+	10, // 23: databricks.zerobus.Zerobus.EphemeralStream:output_type -> databricks.zerobus.EphemeralStreamResponse
+	15, // 24: databricks.zerobus.Zerobus.PersistentStream:output_type -> databricks.zerobus.PersistentStreamResponse
+	17, // 25: databricks.zerobus.Zerobus.RetireStream:output_type -> databricks.zerobus.RetireStreamResponse
+	23, // [23:26] is the sub-list for method output_type
+	20, // [20:23] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_zerobus_service_proto_init() }
@@ -859,13 +1537,31 @@ func file_zerobus_service_proto_init() {
 		(*EphemeralStreamResponse_IngestRecordResponse)(nil),
 		(*EphemeralStreamResponse_CloseStreamSignal)(nil),
 	}
+	file_zerobus_service_proto_msgTypes[11].OneofWrappers = []any{
+		(*ResumeIngestStreamRequest_StreamId)(nil),
+	}
+	file_zerobus_service_proto_msgTypes[13].OneofWrappers = []any{
+		(*PersistentStreamRequest_CreateStream)(nil),
+		(*PersistentStreamRequest_ResumeStream)(nil),
+		(*PersistentStreamRequest_IngestRecord)(nil),
+		(*PersistentStreamRequest_IngestRecordBatch)(nil),
+	}
+	file_zerobus_service_proto_msgTypes[14].OneofWrappers = []any{
+		(*PersistentStreamResponse_CreateStreamResponse)(nil),
+		(*PersistentStreamResponse_ResumeStreamResponse)(nil),
+		(*PersistentStreamResponse_IngestRecordResponse)(nil),
+		(*PersistentStreamResponse_CloseStreamSignal)(nil),
+	}
+	file_zerobus_service_proto_msgTypes[15].OneofWrappers = []any{
+		(*RetireStreamRequest_StreamId)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_zerobus_service_proto_rawDesc), len(file_zerobus_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   10,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/purego/internal/zerobuspb/zerobus_service_grpc.pb.go
+++ b/purego/internal/zerobuspb/zerobus_service_grpc.pb.go
@@ -19,14 +19,37 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Zerobus_EphemeralStream_FullMethodName = "/databricks.zerobus.Zerobus/EphemeralStream"
+	Zerobus_EphemeralStream_FullMethodName  = "/databricks.zerobus.Zerobus/EphemeralStream"
+	Zerobus_PersistentStream_FullMethodName = "/databricks.zerobus.Zerobus/PersistentStream"
+	Zerobus_RetireStream_FullMethodName     = "/databricks.zerobus.Zerobus/RetireStream"
 )
 
 // ZerobusClient is the client API for Zerobus service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// The Zerobus service provides streaming capabilities for ingesting data records
+// into Databricks tables with high throughput and low latency.
 type ZerobusClient interface {
+	// EphemeralStream creates a streaming session for ingesting records.
+	//
+	// This is a bidirectional streaming RPC that allows clients to:
+	// - Create new ephemeral ingestion streams by sending a CreateIngestStreamRequest.
+	// - Ingest records by sending an IngestRecordRequest.
+	// - Receive durability confirmations via IngestRecordResponse.
 	EphemeralStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[EphemeralStreamRequest, EphemeralStreamResponse], error)
+	// IN DEVELOPMENT: may change or be removed.
+	//
+	// Creates or resumes a durable (exactly-once) ingestion stream. The first
+	// message is a CreatePersistentStreamRequest (new stream) or a
+	// ResumeIngestStreamRequest (reconnect by stream_id); everything after is
+	// ingest_record / ingest_record_batch, as on EphemeralStream.
+	PersistentStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[PersistentStreamRequest, PersistentStreamResponse], error)
+	// IN DEVELOPMENT: may change or be removed.
+	//
+	// Permanently retires a persistent stream. Unary and idempotent; callable
+	// without an open connection. A retired stream can never be resumed.
+	RetireStream(ctx context.Context, in *RetireStreamRequest, opts ...grpc.CallOption) (*RetireStreamResponse, error)
 }
 
 type zerobusClient struct {
@@ -50,11 +73,55 @@ func (c *zerobusClient) EphemeralStream(ctx context.Context, opts ...grpc.CallOp
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Zerobus_EphemeralStreamClient = grpc.BidiStreamingClient[EphemeralStreamRequest, EphemeralStreamResponse]
 
+func (c *zerobusClient) PersistentStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[PersistentStreamRequest, PersistentStreamResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Zerobus_ServiceDesc.Streams[1], Zerobus_PersistentStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[PersistentStreamRequest, PersistentStreamResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Zerobus_PersistentStreamClient = grpc.BidiStreamingClient[PersistentStreamRequest, PersistentStreamResponse]
+
+func (c *zerobusClient) RetireStream(ctx context.Context, in *RetireStreamRequest, opts ...grpc.CallOption) (*RetireStreamResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RetireStreamResponse)
+	err := c.cc.Invoke(ctx, Zerobus_RetireStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ZerobusServer is the server API for Zerobus service.
 // All implementations must embed UnimplementedZerobusServer
 // for forward compatibility.
+//
+// The Zerobus service provides streaming capabilities for ingesting data records
+// into Databricks tables with high throughput and low latency.
 type ZerobusServer interface {
+	// EphemeralStream creates a streaming session for ingesting records.
+	//
+	// This is a bidirectional streaming RPC that allows clients to:
+	// - Create new ephemeral ingestion streams by sending a CreateIngestStreamRequest.
+	// - Ingest records by sending an IngestRecordRequest.
+	// - Receive durability confirmations via IngestRecordResponse.
 	EphemeralStream(grpc.BidiStreamingServer[EphemeralStreamRequest, EphemeralStreamResponse]) error
+	// IN DEVELOPMENT: may change or be removed.
+	//
+	// Creates or resumes a durable (exactly-once) ingestion stream. The first
+	// message is a CreatePersistentStreamRequest (new stream) or a
+	// ResumeIngestStreamRequest (reconnect by stream_id); everything after is
+	// ingest_record / ingest_record_batch, as on EphemeralStream.
+	PersistentStream(grpc.BidiStreamingServer[PersistentStreamRequest, PersistentStreamResponse]) error
+	// IN DEVELOPMENT: may change or be removed.
+	//
+	// Permanently retires a persistent stream. Unary and idempotent; callable
+	// without an open connection. A retired stream can never be resumed.
+	RetireStream(context.Context, *RetireStreamRequest) (*RetireStreamResponse, error)
 	mustEmbedUnimplementedZerobusServer()
 }
 
@@ -67,6 +134,12 @@ type UnimplementedZerobusServer struct{}
 
 func (UnimplementedZerobusServer) EphemeralStream(grpc.BidiStreamingServer[EphemeralStreamRequest, EphemeralStreamResponse]) error {
 	return status.Error(codes.Unimplemented, "method EphemeralStream not implemented")
+}
+func (UnimplementedZerobusServer) PersistentStream(grpc.BidiStreamingServer[PersistentStreamRequest, PersistentStreamResponse]) error {
+	return status.Error(codes.Unimplemented, "method PersistentStream not implemented")
+}
+func (UnimplementedZerobusServer) RetireStream(context.Context, *RetireStreamRequest) (*RetireStreamResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RetireStream not implemented")
 }
 func (UnimplementedZerobusServer) mustEmbedUnimplementedZerobusServer() {}
 func (UnimplementedZerobusServer) testEmbeddedByValue()                 {}
@@ -96,17 +169,53 @@ func _Zerobus_EphemeralStream_Handler(srv interface{}, stream grpc.ServerStream)
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Zerobus_EphemeralStreamServer = grpc.BidiStreamingServer[EphemeralStreamRequest, EphemeralStreamResponse]
 
+func _Zerobus_PersistentStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(ZerobusServer).PersistentStream(&grpc.GenericServerStream[PersistentStreamRequest, PersistentStreamResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Zerobus_PersistentStreamServer = grpc.BidiStreamingServer[PersistentStreamRequest, PersistentStreamResponse]
+
+func _Zerobus_RetireStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RetireStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ZerobusServer).RetireStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Zerobus_RetireStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ZerobusServer).RetireStream(ctx, req.(*RetireStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Zerobus_ServiceDesc is the grpc.ServiceDesc for Zerobus service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var Zerobus_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "databricks.zerobus.Zerobus",
 	HandlerType: (*ZerobusServer)(nil),
-	Methods:     []grpc.MethodDesc{},
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "RetireStream",
+			Handler:    _Zerobus_RetireStream_Handler,
+		},
+	},
 	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "EphemeralStream",
 			Handler:       _Zerobus_EphemeralStream_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "PersistentStream",
+			Handler:       _Zerobus_PersistentStream_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
 		},

--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -18,6 +18,37 @@
 
 ### Breaking Changes
 
+- **Adding the Avro record type extends the publicly re-exported gRPC types, which
+  can break compilation for some downstream crates.** The additions
+  (`RecordType::AVRO`, `CreateIngestStreamRequest.avro_schema_json`,
+  `IngestRecordRequest.avro_encoded_record`, `IngestRecordBatchRequest.avro_batch`, and
+  the new `AvroRecordBatch`) are wire-compatible — no runtime or behavior change. But
+  because the crate re-exports the prost-generated types
+  (`databricks_zerobus_ingest_sdk::databricks::zerobus`), code that matches or builds
+  them exhaustively will no longer compile. The builder API (`.json()`,
+  `.compiled_proto()`, `.dynamic_proto()`) and the other-language SDKs are unaffected.
+  The long-term fix (hiding these generated types) is tracked in
+  [#822](https://github.com/databricks/zerobus-sdk/issues/822).
+
+  Migration — every fix is additive:
+  - Exhaustive `match` on `RecordType` with no `_` arm → add `_ => { … }` (or a
+    `RecordType::Avro` arm). (E0004)
+  - Exhaustive `match` on the `ingest_record_request::Record` or
+    `ingest_record_batch_request::Batch` oneof → add a `_ => { … }` arm. (E0004)
+  - Full-field struct literal of `CreateIngestStreamRequest` → add
+    `..Default::default()`. (E0063)
+  - Full-field struct pattern/destructuring of `CreateIngestStreamRequest`
+    (e.g. `let CreateIngestStreamRequest { table_name, descriptor_proto, record_type } = req`)
+    → add `..`. (E0027)
+
+  Unaffected: `x == RecordType::Json`, any `match` that already has a `_` arm, and
+  struct literals/patterns that already use `..`.
+
 ### Deprecations
 
 ### API Changes
+
+- Added the Avro wire surface to the generated gRPC types (`RecordType::AVRO`,
+  `CreateIngestStreamRequest.avro_schema_json`, `IngestRecordRequest.avro_encoded_record`,
+  `IngestRecordBatchRequest.avro_batch`, `AvroRecordBatch`). See **Breaking Changes** for
+  the downstream-compilation impact and migration.

--- a/rust/ffi/src/common.rs
+++ b/rust/ffi/src/common.rs
@@ -184,6 +184,7 @@ pub(crate) fn c_record_type(value: i32) -> RecordType {
     match value {
         1 => RecordType::Proto,
         2 => RecordType::Json,
+        4 => RecordType::Avro,
         _ => RecordType::Unspecified,
     }
 }

--- a/rust/ffi/src/stream.rs
+++ b/rust/ffi/src/stream.rs
@@ -117,6 +117,11 @@ async fn build_stream_from_parts(
             base.compiled_proto(desc)
         }
         RecordType::Json => base.json(),
+        RecordType::Avro => {
+            return Err(ZerobusError::InvalidArgument(
+                "Avro record type is not supported".to_string(),
+            ))
+        }
         RecordType::Unspecified => {
             return Err(ZerobusError::InvalidArgument(
                 "Record type is not specified".to_string(),

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -177,6 +177,7 @@ fn test_cresult_error() {
 fn test_c_record_type_mapping() {
     assert_eq!(c_record_type(1), RecordType::Proto);
     assert_eq!(c_record_type(2), RecordType::Json);
+    assert_eq!(c_record_type(4), RecordType::Avro);
     assert_eq!(c_record_type(999), RecordType::Unspecified);
     assert_eq!(c_record_type(0), RecordType::Unspecified);
 }

--- a/rust/jni/src/sdk.rs
+++ b/rust/jni/src/sdk.rs
@@ -313,6 +313,13 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreateStream
                     base.compiled_proto(desc)
                 }
                 RecordType::Json => base.json(),
+                RecordType::Avro => {
+                    return Err(
+                        databricks_zerobus_ingest_sdk::ZerobusError::InvalidArgument(
+                            "Avro record type is not supported".to_string(),
+                        ),
+                    );
+                }
                 RecordType::Unspecified => {
                     return Err(
                         databricks_zerobus_ingest_sdk::ZerobusError::InvalidArgument(

--- a/rust/sdk/src/stream/grpc/connection.rs
+++ b/rust/sdk/src/stream/grpc/connection.rs
@@ -178,6 +178,8 @@ impl ZerobusStream {
             table_name: Some(table_properties.table_name.to_string()),
             descriptor_proto,
             record_type: Some(record_type.into()),
+            // Avro is not wired into the ephemeral create path yet.
+            avro_schema_json: None,
         });
 
         debug!("Sending CreateStream request.");

--- a/rust/sdk/zerobus_service.proto
+++ b/rust/sdk/zerobus_service.proto
@@ -68,7 +68,6 @@ enum RecordType {
   RECORD_TYPE_UNSPECIFIED = 0;
   PROTO = 1;
   JSON = 2;
-  // 3 is ARROW_IPC on the Zerobus service. 
   reserved 3;
   AVRO = 4;
 }
@@ -131,7 +130,7 @@ message CreateIngestStreamRequest {
   // This descriptor defines the structure of the records being ingested.
   // It must be compatible with the target table's schema.
   //
-  // This is a required field for all stream creation requests.
+  // Required only for streams with record_type = PROTO; ignored otherwise.
   optional bytes descriptor_proto = 3;
 
   // Record type that will be accepted in the stream.
@@ -195,7 +194,7 @@ message IngestRecordBatchRequest {
   optional int64 offset_id = 1;
 
   // Batch of serialized records.
-  // The batch can contain multiple records encoded as either protobuf or JSON.
+  // The batch can contain multiple records encoded as protobuf, JSON, or Avro.
   oneof batch {
     // Batch of protobuf-encoded records. Each record must be serialized according to
     // the protobuf descriptor provided in the CreateIngestStreamRequest.

--- a/rust/sdk/zerobus_service.proto
+++ b/rust/sdk/zerobus_service.proto
@@ -68,6 +68,9 @@ enum RecordType {
   RECORD_TYPE_UNSPECIFIED = 0;
   PROTO = 1;
   JSON = 2;
+  // 3 is ARROW_IPC on the Zerobus service. 
+  reserved 3;
+  AVRO = 4;
 }
 
 /*
@@ -90,6 +93,19 @@ message JsonRecordBatch {
  */
 message ProtoEncodedRecordBatch {
   // Array of protobuf-encoded records.
+  repeated bytes records = 1;
+}
+
+/*
+ * Batch of Avro-encoded records.
+ *
+ * Each element is a single raw Avro binary datum (no framing). The writer
+ * schema is supplied once at stream creation via
+ * CreateIngestStreamRequest.avro_schema_json.
+ */
+message AvroRecordBatch {
+  // Array of raw Avro binary datums. Each datum must be encoded according to
+  // the writer schema provided in CreateIngestStreamRequest.avro_schema_json.
   repeated bytes records = 1;
 }
 
@@ -121,6 +137,12 @@ message CreateIngestStreamRequest {
   // Record type that will be accepted in the stream.
   // Defaults to PROTO for backwards compatibility.
   optional RecordType record_type = 4;
+
+  // Avro writer schema as a JSON-encoded Avro schema string.
+  //
+  // Required when record_type is AVRO. Must be a valid Avro record schema.
+  // Ignored for all other record types.
+  optional string avro_schema_json = 5;
 }
 
 /*
@@ -155,6 +177,10 @@ message IngestRecordRequest {
     // provided in the CreateIngestStreamRequest.
     bytes proto_encoded_record = 2;
     string json_record = 3;
+
+    // A single raw Avro binary datum (no framing). The writer schema is supplied
+    // once at stream creation via CreateIngestStreamRequest.avro_schema_json.
+    bytes avro_encoded_record = 4;
   }
 }
 
@@ -177,6 +203,10 @@ message IngestRecordBatchRequest {
 
     // Batch of JSON-encoded records.
     JsonRecordBatch json_batch = 3;
+
+    // Batch of Avro-encoded records. The writer schema must be provided in
+    // CreateIngestStreamRequest.avro_schema_json.
+    AvroRecordBatch avro_batch = 4;
   }
 }
 
@@ -270,7 +300,7 @@ message ResumeIngestStreamRequest {
   // Protocol buffer descriptor for record serialization/deserialization.
   //
   // Required when the stream was created with record_type PROTO. Must be
-  // compatible with the target table's schema. Not used for JSON or ARROW_IPC
+  // compatible with the target table's schema. Not used for JSON or AVRO
   // record types.
   optional bytes descriptor_proto = 2;
 

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -383,6 +383,7 @@ impl Zerobus for MockZerobusServer {
                                             proto_batch.records.len()
                                         }
                                         Batch::JsonBatch(json_batch) => json_batch.records.len(),
+                                        Batch::AvroBatch(avro_batch) => avro_batch.records.len(),
                                     }
                                 } else {
                                     0

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -1086,6 +1086,11 @@ impl ZerobusSdk {
 
                 let builder = match record_type {
                     RustRecordType::Json => builder.json(),
+                    RustRecordType::Avro => {
+                        return Err(napi::Error::from_reason(
+                            "Avro record type is not supported",
+                        ))
+                    }
                     RustRecordType::Proto | RustRecordType::Unspecified => {
                         let desc = descriptor_proto.ok_or_else(|| {
                             napi::Error::from_reason(

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -42,6 +42,8 @@ pub enum RecordType {
     Json = 0,
     /// Protocol Buffers encoding - records are binary protobuf messages
     Proto = 1,
+    /// Avro encoding - records are raw Avro binary datums (Beta)
+    Avro = 2,
 }
 
 /// Configuration options for the Zerobus stream.
@@ -1018,7 +1020,8 @@ impl ZerobusSdk {
         let record_type = match opts.record_type {
             Some(0) => RustRecordType::Json,
             Some(1) => RustRecordType::Proto,
-            _ => RustRecordType::Proto,
+            Some(2) => RustRecordType::Avro,
+            _ => RustRecordType::Unspecified,
         };
 
         let headers_tsfn = match headers_provider {


### PR DESCRIPTION
## PR stack

- [avro/proto-surface](https://github.com/databricks/zerobus-sdk/pull/811) <- _this PR_
    - [avro/purego](https://github.com/databricks/zerobus-sdk/pull/828)
    - [avro/rust-core](https://github.com/databricks/zerobus-sdk/pull/827)
        - [avro/ffi-c-abi](https://github.com/databricks/zerobus-sdk/pull/830)
            - [avro/go](https://github.com/databricks/zerobus-sdk/pull/831)
            - [avro/cpp](https://github.com/databricks/zerobus-sdk/pull/832)
            - [avro/dotnet](https://github.com/databricks/zerobus-sdk/pull/833)
        - avro/java
        - [avro/python](https://github.com/databricks/zerobus-sdk/pull/851)
        - avro/typescript

## What changes are proposed in this pull request?

Adds the Avro record type to the proto surface (wire contract only) so later PRs can build Avro ingestion on ephemeral streams. No public SDK API and no behavior change yet.

- Proto (`rust/sdk/zerobus_service.proto`): 
   - reserve 3 (ARROW_IPC on the service - this SDK models Arrow as a separate Arrow Flight stream, not a RecordType) 
   - add AVRO = 4; 
   - add `AvroRecordBatch`, `CreateIngestStreamRequest.avro_schema_json`, `IngestRecordRequest.avro_encoded_record`, and `IngestRecordBatchRequest.avro_batch`.
- purego: regenerate `internal/zerobuspb` bindings from the schema. The commit also resyncs pre-existing drift (proto doc-comments + gofmt) and adds a generate CI job that fails if the committed bindings are stale = the gate purego was missing.
- Rust: set `avro_schema_json`: None at the one `CreateIngestStreamRequest` construction site so codegen compiles.

## How is this tested?

```
# Rust - proto compiles + no regressions
cd rust
cargo build -p databricks-zerobus-ingest-sdk
cargo test  -p databricks-zerobus-ingest-sdk

# purego - bindings match the schema (the new CI gate), plus build/vet/test
cd ../purego/internal/zerobuspb
go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2
go generate ./...
cd ../../..
git diff --exit-code -- purego/internal/zerobuspb/   # clean = bindings in sync

cd purego
go build ./...
go vet ./...
go test ./...
```

## Code diff
Most of the code diff is generated (`purego/internal` files): +1005 -87
