### PR TITLE
[Rust] Fall back to system protoc

### DIFF
--- a/rust/NEXT_CHANGELOG.md
+++ b/rust/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 - JSON and protobuf streams now use a dedicated gRPC connection by default.
   Use `ZerobusSdk::builder().connection_per_stream(false)` to retain the prior
   shared HTTP/2 connection behavior. Arrow Flight streams are unchanged.
+- On platforms where vendored `protoc` is not available, fallback to trying `protoc` on `PATH` or `PROTOC` environment variable override.
 
 ### Bug Fixes
 

--- a/rust/sdk/build.rs
+++ b/rust/sdk/build.rs
@@ -5,7 +5,13 @@ use std::env;
 mod zeroparser_proto_build;
 
 fn main() {
-    env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+    if env::var_os("PROTOC").is_none() {
+        if let Ok(protoc) = protoc_bin_vendored::protoc_bin_path() {
+            unsafe {
+                env::set_var("PROTOC", protoc);
+            }
+        }
+    }
     tonic_prost_build::compile_protos("zerobus_service.proto")
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
 

--- a/rust/tests/build.rs
+++ b/rust/tests/build.rs
@@ -1,5 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+    if std::env::var_os("PROTOC").is_none() {
+        if let Ok(protoc) = protoc_bin_vendored::protoc_bin_path() {
+            unsafe {
+                std::env::set_var("PROTOC", protoc);
+            }
+        }
+    }
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)


### PR DESCRIPTION
What/Why: On Illumos current repo will fail at build time because `rust-protoc-bin-vendored` cannot find a `protoc` binary. After this change, build will succeed if there's a suitable `protoc` in your path or a `PROTOC` environment variable set with a suitable path. This makes it possible to compile zerobus-sdk on Illumos.

Changes: 
- Enable zerobus-sdk compilation on platforms without pre-build Google `protoc` binaries.
- New Behavior: if PROTOC env-var set with path, prefer that `protoc` over fetching a pre-built binary from Google.

Upstream: 
- See: https://github.com/stepancheg/rust-protoc-bin-vendored/issues/9

## How is this tested?

I have tested this change building locally on OmniOS as well as running the full test suite [under CI on my fork](https://github.com/notpeter/zerobus-sdk/pull/1).
Passing run [here](https://github.com/notpeter/zerobus-sdk/actions/runs/33526202439/job/99917547908?pr=1).

If you would like to add Illumos to your test suite (via [vmactions/omnios-vm](https://github.com/vmactions/omnios-vm), happy to add that here too.
Similarly [vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm) also exists.