### PR TITLE
[PureGo] [WIP] support for connection per stream

### DIFF
--- a/purego/zerobus/options.go
+++ b/purego/zerobus/options.go
@@ -17,6 +17,7 @@ type sdkConfig struct {
 	tlsConfig                 *tls.Config
 	httpClient                *http.Client
 	dynamicSchemaFetchTimeout time.Duration
+	connectionPerStream       bool
 }
 
 // WithApplicationName appends a caller-supplied identifier such as "my-app/1.0"
@@ -48,6 +49,15 @@ func WithHTTPClient(client *http.Client) Option {
 		if client != nil {
 			c.httpClient = client
 		}
+	}
+}
+
+// WithConnectionPerStream configures the connection per stream flag,
+// if enabled all streams use a dedicated GRPC connection
+// else one shared connection. Default is shared connection
+func WithConnectionPerStream(enabled bool) Option {
+	return func(c *sdkConfig) {
+		c.connectionPerStream = enabled
 	}
 }
 

--- a/purego/zerobus/sdk.go
+++ b/purego/zerobus/sdk.go
@@ -58,6 +58,10 @@ type SDK struct {
 	httpClient                *http.Client
 	dynamicSchemaFetchTimeout time.Duration
 
+	// connection per stream
+	connectionPerStream bool
+	dialConn            func() (*transport.Conn, error)
+
 	// mu guards the open-stream set and closed flag.
 	mu     sync.Mutex
 	closed bool
@@ -80,8 +84,16 @@ func newSDK(conn *transport.Conn, zerobusEndpoint, ucEndpoint string, cfg sdkCon
 		tokenCache:                auth.NewSharedTokenCache(),
 		httpClient:                cfg.httpClient,
 		dynamicSchemaFetchTimeout: fetchTimeout,
+		connectionPerStream:       cfg.connectionPerStream,
 		streams:                   make(map[*Stream]struct{}),
 	}
+}
+
+// newSdkWithDial builds an SDK around a dial func for creating a new connection
+func newSdkWithDial(dialConn func() (*transport.Conn, error), zerobusEndpoint, ucEndpoint string, cfg sdkConfig) *SDK {
+	sdk := newSDK(nil, zerobusEndpoint, ucEndpoint, cfg)
+	sdk.dialConn = dialConn
+	return sdk
 }
 
 // New connects to the Zerobus service and returns an SDK.
@@ -122,7 +134,18 @@ func New(zerobusEndpoint, ucEndpoint string, opts ...Option) (*SDK, error) {
 		dialOpts = append(dialOpts, transport.WithTLSConfig(cfg.tlsConfig))
 	}
 
-	conn, err := transport.Dial(target, dialOpts...)
+	dialConn := func() (*transport.Conn, error) {
+		return transport.Dial(target, dialOpts...)
+	}
+
+	// Don't create a shared connection if each stream has dedicated conn
+	// pass a dialer so each stream can create its own connection
+	if cfg.connectionPerStream {
+		return newSdkWithDial(dialConn, zerobusEndpoint, ucEndpoint, cfg), nil
+	}
+
+	// shared connection using dialer
+	conn, err := dialConn()
 	if err != nil {
 		return nil, &Error{Op: "New", cause: err, retryable: false}
 	}
@@ -155,8 +178,12 @@ func (s *SDK) Close() error {
 		}()
 	}
 	wg.Wait()
-	// Close the connection after stream teardown.
-	errs[len(open)] = s.conn.Close()
+
+	if !s.connectionPerStream {
+		// Close the connection after stream teardown.
+		errs[len(open)] = s.conn.Close()
+	}
+
 	return wrapErr("Close", errors.Join(errs...))
 }
 
@@ -277,8 +304,23 @@ func (s *SDK) createStreamConfigured(
 	if sc.waitReady {
 		openingCtx = ctx
 	}
-	core, err := stream.NewProtoJSONStream(openingCtx, s.conn, params, sc.cfg, sc.callback)
+
+	// create a new connection for each stream if enabled else shared
+	conn := s.conn
+	if s.connectionPerStream {
+		streamConn, dialErr := s.dialConn()
+		if dialErr != nil {
+			return nil, wrapErr(op, dialErr)
+		}
+		conn = streamConn
+	}
+
+	core, err := stream.NewProtoJSONStream(openingCtx, conn, params, sc.cfg, sc.callback)
 	if err != nil {
+		if s.connectionPerStream {
+			// close stream connection in case of error
+			_ = conn.Close()
+		}
 		return nil, wrapErr(op, err)
 	}
 	st := &Stream{
@@ -292,11 +334,16 @@ func (s *SDK) createStreamConfigured(
 		st.jsonConverter, st.jsonConverterErr = dynamicproto.NewFromDescriptorProtoBytes(sc.descriptor)
 		st.conversionGate = make(chan struct{}, 1)
 	}
+
+	if s.connectionPerStream {
+		st.streamConn = conn
+	}
+
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
 		// Stop the stream created before Close won the race.
-		_ = core.Terminate()
+		_ = st.terminate() // this calls stream.Core.Terminate()
 		return nil, &Error{Op: op, cause: fmt.Errorf("SDK is closed"), retryable: false}
 	}
 	s.streams[st] = struct{}{}

--- a/purego/zerobus/stream.go
+++ b/purego/zerobus/stream.go
@@ -2,9 +2,11 @@ package zerobus
 
 import (
 	"context"
+	"sync"
 
 	"github.com/databricks/zerobus-sdk/purego/internal/dynamicproto"
 	"github.com/databricks/zerobus-sdk/purego/internal/stream"
+	"github.com/databricks/zerobus-sdk/purego/internal/transport"
 	"github.com/databricks/zerobus-sdk/purego/internal/zerobuspb"
 )
 
@@ -18,6 +20,10 @@ type Stream struct {
 	conversionGate          chan struct{}
 	maxBatchRecords         int
 	maxBufferedPayloadBytes int64
+
+	// Dedicated connection for stream
+	streamConn    *transport.Conn
+	connCloseOnce sync.Once
 	// sdk is the SDK that created this stream. Close deregisters from it so a
 	// long-lived SDK does not retain streams the caller has already closed.
 	sdk *SDK
@@ -97,12 +103,26 @@ func (s *Stream) Close() error {
 	if s.sdk != nil {
 		s.sdk.forget(s)
 	}
+
+	// close the dedicated stream connection if applicable
+	if s.streamConn != nil {
+		s.connCloseOnce.Do(func() {
+			_ = s.streamConn.Close()
+		})
+	}
 	return wrapErr("Close", err)
 }
 
 // terminate tears down the stream without a final flush (used by SDK.Close).
 func (s *Stream) terminate() error {
-	return wrapErr("Close", s.core.Terminate())
+	err := wrapErr("Close", s.core.Terminate())
+	// close the dedicated stream connection if applicable
+	if s.streamConn != nil {
+		s.connCloseOnce.Do(func() {
+			_ = s.streamConn.Close()
+		})
+	}
+	return err
 }
 
 // IsClosed reports whether the stream has been closed or has failed terminally.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds an opt-in `WithConnectionPerStream(bool)` option to the PureGo SDK. When
enabled, each stream opens its own dedicated gRPC connection instead of all
streams sharing one. Each stream owns its connection and closes it on
teardown; `SDK.Close` still owns the shared connection. Default is shared
(opt-in) for now.

**Why:** today all streams from one SDK multiplex over a single connection,
which caps throughput on high-volume workloads and one shared connection means
TCP head-of-line blocking. Dedicated connections isolate that. This is the PureGo side of
#767, following the Rust approach in #795.

## How is this tested?

Still WIP PR, need some initial design review before finalizing
Not tested yet 
`go build` / `go vet` are clean and existing tests pass