### PR TITLE
[Native] Add per-stream connection option

### DIFF
--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### New Features and Improvements
 
+- JSON and protobuf streams now use a dedicated gRPC connection by default.
+  Call `zerobus_sdk_builder_connection_per_stream(builder, false)` before
+  building the SDK to share one HTTP/2 connection across streams. Arrow Flight
+  streams are unchanged.
+
 ### Bug Fixes
 
 ### Documentation
@@ -19,3 +24,6 @@
 ### Deprecations
 
 ### API Changes
+
+- Added the additive `zerobus_sdk_builder_connection_per_stream` builder
+  setter.

--- a/rust/ffi/README.md
+++ b/rust/ffi/README.md
@@ -68,6 +68,25 @@ private static extern IntPtr zerobus_sdk_new(string endpoint, string ucUrl, ref 
 // Link with -lzerobus_ffi
 ```
 
+### SDK connection ownership
+
+Each JSON/protobuf stream uses a dedicated gRPC connection by default. To
+restore shared HTTP/2 multiplexing, configure the builder before consuming it:
+
+```c
+CZerobusSdkBuilder *builder = zerobus_sdk_builder_new();
+zerobus_sdk_builder_connection_per_stream(builder, false);
+```
+
+Arrow Flight streams already use dedicated connections and are unaffected.
+
+HTTP/2 multiplexes logical streams over one TCP connection. On high-throughput
+workloads over the public internet, packet loss and TCP retransmissions can
+cause head-of-line blocking across every stream on that connection, reducing
+aggregate throughput. Dedicated connections isolate that loss. For many
+smaller, low-throughput streams, shared multiplexing is recommended to reduce
+connection overhead.
+
 ### Async stream creation callback
 
 For callers that do not want to block a thread in the synchronous stream

--- a/rust/ffi/src/builder.rs
+++ b/rust/ffi/src/builder.rs
@@ -138,6 +138,19 @@ pub extern "C" fn zerobus_sdk_builder_application_name(
     })
 }
 
+/// Controls whether each JSON/protobuf stream receives a dedicated gRPC
+/// connection. Enabled by default. Set to false to share one connection across
+/// all streams created from the SDK. No-op on null.
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_builder_connection_per_stream(
+    builder: *mut CZerobusSdkBuilder,
+    enabled: bool,
+) {
+    ffi_guard(ptr::null_mut(), (), move || unsafe {
+        with_builder(builder, |b| b.connection_per_stream(enabled))
+    })
+}
+
 /// Selects a no-TLS gRPC channel. TLS is on by default.
 #[no_mangle]
 pub extern "C" fn zerobus_sdk_builder_disable_tls(builder: *mut CZerobusSdkBuilder) {

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -2,16 +2,16 @@ use crate::{
     c_record_type, ffi_guard, intern_header_key, validate_sdk_ptr, validate_stream_ptr,
     write_error_result, write_success_result, zerobus_free_error_message,
     zerobus_get_default_config, zerobus_sdk_builder_application_name, zerobus_sdk_builder_build,
-    zerobus_sdk_builder_disable_tls, zerobus_sdk_builder_endpoint, zerobus_sdk_builder_free,
-    zerobus_sdk_builder_new, zerobus_sdk_builder_sdk_identifier,
-    zerobus_sdk_builder_unity_catalog_url, zerobus_sdk_create_stream,
-    zerobus_sdk_create_stream_async, zerobus_sdk_create_stream_with_headers_provider_async,
-    zerobus_sdk_free, zerobus_sdk_recreate_stream_async, zerobus_stream_close_async,
-    zerobus_stream_flush_async, zerobus_stream_get_unacked_records_async,
-    zerobus_stream_ingest_json_record_async, zerobus_stream_ingest_json_records_async,
-    zerobus_stream_ingest_proto_record_async, zerobus_stream_ingest_proto_records_async,
-    zerobus_stream_wait_for_offset_async, CHeaders, CRecordArray, CResult, CallbackHeadersProvider,
-    RecordType, ZerobusError,
+    zerobus_sdk_builder_connection_per_stream, zerobus_sdk_builder_disable_tls,
+    zerobus_sdk_builder_endpoint, zerobus_sdk_builder_free, zerobus_sdk_builder_new,
+    zerobus_sdk_builder_sdk_identifier, zerobus_sdk_builder_unity_catalog_url,
+    zerobus_sdk_create_stream, zerobus_sdk_create_stream_async,
+    zerobus_sdk_create_stream_with_headers_provider_async, zerobus_sdk_free,
+    zerobus_sdk_recreate_stream_async, zerobus_stream_close_async, zerobus_stream_flush_async,
+    zerobus_stream_get_unacked_records_async, zerobus_stream_ingest_json_record_async,
+    zerobus_stream_ingest_json_records_async, zerobus_stream_ingest_proto_record_async,
+    zerobus_stream_ingest_proto_records_async, zerobus_stream_wait_for_offset_async, CHeaders,
+    CRecordArray, CResult, CallbackHeadersProvider, RecordType, ZerobusError,
 };
 use databricks_zerobus_ingest_sdk::HeadersProvider;
 use std::ffi::{CStr, CString};
@@ -316,7 +316,22 @@ fn test_builder_setters_on_null_are_safe() {
     zerobus_sdk_builder_unity_catalog_url(ptr::null_mut(), s.as_ptr());
     zerobus_sdk_builder_sdk_identifier(ptr::null_mut(), s.as_ptr());
     zerobus_sdk_builder_application_name(ptr::null_mut(), s.as_ptr());
+    zerobus_sdk_builder_connection_per_stream(ptr::null_mut(), false);
     zerobus_sdk_builder_disable_tls(ptr::null_mut());
+}
+
+#[test]
+fn test_sdk_builder_connection_per_stream_can_be_disabled() {
+    let endpoint_c = CString::new("https://workspace.zerobus.databricks.com").unwrap();
+    let builder = zerobus_sdk_builder_new();
+    zerobus_sdk_builder_endpoint(builder, endpoint_c.as_ptr());
+    zerobus_sdk_builder_connection_per_stream(builder, false);
+
+    let mut result = CResult::success();
+    let sdk = zerobus_sdk_builder_build(builder, &mut result);
+    assert!(!sdk.is_null());
+    assert!(result.success);
+    zerobus_sdk_free(sdk);
 }
 
 #[test]

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -455,6 +455,13 @@ void zerobus_sdk_builder_sdk_identifier(struct CZerobusSdkBuilder *builder, cons
 void zerobus_sdk_builder_application_name(struct CZerobusSdkBuilder *builder, const char *value);
 
 /**
+ * Controls whether each JSON/protobuf stream receives a dedicated gRPC
+ * connection. Enabled by default. Set to false to share one connection across
+ * all streams created from the SDK. No-op on null.
+ */
+void zerobus_sdk_builder_connection_per_stream(struct CZerobusSdkBuilder *builder, bool enabled);
+
+/**
  * Selects a no-TLS gRPC channel. TLS is on by default.
  */
 void zerobus_sdk_builder_disable_tls(struct CZerobusSdkBuilder *builder);

--- a/rust/jni/src/sdk.rs
+++ b/rust/jni/src/sdk.rs
@@ -52,7 +52,7 @@ impl NativeSdkHandle {
 ///
 /// # JNI Signature
 /// ```java
-/// private static native long nativeCreate(String serverEndpoint, String unityCatalogEndpoint, String applicationName);
+/// private static native long nativeCreate(String serverEndpoint, String unityCatalogEndpoint, String applicationName, boolean connectionPerStream);
 /// ```
 #[no_mangle]
 pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'local>(
@@ -61,6 +61,7 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'loca
     server_endpoint: JString<'local>,
     unity_catalog_endpoint: JString<'local>,
     application_name: JString<'local>,
+    connection_per_stream: jboolean,
 ) -> jlong {
     // Extract the endpoint strings
     let server_endpoint: String = match env.get_string(&server_endpoint) {
@@ -96,7 +97,8 @@ pub extern "system" fn Java_com_databricks_zerobus_ZerobusSdk_nativeCreate<'loca
     let builder = ZerobusSdk::builder()
         .endpoint(server_endpoint)
         .unity_catalog_url(unity_catalog_endpoint)
-        .sdk_identifier(sdk_identifier);
+        .sdk_identifier(sdk_identifier)
+        .connection_per_stream(connection_per_stream != JNI_FALSE);
     let builder = match application_name {
         Some(name) => builder.application_name(name),
         None => builder,


### PR DESCRIPTION
## Summary

- expose `zerobus_sdk_builder_connection_per_stream` through the stable C ABI
- pass the setting through the Java JNI `nativeCreate` bridge
- preserve the Rust SDK default of one dedicated connection per JSON/protobuf stream
- document when shared HTTP/2 multiplexing is preferable

This is the native prerequisite for wrapper PR #794. After this merges, build/release both the C FFI and JNI artifacts. Refresh the five checked-in Go archives from the new FFI build before #794 merges; the JNI build run is consumed by the Java release workflow.

## Testing

- `cargo test -p zerobus-ffi` (90 passed)
- `cargo test -p zerobus-jni` (4 passed)