### PR TITLE
[PureC] Add pure-C SDK skeleton

### DIFF
--- a/purec/.clang-format
+++ b/purec/.clang-format
@@ -1,0 +1,12 @@
+# Formatting for the Zerobus Pure C SDK. Linux brace style (function braces on
+# their own line, control-statement braces on the same line), 4-space indent,
+# 80-column limit.
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 80
+BreakBeforeBraces: Linux
+AlignAfterOpenBracket: Align
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+SortIncludes: true

--- a/purec/.gitignore
+++ b/purec/.gitignore
@@ -1,0 +1,7 @@
+# CMake build trees
+/build/
+/build-*/
+compile_commands.json
+
+# clangd index cache
+/.cache/

--- a/purec/CMakeLists.txt
+++ b/purec/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Zerobus Pure C SDK build: the library, examples, and tests.
+#
+# No third-party dependencies — the SDK is the public API, its input validation,
+# and error/ownership plumbing, so it needs nothing beyond a C99 compiler and
+# the C standard library. The networking core (transport, OAuth, record codec,
+# threading) is not implemented yet; it will add nghttp2 and OpenSSL.
+cmake_minimum_required(VERSION 3.13)
+project(zerobus_c LANGUAGES C VERSION 0.0.1)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+# Reject compiler extensions: build as -std=c99, not -std=gnu99, so a GNU-ism
+# cannot slip in unnoticed against the documented C99 baseline.
+set(CMAKE_C_EXTENSIONS OFF)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Hidden visibility by default: only ZEROBUS_API symbols are exported from a
+# shared build. ELF visibility only affects the dynamic symbol table, so the
+# static archive still carries its external zb_* helpers as globals.
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
+# Optional sanitizer, e.g. -DZEROBUS_SANITIZE=address (or thread, undefined).
+set(ZEROBUS_SANITIZE "" CACHE STRING "Runtime sanitizer: address|thread|undefined")
+
+# Treat compiler warnings as errors (used by `make lint`; off for normal builds).
+option(ZEROBUS_WERROR "Treat compiler warnings as errors" OFF)
+
+# Warning flags shared by the library, tests, and example. -Werror is appended
+# only under ZEROBUS_WERROR, so a normal build surfaces warnings without failing.
+set(ZEROBUS_WARN_FLAGS -Wall -Wextra)
+if(ZEROBUS_WERROR)
+  list(APPEND ZEROBUS_WARN_FLAGS -Werror)
+endif()
+
+set(ZEROBUS_SOURCES
+  src/error.c
+  src/utils.c
+  src/sdk.c
+  src/stream.c
+)
+
+add_library(zerobus_c STATIC ${ZEROBUS_SOURCES})
+add_library(zerobus::c ALIAS zerobus_c)
+
+target_include_directories(zerobus_c
+  PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+target_compile_options(zerobus_c PRIVATE ${ZEROBUS_WARN_FLAGS})
+
+# Same sources compiled with ZB_TESTING, which gives ZB_STATIC helpers external
+# linkage so unit tests can call them directly. Not shipped.
+add_library(zerobus_c_testing STATIC ${ZEROBUS_SOURCES})
+target_compile_definitions(zerobus_c_testing PUBLIC ZB_TESTING)
+target_include_directories(zerobus_c_testing
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_options(zerobus_c_testing PRIVATE ${ZEROBUS_WARN_FLAGS})
+
+if(ZEROBUS_SANITIZE)
+  foreach(lib zerobus_c zerobus_c_testing)
+    target_compile_options(${lib} PUBLIC -fsanitize=${ZEROBUS_SANITIZE} -fno-omit-frame-pointer -g)
+    target_link_options(${lib} PUBLIC -fsanitize=${ZEROBUS_SANITIZE})
+  endforeach()
+endif()
+
+enable_testing()
+add_subdirectory(examples)
+add_subdirectory(tests)

--- a/purec/Makefile
+++ b/purec/Makefile
@@ -1,0 +1,71 @@
+# Makefile for the Zerobus Pure C SDK: convenience wrappers around CMake/CTest.
+
+BUILD_TYPE ?= Release
+JOBS ?= 4
+
+SANITIZE ?=
+SANITIZE_FLAG := $(if $(SANITIZE),-DZEROBUS_SANITIZE=$(SANITIZE),)
+
+# Extra -D flags forwarded to cmake configure (lint sets -DZEROBUS_WERROR=ON).
+CMAKE_EXTRA ?=
+
+# Sanitizer builds use their own build dir so they don't clash with a normal
+# build dir. Override BUILD_DIR to force a specific path.
+BUILD_DIR ?= $(if $(SANITIZE),build-$(SANITIZE),build)
+
+# All hand-written C sources (excludes the CMake build tree).
+SOURCES := $(shell find include src examples tests -name '*.c' -o -name '*.h' 2>/dev/null)
+
+.PHONY: help configure build test examples lint fmt fmt-check clean check verify
+
+help:
+	@echo "Available targets:"
+	@echo "  make build      - Configure and build the SDK, examples, and tests"
+	@echo "  make test       - Build and run the offline test suite (ctest)"
+	@echo "  make examples   - Build the example binaries"
+	@echo "  make fmt        - Format all C sources with clang-format"
+	@echo "  make fmt-check  - Check formatting without modifying files"
+	@echo "  make lint       - Warnings-as-errors build (-Werror)"
+	@echo "  make check      - fmt-check + lint (static gates, no tests)"
+	@echo "  make verify     - Full workspace check: check + tests, plain and sanitized"
+	@echo "  make clean      - Remove the build directory"
+	@echo ""
+	@echo "  Add SANITIZE=address (or thread/undefined) to build+test with a"
+	@echo "  sanitizer, e.g. 'make test SANITIZE=address'."
+
+configure:
+	cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(SANITIZE_FLAG) $(CMAKE_EXTRA)
+
+build: configure
+	cmake --build $(BUILD_DIR) -j $(JOBS)
+
+test: build
+	cd $(BUILD_DIR) && ctest --output-on-failure
+
+examples: build
+	@echo "Examples built under $(BUILD_DIR)/examples/"
+
+fmt:
+	clang-format -i $(SOURCES)
+
+fmt-check:
+	clang-format --dry-run --Werror $(SOURCES)
+
+# No clang-tidy here, so -Wall -Wextra is the linter: run the build with
+# -Werror. Its own tree keeps the flag out of the normal build's cache.
+lint:
+	$(MAKE) build BUILD_DIR=build-lint CMAKE_EXTRA=-DZEROBUS_WERROR=ON
+
+check: fmt-check lint
+
+# Full workspace check: static checks, then the suite plain and under all three
+# sanitizers. address and thread can't coexist, so undefined rides with each.
+verify:
+	$(MAKE) check
+	$(MAKE) test
+	$(MAKE) test SANITIZE=address,undefined
+	$(MAKE) test SANITIZE=thread,undefined
+
+clean:
+	rm -rf build build-*

--- a/purec/Makefile
+++ b/purec/Makefile
@@ -13,10 +13,24 @@ CMAKE_EXTRA ?=
 # build dir. Override BUILD_DIR to force a specific path.
 BUILD_DIR ?= $(if $(SANITIZE),build-$(SANITIZE),build)
 
+# Coverage uses its own build dir (matched by `clean`'s build-* glob).
+COV_DIR ?= build-cov
+COV_OBJ_DIR := $(COV_DIR)/CMakeFiles/zerobus_c_testing.dir/src
+
+# gcov must match the compiler that built the objects or it misreads the
+# coverage data (.gcno/.gcda). CMake builds with cc, so pick the gcov-N whose
+# major version matches cc, and fall back to plain gcov. Override with GCOV=...
+GCOV ?= $(shell \
+	major=$$(cc -dumpversion 2>/dev/null | cut -d. -f1); \
+	if command -v gcov-$$major >/dev/null 2>&1; \
+		then echo gcov-$$major; \
+		else echo gcov; \
+	fi)
+
 # All hand-written C sources (excludes the CMake build tree).
 SOURCES := $(shell find include src examples tests -name '*.c' -o -name '*.h' 2>/dev/null)
 
-.PHONY: help configure build test examples lint fmt fmt-check clean check verify
+.PHONY: help configure build test examples lint fmt fmt-check clean check verify coverage
 
 help:
 	@echo "Available targets:"
@@ -28,7 +42,8 @@ help:
 	@echo "  make lint       - Warnings-as-errors build (-Werror)"
 	@echo "  make check      - fmt-check + lint (static gates, no tests)"
 	@echo "  make verify     - Full workspace check: check + tests, plain and sanitized"
-	@echo "  make clean      - Remove the build directory"
+	@echo "  make coverage   - Coverage build+test, then gcov: read .gcov files for uncovered lines (#####)"
+	@echo "  make clean      - Remove the build dirs (build, build-*, and BUILD_DIR)"
 	@echo ""
 	@echo "  Add SANITIZE=address (or thread/undefined) to build+test with a"
 	@echo "  sanitizer, e.g. 'make test SANITIZE=address'."
@@ -62,10 +77,21 @@ check: fmt-check lint
 # Full workspace check: static checks, then the suite plain and under all three
 # sanitizers. address and thread can't coexist, so undefined rides with each.
 verify:
+	$(MAKE) clean
 	$(MAKE) check
 	$(MAKE) test
 	$(MAKE) test SANITIZE=address,undefined
 	$(MAKE) test SANITIZE=thread,undefined
 
+# Coverage: build and test with gcov instrumentation, then run gcov.
+# Read the generated .gcov files to see which lines are not covered.
+coverage:
+	rm -rf $(COV_DIR)
+	cmake -S . -B $(COV_DIR) -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="--coverage -O0 -g" \
+		-DCMAKE_EXE_LINKER_FLAGS="--coverage" $(CMAKE_EXTRA)
+	cmake --build $(COV_DIR) -j $(JOBS)
+	cd $(COV_DIR) && ctest --output-on-failure
+	cd $(COV_OBJ_DIR) && $(GCOV) *.gcno
+
 clean:
-	rm -rf build build-*
+	rm -rf $(BUILD_DIR) build build-*

--- a/purec/examples/CMakeLists.txt
+++ b/purec/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Example binaries. They link the SDK's public API only.
+add_executable(zerobus_json_example json/main.c)
+target_link_libraries(zerobus_json_example PRIVATE zerobus_c)
+target_compile_options(zerobus_json_example PRIVATE ${ZEROBUS_WARN_FLAGS})

--- a/purec/examples/json/main.c
+++ b/purec/examples/json/main.c
@@ -1,0 +1,139 @@
+/*
+ * Minimal end-to-end JSON ingestion example: build an SDK, open an
+ * OAuth-authenticated ephemeral JSON stream, queue a few records without
+ * waiting after each one, flush once, then close and free everything.
+ *
+ * NOTE: the SDK is under early development. The operations validate inputs and
+ * return the documented statuses but perform no network I/O yet, so this shows
+ * the API shape and lifecycle rather than delivering records.
+ *
+ * The table schema must match the two example JSON fields (id, message), or the
+ * records must be replaced with ones matching the selected table.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include <zerobus/zerobus.h>
+
+static zerobus_string_view_t string_view(const char *value)
+{
+    return (zerobus_string_view_t){value, strlen(value)};
+}
+
+static void print_error(const zerobus_error_t *error)
+{
+    if (error == NULL) {
+        fputs("zerobus: operation failed without details\n", stderr);
+        return;
+    }
+    zerobus_string_view_t message = zerobus_error_message(error);
+    fprintf(stderr, "zerobus: %.*s\n", (int)message.len, message.data);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 6) {
+        fprintf(stderr,
+                "usage: %s <zerobus-endpoint> <uc-endpoint> "
+                "<table> <client-id> <client-secret>\n",
+                argv[0]);
+        return 2;
+    }
+
+    const char *records[] = {
+        "{\"id\":1,\"message\":\"hello\"}",
+        "{\"id\":2,\"message\":\"from C\"}",
+    };
+
+    zerobus_error_t *error = NULL;
+    zerobus_sdk_builder_t *sdk_builder = NULL;
+    zerobus_stream_builder_t *stream_builder = NULL;
+    zerobus_sdk_t *sdk = NULL;
+    zerobus_stream_t *stream = NULL;
+    zerobus_status_t status;
+    int exit_code = 1;
+
+    status = zerobus_sdk_builder_new(&sdk_builder, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_sdk_builder_set_endpoint(sdk_builder, string_view(argv[1]),
+                                              &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_sdk_builder_set_unity_catalog_endpoint(
+        sdk_builder, string_view(argv[2]), &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_sdk_builder_build(sdk_builder, &sdk, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    zerobus_sdk_builder_free(sdk_builder);
+    sdk_builder = NULL;
+
+    status = zerobus_stream_builder_new(sdk, &stream_builder, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_stream_builder_set_table(stream_builder,
+                                              string_view(argv[3]), &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_stream_builder_set_oauth(
+        stream_builder, string_view(argv[4]), string_view(argv[5]), &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_stream_builder_build(stream_builder, &stream, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    zerobus_stream_builder_free(stream_builder);
+    stream_builder = NULL;
+
+    /* Queue all records. Do NOT wait for each record's acknowledgment. */
+    for (size_t i = 0; i < sizeof(records) / sizeof(records[0]); ++i) {
+        status = zerobus_stream_ingest_json_record(
+            stream, string_view(records[i]), &error);
+        if (status != ZEROBUS_STATUS_OK) {
+            goto fail;
+        }
+    }
+
+    /* One durability barrier for everything admitted above. */
+    status = zerobus_stream_flush(stream, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    status = zerobus_stream_close(stream, &error);
+    if (status != ZEROBUS_STATUS_OK) {
+        goto fail;
+    }
+
+    printf("ingested %zu records\n", sizeof(records) / sizeof(records[0]));
+    exit_code = 0;
+
+fail:
+    if (error != NULL) {
+        print_error(error);
+        zerobus_error_free(error);
+    }
+    zerobus_stream_builder_free(stream_builder);
+    zerobus_sdk_builder_free(sdk_builder);
+    zerobus_stream_free(stream);
+    zerobus_sdk_free(sdk);
+    return exit_code;
+}

--- a/purec/examples/json/main.c
+++ b/purec/examples/json/main.c
@@ -11,14 +11,10 @@
  * records must be replaced with ones matching the selected table.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <zerobus/zerobus.h>
-
-static zerobus_string_view_t string_view(const char *value)
-{
-    return (zerobus_string_view_t){value, strlen(value)};
-}
 
 static void print_error(const zerobus_error_t *error)
 {
@@ -32,11 +28,19 @@ static void print_error(const zerobus_error_t *error)
 
 int main(int argc, char **argv)
 {
-    if (argc != 6) {
+    if (argc != 5) {
         fprintf(stderr,
                 "usage: %s <zerobus-endpoint> <uc-endpoint> "
-                "<table> <client-id> <client-secret>\n",
+                "<table> <client-id>\n"
+                "the OAuth client secret is read from the "
+                "DATABRICKS_CLIENT_SECRET environment variable\n",
                 argv[0]);
+        return 2;
+    }
+
+    const char *client_secret = getenv("DATABRICKS_CLIENT_SECRET");
+    if (client_secret == NULL) {
+        fputs("DATABRICKS_CLIENT_SECRET must be set\n", stderr);
         return 2;
     }
 
@@ -58,14 +62,14 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    status = zerobus_sdk_builder_set_endpoint(sdk_builder, string_view(argv[1]),
-                                              &error);
+    status = zerobus_sdk_builder_set_endpoint(
+        sdk_builder, zerobus_string_view(argv[1]), &error);
     if (status != ZEROBUS_STATUS_OK) {
         goto fail;
     }
 
     status = zerobus_sdk_builder_set_unity_catalog_endpoint(
-        sdk_builder, string_view(argv[2]), &error);
+        sdk_builder, zerobus_string_view(argv[2]), &error);
     if (status != ZEROBUS_STATUS_OK) {
         goto fail;
     }
@@ -83,14 +87,15 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    status = zerobus_stream_builder_set_table(stream_builder,
-                                              string_view(argv[3]), &error);
+    status = zerobus_stream_builder_set_table(
+        stream_builder, zerobus_string_view(argv[3]), &error);
     if (status != ZEROBUS_STATUS_OK) {
         goto fail;
     }
 
     status = zerobus_stream_builder_set_oauth(
-        stream_builder, string_view(argv[4]), string_view(argv[5]), &error);
+        stream_builder, zerobus_string_view(argv[4]),
+        zerobus_string_view(client_secret), &error);
     if (status != ZEROBUS_STATUS_OK) {
         goto fail;
     }
@@ -103,18 +108,22 @@ int main(int argc, char **argv)
     zerobus_stream_builder_free(stream_builder);
     stream_builder = NULL;
 
-    /* Queue all records. Do NOT wait for each record's acknowledgment. */
+    /* Queue all records. Do NOT wait for each record's acknowledgment.
+     * The networking core is not implemented yet, so ingest and flush validate
+     * their inputs and return ZEROBUS_STATUS_UNIMPLEMENTED. Treat that as the
+     * expected outcome during development. */
     for (size_t i = 0; i < sizeof(records) / sizeof(records[0]); ++i) {
         status = zerobus_stream_ingest_json_record(
-            stream, string_view(records[i]), &error);
-        if (status != ZEROBUS_STATUS_OK) {
+            stream, zerobus_string_view(records[i]), NULL, &error);
+        if (status != ZEROBUS_STATUS_OK &&
+            status != ZEROBUS_STATUS_UNIMPLEMENTED) {
             goto fail;
         }
     }
 
     /* One durability barrier for everything admitted above. */
     status = zerobus_stream_flush(stream, &error);
-    if (status != ZEROBUS_STATUS_OK) {
+    if (status != ZEROBUS_STATUS_OK && status != ZEROBUS_STATUS_UNIMPLEMENTED) {
         goto fail;
     }
 
@@ -123,10 +132,15 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    printf("ingested %zu records\n", sizeof(records) / sizeof(records[0]));
+    printf("exercised the ingest lifecycle for %zu records (no network I/O "
+           "yet)\n",
+           sizeof(records) / sizeof(records[0]));
     exit_code = 0;
 
 fail:
+    if (stream != NULL) {
+        zerobus_stream_close(stream, NULL);
+    }
     if (error != NULL) {
         print_error(error);
         zerobus_error_free(error);

--- a/purec/include/zerobus/common.h
+++ b/purec/include/zerobus/common.h
@@ -1,0 +1,91 @@
+/*
+ * Zerobus Pure C SDK — shared declarations for the public headers.
+ *
+ * Export macros, opaque handle typedefs, view types, and status codes. Every
+ * module header includes this file. C99, with C++ compatibility via extern "C".
+ */
+#ifndef ZEROBUS_COMMON_H
+#define ZEROBUS_COMMON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * ZEROBUS_API decorates the public symbols and ZEROBUS_CALL pins their calling
+ * convention. We ship only a static archive, which needs no export decoration
+ * yet — a future shared or DLL build will add it.
+ */
+#ifndef ZEROBUS_API
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ZEROBUS_API __attribute__((visibility("default")))
+#else
+#define ZEROBUS_API
+#endif
+#endif
+
+#ifndef ZEROBUS_CALL
+#if defined(_WIN32) && !defined(_WIN64)
+#define ZEROBUS_CALL __cdecl
+#else
+#define ZEROBUS_CALL
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct zerobus_sdk_builder zerobus_sdk_builder_t;
+typedef struct zerobus_sdk zerobus_sdk_t;
+typedef struct zerobus_stream_builder zerobus_stream_builder_t;
+typedef struct zerobus_stream zerobus_stream_t;
+typedef struct zerobus_error zerobus_error_t;
+
+/*
+ * A borrowed view of UTF-8 text: the caller must pass valid UTF-8 with no
+ * embedded NUL. It need not be NUL-terminated, and is read only for the
+ * duration of the call it is passed to. {NULL, 0} is empty. {NULL, nonzero} is
+ * invalid.
+ */
+typedef struct zerobus_string_view {
+    const char *data;
+    size_t len;
+} zerobus_string_view_t;
+
+/* C uses a compound literal. C++ (which has none) uses a braced temporary. */
+#ifdef __cplusplus
+#define ZEROBUS_STRING_LITERAL(value)                                          \
+    (zerobus_string_view_t{(value), sizeof(value) - 1u})
+#else
+#define ZEROBUS_STRING_LITERAL(value)                                          \
+    ((zerobus_string_view_t){(value), sizeof(value) - 1u})
+#endif
+
+/*
+ * Status codes have a fixed-width ABI. Values are explicit and are never
+ * reordered or reused.
+ */
+typedef uint32_t zerobus_status_t;
+
+enum {
+    ZEROBUS_STATUS_OK = 0,
+    ZEROBUS_STATUS_UNKNOWN = 1,
+    ZEROBUS_STATUS_INVALID_ARGUMENT = 2,
+    ZEROBUS_STATUS_DEADLINE_EXCEEDED = 3,
+    ZEROBUS_STATUS_CANCELLED = 4,
+    ZEROBUS_STATUS_FAILED_PRECONDITION = 5,
+    ZEROBUS_STATUS_RESOURCE_EXHAUSTED = 6,
+    ZEROBUS_STATUS_UNAUTHENTICATED = 7,
+    ZEROBUS_STATUS_PERMISSION_DENIED = 8,
+    ZEROBUS_STATUS_NOT_FOUND = 9,
+    ZEROBUS_STATUS_UNAVAILABLE = 10,
+    ZEROBUS_STATUS_UNIMPLEMENTED = 11,
+    ZEROBUS_STATUS_OUT_OF_MEMORY = 12,
+    ZEROBUS_STATUS_INTERNAL = 13
+};
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEROBUS_COMMON_H */

--- a/purec/include/zerobus/common.h
+++ b/purec/include/zerobus/common.h
@@ -7,8 +7,10 @@
 #ifndef ZEROBUS_COMMON_H
 #define ZEROBUS_COMMON_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 /*
  * ZEROBUS_API decorates the public symbols and ZEROBUS_CALL pins their calling
@@ -52,18 +54,18 @@ typedef struct zerobus_string_view {
     size_t len;
 } zerobus_string_view_t;
 
-/* C uses a compound literal. C++ (which has none) uses a braced temporary. */
-#ifdef __cplusplus
-#define ZEROBUS_STRING_LITERAL(value)                                          \
-    (zerobus_string_view_t{(value), sizeof(value) - 1u})
-#else
-#define ZEROBUS_STRING_LITERAL(value)                                          \
-    ((zerobus_string_view_t){(value), sizeof(value) - 1u})
-#endif
+static inline zerobus_string_view_t zerobus_string_view(const char *data)
+{
+    zerobus_string_view_t view = {data, data ? strlen(data) : 0};
+    return view;
+}
 
 /*
  * Status codes have a fixed-width ABI. Values are explicit and are never
  * reordered or reused.
+ *
+ * The set is not frozen until version 1.0: new codes may be added (never
+ * renumbered) as the networking core adds error paths.
  */
 typedef uint32_t zerobus_status_t;
 
@@ -83,6 +85,10 @@ enum {
     ZEROBUS_STATUS_OUT_OF_MEMORY = 12,
     ZEROBUS_STATUS_INTERNAL = 13
 };
+
+/* A record's position within its stream: returned by ingest as a handle to
+ * wait on, monotonically increasing. */
+typedef int64_t zerobus_offset_t;
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/purec/include/zerobus/error.h
+++ b/purec/include/zerobus/error.h
@@ -1,0 +1,28 @@
+/*
+ * Zerobus Pure C SDK — error objects.
+ */
+#ifndef ZEROBUS_ERROR_H
+#define ZEROBUS_ERROR_H
+
+#include "zerobus/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Failable functions take an optional `zerobus_error_t **out_error`. On
+ * failure it may be populated with an owned error, which the caller must free
+ * with zerobus_error_free. Passing NULL discards the error. */
+
+/* The returned view is borrowed from the error, valid only until it is freed.
+ */
+ZEROBUS_API zerobus_string_view_t ZEROBUS_CALL
+zerobus_error_message(const zerobus_error_t *error);
+
+ZEROBUS_API void ZEROBUS_CALL zerobus_error_free(zerobus_error_t *error);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEROBUS_ERROR_H */

--- a/purec/include/zerobus/error.h
+++ b/purec/include/zerobus/error.h
@@ -10,14 +10,46 @@
 extern "C" {
 #endif
 
-/* Failable functions take an optional `zerobus_error_t **out_error`. On
- * failure it may be populated with an owned error, which the caller must free
- * with zerobus_error_free. Passing NULL discards the error. */
+/*
+ * Error-reporting contract for every failable function.
+ *
+ * Failable functions take an optional out-parameter,
+ * `zerobus_error_t **out_error`:
+ *
+ *   - Pass NULL to discard the error detail. The status code is still returned.
+ *   - Otherwise `*out_error` MUST be NULL on entry. On failure the function
+ *     might set it to an owned error that the caller must free with
+ *     zerobus_error_free. On success it is left NULL.
+ *
+ * A non-NULL `*out_error` on entry can only mean a leaked or reused error, so
+ * the function refuses the call: it returns ZEROBUS_STATUS_INVALID_ARGUMENT and
+ * leaves the existing error untouched. This surfaces the mistake instead of
+ * silently overwriting (and leaking) the previous error.
+ *
+ * When reusing one variable across calls, reset it to NULL between them:
+ *
+ *     zerobus_error_t *err = NULL;
+ *     if (zerobus_stream_flush(stream, &err) != ZEROBUS_STATUS_OK) {
+ *         // inspect err ...
+ *         zerobus_error_free(err);
+ *         err = NULL;               // required before passing &err again
+ *     }
+ */
 
 /* The returned view is borrowed from the error, valid only until it is freed.
  */
 ZEROBUS_API zerobus_string_view_t ZEROBUS_CALL
 zerobus_error_message(const zerobus_error_t *error);
+
+/* The status code carried by the error. Returns ZEROBUS_STATUS_UNKNOWN for a
+ * NULL error. */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL
+zerobus_error_status(const zerobus_error_t *error);
+
+/* Whether retrying the failed operation may succeed (a transient failure).
+ * Derived from the status code. False for a NULL error. */
+ZEROBUS_API bool ZEROBUS_CALL
+zerobus_error_is_retryable(const zerobus_error_t *error);
 
 ZEROBUS_API void ZEROBUS_CALL zerobus_error_free(zerobus_error_t *error);
 

--- a/purec/include/zerobus/sdk.h
+++ b/purec/include/zerobus/sdk.h
@@ -1,0 +1,48 @@
+/*
+ * Zerobus Pure C SDK — SDK builder and SDK handle.
+ */
+#ifndef ZEROBUS_SDK_H
+#define ZEROBUS_SDK_H
+
+#include "zerobus/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * SDK builder. The endpoint setters validate the URL and copy their inputs, so
+ * a malformed endpoint is rejected at set time. TLS is always enabled with
+ * system root certificates. The builder is not consumed by build and must be
+ * freed separately.
+ */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_sdk_builder_new(
+    zerobus_sdk_builder_t **out_builder, zerobus_error_t **out_error);
+
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_sdk_builder_set_endpoint(
+    zerobus_sdk_builder_t *builder, zerobus_string_view_t zerobus_endpoint,
+    zerobus_error_t **out_error);
+
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL
+zerobus_sdk_builder_set_unity_catalog_endpoint(
+    zerobus_sdk_builder_t *builder,
+    zerobus_string_view_t unity_catalog_endpoint, zerobus_error_t **out_error);
+
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL
+zerobus_sdk_builder_build(const zerobus_sdk_builder_t *builder,
+                          zerobus_sdk_t **out_sdk, zerobus_error_t **out_error);
+
+ZEROBUS_API void ZEROBUS_CALL
+zerobus_sdk_builder_free(zerobus_sdk_builder_t *builder);
+
+/*
+ * Best-effort cleanup, cannot report failures. The SDK is borrowed by every
+ * stream and stream builder created from it, so free those first.
+ */
+ZEROBUS_API void ZEROBUS_CALL zerobus_sdk_free(zerobus_sdk_t *sdk);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEROBUS_SDK_H */

--- a/purec/include/zerobus/sdk.h
+++ b/purec/include/zerobus/sdk.h
@@ -12,9 +12,8 @@ extern "C" {
 
 /*
  * SDK builder. The endpoint setters validate the URL and copy their inputs, so
- * a malformed endpoint is rejected at set time. TLS is always enabled with
- * system root certificates. The builder is not consumed by build and must be
- * freed separately.
+ * a malformed endpoint is rejected at set time. The builder is not consumed by
+ * build and must be freed separately.
  */
 ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_sdk_builder_new(
     zerobus_sdk_builder_t **out_builder, zerobus_error_t **out_error);

--- a/purec/include/zerobus/stream.h
+++ b/purec/include/zerobus/stream.h
@@ -1,0 +1,79 @@
+/*
+ * Zerobus Pure C SDK — stream builder, stream handle, and ingestion.
+ */
+#ifndef ZEROBUS_STREAM_H
+#define ZEROBUS_STREAM_H
+
+#include "zerobus/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Stream builder. Requires a fully qualified catalog.schema.table name and
+ * OAuth client credentials. Streams are ephemeral gRPC JSON streams
+ * authenticated with Unity Catalog OAuth. Credential copies are zeroed on free.
+ *
+ * The SDK passed to new() is borrowed and must outlive this builder and every
+ * stream built from it.
+ */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_new(
+    zerobus_sdk_t *sdk, zerobus_stream_builder_t **out_builder,
+    zerobus_error_t **out_error);
+
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_set_table(
+    zerobus_stream_builder_t *builder, zerobus_string_view_t table_name,
+    zerobus_error_t **out_error);
+
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_set_oauth(
+    zerobus_stream_builder_t *builder, zerobus_string_view_t client_id,
+    zerobus_string_view_t client_secret, zerobus_error_t **out_error);
+
+/*
+ * Validates configuration and opens the initial authenticated connection. The
+ * builder is not consumed and may be reused or freed.
+ */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_build(
+    const zerobus_stream_builder_t *builder, zerobus_stream_t **out_stream,
+    zerobus_error_t **out_error);
+
+ZEROBUS_API void ZEROBUS_CALL
+zerobus_stream_builder_free(zerobus_stream_builder_t *builder);
+
+/*
+ * Ingest one JSON record: exactly one well-formed UTF-8 JSON value, sent
+ * verbatim (not reshaped to the table schema). Success means the record was
+ * copied and queued locally, not acknowledged by the server, so the caller may
+ * reuse the bytes on return.
+ *
+ * The record format is fixed at build time. Other formats add their own ingest
+ * functions.
+ */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_ingest_json_record(
+    zerobus_stream_t *stream, zerobus_string_view_t json_record,
+    zerobus_error_t **out_error);
+
+/* Wait until the server acknowledges every record queued before this call. */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL
+zerobus_stream_flush(zerobus_stream_t *stream, zerobus_error_t **out_error);
+
+/*
+ * Stop ingestion, flush pending records, and tear down the stream. Idempotent.
+ * If the flush fails, teardown still happens and the error is returned. After
+ * close, ingest returns FAILED_PRECONDITION.
+ */
+ZEROBUS_API zerobus_status_t ZEROBUS_CALL
+zerobus_stream_close(zerobus_stream_t *stream, zerobus_error_t **out_error);
+
+/*
+ * Release the handle. If the stream was not closed, tears down best-effort with
+ * no durability guarantee. The SDK must still be alive.
+ */
+ZEROBUS_API void ZEROBUS_CALL zerobus_stream_free(zerobus_stream_t *stream);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEROBUS_STREAM_H */

--- a/purec/include/zerobus/stream.h
+++ b/purec/include/zerobus/stream.h
@@ -1,5 +1,9 @@
 /*
  * Zerobus Pure C SDK — stream builder, stream handle, and ingestion.
+ *
+ * Thread-safety: a stream and its builder are not thread-safe. Use one caller
+ * thread per stream — do not call ingest/flush/close concurrently on the same
+ * stream. (Internal synchronization arrives with the transport core.)
  */
 #ifndef ZEROBUS_STREAM_H
 #define ZEROBUS_STREAM_H
@@ -31,8 +35,12 @@ ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_set_oauth(
     zerobus_string_view_t client_secret, zerobus_error_t **out_error);
 
 /*
- * Validates configuration and opens the initial authenticated connection. The
- * builder is not consumed and may be reused or freed.
+ * Validates configuration and (once implemented) opens the initial
+ * authenticated connection. The builder is not consumed and may be reused or
+ * freed.
+ *
+ * Not implemented yet: validates configuration and returns a usable handle
+ * without opening a connection.
  */
 ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_builder_build(
     const zerobus_stream_builder_t *builder, zerobus_stream_t **out_stream,
@@ -42,26 +50,37 @@ ZEROBUS_API void ZEROBUS_CALL
 zerobus_stream_builder_free(zerobus_stream_builder_t *builder);
 
 /*
- * Ingest one JSON record: exactly one well-formed UTF-8 JSON value, sent
- * verbatim (not reshaped to the table schema). Success means the record was
- * copied and queued locally, not acknowledged by the server, so the caller may
- * reuse the bytes on return.
+ * Ingest one JSON record, sent verbatim (not reshaped to the table schema).
+ * The record must be non-empty and no larger than the payload limit. Success
+ * means the record was copied and queued locally, not acknowledged by the
+ * server, so the caller may reuse the bytes on return.
  *
- * The record format is fixed at build time. Other formats add their own ingest
- * functions.
+ * On success *out_offset, when non-NULL, receives the record's stream offset —
+ * a handle to wait on later.
+ *
+ * Not implemented yet: validates its inputs, then returns
+ * ZEROBUS_STATUS_UNIMPLEMENTED until the networking core lands.
  */
 ZEROBUS_API zerobus_status_t ZEROBUS_CALL zerobus_stream_ingest_json_record(
     zerobus_stream_t *stream, zerobus_string_view_t json_record,
-    zerobus_error_t **out_error);
+    zerobus_offset_t *out_offset, zerobus_error_t **out_error);
 
-/* Wait until the server acknowledges every record queued before this call. */
+/*
+ * Wait until the server acknowledges every record queued before this call.
+ *
+ * Not implemented yet: returns ZEROBUS_STATUS_UNIMPLEMENTED until the
+ * networking core lands.
+ */
 ZEROBUS_API zerobus_status_t ZEROBUS_CALL
 zerobus_stream_flush(zerobus_stream_t *stream, zerobus_error_t **out_error);
 
 /*
  * Stop ingestion, flush pending records, and tear down the stream. Idempotent.
  * If the flush fails, teardown still happens and the error is returned. After
- * close, ingest returns FAILED_PRECONDITION.
+ * close, ingest and flush return FAILED_PRECONDITION.
+ *
+ * Not implemented yet: only marks the stream closed, no flush or teardown until
+ * the networking core lands.
  */
 ZEROBUS_API zerobus_status_t ZEROBUS_CALL
 zerobus_stream_close(zerobus_stream_t *stream, zerobus_error_t **out_error);

--- a/purec/include/zerobus/zerobus.h
+++ b/purec/include/zerobus/zerobus.h
@@ -1,0 +1,19 @@
+/*
+ * Zerobus Pure C SDK — public API umbrella header.
+ *
+ * Includes the whole public surface. Per-area headers can be included directly:
+ * common.h, error.h, sdk.h, stream.h.
+ *
+ * The SDK is under early development: the functions validate inputs and honor
+ * the documented status/ownership rules, but the networking core is not
+ * implemented yet. See README.md.
+ */
+#ifndef ZEROBUS_H
+#define ZEROBUS_H
+
+#include "zerobus/common.h" // IWYU pragma: export
+#include "zerobus/error.h"  // IWYU pragma: export
+#include "zerobus/sdk.h"    // IWYU pragma: export
+#include "zerobus/stream.h" // IWYU pragma: export
+
+#endif /* ZEROBUS_H */

--- a/purec/src/error.c
+++ b/purec/src/error.c
@@ -1,0 +1,85 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "zerobus/error.h"
+
+static char *format_message(const char *fmt, va_list ap, size_t *out_len)
+{
+    va_list ap2;
+    va_copy(ap2, ap);
+    int needed = vsnprintf(NULL, 0, fmt, ap2);
+    va_end(ap2);
+    if (needed < 0) {
+        *out_len = 0;
+        return NULL;
+    }
+    char *buf = (char *)malloc((size_t)needed + 1);
+    if (buf == NULL) {
+        *out_len = 0;
+        return NULL;
+    }
+    vsnprintf(buf, (size_t)needed + 1, fmt, ap);
+    *out_len = (size_t)needed;
+    return buf;
+}
+
+/*
+ * Shared body taking a va_list, so both public constructors format the message
+ * once.
+ */
+static zerobus_error_t *error_vnewf(zerobus_status_t code, const char *fmt,
+                                    va_list ap)
+{
+    zerobus_error_t *err = (zerobus_error_t *)calloc(1, sizeof(*err));
+    if (err == NULL) {
+        return NULL;
+    }
+    err->code = code;
+    err->message = format_message(fmt, ap, &err->message_len);
+    if (err->message == NULL) {
+        free(err);
+        return NULL;
+    }
+    return err;
+}
+
+zerobus_error_t *zb_error_newf(zerobus_status_t code, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    zerobus_error_t *err = error_vnewf(code, fmt, ap);
+    va_end(ap);
+    return err;
+}
+
+zerobus_status_t zb_fail(zerobus_error_t **out_error, zerobus_status_t code,
+                         const char *fmt, ...)
+{
+    if (out_error != NULL) {
+        va_list ap;
+        va_start(ap, fmt);
+        *out_error = error_vnewf(code, fmt, ap);
+        va_end(ap);
+    }
+    return code;
+}
+
+zerobus_string_view_t zerobus_error_message(const zerobus_error_t *error)
+{
+    if (error == NULL || error->message == NULL) {
+        return (zerobus_string_view_t){NULL, 0};
+    }
+    return (zerobus_string_view_t){error->message, error->message_len};
+}
+
+void zerobus_error_free(zerobus_error_t *error)
+{
+    if (error == NULL) {
+        return;
+    }
+    free(error->message);
+    free(error);
+}

--- a/purec/src/error.c
+++ b/purec/src/error.c
@@ -75,6 +75,33 @@ zerobus_string_view_t zerobus_error_message(const zerobus_error_t *error)
     return (zerobus_string_view_t){error->message, error->message_len};
 }
 
+zerobus_status_t zerobus_error_status(const zerobus_error_t *error)
+{
+    if (error == NULL) {
+        return ZEROBUS_STATUS_UNKNOWN;
+    }
+    return error->code;
+}
+
+/* Temporary status-based classification until the transport core defines
+ * retryability precisely. */
+bool zerobus_error_is_retryable(const zerobus_error_t *error)
+{
+    if (error == NULL) {
+        return false;
+    }
+    switch (error->code) {
+    case ZEROBUS_STATUS_INVALID_ARGUMENT:
+    case ZEROBUS_STATUS_UNAUTHENTICATED:
+    case ZEROBUS_STATUS_PERMISSION_DENIED:
+    case ZEROBUS_STATUS_NOT_FOUND:
+    case ZEROBUS_STATUS_UNIMPLEMENTED:
+        return false;
+    default:
+        return true;
+    }
+}
+
 void zerobus_error_free(zerobus_error_t *error)
 {
     if (error == NULL) {

--- a/purec/src/error.h
+++ b/purec/src/error.h
@@ -1,0 +1,38 @@
+/*
+ * Internal error construction, shared by every public entry point.
+ */
+#ifndef ZB_ERROR_H
+#define ZB_ERROR_H
+
+#include "zerobus/common.h"
+
+struct zerobus_error {
+    zerobus_status_t code;
+    char *message;
+    size_t message_len;
+};
+
+/*
+ * Build an owned error with a printf-formatted message. Returns NULL only if
+ * allocating the error itself fails, which callers surface as
+ * ZEROBUS_STATUS_OUT_OF_MEMORY with *out_error == NULL.
+ */
+zerobus_error_t *zb_error_newf(zerobus_status_t code, const char *fmt, ...)
+#if defined(__GNUC__)
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
+
+/*
+ * Convenience for the common "set *out_error (if non-NULL) and return status"
+ * pattern used by every public entry point. When error allocation fails, leaves
+ * *out_error as NULL. Always returns `code`.
+ */
+zerobus_status_t zb_fail(zerobus_error_t **out_error, zerobus_status_t code,
+                         const char *fmt, ...)
+#if defined(__GNUC__)
+    __attribute__((format(printf, 3, 4)))
+#endif
+    ;
+
+#endif /* ZB_ERROR_H */

--- a/purec/src/sdk.c
+++ b/purec/src/sdk.c
@@ -1,0 +1,213 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "utils.h"
+#include "zerobus/sdk.h"
+
+struct zerobus_sdk_builder {
+    char *endpoint;    /* zerobus endpoint, owned */
+    char *uc_endpoint; /* unity catalog endpoint, owned */
+};
+
+struct zerobus_sdk {
+    /* Independent copies of the validated configuration. */
+    char *endpoint;
+    char *uc_endpoint;
+};
+
+/* ---- builder ----------------------------------------------------------- */
+
+zerobus_status_t zerobus_sdk_builder_new(zerobus_sdk_builder_t **out_builder,
+                                         zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (out_builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "out_builder must not be NULL");
+    }
+    *out_builder = NULL;
+    zerobus_sdk_builder_t *b = (zerobus_sdk_builder_t *)calloc(1, sizeof(*b));
+    if (b == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    *out_builder = b;
+    return ZEROBUS_STATUS_OK;
+}
+
+static zerobus_status_t validate_endpoint(const char *endpoint,
+                                          const char *label, char **out_host,
+                                          zerobus_error_t **out_error)
+{
+    bool is_https = false;
+    switch (zb_url_validate(endpoint, out_host, &is_https)) {
+    case ZB_URL_OK:
+        break;
+    case ZB_URL_NO_SCHEME:
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "%s must start with https://: %s", label, endpoint);
+    case ZB_URL_EMPTY_HOST:
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "%s has no host: %s", label, endpoint);
+    case ZB_URL_BAD_HOST:
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "%s host is malformed: %s", label, endpoint);
+    case ZB_URL_BAD_PORT:
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "%s has an invalid port: %s", label, endpoint);
+    case ZB_URL_OOM:
+    default:
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    if (!is_https) {
+        if (out_host != NULL) {
+            free(*out_host);
+            *out_host = NULL;
+        }
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "%s must use https: %s", label, endpoint);
+    }
+    return ZEROBUS_STATUS_OK;
+}
+
+zerobus_status_t
+zerobus_sdk_builder_set_endpoint(zerobus_sdk_builder_t *builder,
+                                 zerobus_string_view_t zerobus_endpoint,
+                                 zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder must not be NULL");
+    }
+    if (!zb_is_valid_string(zerobus_endpoint)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "zerobus endpoint must be non-empty valid UTF-8");
+    }
+    /* Validate before storing (transactional): a rejected endpoint leaves the
+     * previous value in place. */
+    char *copy = zb_strdup_view(zerobus_endpoint);
+    if (copy == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    char *host = NULL;
+    zerobus_status_t s =
+        validate_endpoint(copy, "zerobus endpoint", &host, out_error);
+    if (s != ZEROBUS_STATUS_OK) {
+        free(copy);
+        return s;
+    }
+    /* Zerobus-only: require a dot with a label after it, so a single-label host
+     * ("localhost", "localhost.") is rejected. */
+    const char *dot = strchr(host, '.');
+    if (dot == NULL || dot[1] == '\0') {
+        zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                "zerobus endpoint host \"%s\" has no workspace subdomain",
+                host);
+        free(host);
+        free(copy);
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
+    }
+    free(host);
+    free(builder->endpoint);
+    builder->endpoint = copy;
+    return ZEROBUS_STATUS_OK;
+}
+
+zerobus_status_t zerobus_sdk_builder_set_unity_catalog_endpoint(
+    zerobus_sdk_builder_t *builder,
+    zerobus_string_view_t unity_catalog_endpoint, zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder must not be NULL");
+    }
+    if (!zb_is_valid_string(unity_catalog_endpoint)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "unity catalog endpoint must be non-empty valid UTF-8");
+    }
+    char *copy = zb_strdup_view(unity_catalog_endpoint);
+    if (copy == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    /* Host presence is enough for the UC endpoint; no subdomain requirement. */
+    zerobus_status_t s =
+        validate_endpoint(copy, "unity catalog endpoint", NULL, out_error);
+    if (s != ZEROBUS_STATUS_OK) {
+        free(copy);
+        return s;
+    }
+    free(builder->uc_endpoint);
+    builder->uc_endpoint = copy;
+    return ZEROBUS_STATUS_OK;
+}
+
+zerobus_status_t zerobus_sdk_builder_build(const zerobus_sdk_builder_t *builder,
+                                           zerobus_sdk_t **out_sdk,
+                                           zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (out_sdk != NULL) {
+        *out_sdk = NULL;
+    }
+    if (builder == NULL || out_sdk == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder and out_sdk must not be NULL");
+    }
+    if (builder->endpoint == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "zerobus endpoint is required");
+    }
+    if (builder->uc_endpoint == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "unity catalog endpoint is required");
+    }
+
+    /* Endpoints were validated when set.
+     * TODO: initialize shared TLS/OAuth/transport state. */
+    zerobus_sdk_t *sdk = (zerobus_sdk_t *)calloc(1, sizeof(*sdk));
+    if (sdk == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    sdk->endpoint = zb_strdup(builder->endpoint);
+    sdk->uc_endpoint = zb_strdup(builder->uc_endpoint);
+    if (sdk->endpoint == NULL || sdk->uc_endpoint == NULL) {
+        zerobus_sdk_free(sdk);
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+
+    *out_sdk = sdk;
+    return ZEROBUS_STATUS_OK;
+}
+
+void zerobus_sdk_builder_free(zerobus_sdk_builder_t *builder)
+{
+    if (builder == NULL) {
+        return;
+    }
+    free(builder->endpoint);
+    free(builder->uc_endpoint);
+    free(builder);
+}
+
+/* ---- SDK --------------------------------------------------------------- */
+
+void zerobus_sdk_free(zerobus_sdk_t *sdk)
+{
+    if (sdk == NULL) {
+        return;
+    }
+    /* TODO: tear down shared transport/auth resources (best-effort). */
+    free(sdk->endpoint);
+    free(sdk->uc_endpoint);
+    free(sdk);
+}

--- a/purec/src/sdk.c
+++ b/purec/src/sdk.c
@@ -1,5 +1,5 @@
+#include <limits.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "error.h"
 #include "utils.h"
@@ -21,14 +21,16 @@ struct zerobus_sdk {
 zerobus_status_t zerobus_sdk_builder_new(zerobus_sdk_builder_t **out_builder,
                                          zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_builder != NULL) {
+        *out_builder = NULL;
+    }
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (out_builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "out_builder must not be NULL");
     }
-    *out_builder = NULL;
     zerobus_sdk_builder_t *b = (zerobus_sdk_builder_t *)calloc(1, sizeof(*b));
     if (b == NULL) {
         return ZEROBUS_STATUS_OUT_OF_MEMORY;
@@ -37,39 +39,39 @@ zerobus_status_t zerobus_sdk_builder_new(zerobus_sdk_builder_t **out_builder,
     return ZEROBUS_STATUS_OK;
 }
 
-static zerobus_status_t validate_endpoint(const char *endpoint,
-                                          const char *label, char **out_host,
-                                          zerobus_error_t **out_error)
+/* Accepts a bare http(s)://host[:port] origin for both endpoints; https is the
+ * norm, http is for a local plaintext server. */
+static bool validate_endpoint(zerobus_string_view_t endpoint, const char *label,
+                              zerobus_error_t **out_error)
 {
-    bool is_https = false;
-    switch (zb_url_validate(endpoint, out_host, &is_https)) {
+    const char *fmt;
+    switch (zb_url_validate(endpoint)) {
     case ZB_URL_OK:
-        break;
+        return true;
     case ZB_URL_NO_SCHEME:
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "%s must start with https://: %s", label, endpoint);
+        fmt = "%s must start with http:// or https://: %.*s";
+        break;
     case ZB_URL_EMPTY_HOST:
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "%s has no host: %s", label, endpoint);
+        fmt = "%s has no host: %.*s";
+        break;
     case ZB_URL_BAD_HOST:
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "%s host is malformed: %s", label, endpoint);
+        fmt = "%s host is malformed: %.*s";
+        break;
     case ZB_URL_BAD_PORT:
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "%s has an invalid port: %s", label, endpoint);
-    case ZB_URL_OOM:
+        fmt = "%s has an invalid port: %.*s";
+        break;
+    case ZB_URL_HAS_PATH:
     default:
-        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+        fmt = "%s must be a bare scheme://host[:port] with no path, query, "
+              "fragment, or trailing slash: %.*s";
+        break;
     }
-    if (!is_https) {
-        if (out_host != NULL) {
-            free(*out_host);
-            *out_host = NULL;
-        }
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "%s must use https: %s", label, endpoint);
+    if (out_error != NULL) {
+        int shown = endpoint.len > INT_MAX ? INT_MAX : (int)endpoint.len;
+        *out_error = zb_error_newf(ZEROBUS_STATUS_INVALID_ARGUMENT, fmt, label,
+                                   shown, endpoint.data);
     }
-    return ZEROBUS_STATUS_OK;
+    return false;
 }
 
 zerobus_status_t
@@ -77,8 +79,8 @@ zerobus_sdk_builder_set_endpoint(zerobus_sdk_builder_t *builder,
                                  zerobus_string_view_t zerobus_endpoint,
                                  zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -88,33 +90,12 @@ zerobus_sdk_builder_set_endpoint(zerobus_sdk_builder_t *builder,
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "zerobus endpoint must be non-empty valid UTF-8");
     }
-    /* Validate before storing (transactional): a rejected endpoint leaves the
-     * previous value in place. */
-    char *copy = zb_strdup_view(zerobus_endpoint);
-    if (copy == NULL) {
-        return ZEROBUS_STATUS_OUT_OF_MEMORY;
-    }
-    char *host = NULL;
-    zerobus_status_t s =
-        validate_endpoint(copy, "zerobus endpoint", &host, out_error);
-    if (s != ZEROBUS_STATUS_OK) {
-        free(copy);
-        return s;
-    }
-    /* Zerobus-only: require a dot with a label after it, so a single-label host
-     * ("localhost", "localhost.") is rejected. */
-    const char *dot = strchr(host, '.');
-    if (dot == NULL || dot[1] == '\0') {
-        zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                "zerobus endpoint host \"%s\" has no workspace subdomain",
-                host);
-        free(host);
-        free(copy);
+    if (!validate_endpoint(zerobus_endpoint, "zerobus endpoint", out_error)) {
         return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
-    free(host);
-    free(builder->endpoint);
-    builder->endpoint = copy;
+    if (!zb_replace_string(&builder->endpoint, zerobus_endpoint)) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
     return ZEROBUS_STATUS_OK;
 }
 
@@ -122,8 +103,8 @@ zerobus_status_t zerobus_sdk_builder_set_unity_catalog_endpoint(
     zerobus_sdk_builder_t *builder,
     zerobus_string_view_t unity_catalog_endpoint, zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -133,19 +114,13 @@ zerobus_status_t zerobus_sdk_builder_set_unity_catalog_endpoint(
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "unity catalog endpoint must be non-empty valid UTF-8");
     }
-    char *copy = zb_strdup_view(unity_catalog_endpoint);
-    if (copy == NULL) {
+    if (!validate_endpoint(unity_catalog_endpoint, "unity catalog endpoint",
+                           out_error)) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
+    }
+    if (!zb_replace_string(&builder->uc_endpoint, unity_catalog_endpoint)) {
         return ZEROBUS_STATUS_OUT_OF_MEMORY;
     }
-    /* Host presence is enough for the UC endpoint; no subdomain requirement. */
-    zerobus_status_t s =
-        validate_endpoint(copy, "unity catalog endpoint", NULL, out_error);
-    if (s != ZEROBUS_STATUS_OK) {
-        free(copy);
-        return s;
-    }
-    free(builder->uc_endpoint);
-    builder->uc_endpoint = copy;
     return ZEROBUS_STATUS_OK;
 }
 
@@ -153,11 +128,11 @@ zerobus_status_t zerobus_sdk_builder_build(const zerobus_sdk_builder_t *builder,
                                            zerobus_sdk_t **out_sdk,
                                            zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
-    }
     if (out_sdk != NULL) {
         *out_sdk = NULL;
+    }
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL || out_sdk == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,

--- a/purec/src/stream.c
+++ b/purec/src/stream.c
@@ -1,0 +1,248 @@
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "error.h"
+#include "utils.h"
+#include "zerobus/stream.h"
+
+/* Record size limit: just under the server's ~10 MiB request cap, leaving
+ * headroom for framing and protocol overhead. No public knob for it yet. */
+#define ZB_MAX_PAYLOAD_BYTES (10u * 1024u * 1024u - 64u * 1024u)
+
+struct zerobus_stream_builder {
+    zerobus_sdk_t *sdk; /* borrowed, must outlive the builder and its streams */
+    char *table;
+    char *client_id;
+    char *client_secret; /* zeroized on free */
+};
+
+struct zerobus_stream {
+    zerobus_sdk_t *sdk; /* borrowed, must outlive the stream */
+    char *table;
+    char *client_id;
+    char *client_secret; /* zeroized on free */
+
+    bool closed; /* set by close, rejects ingest once true */
+};
+
+/* ---- builder ----------------------------------------------------------- */
+
+zerobus_status_t
+zerobus_stream_builder_new(zerobus_sdk_t *sdk,
+                           zerobus_stream_builder_t **out_builder,
+                           zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (out_builder != NULL) {
+        *out_builder = NULL;
+    }
+    if (sdk == NULL || out_builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "sdk and out_builder must not be NULL");
+    }
+    zerobus_stream_builder_t *b =
+        (zerobus_stream_builder_t *)calloc(1, sizeof(*b));
+    if (b == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    b->sdk = sdk;
+    *out_builder = b;
+    return ZEROBUS_STATUS_OK;
+}
+
+zerobus_status_t
+zerobus_stream_builder_set_table(zerobus_stream_builder_t *builder,
+                                 zerobus_string_view_t table_name,
+                                 zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder must not be NULL");
+    }
+    if (!zb_is_valid_string(table_name)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "table name must be non-empty valid UTF-8");
+    }
+    if (!zb_table_name_is_valid(table_name)) {
+        return zb_fail(
+            out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+            "table name must be fully qualified as catalog.schema.table");
+    }
+    if (!zb_replace_string(&builder->table, table_name)) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    return ZEROBUS_STATUS_OK;
+}
+
+zerobus_status_t zerobus_stream_builder_set_oauth(
+    zerobus_stream_builder_t *builder, zerobus_string_view_t client_id,
+    zerobus_string_view_t client_secret, zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (builder == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder must not be NULL");
+    }
+    if (!zb_is_valid_string(client_id) || !zb_is_valid_string(client_secret)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "client id and secret must be non-empty valid UTF-8");
+    }
+    /* Allocate both copies before mutating the builder (transactional). */
+    char *id_copy = zb_strdup_view(client_id);
+    char *secret_copy = zb_strdup_view(client_secret);
+    if (id_copy == NULL || secret_copy == NULL) {
+        free(id_copy);
+        zb_secure_free_cstr(secret_copy);
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    free(builder->client_id);
+    zb_secure_free_cstr(builder->client_secret);
+    builder->client_id = id_copy;
+    builder->client_secret = secret_copy;
+    return ZEROBUS_STATUS_OK;
+}
+
+void zerobus_stream_builder_free(zerobus_stream_builder_t *builder)
+{
+    if (builder == NULL) {
+        return;
+    }
+    free(builder->table);
+    free(builder->client_id);
+    zb_secure_free_cstr(builder->client_secret);
+    free(builder);
+}
+
+zerobus_status_t
+zerobus_stream_builder_build(const zerobus_stream_builder_t *builder,
+                             zerobus_stream_t **out_stream,
+                             zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (out_stream != NULL) {
+        *out_stream = NULL;
+    }
+    if (builder == NULL || out_stream == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "builder and out_stream must not be NULL");
+    }
+    if (builder->table == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "table name is required");
+    }
+    if (builder->client_id == NULL || builder->client_secret == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "OAuth client credentials are required");
+    }
+
+    /* TODO: mint an OAuth token and open the authenticated stream. */
+    zerobus_stream_t *s = (zerobus_stream_t *)calloc(1, sizeof(*s));
+    if (s == NULL) {
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+    s->sdk = builder->sdk;
+    s->table = zb_strdup(builder->table);
+    s->client_id = zb_strdup(builder->client_id);
+    s->client_secret = zb_strdup(builder->client_secret);
+    if (s->table == NULL || s->client_id == NULL || s->client_secret == NULL) {
+        zerobus_stream_free(s);
+        return ZEROBUS_STATUS_OUT_OF_MEMORY;
+    }
+
+    *out_stream = s;
+    return ZEROBUS_STATUS_OK;
+}
+
+/* ---- ingest ------------------------------------------------------------ */
+
+zerobus_status_t
+zerobus_stream_ingest_json_record(zerobus_stream_t *stream,
+                                  zerobus_string_view_t json_record,
+                                  zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (stream == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "stream must not be NULL");
+    }
+    if (stream->closed) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "stream is closing or closed");
+    }
+    if (zb_is_empty(json_record)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "record must be a non-empty JSON value");
+    }
+    if (json_record.len > ZB_MAX_PAYLOAD_BYTES) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "record of %zu bytes exceeds the %u-byte limit",
+                       json_record.len, (unsigned)ZB_MAX_PAYLOAD_BYTES);
+    }
+    if (!zb_is_valid_json(json_record)) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "record is not a well-formed UTF-8 JSON value");
+    }
+
+    /* TODO: copy the record, assign its sequence, and queue it for the sender.
+     */
+    return ZEROBUS_STATUS_OK;
+}
+
+/* ---- flush ------------------------------------------------------------- */
+
+zerobus_status_t zerobus_stream_flush(zerobus_stream_t *stream,
+                                      zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (stream == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "stream must not be NULL");
+    }
+    /* TODO: wait for the server to acknowledge every queued record. */
+    return ZEROBUS_STATUS_OK;
+}
+
+/* ---- close ------------------------------------------------------------- */
+
+zerobus_status_t zerobus_stream_close(zerobus_stream_t *stream,
+                                      zerobus_error_t **out_error)
+{
+    if (out_error != NULL) {
+        *out_error = NULL;
+    }
+    if (stream == NULL) {
+        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
+                       "stream must not be NULL");
+    }
+    /* TODO: flush pending records before teardown, returning any flush error.
+     */
+    stream->closed = true;
+    return ZEROBUS_STATUS_OK;
+}
+
+/* ---- free -------------------------------------------------------------- */
+
+void zerobus_stream_free(zerobus_stream_t *stream)
+{
+    if (stream == NULL) {
+        return;
+    }
+    /* TODO: tear down the transport and join I/O workers before freeing. */
+    free(stream->table);
+    free(stream->client_id);
+    zb_secure_free_cstr(stream->client_secret);
+    free(stream);
+}

--- a/purec/src/stream.c
+++ b/purec/src/stream.c
@@ -32,11 +32,11 @@ zerobus_stream_builder_new(zerobus_sdk_t *sdk,
                            zerobus_stream_builder_t **out_builder,
                            zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
-    }
     if (out_builder != NULL) {
         *out_builder = NULL;
+    }
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (sdk == NULL || out_builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -57,8 +57,8 @@ zerobus_stream_builder_set_table(zerobus_stream_builder_t *builder,
                                  zerobus_string_view_t table_name,
                                  zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -83,8 +83,8 @@ zerobus_status_t zerobus_stream_builder_set_oauth(
     zerobus_stream_builder_t *builder, zerobus_string_view_t client_id,
     zerobus_string_view_t client_secret, zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -109,27 +109,16 @@ zerobus_status_t zerobus_stream_builder_set_oauth(
     return ZEROBUS_STATUS_OK;
 }
 
-void zerobus_stream_builder_free(zerobus_stream_builder_t *builder)
-{
-    if (builder == NULL) {
-        return;
-    }
-    free(builder->table);
-    free(builder->client_id);
-    zb_secure_free_cstr(builder->client_secret);
-    free(builder);
-}
-
 zerobus_status_t
 zerobus_stream_builder_build(const zerobus_stream_builder_t *builder,
                              zerobus_stream_t **out_stream,
                              zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
-    }
     if (out_stream != NULL) {
         *out_stream = NULL;
+    }
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (builder == NULL || out_stream == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -162,15 +151,25 @@ zerobus_stream_builder_build(const zerobus_stream_builder_t *builder,
     return ZEROBUS_STATUS_OK;
 }
 
-/* ---- ingest ------------------------------------------------------------ */
-
-zerobus_status_t
-zerobus_stream_ingest_json_record(zerobus_stream_t *stream,
-                                  zerobus_string_view_t json_record,
-                                  zerobus_error_t **out_error)
+void zerobus_stream_builder_free(zerobus_stream_builder_t *builder)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (builder == NULL) {
+        return;
+    }
+    free(builder->table);
+    free(builder->client_id);
+    zb_secure_free_cstr(builder->client_secret);
+    free(builder);
+}
+
+/* ---- stream ------------------------------------------------------------ */
+
+zerobus_status_t zerobus_stream_ingest_json_record(
+    zerobus_stream_t *stream, zerobus_string_view_t json_record,
+    zerobus_offset_t *out_offset, zerobus_error_t **out_error)
+{
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (stream == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
@@ -182,58 +181,58 @@ zerobus_stream_ingest_json_record(zerobus_stream_t *stream,
     }
     if (zb_is_empty(json_record)) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "record must be a non-empty JSON value");
+                       "record must be non-empty");
     }
     if (json_record.len > ZB_MAX_PAYLOAD_BYTES) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "record of %zu bytes exceeds the %u-byte limit",
                        json_record.len, (unsigned)ZB_MAX_PAYLOAD_BYTES);
     }
-    if (!zb_is_valid_json(json_record)) {
-        return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
-                       "record is not a well-formed UTF-8 JSON value");
-    }
 
-    /* TODO: copy the record, assign its sequence, and queue it for the sender.
-     */
-    return ZEROBUS_STATUS_OK;
+    /* TODO: copy the record, assign its offset, and queue it for the sender. On
+     * success write the offset to *out_offset when non-NULL. Returns
+     * UNIMPLEMENTED until the networking core lands. */
+    (void)out_offset;
+    return ZEROBUS_STATUS_UNIMPLEMENTED;
 }
-
-/* ---- flush ------------------------------------------------------------- */
 
 zerobus_status_t zerobus_stream_flush(zerobus_stream_t *stream,
                                       zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (stream == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "stream must not be NULL");
     }
-    /* TODO: wait for the server to acknowledge every queued record. */
-    return ZEROBUS_STATUS_OK;
+    if (stream->closed) {
+        return zb_fail(out_error, ZEROBUS_STATUS_FAILED_PRECONDITION,
+                       "stream is closing or closed");
+    }
+    /* TODO: wait for the server to acknowledge every queued record. Returns
+     * UNIMPLEMENTED until the networking core lands. */
+    return ZEROBUS_STATUS_UNIMPLEMENTED;
 }
-
-/* ---- close ------------------------------------------------------------- */
 
 zerobus_status_t zerobus_stream_close(zerobus_stream_t *stream,
                                       zerobus_error_t **out_error)
 {
-    if (out_error != NULL) {
-        *out_error = NULL;
+    if (out_error != NULL && *out_error != NULL) {
+        return ZEROBUS_STATUS_INVALID_ARGUMENT;
     }
     if (stream == NULL) {
         return zb_fail(out_error, ZEROBUS_STATUS_INVALID_ARGUMENT,
                        "stream must not be NULL");
+    }
+    if (stream->closed) {
+        return ZEROBUS_STATUS_OK;
     }
     /* TODO: flush pending records before teardown, returning any flush error.
      */
     stream->closed = true;
     return ZEROBUS_STATUS_OK;
 }
-
-/* ---- free -------------------------------------------------------------- */
 
 void zerobus_stream_free(zerobus_stream_t *stream)
 {

--- a/purec/src/utils.c
+++ b/purec/src/utils.c
@@ -1,0 +1,533 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+/* ---- UTF-8 -------------------------------------------------------------- */
+
+ZB_STATIC bool is_valid_utf8(const char *text, size_t len)
+{
+    /* Byte inspection below needs unsigned arithmetic: char is signed on some
+     * platforms, which would break the lead/continuation-byte masks. */
+    const uint8_t *bytes = (const uint8_t *)text;
+    if (bytes == NULL) {
+        return len == 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        uint8_t c = bytes[i];
+        if (c == 0x00) {
+            return false; /* embedded NUL */
+        }
+        if (c < 0x80) {
+            continue;
+        }
+        size_t extra;
+        uint8_t lo, hi;
+        if ((c & 0xE0) == 0xC0) {
+            extra = 1;
+            lo = 0x80;
+            hi = 0xBF;
+            if (c < 0xC2) {
+                return false; /* overlong 2-byte */
+            }
+        } else if ((c & 0xF0) == 0xE0) {
+            extra = 2;
+            /* Constrain the first continuation byte to reject overlong forms
+             * and UTF-16 surrogates. */
+            lo = (c == 0xE0) ? 0xA0 : 0x80;
+            hi = (c == 0xED) ? 0x9F : 0xBF;
+        } else if ((c & 0xF8) == 0xF0) {
+            extra = 3;
+            lo = (c == 0xF0) ? 0x90 : 0x80;
+            hi = (c == 0xF4) ? 0x8F : 0xBF;
+            if (c > 0xF4) {
+                return false; /* > U+10FFFF */
+            }
+        } else {
+            return false; /* invalid lead byte or stray continuation */
+        }
+        if (i + extra >= len) {
+            return false; /* truncated sequence */
+        }
+        uint8_t first = bytes[i + 1];
+        if (first < lo || first > hi) {
+            return false;
+        }
+        for (size_t k = 2; k <= extra; ++k) {
+            uint8_t cc = bytes[i + k];
+            if ((cc & 0xC0) != 0x80) {
+                return false;
+            }
+        }
+        i += extra; /* the loop's i++ accounts for the lead byte */
+    }
+    return true;
+}
+
+/* ---- minimal JSON structural validator --------------------------------- */
+
+typedef struct {
+    const uint8_t *p;
+    const uint8_t *end;
+} json_reader;
+
+static void json_skip_ws(json_reader *r)
+{
+    while (r->p < r->end) {
+        uint8_t c = *r->p;
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            r->p++;
+        } else {
+            break;
+        }
+    }
+}
+
+static bool json_value(json_reader *r, int depth);
+
+static bool json_literal(json_reader *r, const char *lit)
+{
+    size_t n = strlen(lit);
+    if ((size_t)(r->end - r->p) < n || memcmp(r->p, lit, n) != 0) {
+        return false;
+    }
+    r->p += n;
+    return true;
+}
+
+static bool json_string(json_reader *r)
+{
+    if (r->p >= r->end || *r->p != '"') {
+        return false;
+    }
+    r->p++;
+    while (r->p < r->end) {
+        uint8_t c = *r->p++;
+        if (c == '"') {
+            return true;
+        }
+        if (c == '\\') {
+            if (r->p >= r->end) {
+                return false;
+            }
+            uint8_t e = *r->p++;
+            if (e == 'u') {
+                if (r->end - r->p < 4) {
+                    return false;
+                }
+                for (int i = 0; i < 4; ++i) {
+                    uint8_t h = *r->p++;
+                    bool hex = (h >= '0' && h <= '9') ||
+                               (h >= 'a' && h <= 'f') || (h >= 'A' && h <= 'F');
+                    if (!hex) {
+                        return false;
+                    }
+                }
+            } else if (e != '"' && e != '\\' && e != '/' && e != 'b' &&
+                       e != 'f' && e != 'n' && e != 'r' && e != 't') {
+                return false;
+            }
+        } else if (c < 0x20) {
+            return false; /* control characters must be escaped */
+        }
+    }
+    return false; /* unterminated */
+}
+
+static bool json_number(json_reader *r)
+{
+    const uint8_t *start = r->p;
+    if (r->p < r->end && *r->p == '-') {
+        r->p++;
+    }
+    if (r->p >= r->end) {
+        return false;
+    }
+    if (*r->p == '0') {
+        r->p++;
+    } else if (*r->p >= '1' && *r->p <= '9') {
+        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
+            r->p++;
+        }
+    } else {
+        return false;
+    }
+    if (r->p < r->end && *r->p == '.') {
+        r->p++;
+        if (r->p >= r->end || *r->p < '0' || *r->p > '9') {
+            return false;
+        }
+        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
+            r->p++;
+        }
+    }
+    if (r->p < r->end && (*r->p == 'e' || *r->p == 'E')) {
+        r->p++;
+        if (r->p < r->end && (*r->p == '+' || *r->p == '-')) {
+            r->p++;
+        }
+        if (r->p >= r->end || *r->p < '0' || *r->p > '9') {
+            return false;
+        }
+        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
+            r->p++;
+        }
+    }
+    return r->p != start;
+}
+
+static bool json_array(json_reader *r, int depth)
+{
+    if (depth > ZB_JSON_MAX_DEPTH) {
+        return false;
+    }
+    r->p++; /* consume '[' */
+    json_skip_ws(r);
+    if (r->p < r->end && *r->p == ']') {
+        r->p++;
+        return true;
+    }
+    for (;;) {
+        if (!json_value(r, depth)) {
+            return false;
+        }
+        json_skip_ws(r);
+        if (r->p >= r->end) {
+            return false;
+        }
+        if (*r->p == ',') {
+            r->p++;
+            continue;
+        }
+        if (*r->p == ']') {
+            r->p++;
+            return true;
+        }
+        return false;
+    }
+}
+
+static bool json_object(json_reader *r, int depth)
+{
+    if (depth > ZB_JSON_MAX_DEPTH) {
+        return false;
+    }
+    r->p++; /* consume '{' */
+    json_skip_ws(r);
+    if (r->p < r->end && *r->p == '}') {
+        r->p++;
+        return true;
+    }
+    for (;;) {
+        json_skip_ws(r);
+        if (!json_string(r)) {
+            return false;
+        }
+        json_skip_ws(r);
+        if (r->p >= r->end || *r->p != ':') {
+            return false;
+        }
+        r->p++;
+        json_skip_ws(r);
+        if (!json_value(r, depth)) {
+            return false;
+        }
+        json_skip_ws(r);
+        if (r->p >= r->end) {
+            return false;
+        }
+        if (*r->p == ',') {
+            r->p++;
+            continue;
+        }
+        if (*r->p == '}') {
+            r->p++;
+            return true;
+        }
+        return false;
+    }
+}
+
+static bool json_value(json_reader *r, int depth)
+{
+    json_skip_ws(r);
+    if (r->p >= r->end) {
+        return false;
+    }
+    switch (*r->p) {
+    case '{':
+        return json_object(r, depth + 1);
+    case '[':
+        return json_array(r, depth + 1);
+    case '"':
+        return json_string(r);
+    case 't':
+        return json_literal(r, "true");
+    case 'f':
+        return json_literal(r, "false");
+    case 'n':
+        return json_literal(r, "null");
+    default:
+        return json_number(r);
+    }
+}
+
+ZB_STATIC bool is_valid_json(const char *text, size_t len)
+{
+    if (text == NULL || len == 0) {
+        return false;
+    }
+    if (!is_valid_utf8(text, len)) {
+        return false;
+    }
+    const uint8_t *bytes = (const uint8_t *)text;
+    json_reader r = {bytes, bytes + len};
+    if (!json_value(&r, 0)) {
+        return false;
+    }
+    json_skip_ws(&r);
+    return r.p == r.end; /* nothing but whitespace may trail the value */
+}
+
+/* ---- view classification ----------------------------------------------- */
+
+bool zb_is_empty(zerobus_string_view_t view)
+{
+    return view.data == NULL || view.len == 0;
+}
+
+bool zb_is_valid_string(zerobus_string_view_t view)
+{
+    if (zb_is_empty(view)) {
+        return false;
+    }
+    return is_valid_utf8(view.data, view.len);
+}
+
+bool zb_is_valid_json(zerobus_string_view_t view)
+{
+    if (zb_is_empty(view)) {
+        return false;
+    }
+    return is_valid_json(view.data, view.len);
+}
+
+/* ---- table name -------------------------------------------------------- */
+
+bool zb_table_name_is_valid(zerobus_string_view_t table)
+{
+    if (!zb_is_valid_string(table)) {
+        return false;
+    }
+    /* Exactly three non-empty, dot-separated components. */
+    size_t component_len = 0;
+    size_t components = 0;
+    for (size_t i = 0; i < table.len; ++i) {
+        if (table.data[i] == '.') {
+            if (component_len == 0) {
+                return false; /* empty component (leading, trailing, or "..") */
+            }
+            components++;
+            component_len = 0;
+        } else {
+            component_len++;
+        }
+    }
+    if (component_len == 0) {
+        return false; /* trailing dot */
+    }
+    components++;
+    return components == 3;
+}
+
+/* ---- endpoint URL ------------------------------------------------------- */
+
+/* Non-empty dot-separated labels, with one optional trailing dot (the DNS root
+ * form). Rejects "a..b", ".a" and "". */
+ZB_STATIC bool host_labels_are_valid(const char *host, size_t len)
+{
+    size_t label = 0;
+    for (size_t i = 0; i < len; ++i) {
+        if (host[i] == '.') {
+            if (label == 0) {
+                return false;
+            }
+            label = 0;
+        } else {
+            label++;
+        }
+    }
+    /* Empty labels (leading or interior) are already rejected in the loop, so
+     * reaching here with a non-empty host means every label is valid. */
+    return len > 0;
+}
+
+zb_url_result zb_url_validate(const char *endpoint, char **out_host,
+                              bool *out_is_https)
+{
+    if (out_host != NULL) {
+        *out_host = NULL;
+    }
+    if (endpoint == NULL) {
+        return ZB_URL_NO_SCHEME;
+    }
+
+    const char *rest;
+    bool is_https;
+    if (strncmp(endpoint, "https://", 8) == 0) {
+        rest = endpoint + 8;
+        is_https = true;
+    } else if (strncmp(endpoint, "http://", 7) == 0) {
+        rest = endpoint + 7;
+        is_https = false;
+    } else {
+        return ZB_URL_NO_SCHEME;
+    }
+
+    /* The authority ends at the first '/', '?' or '#'. */
+    size_t authority_len = 0;
+    while (rest[authority_len] != '\0' && rest[authority_len] != '/' &&
+           rest[authority_len] != '?' && rest[authority_len] != '#') {
+        ++authority_len;
+    }
+    if (authority_len == 0) {
+        return ZB_URL_EMPTY_HOST;
+    }
+
+    /* Userinfo ("user[:pass]@host") is not supported. */
+    for (size_t i = 0; i < authority_len; ++i) {
+        if (rest[i] == '@') {
+            return ZB_URL_BAD_HOST;
+        }
+    }
+
+    /* The host is the authority up to an optional ":port". IPv6 literals in
+     * [brackets] carry their own colons and are not supported. */
+    size_t host_len = authority_len;
+    for (size_t i = 0; i < authority_len; ++i) {
+        if (rest[i] == ':') {
+            host_len = i;
+            break;
+        }
+    }
+    if (host_len == 0) {
+        return ZB_URL_EMPTY_HOST;
+    }
+    if (rest[0] == '[') {
+        return ZB_URL_BAD_HOST;
+    }
+    for (size_t i = 0; i < host_len; ++i) {
+        unsigned char c = (unsigned char)rest[i];
+        if (c <= ' ' || c == 0x7f) { /* no spaces or control characters */
+            return ZB_URL_BAD_HOST;
+        }
+    }
+    if (!host_labels_are_valid(rest, host_len)) {
+        return ZB_URL_BAD_HOST;
+    }
+
+    /* A present port must be a non-empty run of digits in 1..65535. */
+    if (host_len < authority_len) {
+        if (host_len + 1 == authority_len) { /* ':' with nothing after it */
+            return ZB_URL_BAD_PORT;
+        }
+        unsigned long port = 0;
+        for (size_t i = host_len + 1; i < authority_len; ++i) {
+            if (rest[i] < '0' || rest[i] > '9') {
+                return ZB_URL_BAD_PORT;
+            }
+            port = port * 10u + (unsigned long)(rest[i] - '0');
+            if (port > 65535u) {
+                return ZB_URL_BAD_PORT;
+            }
+        }
+        if (port == 0) {
+            return ZB_URL_BAD_PORT;
+        }
+    }
+
+    /* Both out-params are written only on success, so a failure leaves them as
+     * the caller set them (*out_host was NULL'd on entry). */
+    if (out_host != NULL) {
+        char *host = zb_strndup(rest, host_len);
+        if (host == NULL) {
+            return ZB_URL_OOM;
+        }
+        *out_host = host;
+    }
+    if (out_is_https != NULL) {
+        *out_is_https = is_https;
+    }
+    return ZB_URL_OK;
+}
+
+/* ---- owned-memory helpers ---------------------------------------------- */
+
+bool zb_replace_string(char **target, zerobus_string_view_t view)
+{
+    char *copy = zb_strdup_view(view);
+    if (copy == NULL) {
+        return false;
+    }
+    free(*target);
+    *target = copy;
+    return true;
+}
+
+char *zb_strndup(const char *src, size_t len)
+{
+    if (src == NULL) {
+        return NULL;
+    }
+    char *out = (char *)malloc(len + 1);
+    if (out == NULL) {
+        return NULL;
+    }
+    memcpy(out, src, len);
+    out[len] = '\0';
+    return out;
+}
+
+char *zb_strdup_view(zerobus_string_view_t view)
+{
+    return zb_strndup(view.data, view.len);
+}
+
+char *zb_strdup(const char *s)
+{
+    if (s == NULL) {
+        return NULL;
+    }
+    return zb_strndup(s, strlen(s));
+}
+
+/*
+ * A volatile pointer stops a compiler from treating the store as dead. It is
+ * the plain-C stand-in for the platform explicit_bzero / SecureZeroMemory the
+ * production layer would use.
+ */
+void zb_secure_zero(void *p, size_t len)
+{
+    if (p == NULL || len == 0) {
+        return;
+    }
+    volatile unsigned char *q = (volatile unsigned char *)p;
+    while (len-- > 0) {
+        *q++ = 0;
+    }
+}
+
+void zb_secure_free(void *p, size_t len)
+{
+    if (p == NULL) {
+        return;
+    }
+    zb_secure_zero(p, len);
+    free(p);
+}
+
+void zb_secure_free_cstr(char *s)
+{
+    zb_secure_free(s, s != NULL ? strlen(s) : 0);
+}

--- a/purec/src/utils.c
+++ b/purec/src/utils.c
@@ -47,7 +47,7 @@ ZB_STATIC bool is_valid_utf8(const char *text, size_t len)
         } else {
             return false; /* invalid lead byte or stray continuation */
         }
-        if (i + extra >= len) {
+        if (extra >= len - i) {
             return false; /* truncated sequence */
         }
         uint8_t first = bytes[i + 1];
@@ -65,231 +65,6 @@ ZB_STATIC bool is_valid_utf8(const char *text, size_t len)
     return true;
 }
 
-/* ---- minimal JSON structural validator --------------------------------- */
-
-typedef struct {
-    const uint8_t *p;
-    const uint8_t *end;
-} json_reader;
-
-static void json_skip_ws(json_reader *r)
-{
-    while (r->p < r->end) {
-        uint8_t c = *r->p;
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
-            r->p++;
-        } else {
-            break;
-        }
-    }
-}
-
-static bool json_value(json_reader *r, int depth);
-
-static bool json_literal(json_reader *r, const char *lit)
-{
-    size_t n = strlen(lit);
-    if ((size_t)(r->end - r->p) < n || memcmp(r->p, lit, n) != 0) {
-        return false;
-    }
-    r->p += n;
-    return true;
-}
-
-static bool json_string(json_reader *r)
-{
-    if (r->p >= r->end || *r->p != '"') {
-        return false;
-    }
-    r->p++;
-    while (r->p < r->end) {
-        uint8_t c = *r->p++;
-        if (c == '"') {
-            return true;
-        }
-        if (c == '\\') {
-            if (r->p >= r->end) {
-                return false;
-            }
-            uint8_t e = *r->p++;
-            if (e == 'u') {
-                if (r->end - r->p < 4) {
-                    return false;
-                }
-                for (int i = 0; i < 4; ++i) {
-                    uint8_t h = *r->p++;
-                    bool hex = (h >= '0' && h <= '9') ||
-                               (h >= 'a' && h <= 'f') || (h >= 'A' && h <= 'F');
-                    if (!hex) {
-                        return false;
-                    }
-                }
-            } else if (e != '"' && e != '\\' && e != '/' && e != 'b' &&
-                       e != 'f' && e != 'n' && e != 'r' && e != 't') {
-                return false;
-            }
-        } else if (c < 0x20) {
-            return false; /* control characters must be escaped */
-        }
-    }
-    return false; /* unterminated */
-}
-
-static bool json_number(json_reader *r)
-{
-    const uint8_t *start = r->p;
-    if (r->p < r->end && *r->p == '-') {
-        r->p++;
-    }
-    if (r->p >= r->end) {
-        return false;
-    }
-    if (*r->p == '0') {
-        r->p++;
-    } else if (*r->p >= '1' && *r->p <= '9') {
-        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
-            r->p++;
-        }
-    } else {
-        return false;
-    }
-    if (r->p < r->end && *r->p == '.') {
-        r->p++;
-        if (r->p >= r->end || *r->p < '0' || *r->p > '9') {
-            return false;
-        }
-        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
-            r->p++;
-        }
-    }
-    if (r->p < r->end && (*r->p == 'e' || *r->p == 'E')) {
-        r->p++;
-        if (r->p < r->end && (*r->p == '+' || *r->p == '-')) {
-            r->p++;
-        }
-        if (r->p >= r->end || *r->p < '0' || *r->p > '9') {
-            return false;
-        }
-        while (r->p < r->end && *r->p >= '0' && *r->p <= '9') {
-            r->p++;
-        }
-    }
-    return r->p != start;
-}
-
-static bool json_array(json_reader *r, int depth)
-{
-    if (depth > ZB_JSON_MAX_DEPTH) {
-        return false;
-    }
-    r->p++; /* consume '[' */
-    json_skip_ws(r);
-    if (r->p < r->end && *r->p == ']') {
-        r->p++;
-        return true;
-    }
-    for (;;) {
-        if (!json_value(r, depth)) {
-            return false;
-        }
-        json_skip_ws(r);
-        if (r->p >= r->end) {
-            return false;
-        }
-        if (*r->p == ',') {
-            r->p++;
-            continue;
-        }
-        if (*r->p == ']') {
-            r->p++;
-            return true;
-        }
-        return false;
-    }
-}
-
-static bool json_object(json_reader *r, int depth)
-{
-    if (depth > ZB_JSON_MAX_DEPTH) {
-        return false;
-    }
-    r->p++; /* consume '{' */
-    json_skip_ws(r);
-    if (r->p < r->end && *r->p == '}') {
-        r->p++;
-        return true;
-    }
-    for (;;) {
-        json_skip_ws(r);
-        if (!json_string(r)) {
-            return false;
-        }
-        json_skip_ws(r);
-        if (r->p >= r->end || *r->p != ':') {
-            return false;
-        }
-        r->p++;
-        json_skip_ws(r);
-        if (!json_value(r, depth)) {
-            return false;
-        }
-        json_skip_ws(r);
-        if (r->p >= r->end) {
-            return false;
-        }
-        if (*r->p == ',') {
-            r->p++;
-            continue;
-        }
-        if (*r->p == '}') {
-            r->p++;
-            return true;
-        }
-        return false;
-    }
-}
-
-static bool json_value(json_reader *r, int depth)
-{
-    json_skip_ws(r);
-    if (r->p >= r->end) {
-        return false;
-    }
-    switch (*r->p) {
-    case '{':
-        return json_object(r, depth + 1);
-    case '[':
-        return json_array(r, depth + 1);
-    case '"':
-        return json_string(r);
-    case 't':
-        return json_literal(r, "true");
-    case 'f':
-        return json_literal(r, "false");
-    case 'n':
-        return json_literal(r, "null");
-    default:
-        return json_number(r);
-    }
-}
-
-ZB_STATIC bool is_valid_json(const char *text, size_t len)
-{
-    if (text == NULL || len == 0) {
-        return false;
-    }
-    if (!is_valid_utf8(text, len)) {
-        return false;
-    }
-    const uint8_t *bytes = (const uint8_t *)text;
-    json_reader r = {bytes, bytes + len};
-    if (!json_value(&r, 0)) {
-        return false;
-    }
-    json_skip_ws(&r);
-    return r.p == r.end; /* nothing but whitespace may trail the value */
-}
-
 /* ---- view classification ----------------------------------------------- */
 
 bool zb_is_empty(zerobus_string_view_t view)
@@ -303,14 +78,6 @@ bool zb_is_valid_string(zerobus_string_view_t view)
         return false;
     }
     return is_valid_utf8(view.data, view.len);
-}
-
-bool zb_is_valid_json(zerobus_string_view_t view)
-{
-    if (zb_is_empty(view)) {
-        return false;
-    }
-    return is_valid_json(view.data, view.len);
 }
 
 /* ---- table name -------------------------------------------------------- */
@@ -363,63 +130,77 @@ ZB_STATIC bool host_labels_are_valid(const char *host, size_t len)
     return len > 0;
 }
 
-zb_url_result zb_url_validate(const char *endpoint, char **out_host,
-                              bool *out_is_https)
+/* True if s (len bytes) begins with prefix, matched case-insensitively. prefix
+ * is NUL-terminated and must be lowercase (only s is folded). */
+static bool starts_with(const char *s, size_t len, const char *prefix)
 {
-    if (out_host != NULL) {
-        *out_host = NULL;
+    for (size_t i = 0; prefix[i] != '\0'; ++i) {
+        if (i >= len) {
+            return false;
+        }
+        char c = s[i];
+        if (c >= 'A' && c <= 'Z') {
+            c = (char)(c - 'A' + 'a');
+        }
+        if (c != prefix[i]) {
+            return false;
+        }
     }
-    if (endpoint == NULL) {
+    return true;
+}
+
+zb_url_result zb_url_validate(zerobus_string_view_t endpoint)
+{
+    if (endpoint.data == NULL) {
         return ZB_URL_NO_SCHEME;
     }
 
     const char *rest;
-    bool is_https;
-    if (strncmp(endpoint, "https://", 8) == 0) {
-        rest = endpoint + 8;
-        is_https = true;
-    } else if (strncmp(endpoint, "http://", 7) == 0) {
-        rest = endpoint + 7;
-        is_https = false;
+    size_t rest_len;
+    if (starts_with(endpoint.data, endpoint.len, "https://")) {
+        rest = endpoint.data + 8;
+        rest_len = endpoint.len - 8;
+    } else if (starts_with(endpoint.data, endpoint.len, "http://")) {
+        rest = endpoint.data + 7;
+        rest_len = endpoint.len - 7;
     } else {
         return ZB_URL_NO_SCHEME;
     }
 
-    /* The authority ends at the first '/', '?' or '#'. */
+    /* The authority ends at the first '/', '\', '?' or '#' (or the end). For
+     * http/https, WHATWG treats '\' like '/', so it delimits the authority too.
+     */
     size_t authority_len = 0;
-    while (rest[authority_len] != '\0' && rest[authority_len] != '/' &&
-           rest[authority_len] != '?' && rest[authority_len] != '#') {
+    while (authority_len < rest_len && rest[authority_len] != '/' &&
+           rest[authority_len] != '\\' && rest[authority_len] != '?' &&
+           rest[authority_len] != '#') {
         ++authority_len;
     }
     if (authority_len == 0) {
         return ZB_URL_EMPTY_HOST;
     }
 
-    /* Userinfo ("user[:pass]@host") is not supported. */
-    for (size_t i = 0; i < authority_len; ++i) {
-        if (rest[i] == '@') {
-            return ZB_URL_BAD_HOST;
-        }
+    /* Userinfo ("user[:pass]@host") is not supported. Reject '@' across the
+     * whole authority, before the ':' split, so "user:pass@host" is BAD_HOST
+     * and not a bogus BAD_PORT (the first ':' is inside the userinfo). */
+    if (memchr(rest, '@', authority_len) != NULL) {
+        return ZB_URL_BAD_HOST;
     }
 
-    /* The host is the authority up to an optional ":port". IPv6 literals in
-     * [brackets] carry their own colons and are not supported. */
-    size_t host_len = authority_len;
-    for (size_t i = 0; i < authority_len; ++i) {
-        if (rest[i] == ':') {
-            host_len = i;
-            break;
-        }
-    }
+    /* The host is the authority up to an optional ":port". */
+    const char *colon = (const char *)memchr(rest, ':', authority_len);
+    size_t host_len = colon != NULL ? (size_t)(colon - rest) : authority_len;
     if (host_len == 0) {
         return ZB_URL_EMPTY_HOST;
     }
-    if (rest[0] == '[') {
-        return ZB_URL_BAD_HOST;
-    }
+    /* Reject control/space and the WHATWG forbidden host code points reachable
+     * here: [ ] < > ^ | ('/', '\', '?', '#' already ended the authority, ':'
+     * split off the port, '@' was rejected above). Forbidding brackets also
+     * rejects IPv6 literals. */
     for (size_t i = 0; i < host_len; ++i) {
         unsigned char c = (unsigned char)rest[i];
-        if (c <= ' ' || c == 0x7f) { /* no spaces or control characters */
+        if (c <= ' ' || c == 0x7f || c == '[' || c == ']' || c == '<' ||
+            c == '>' || c == '^' || c == '|') {
             return ZB_URL_BAD_HOST;
         }
     }
@@ -447,17 +228,10 @@ zb_url_result zb_url_validate(const char *endpoint, char **out_host,
         }
     }
 
-    /* Both out-params are written only on success, so a failure leaves them as
-     * the caller set them (*out_host was NULL'd on entry). */
-    if (out_host != NULL) {
-        char *host = zb_strndup(rest, host_len);
-        if (host == NULL) {
-            return ZB_URL_OOM;
-        }
-        *out_host = host;
-    }
-    if (out_is_https != NULL) {
-        *out_is_https = is_https;
+    /* Only a bare origin is allowed: reject a path, query, fragment, or even a
+     * trailing '/' so the accepted string is safe to append a path to. */
+    if (authority_len != rest_len) {
+        return ZB_URL_HAS_PATH;
     }
     return ZB_URL_OK;
 }
@@ -477,8 +251,8 @@ bool zb_replace_string(char **target, zerobus_string_view_t view)
 
 char *zb_strndup(const char *src, size_t len)
 {
-    if (src == NULL) {
-        return NULL;
+    if (src == NULL || len == SIZE_MAX) {
+        return NULL; /* len + 1 would wrap to 0 */
     }
     char *out = (char *)malloc(len + 1);
     if (out == NULL) {

--- a/purec/src/utils.h
+++ b/purec/src/utils.h
@@ -1,0 +1,100 @@
+/*
+ * Input validation and owned-memory helpers shared by the public entry points
+ * in sdk.c and stream.c. Local checks only: no transport, OAuth, protobuf, TLS
+ * or threading code lives here.
+ */
+#ifndef ZB_UTILS_H
+#define ZB_UTILS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "zerobus/common.h"
+
+/* ZB_STATIC marks a helper `static` in the shipped build, and external under a
+ * ZB_TESTING build so unit tests can call it directly (its prototype then goes
+ * in the ZB_TESTING block at the end of this header).
+ *
+ * ZB_TESTING only changes linkage and adds declarations, never guards behavior,
+ * so the testing build stays behaviorally identical to what ships. A real test
+ * seam (fault injection, a mock clock) uses a function pointer or link
+ * substitution, not #ifdef ZB_TESTING. */
+#ifdef ZB_TESTING
+#define ZB_STATIC
+#else
+#define ZB_STATIC static
+#endif
+
+/* Caps JSON container nesting so a deeply nested record cannot overflow the
+ * stack through the validator's recursion. */
+#define ZB_JSON_MAX_DEPTH 1024
+
+/* {NULL, 0} is empty; {NULL, nonzero} is invalid and also reported as empty. */
+bool zb_is_empty(zerobus_string_view_t view);
+
+/* Non-empty, well-formed UTF-8, no embedded NUL. */
+bool zb_is_valid_string(zerobus_string_view_t view);
+
+/* Exactly one well-formed JSON value, surrounded only by optional whitespace.
+ * Structural check, not a schema check. */
+bool zb_is_valid_json(zerobus_string_view_t view);
+
+/*
+ * Report whether a table name is a fully qualified catalog.schema.table: three
+ * non-empty, dot-separated components. This is a simplified structural check —
+ * it does not parse backtick-quoted identifiers or validate character sets.
+ */
+bool zb_table_name_is_valid(zerobus_string_view_t table);
+
+/* Outcome of validating an endpoint URL. */
+typedef enum {
+    ZB_URL_OK = 0,
+    ZB_URL_NO_SCHEME,  /* neither "http://" nor "https://" */
+    ZB_URL_EMPTY_HOST, /* nothing between the scheme and the port/path */
+    ZB_URL_BAD_HOST,   /* empty label, userinfo, IPv6 literal, or a bad char */
+    ZB_URL_BAD_PORT,   /* ":port" is empty or not a number in 1..65535 */
+    ZB_URL_OOM         /* allocating the returned host copy failed */
+} zb_url_result;
+
+/*
+ * Validate an "http(s)://host[:port][/path]" endpoint. *out_is_https reports
+ * the scheme (which scheme is acceptable is the caller's policy). On ZB_URL_OK,
+ * and when out_host is non-NULL, *out_host is a freshly allocated host (no port
+ * or path) that the caller frees. On failure *out_host is NULL and
+ * *out_is_https is untouched.
+ */
+zb_url_result zb_url_validate(const char *endpoint, char **out_host,
+                              bool *out_is_https);
+
+/* Replace *target with a copy of view, freeing the previous value. False on
+ * OOM, leaving *target untouched. */
+bool zb_replace_string(char **target, zerobus_string_view_t view);
+
+/* Duplicate len bytes of src into a fresh NUL-terminated buffer. A NULL src
+ * yields NULL (any len); a non-NULL src with len 0 yields ""; NULL on OOM. */
+char *zb_strndup(const char *src, size_t len);
+
+/* zb_strndup(view.data, view.len). */
+char *zb_strdup_view(zerobus_string_view_t view);
+
+/* zb_strndup(s, strlen(s)), except a NULL s yields NULL. */
+char *zb_strdup(const char *s);
+
+/* Overwrite len bytes at p in a way the optimizer may not elide. Used for OAuth
+ * secrets before freeing. NULL-safe. */
+void zb_secure_zero(void *p, size_t len);
+
+/* Free after securely zeroing len bytes. NULL-safe. */
+void zb_secure_free(void *p, size_t len);
+
+/* zb_secure_free for a NUL-terminated string: zeroes strlen(s) bytes.
+ * NULL-safe. */
+void zb_secure_free_cstr(char *s);
+
+#ifdef ZB_TESTING
+bool is_valid_utf8(const char *text, size_t len);
+bool is_valid_json(const char *text, size_t len);
+bool host_labels_are_valid(const char *host, size_t len);
+#endif
+
+#endif /* ZB_UTILS_H */

--- a/purec/src/utils.h
+++ b/purec/src/utils.h
@@ -25,19 +25,11 @@
 #define ZB_STATIC static
 #endif
 
-/* Caps JSON container nesting so a deeply nested record cannot overflow the
- * stack through the validator's recursion. */
-#define ZB_JSON_MAX_DEPTH 1024
-
 /* {NULL, 0} is empty; {NULL, nonzero} is invalid and also reported as empty. */
 bool zb_is_empty(zerobus_string_view_t view);
 
 /* Non-empty, well-formed UTF-8, no embedded NUL. */
 bool zb_is_valid_string(zerobus_string_view_t view);
-
-/* Exactly one well-formed JSON value, surrounded only by optional whitespace.
- * Structural check, not a schema check. */
-bool zb_is_valid_json(zerobus_string_view_t view);
 
 /*
  * Report whether a table name is a fully qualified catalog.schema.table: three
@@ -50,21 +42,19 @@ bool zb_table_name_is_valid(zerobus_string_view_t table);
 typedef enum {
     ZB_URL_OK = 0,
     ZB_URL_NO_SCHEME,  /* neither "http://" nor "https://" */
-    ZB_URL_EMPTY_HOST, /* nothing between the scheme and the port/path */
+    ZB_URL_EMPTY_HOST, /* nothing between the scheme and the port */
     ZB_URL_BAD_HOST,   /* empty label, userinfo, IPv6 literal, or a bad char */
     ZB_URL_BAD_PORT,   /* ":port" is empty or not a number in 1..65535 */
-    ZB_URL_OOM         /* allocating the returned host copy failed */
+    ZB_URL_HAS_PATH    /* a path, query, fragment, or trailing '/' after host */
 } zb_url_result;
 
 /*
- * Validate an "http(s)://host[:port][/path]" endpoint. *out_is_https reports
- * the scheme (which scheme is acceptable is the caller's policy). On ZB_URL_OK,
- * and when out_host is non-NULL, *out_host is a freshly allocated host (no port
- * or path) that the caller frees. On failure *out_host is NULL and
- * *out_is_https is untouched.
+ * Validate that endpoint is a bare "http(s)://host[:port]" origin. Anything
+ * after the host and optional port — a path, query, fragment, or even a
+ * trailing "/" — is rejected (ZB_URL_HAS_PATH), so the accepted string is safe
+ * to store and append a path to (e.g. the OAuth "/oidc/v1/token").
  */
-zb_url_result zb_url_validate(const char *endpoint, char **out_host,
-                              bool *out_is_https);
+zb_url_result zb_url_validate(zerobus_string_view_t endpoint);
 
 /* Replace *target with a copy of view, freeing the previous value. False on
  * OOM, leaving *target untouched. */
@@ -93,7 +83,6 @@ void zb_secure_free_cstr(char *s);
 
 #ifdef ZB_TESTING
 bool is_valid_utf8(const char *text, size_t len);
-bool is_valid_json(const char *text, size_t len);
 bool host_labels_are_valid(const char *host, size_t len);
 #endif
 

--- a/purec/tests/CMakeLists.txt
+++ b/purec/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# All unit tests link the ZB_TESTING build. It is a superset of the shipped
+# library (every public symbol, plus ZB_STATIC helpers exposed for testing) and
+# is behaviorally identical to it, so a public-only test pays nothing to link
+# it. Each tests/src/<name>_test.c tests the functions in src/<name>.
+set(ZEROBUS_TESTS error_test utils_test sdk_test stream_test)
+
+foreach(test ${ZEROBUS_TESTS})
+  add_executable(${test} src/${test}.c)
+  target_link_libraries(${test} PRIVATE zerobus_c_testing)
+  target_compile_options(${test} PRIVATE ${ZEROBUS_WARN_FLAGS})
+  add_test(NAME ${test} COMMAND ${test})
+endforeach()

--- a/purec/tests/src/error_test.c
+++ b/purec/tests/src/error_test.c
@@ -1,0 +1,58 @@
+/* Unit tests for the error object and its ownership contract. */
+#include <string.h>
+
+#include "error.h"
+#include "test_common.h"
+
+static void test_error_newf(void)
+{
+    zerobus_error_t *e = zb_error_newf(ZEROBUS_STATUS_INVALID_ARGUMENT,
+                                       "bad value %d for %s", 42, "field");
+    CHECK(e != NULL);
+    zerobus_string_view_t m = zerobus_error_message(e);
+    CHECK(m.len == strlen("bad value 42 for field"));
+    CHECK(memcmp(m.data, "bad value 42 for field", m.len) == 0);
+    zerobus_error_free(e);
+}
+
+static void test_error_message_null(void)
+{
+    zerobus_string_view_t m = zerobus_error_message(NULL);
+    CHECK(m.data == NULL);
+    CHECK_EQ_INT(m.len, 0);
+}
+
+static void test_error_free_null(void)
+{
+    zerobus_error_free(NULL); /* must be a no-op */
+    CHECK(1);
+}
+
+static void test_fail_sets_error(void)
+{
+    zerobus_error_t *e = NULL;
+    zerobus_status_t s =
+        zb_fail(&e, ZEROBUS_STATUS_UNAVAILABLE, "temporary %s", "glitch");
+    CHECK_EQ_INT(s, ZEROBUS_STATUS_UNAVAILABLE);
+    CHECK(e != NULL);
+    zerobus_string_view_t m = zerobus_error_message(e);
+    CHECK(m.len == strlen("temporary glitch"));
+    zerobus_error_free(e);
+}
+
+static void test_fail_null_out(void)
+{
+    /* A NULL out_error slot must still return the status without crashing. */
+    zerobus_status_t s = zb_fail(NULL, ZEROBUS_STATUS_INTERNAL, "no slot");
+    CHECK_EQ_INT(s, ZEROBUS_STATUS_INTERNAL);
+}
+
+int main(void)
+{
+    test_error_newf();
+    test_error_message_null();
+    test_error_free_null();
+    test_fail_sets_error();
+    test_fail_null_out();
+    TEST_MAIN_RETURN();
+}

--- a/purec/tests/src/error_test.c
+++ b/purec/tests/src/error_test.c
@@ -47,6 +47,40 @@ static void test_fail_null_out(void)
     CHECK_EQ_INT(s, ZEROBUS_STATUS_INTERNAL);
 }
 
+static void test_error_status(void)
+{
+    zerobus_error_t *e = zb_error_newf(ZEROBUS_STATUS_UNAVAILABLE, "temporary");
+    CHECK(e != NULL);
+    CHECK_EQ_INT(zerobus_error_status(e), ZEROBUS_STATUS_UNAVAILABLE);
+    zerobus_error_free(e);
+
+    /* A NULL error reports UNKNOWN. */
+    CHECK_EQ_INT(zerobus_error_status(NULL), ZEROBUS_STATUS_UNKNOWN);
+}
+
+static void test_error_is_retryable(void)
+{
+    zerobus_error_t *retry = zb_error_newf(ZEROBUS_STATUS_UNAVAILABLE, "again");
+    CHECK(retry != NULL);
+    CHECK(zerobus_error_is_retryable(retry));
+    zerobus_error_free(retry);
+
+    zerobus_error_t *fatal =
+        zb_error_newf(ZEROBUS_STATUS_INVALID_ARGUMENT, "nope");
+    CHECK(fatal != NULL);
+    CHECK(!zerobus_error_is_retryable(fatal));
+    zerobus_error_free(fatal);
+
+    /* Transient transport failures are retryable. */
+    zerobus_error_t *internal = zb_error_newf(ZEROBUS_STATUS_INTERNAL, "blip");
+    CHECK(internal != NULL);
+    CHECK(zerobus_error_is_retryable(internal));
+    zerobus_error_free(internal);
+
+    /* A NULL error is not retryable. */
+    CHECK(!zerobus_error_is_retryable(NULL));
+}
+
 int main(void)
 {
     test_error_newf();
@@ -54,5 +88,7 @@ int main(void)
     test_error_free_null();
     test_fail_sets_error();
     test_fail_null_out();
+    test_error_status();
+    test_error_is_retryable();
     TEST_MAIN_RETURN();
 }

--- a/purec/tests/src/sdk_test.c
+++ b/purec/tests/src/sdk_test.c
@@ -1,0 +1,219 @@
+/* Unit tests for the SDK builder and SDK handle (sdk.c). */
+#include "test_common.h"
+
+static void test_sdk_builder_validation(void)
+{
+    zerobus_error_t *err = NULL;
+
+    /* NULL out_builder. */
+    CHECK_EQ_INT(zerobus_sdk_builder_new(NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    zerobus_sdk_builder_t *b = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_new(&b, &err), ZEROBUS_STATUS_OK);
+    CHECK(b != NULL);
+    CHECK(err == NULL);
+
+    /* Empty endpoint views are invalid, for both setters. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, (zerobus_string_view_t){NULL, 0}, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     b, (zerobus_string_view_t){NULL, 0}, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Build with no endpoint at all. */
+    zerobus_sdk_t *sdk = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, &sdk, &err),
+                 ZEROBUS_STATUS_FAILED_PRECONDITION);
+    CHECK(sdk == NULL);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Endpoint set, but no UC endpoint. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("https://ws.zerobus.r.cloud.databricks.com"), &err),
+                 ZEROBUS_STATUS_OK);
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, &sdk, &err),
+                 ZEROBUS_STATUS_FAILED_PRECONDITION);
+    zerobus_error_free(err);
+    err = NULL;
+
+    zerobus_sdk_builder_free(b);
+}
+
+static void test_sdk_builder_bad_endpoint(void)
+{
+    zerobus_error_t *err = NULL;
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_builder_new(&b, NULL);
+
+    /* The zerobus endpoint setter validates the URL immediately (fail-fast),
+     * leaving the builder's previous value untouched on rejection. */
+
+    /* Missing scheme. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("ws.zerobus.databricks.com"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK(err != NULL);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Plaintext scheme is rejected (secrets must not traverse http). */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("http://ws.zerobus.databricks.com"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Single-label host has no workspace subdomain. */
+    CHECK_EQ_INT(
+        zerobus_sdk_builder_set_endpoint(b, sv("https://localhostname"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Scheme present but no host. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Host with an empty label. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://a..b"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* A malformed ":port". */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("https://ws.zerobus.databricks.com:notaport"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Single label with a DNS-root trailing dot still has no subdomain. */
+    CHECK_EQ_INT(
+        zerobus_sdk_builder_set_endpoint(b, sv("https://localhost."), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* The UC endpoint setter validates too, but without the subdomain rule:
+     * a bad host is rejected, while a single-label host is accepted. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     b, sv("https://a..b"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     b, sv("https://localhost"), &err),
+                 ZEROBUS_STATUS_OK);
+    CHECK(err == NULL);
+
+    zerobus_sdk_builder_free(b);
+}
+
+/* NULL-builder setters and NULL out_sdk. */
+static void test_sdk_builder_edges(void)
+{
+    zerobus_error_t *err = NULL;
+
+    CHECK_EQ_INT(
+        zerobus_sdk_builder_set_endpoint(NULL, sv("https://a.b"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     NULL, sv("https://a.b"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_builder_new(&b, NULL);
+
+    /* NULL out_sdk. */
+    zerobus_sdk_builder_set_endpoint(
+        b, sv("https://ws.zerobus.r.cloud.databricks.com"), NULL);
+    zerobus_sdk_builder_set_unity_catalog_endpoint(
+        b, sv("https://ws.cloud.databricks.com"), NULL);
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+
+    zerobus_sdk_builder_free(b);
+}
+
+static void test_sdk_build_ok(void)
+{
+    /* A valid configuration builds an SDK locally (no network at build time).
+     */
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_builder_new(&b, NULL);
+    zerobus_sdk_builder_set_endpoint(
+        b, sv("https://myws.zerobus.us-west.cloud.databricks.com"), NULL);
+    zerobus_sdk_builder_set_unity_catalog_endpoint(
+        b, sv("https://myws.cloud.databricks.com"), NULL);
+
+    zerobus_error_t *err = NULL;
+    zerobus_sdk_t *sdk = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, &sdk, &err), ZEROBUS_STATUS_OK);
+    CHECK(sdk != NULL);
+    CHECK(err == NULL);
+
+    zerobus_sdk_builder_free(b);
+    zerobus_sdk_free(sdk);
+}
+
+/* A rejected setter is transactional: it leaves the previous value in place. */
+static void test_sdk_setter_transactional(void)
+{
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_builder_new(&b, NULL);
+
+    CHECK_EQ_INT(
+        zerobus_sdk_builder_set_endpoint(
+            b, sv("https://myws.zerobus.us-west.cloud.databricks.com"), NULL),
+        ZEROBUS_STATUS_OK);
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     b, sv("https://myws.cloud.databricks.com"), NULL),
+                 ZEROBUS_STATUS_OK);
+
+    /* A later rejected set_endpoint must not clobber the good value. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://a..b"), NULL),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+
+    /* Build still succeeds using the endpoint set before the failed call. */
+    zerobus_sdk_t *sdk = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, &sdk, NULL), ZEROBUS_STATUS_OK);
+    CHECK(sdk != NULL);
+
+    zerobus_sdk_builder_free(b);
+    zerobus_sdk_free(sdk);
+}
+
+/* Every SDK-side *_free accepts NULL. */
+static void test_sdk_free_null_safe(void)
+{
+    zerobus_sdk_builder_free(NULL);
+    zerobus_sdk_free(NULL);
+    CHECK(1);
+}
+
+int main(void)
+{
+    test_sdk_builder_validation();
+    test_sdk_builder_bad_endpoint();
+    test_sdk_builder_edges();
+    test_sdk_build_ok();
+    test_sdk_setter_transactional();
+    test_sdk_free_null_safe();
+    TEST_MAIN_RETURN();
+}

--- a/purec/tests/src/sdk_test.c
+++ b/purec/tests/src/sdk_test.c
@@ -48,16 +48,16 @@ static void test_sdk_builder_validation(void)
     zerobus_sdk_builder_free(b);
 }
 
-static void test_sdk_builder_bad_endpoint(void)
+static void test_sdk_builder_endpoint_rules(void)
 {
     zerobus_error_t *err = NULL;
     zerobus_sdk_builder_t *b = NULL;
     zerobus_sdk_builder_new(&b, NULL);
 
-    /* The zerobus endpoint setter validates the URL immediately (fail-fast),
-     * leaving the builder's previous value untouched on rejection. */
+    /* The setter validates the URL immediately (fail-fast), leaving the
+     * builder's previous value untouched on rejection. */
 
-    /* Missing scheme. */
+    /* Rejected: missing scheme. */
     CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
                      b, sv("ws.zerobus.databricks.com"), &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
@@ -65,55 +65,52 @@ static void test_sdk_builder_bad_endpoint(void)
     zerobus_error_free(err);
     err = NULL;
 
-    /* Plaintext scheme is rejected (secrets must not traverse http). */
-    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
-                     b, sv("http://ws.zerobus.databricks.com"), &err),
-                 ZEROBUS_STATUS_INVALID_ARGUMENT);
-    zerobus_error_free(err);
-    err = NULL;
-
-    /* Single-label host has no workspace subdomain. */
-    CHECK_EQ_INT(
-        zerobus_sdk_builder_set_endpoint(b, sv("https://localhostname"), &err),
-        ZEROBUS_STATUS_INVALID_ARGUMENT);
-    zerobus_error_free(err);
-    err = NULL;
-
-    /* Scheme present but no host. */
+    /* Rejected: no host, an empty label, a malformed port. */
     CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://"), &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
-
-    /* Host with an empty label. */
     CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://a..b"), &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
-
-    /* A malformed ":port". */
     CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
                      b, sv("https://ws.zerobus.databricks.com:notaport"), &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
 
-    /* Single label with a DNS-root trailing dot still has no subdomain. */
-    CHECK_EQ_INT(
-        zerobus_sdk_builder_set_endpoint(b, sv("https://localhost."), &err),
-        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    /* Rejected: a path or a trailing slash — only a bare origin is stored. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("https://ws.zerobus.databricks.com/path"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("https://ws.zerobus.databricks.com/"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
 
-    /* The UC endpoint setter validates too, but without the subdomain rule:
-     * a bad host is rejected, while a single-label host is accepted. */
+    /* Accepted: http (plaintext, for local/dev) and a single-label host — no
+     * https-only or workspace-subdomain rule. */
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(
+                     b, sv("http://ws.zerobus.databricks.com"), &err),
+                 ZEROBUS_STATUS_OK);
+    CHECK(err == NULL);
+    CHECK_EQ_INT(
+        zerobus_sdk_builder_set_endpoint(b, sv("https://localhost:8080"), &err),
+        ZEROBUS_STATUS_OK);
+    CHECK(err == NULL);
+
+    /* The UC endpoint setter uses the same rules. */
     CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
                      b, sv("https://a..b"), &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
     CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
-                     b, sv("https://localhost"), &err),
+                     b, sv("http://localhost"), &err),
                  ZEROBUS_STATUS_OK);
     CHECK(err == NULL);
 
@@ -207,13 +204,44 @@ static void test_sdk_free_null_safe(void)
     CHECK(1);
 }
 
+/* A non-NULL *out_error on entry is refused at every entry point, and the
+ * existing error is left untouched (not overwritten, freed, or replaced). */
+static void test_sdk_out_error_must_be_null(void)
+{
+    zerobus_error_t *err = NULL;
+    /* Seed a live error through a genuine failure. */
+    CHECK_EQ_INT(zerobus_sdk_builder_new(NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK(err != NULL);
+    const zerobus_error_t *seeded = err;
+
+    /* The guard runs first, so the other arguments do not matter. */
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_t *sdk = NULL;
+    CHECK_EQ_INT(zerobus_sdk_builder_new(&b, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_sdk_builder_set_endpoint(b, sv("https://a.b.c"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_sdk_builder_set_unity_catalog_endpoint(
+                     b, sv("https://a.b"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_sdk_builder_build(b, &sdk, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+
+    CHECK(err == seeded); /* same object: untouched */
+    CHECK(b == NULL);
+    CHECK(sdk == NULL);
+    zerobus_error_free(err);
+}
+
 int main(void)
 {
     test_sdk_builder_validation();
-    test_sdk_builder_bad_endpoint();
+    test_sdk_builder_endpoint_rules();
     test_sdk_builder_edges();
     test_sdk_build_ok();
     test_sdk_setter_transactional();
     test_sdk_free_null_safe();
+    test_sdk_out_error_must_be_null();
     TEST_MAIN_RETURN();
 }

--- a/purec/tests/src/stream_test.c
+++ b/purec/tests/src/stream_test.c
@@ -1,0 +1,273 @@
+/* Unit tests for the stream builder and stream handle (stream.c). */
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_common.h"
+
+/* ---- helpers ----------------------------------------------------------- */
+
+/* Build a valid SDK for the stream tests. Caller frees it. */
+static zerobus_sdk_t *make_sdk(void)
+{
+    zerobus_sdk_builder_t *b = NULL;
+    zerobus_sdk_builder_new(&b, NULL);
+    zerobus_sdk_builder_set_endpoint(
+        b, sv("https://myws.zerobus.us-west.cloud.databricks.com"), NULL);
+    zerobus_sdk_builder_set_unity_catalog_endpoint(
+        b, sv("https://myws.cloud.databricks.com"), NULL);
+    zerobus_sdk_t *sdk = NULL;
+    zerobus_sdk_builder_build(b, &sdk, NULL);
+    zerobus_sdk_builder_free(b);
+    return sdk;
+}
+
+/* Build a valid stream for the ingest/flush/close tests. Caller frees the
+ * stream and the SDK passed in. */
+static zerobus_stream_t *make_stream(zerobus_sdk_t *sdk)
+{
+    zerobus_stream_builder_t *stb = NULL;
+    zerobus_stream_builder_new(sdk, &stb, NULL);
+    zerobus_stream_builder_set_table(stb, sv("cat.sch.tbl"), NULL);
+    zerobus_stream_builder_set_oauth(stb, sv("client-id"), sv("client-secret"),
+                                     NULL);
+    zerobus_stream_t *stream = NULL;
+    zerobus_stream_builder_build(stb, &stream, NULL);
+    zerobus_stream_builder_free(stb);
+    return stream;
+}
+
+/* ---- tests ------------------------------------------------------------- */
+
+static void test_stream_builder_validation(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    CHECK(sdk != NULL);
+
+    zerobus_error_t *err = NULL;
+
+    /* NULL sdk. */
+    zerobus_stream_builder_t *stb = NULL;
+    CHECK_EQ_INT(zerobus_stream_builder_new(NULL, &stb, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    CHECK_EQ_INT(zerobus_stream_builder_new(sdk, &stb, &err),
+                 ZEROBUS_STATUS_OK);
+    CHECK(stb != NULL);
+
+    /* Empty table. */
+    CHECK_EQ_INT(zerobus_stream_builder_set_table(
+                     stb, (zerobus_string_view_t){NULL, 0}, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Not fully qualified (catalog.schema.table). */
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_table(stb, sv("schema.table"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Empty credentials. */
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(stb, sv(""), sv("secret"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Build without a table set: fails before any network work. */
+    zerobus_stream_t *stream = NULL;
+    CHECK_EQ_INT(zerobus_stream_builder_build(stb, &stream, &err),
+                 ZEROBUS_STATUS_FAILED_PRECONDITION);
+    CHECK(stream == NULL);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Table set but no credentials: still fails the precondition. */
+    zerobus_stream_builder_set_table(stb, sv("cat.sch.tbl"), NULL);
+    CHECK_EQ_INT(zerobus_stream_builder_build(stb, &stream, &err),
+                 ZEROBUS_STATUS_FAILED_PRECONDITION);
+    zerobus_error_free(err);
+    err = NULL;
+
+    zerobus_stream_builder_free(stb);
+    zerobus_sdk_free(sdk);
+}
+
+/* NULL-builder setters and NULL out_stream. */
+static void test_stream_builder_edges(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    zerobus_error_t *err = NULL;
+
+    CHECK_EQ_INT(zerobus_stream_builder_set_table(NULL, sv("c.s.t"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(NULL, sv("id"), sv("secret"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    zerobus_stream_builder_t *stb = NULL;
+    zerobus_stream_builder_new(sdk, &stb, NULL);
+
+    /* NULL out_stream. */
+    zerobus_stream_builder_set_table(stb, sv("c.s.t"), NULL);
+    CHECK_EQ_INT(zerobus_stream_builder_build(stb, NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+
+    zerobus_stream_builder_free(stb);
+    zerobus_sdk_free(sdk);
+}
+
+/* set_oauth is transactional: a second valid call replaces (and frees) the
+ * previous credentials, and a rejected call leaves them in place. */
+static void test_stream_oauth_transactional(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    zerobus_stream_builder_t *stb = NULL;
+    zerobus_stream_builder_new(sdk, &stb, NULL);
+    zerobus_stream_builder_set_table(stb, sv("cat.sch.tbl"), NULL);
+
+    /* A second valid set_oauth replaces (and frees) the first. */
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(stb, sv("id1"), sv("sec1"), NULL),
+        ZEROBUS_STATUS_OK);
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(stb, sv("id2"), sv("sec2"), NULL),
+        ZEROBUS_STATUS_OK);
+
+    /* A rejected set_oauth must not clobber the credentials already set. */
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(stb, sv(""), sv("sec3"), NULL),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+
+    /* Build still succeeds using the credentials set before the failed call. */
+    zerobus_stream_t *stream = NULL;
+    CHECK_EQ_INT(zerobus_stream_builder_build(stb, &stream, NULL),
+                 ZEROBUS_STATUS_OK);
+    CHECK(stream != NULL);
+
+    zerobus_stream_free(stream);
+    zerobus_stream_builder_free(stb);
+    zerobus_sdk_free(sdk);
+}
+
+static void test_ingest_validation(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    zerobus_stream_t *stream = make_stream(sdk);
+    CHECK(stream != NULL);
+
+    zerobus_error_t *err = NULL;
+
+    /* NULL stream. */
+    CHECK_EQ_INT(zerobus_stream_ingest_json_record(NULL, sv("{}"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Empty record. */
+    CHECK_EQ_INT(zerobus_stream_ingest_json_record(
+                     stream, (zerobus_string_view_t){NULL, 0}, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Malformed JSON. */
+    CHECK_EQ_INT(
+        zerobus_stream_ingest_json_record(stream, sv("{not json"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Well-formed JSON is admitted. */
+    CHECK_EQ_INT(zerobus_stream_ingest_json_record(
+                     stream, sv("{\"id\":1,\"m\":\"hi\"}"), &err),
+                 ZEROBUS_STATUS_OK);
+    CHECK(err == NULL);
+
+    /* A record past the size ceiling is refused before JSON parsing. */
+    size_t big = 11u * 1024u * 1024u;
+    char *buf = (char *)malloc(big);
+    CHECK(buf != NULL);
+    if (buf != NULL) {
+        memset(buf, 'a', big);
+        CHECK_EQ_INT(zerobus_stream_ingest_json_record(
+                         stream, (zerobus_string_view_t){buf, big}, &err),
+                     ZEROBUS_STATUS_INVALID_ARGUMENT);
+        zerobus_error_free(err);
+        free(buf);
+    }
+
+    zerobus_stream_free(stream);
+    zerobus_sdk_free(sdk);
+}
+
+static void test_flush_close_idempotent(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    zerobus_stream_t *stream = make_stream(sdk);
+    CHECK(stream != NULL);
+
+    zerobus_error_t *err = NULL;
+
+    /* NULL stream. */
+    CHECK_EQ_INT(zerobus_stream_flush(NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+    CHECK_EQ_INT(zerobus_stream_close(NULL, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    zerobus_error_free(err);
+    err = NULL;
+
+    CHECK_EQ_INT(zerobus_stream_flush(stream, &err), ZEROBUS_STATUS_OK);
+    CHECK_EQ_INT(zerobus_stream_close(stream, &err), ZEROBUS_STATUS_OK);
+    /* Idempotent: a second close still succeeds. */
+    CHECK_EQ_INT(zerobus_stream_close(stream, &err), ZEROBUS_STATUS_OK);
+    CHECK(err == NULL);
+
+    /* After close, ingest is rejected with FAILED_PRECONDITION. */
+    CHECK_EQ_INT(
+        zerobus_stream_ingest_json_record(stream, sv("{\"id\":2}"), &err),
+        ZEROBUS_STATUS_FAILED_PRECONDITION);
+    zerobus_error_free(err);
+    err = NULL;
+
+    /* Even a malformed record: the closed check precedes record validation. */
+    CHECK_EQ_INT(
+        zerobus_stream_ingest_json_record(stream, sv("{not json"), &err),
+        ZEROBUS_STATUS_FAILED_PRECONDITION);
+    zerobus_error_free(err);
+
+    /* Flush after close remains valid (nothing pending). */
+    CHECK_EQ_INT(zerobus_stream_flush(stream, NULL), ZEROBUS_STATUS_OK);
+
+    zerobus_stream_free(stream);
+    zerobus_sdk_free(sdk);
+}
+
+/* Every stream-side *_free accepts NULL. */
+static void test_stream_free_null_safe(void)
+{
+    zerobus_stream_builder_free(NULL);
+    zerobus_stream_free(NULL);
+    CHECK(1);
+}
+
+int main(void)
+{
+    test_stream_builder_validation();
+    test_stream_builder_edges();
+    test_stream_oauth_transactional();
+    test_ingest_validation();
+    test_flush_close_idempotent();
+    test_stream_free_null_safe();
+    TEST_MAIN_RETURN();
+}

--- a/purec/tests/src/stream_test.c
+++ b/purec/tests/src/stream_test.c
@@ -167,39 +167,35 @@ static void test_ingest_validation(void)
     zerobus_error_t *err = NULL;
 
     /* NULL stream. */
-    CHECK_EQ_INT(zerobus_stream_ingest_json_record(NULL, sv("{}"), &err),
+    CHECK_EQ_INT(zerobus_stream_ingest_json_record(NULL, sv("{}"), NULL, &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
 
     /* Empty record. */
     CHECK_EQ_INT(zerobus_stream_ingest_json_record(
-                     stream, (zerobus_string_view_t){NULL, 0}, &err),
+                     stream, (zerobus_string_view_t){NULL, 0}, NULL, &err),
                  ZEROBUS_STATUS_INVALID_ARGUMENT);
     zerobus_error_free(err);
     err = NULL;
 
-    /* Malformed JSON. */
     CHECK_EQ_INT(
-        zerobus_stream_ingest_json_record(stream, sv("{not json"), &err),
-        ZEROBUS_STATUS_INVALID_ARGUMENT);
-    zerobus_error_free(err);
-    err = NULL;
-
-    /* Well-formed JSON is admitted. */
+        zerobus_stream_ingest_json_record(stream, sv("record"), NULL, &err),
+        ZEROBUS_STATUS_UNIMPLEMENTED);
+    CHECK(err == NULL);
     CHECK_EQ_INT(zerobus_stream_ingest_json_record(
-                     stream, sv("{\"id\":1,\"m\":\"hi\"}"), &err),
-                 ZEROBUS_STATUS_OK);
+                     stream, sv("{\"id\":1,\"m\":\"hi\"}"), NULL, &err),
+                 ZEROBUS_STATUS_UNIMPLEMENTED);
     CHECK(err == NULL);
 
-    /* A record past the size ceiling is refused before JSON parsing. */
+    /* A record past the size ceiling is refused by the size gate. */
     size_t big = 11u * 1024u * 1024u;
     char *buf = (char *)malloc(big);
     CHECK(buf != NULL);
     if (buf != NULL) {
         memset(buf, 'a', big);
         CHECK_EQ_INT(zerobus_stream_ingest_json_record(
-                         stream, (zerobus_string_view_t){buf, big}, &err),
+                         stream, (zerobus_string_view_t){buf, big}, NULL, &err),
                      ZEROBUS_STATUS_INVALID_ARGUMENT);
         zerobus_error_free(err);
         free(buf);
@@ -227,7 +223,8 @@ static void test_flush_close_idempotent(void)
     zerobus_error_free(err);
     err = NULL;
 
-    CHECK_EQ_INT(zerobus_stream_flush(stream, &err), ZEROBUS_STATUS_OK);
+    CHECK_EQ_INT(zerobus_stream_flush(stream, &err),
+                 ZEROBUS_STATUS_UNIMPLEMENTED);
     CHECK_EQ_INT(zerobus_stream_close(stream, &err), ZEROBUS_STATUS_OK);
     /* Idempotent: a second close still succeeds. */
     CHECK_EQ_INT(zerobus_stream_close(stream, &err), ZEROBUS_STATUS_OK);
@@ -235,19 +232,20 @@ static void test_flush_close_idempotent(void)
 
     /* After close, ingest is rejected with FAILED_PRECONDITION. */
     CHECK_EQ_INT(
-        zerobus_stream_ingest_json_record(stream, sv("{\"id\":2}"), &err),
+        zerobus_stream_ingest_json_record(stream, sv("{\"id\":2}"), NULL, &err),
         ZEROBUS_STATUS_FAILED_PRECONDITION);
     zerobus_error_free(err);
     err = NULL;
 
     /* Even a malformed record: the closed check precedes record validation. */
     CHECK_EQ_INT(
-        zerobus_stream_ingest_json_record(stream, sv("{not json"), &err),
+        zerobus_stream_ingest_json_record(stream, sv("{not json"), NULL, &err),
         ZEROBUS_STATUS_FAILED_PRECONDITION);
     zerobus_error_free(err);
 
-    /* Flush after close remains valid (nothing pending). */
-    CHECK_EQ_INT(zerobus_stream_flush(stream, NULL), ZEROBUS_STATUS_OK);
+    /* Flush after close is rejected, like ingest. */
+    CHECK_EQ_INT(zerobus_stream_flush(stream, NULL),
+                 ZEROBUS_STATUS_FAILED_PRECONDITION);
 
     zerobus_stream_free(stream);
     zerobus_sdk_free(sdk);
@@ -261,6 +259,49 @@ static void test_stream_free_null_safe(void)
     CHECK(1);
 }
 
+/* A non-NULL *out_error on entry is refused at every entry point, and the
+ * existing error is left untouched (not overwritten, freed, or replaced). */
+static void test_stream_out_error_must_be_null(void)
+{
+    zerobus_sdk_t *sdk = make_sdk();
+    zerobus_stream_t *stream = make_stream(sdk);
+
+    zerobus_error_t *err = NULL;
+    /* Seed a live error through a genuine failure. */
+    zerobus_stream_builder_t *stb = NULL;
+    CHECK_EQ_INT(zerobus_stream_builder_new(NULL, &stb, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK(err != NULL);
+    const zerobus_error_t *seeded = err;
+
+    /* The guard runs first, so the other arguments do not matter. */
+    zerobus_stream_t *st = NULL;
+    CHECK_EQ_INT(zerobus_stream_builder_new(sdk, &stb, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_stream_builder_set_table(stb, sv("c.s.t"), &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(
+        zerobus_stream_builder_set_oauth(stb, sv("id"), sv("secret"), &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_stream_builder_build(stb, &st, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(
+        zerobus_stream_ingest_json_record(stream, sv("{\"id\":1}"), NULL, &err),
+        ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_stream_flush(stream, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+    CHECK_EQ_INT(zerobus_stream_close(stream, &err),
+                 ZEROBUS_STATUS_INVALID_ARGUMENT);
+
+    CHECK(err == seeded); /* same object: untouched */
+    CHECK(stb == NULL);
+    CHECK(st == NULL);
+    zerobus_error_free(err);
+
+    zerobus_stream_free(stream);
+    zerobus_sdk_free(sdk);
+}
+
 int main(void)
 {
     test_stream_builder_validation();
@@ -269,5 +310,6 @@ int main(void)
     test_ingest_validation();
     test_flush_close_idempotent();
     test_stream_free_null_safe();
+    test_stream_out_error_must_be_null();
     TEST_MAIN_RETURN();
 }

--- a/purec/tests/src/test_common.h
+++ b/purec/tests/src/test_common.h
@@ -1,0 +1,41 @@
+/*
+ * Shared support for the offline unit tests (no external framework): assertion
+ * macros, the failure counter, and helpers common to more than one test file.
+ */
+#ifndef ZB_TEST_COMMON_H
+#define ZB_TEST_COMMON_H
+
+#include <stdio.h> // IWYU pragma: keep (fprintf, used in the CHECK macros below)
+#include <string.h>
+
+#include "zerobus/zerobus.h"
+
+static int zb_test_failures = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            fprintf(stderr, "  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);  \
+            zb_test_failures++;                                                \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_EQ_INT(a, b)                                                     \
+    do {                                                                       \
+        long long _a = (long long)(a), _b = (long long)(b);                    \
+        if (_a != _b) {                                                        \
+            fprintf(stderr, "  FAIL %s:%d: %s (%lld) != %s (%lld)\n",          \
+                    __FILE__, __LINE__, #a, _a, #b, _b);                       \
+            zb_test_failures++;                                                \
+        }                                                                      \
+    } while (0)
+
+#define TEST_MAIN_RETURN() return zb_test_failures == 0 ? 0 : 1
+
+/* Build a string view from a NUL-terminated C string. */
+static inline zerobus_string_view_t sv(const char *s)
+{
+    return (zerobus_string_view_t){s, strlen(s)};
+}
+
+#endif /* ZB_TEST_COMMON_H */

--- a/purec/tests/src/utils_test.c
+++ b/purec/tests/src/utils_test.c
@@ -1,0 +1,383 @@
+/* Unit tests for the input-validation and owned-string helpers in utils.c. */
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_common.h"
+#include "utils.h"
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static bool utf8_ok(const char *s)
+{
+    return is_valid_utf8(s, strlen(s));
+}
+
+static bool json_ok(const char *s)
+{
+    return is_valid_json(s, strlen(s));
+}
+
+/* Wrap "0" in `depth` levels of `open`/`close` and report whether it validates,
+ * e.g. nested_ok("[", "]", 3) checks "[[[0]]]". */
+static bool nested_ok(const char *open, const char *close, size_t depth)
+{
+    size_t ol = strlen(open), cl = strlen(close);
+    char *buf = (char *)malloc(depth * ol + 1 + depth * cl);
+    if (buf == NULL) {
+        return false;
+    }
+    char *p = buf;
+    for (size_t i = 0; i < depth; ++i) {
+        memcpy(p, open, ol);
+        p += ol;
+    }
+    *p++ = '0';
+    for (size_t i = 0; i < depth; ++i) {
+        memcpy(p, close, cl);
+        p += cl;
+    }
+    bool ok = is_valid_json(buf, (size_t)(p - buf));
+    free(buf);
+    return ok;
+}
+
+static bool labels_ok(const char *s)
+{
+    return host_labels_are_valid(s, strlen(s));
+}
+
+/* ---- tests ------------------------------------------------------------- */
+
+static void test_view_classification(void)
+{
+    CHECK(zb_is_empty((zerobus_string_view_t){NULL, 0}));
+    CHECK(zb_is_empty((zerobus_string_view_t){"x", 0}));
+    CHECK(zb_is_empty((zerobus_string_view_t){NULL, 5})); /* invalid */
+    CHECK(!zb_is_empty(sv("x")));
+
+    CHECK(zb_is_valid_json(sv("{\"a\":1}")));
+    CHECK(!zb_is_valid_json(sv("{bad")));
+    CHECK(!zb_is_valid_json((zerobus_string_view_t){NULL, 0}));
+
+    CHECK(zb_is_valid_string(sv("hello")));
+    CHECK(!zb_is_valid_string((zerobus_string_view_t){NULL, 0}));
+    /* An embedded NUL makes an otherwise non-empty view invalid. */
+    CHECK(!zb_is_valid_string((zerobus_string_view_t){"a\0b", 3}));
+}
+
+static void test_utf8(void)
+{
+    CHECK(is_valid_utf8(NULL, 0));  /* NULL with zero length is vacuously ok */
+    CHECK(!is_valid_utf8(NULL, 1)); /* NULL with a length is not */
+    CHECK(utf8_ok(""));             /* empty run of bytes is valid UTF-8 */
+    CHECK(utf8_ok("plain ascii"));
+    CHECK(utf8_ok("caf\xC3\xA9"));         /* café (2-byte) */
+    CHECK(utf8_ok("\xE2\x9C\x93"));        /* check mark (3-byte) */
+    CHECK(utf8_ok("\xF0\x9F\x98\x80"));    /* emoji (4-byte) */
+    CHECK(utf8_ok("caf\xC3\xA9 au lait")); /* multi-byte then more text */
+    CHECK(utf8_ok("\xF4\x8F\xBF\xBF"));    /* U+10FFFF, the maximum */
+
+    CHECK(!is_valid_utf8("a\0b", 3));             /* embedded NUL */
+    CHECK(!is_valid_utf8("\x80", 1));             /* stray continuation byte */
+    CHECK(!is_valid_utf8("\xFF", 1));             /* invalid lead byte */
+    CHECK(!is_valid_utf8("\xC3", 1));             /* truncated 2-byte */
+    CHECK(!is_valid_utf8("\xC0\xAF", 2));         /* overlong 2-byte */
+    CHECK(!is_valid_utf8("\xE0\x80\x80", 3));     /* overlong 3-byte (E0) */
+    CHECK(!is_valid_utf8("\xF0\x80\x80\x80", 4)); /* overlong 4-byte (F0) */
+    CHECK(!is_valid_utf8("\xED\xA0\x80", 3));     /* UTF-16 surrogate U+D800 */
+    CHECK(!is_valid_utf8("\xF5\x80\x80\x80", 4)); /* lead > F4 */
+    CHECK(!is_valid_utf8("\xF4\x90\x80\x80", 4)); /* > U+10FFFF (F4 bound) */
+    CHECK(!is_valid_utf8("\xE2\x28\xA1", 3));     /* bad first continuation */
+    CHECK(!is_valid_utf8("\xE2\x9C\x28", 3));     /* bad later continuation */
+}
+
+static void test_json(void)
+{
+    /* Guard: is_valid_json rejects NULL and zero length up front. */
+    CHECK(!is_valid_json(NULL, 0));
+    CHECK(!is_valid_json("x", 0));
+
+    /* Literals, objects, arrays, whitespace. */
+    CHECK(json_ok("{}"));
+    CHECK(json_ok("[]"));
+    CHECK(json_ok("true"));
+    CHECK(json_ok("false"));
+    CHECK(json_ok("null"));
+    CHECK(json_ok("{\"id\":1,\"message\":\"hello\"}"));
+    CHECK(json_ok("[1, 2, 3, true, false, null]"));
+    CHECK(json_ok("[[1],[2,3],{\"k\":[]}]"));
+    CHECK(json_ok("  \t\n{\"k\": \"v\"}\r ")); /* surrounding whitespace ok */
+
+    /* Numbers. */
+    CHECK(json_ok("0"));
+    CHECK(json_ok("-0"));
+    CHECK(json_ok("123"));
+    CHECK(json_ok("-12.5e+3"));
+    CHECK(json_ok("1E10"));
+    CHECK(json_ok("1.5e-3"));
+    CHECK(!json_ok("01")); /* leading zero */
+    CHECK(!json_ok("1.")); /* fraction without a digit */
+    CHECK(!json_ok("-"));  /* lone minus */
+    CHECK(!json_ok("1e")); /* exponent without a digit */
+    CHECK(!json_ok("+1")); /* leading plus */
+    CHECK(!json_ok(".5")); /* fraction without an integer part */
+
+    /* Strings and escapes. */
+    CHECK(json_ok("\"a \\\"quoted\\\" string\""));
+    CHECK(json_ok("\"\\n\\t\\r\\b\\f\\/\\\\\"")); /* all single escapes */
+    CHECK(json_ok("\"\\u00e9\""));                /* valid \u escape */
+    CHECK(json_ok("\"\\uD800\""));  /* lone surrogate: structural only */
+    CHECK(!json_ok("\"\\x\""));     /* invalid escape */
+    CHECK(!json_ok("\"\\u12\""));   /* \u too short */
+    CHECK(!json_ok("\"\\uzzzz\"")); /* \u bad hex */
+    CHECK(!json_ok("\"\x01\""));    /* unescaped control char */
+    CHECK(!json_ok("\"abc"));       /* unterminated string */
+    CHECK(!json_ok("\"\\"));        /* backslash at end of input */
+    CHECK(!json_ok("\xFF"));        /* non-empty but invalid UTF-8 */
+
+    /* Object member not followed by ',' or '}'. */
+    CHECK(!json_ok("{\"a\":1 2}"));
+
+    /* Arrays. */
+    CHECK(!json_ok("["));       /* unterminated */
+    CHECK(!json_ok("[1"));      /* unterminated after a value */
+    CHECK(!json_ok("[1, 2,]")); /* trailing comma */
+    CHECK(!json_ok("[1 2]"));   /* missing comma */
+
+    /* Objects. */
+    CHECK(!json_ok("{"));          /* unterminated */
+    CHECK(!json_ok("{\"k\"}"));    /* missing colon */
+    CHECK(!json_ok("{\"k\": }"));  /* missing value */
+    CHECK(!json_ok("{\"k\":1"));   /* unterminated after a member */
+    CHECK(!json_ok("{\"k\":1,}")); /* trailing comma */
+    CHECK(!json_ok("{1:2}"));      /* non-string key */
+
+    /* Whole-value framing. */
+    CHECK(!json_ok(""));       /* empty is not a JSON value */
+    CHECK(!json_ok("   "));    /* whitespace only */
+    CHECK(!json_ok("nul"));    /* incomplete literal */
+    CHECK(!json_ok("42 abc")); /* trailing garbage after a value */
+}
+
+static void test_json_depth(void)
+{
+    /* A long run of bare openers must be rejected, not overflow the stack. */
+    size_t runaway = ZB_JSON_MAX_DEPTH * 1000;
+    char *deep = (char *)malloc(runaway);
+    CHECK(deep != NULL);
+    if (deep != NULL) {
+        memset(deep, '[', runaway);
+        CHECK(!is_valid_json(deep, runaway));
+        free(deep);
+    }
+
+    /* Nesting exactly at the cap validates; one level deeper is rejected. */
+    CHECK(nested_ok("[", "]", ZB_JSON_MAX_DEPTH));
+    CHECK(!nested_ok("[", "]", ZB_JSON_MAX_DEPTH + 1));
+    CHECK(nested_ok("{\"a\":", "}", ZB_JSON_MAX_DEPTH));
+    CHECK(!nested_ok("{\"a\":", "}", ZB_JSON_MAX_DEPTH + 1));
+
+    /* Alternating object/array nesting. */
+    CHECK(nested_ok("{\"a\":[", "]}", ZB_JSON_MAX_DEPTH / 2));
+    CHECK(!nested_ok("{\"a\":[", "]}", ZB_JSON_MAX_DEPTH / 2 + 1));
+}
+
+static void test_table_name(void)
+{
+    CHECK(zb_table_name_is_valid(sv("catalog.schema.table")));
+    CHECK(zb_table_name_is_valid(sv("c.s.t")));
+
+    CHECK(!zb_table_name_is_valid(sv("schema.table")));    /* 2 parts */
+    CHECK(!zb_table_name_is_valid(sv("a.b.c.d")));         /* 4 parts */
+    CHECK(!zb_table_name_is_valid(sv("catalog..table")));  /* empty middle */
+    CHECK(!zb_table_name_is_valid(sv(".schema.table")));   /* leading dot */
+    CHECK(!zb_table_name_is_valid(sv("catalog.schema."))); /* trailing dot */
+    CHECK(!zb_table_name_is_valid(sv("catalog")));         /* no dots */
+    CHECK(!zb_table_name_is_valid((zerobus_string_view_t){NULL, 0}));
+}
+
+static void test_url_validate(void)
+{
+    char *host = NULL;
+    bool https = false;
+
+    CHECK_EQ_INT(zb_url_validate("https://ws.zerobus.r.cloud.databricks.com",
+                                 &host, &https),
+                 ZB_URL_OK);
+    CHECK(host != NULL &&
+          strcmp(host, "ws.zerobus.r.cloud.databricks.com") == 0);
+    CHECK(https);
+    free(host);
+    host = NULL;
+
+    /* Port and path are stripped from the returned host. */
+    CHECK_EQ_INT(
+        zb_url_validate("https://host.example.com:8443/path", &host, &https),
+        ZB_URL_OK);
+    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
+    free(host);
+    host = NULL;
+
+    /* Both out-params are optional. */
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com", NULL, NULL),
+                 ZB_URL_OK);
+
+    /* http is valid syntax; the scheme is reported, not rejected. Requiring
+     * TLS is the caller's policy. */
+    CHECK_EQ_INT(zb_url_validate("http://host.example.com", &host, &https),
+                 ZB_URL_OK);
+    CHECK(!https);
+    free(host);
+    host = NULL;
+
+    /* A single trailing dot is the DNS root form. */
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com.", &host, &https),
+                 ZB_URL_OK);
+    free(host);
+    host = NULL;
+
+    /* No scheme at all. */
+    CHECK_EQ_INT(zb_url_validate("host.example.com", &host, &https),
+                 ZB_URL_NO_SCHEME);
+    CHECK(host == NULL);
+    CHECK_EQ_INT(zb_url_validate("ftp://host.example.com", &host, &https),
+                 ZB_URL_NO_SCHEME);
+    CHECK_EQ_INT(zb_url_validate(NULL, &host, &https), ZB_URL_NO_SCHEME);
+
+    /* Missing host. */
+    CHECK_EQ_INT(zb_url_validate("https://", &host, &https), ZB_URL_EMPTY_HOST);
+    CHECK_EQ_INT(zb_url_validate("https:///path", &host, &https),
+                 ZB_URL_EMPTY_HOST);
+    CHECK_EQ_INT(zb_url_validate("https://:443", &host, &https),
+                 ZB_URL_EMPTY_HOST);
+
+    /* Empty labels are not a valid hostname. */
+    CHECK_EQ_INT(zb_url_validate("https://a..b", &host, &https),
+                 ZB_URL_BAD_HOST);
+    CHECK(host == NULL);
+    CHECK_EQ_INT(zb_url_validate("https://.a", &host, &https), ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate("https://a..b:443/p", &host, &https),
+                 ZB_URL_BAD_HOST);
+
+    /* Userinfo, IPv6 literals, and unsafe host characters are rejected. */
+    CHECK_EQ_INT(
+        zb_url_validate("https://user@host.example.com", &host, &https),
+        ZB_URL_BAD_HOST);
+    CHECK(host == NULL);
+    CHECK_EQ_INT(zb_url_validate("https://[::1]", &host, &https),
+                 ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate("https://ho st.example.com", &host, &https),
+                 ZB_URL_BAD_HOST);
+
+    /* A ":port" must be a number in 1..65535. */
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com:", &host, &https),
+                 ZB_URL_BAD_PORT);
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com:abc", &host, &https),
+                 ZB_URL_BAD_PORT);
+    CHECK_EQ_INT(
+        zb_url_validate("https://host.example.com:99999", &host, &https),
+        ZB_URL_BAD_PORT);
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com:0", &host, &https),
+                 ZB_URL_BAD_PORT);
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com:443", &host, &https),
+                 ZB_URL_OK);
+    free(host);
+    host = NULL;
+
+    /* The authority ends at '?' or '#'; the host is extracted and the rest
+     * ignored. */
+    CHECK_EQ_INT(zb_url_validate("https://host.example.com?x=1", &host, &https),
+                 ZB_URL_OK);
+    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
+    free(host);
+    host = NULL;
+    CHECK_EQ_INT(
+        zb_url_validate("https://host.example.com#frag", &host, &https),
+        ZB_URL_OK);
+    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
+    free(host);
+    host = NULL;
+}
+
+static void test_host_labels(void)
+{
+    CHECK(labels_ok("a"));
+    CHECK(labels_ok("host.example.com"));
+    CHECK(labels_ok("host.example.com.")); /* trailing dot: DNS root form */
+
+    CHECK(!labels_ok(""));     /* empty */
+    CHECK(!labels_ok("."));    /* only a dot */
+    CHECK(!labels_ok(".a"));   /* leading empty label */
+    CHECK(!labels_ok("a..b")); /* interior empty label */
+}
+
+static void test_strdup(void)
+{
+    /* Each variant duplicates a non-NULL input into a fresh copy. */
+    char *hello = zb_strndup("hello", 5);
+    CHECK(hello != NULL && strcmp(hello, "hello") == 0);
+    free(hello);
+
+    /* Partial copy is NUL-terminated. */
+    char *hel = zb_strndup("hello", 3);
+    CHECK(hel != NULL && strcmp(hel, "hel") == 0);
+    free(hel);
+
+    char *from_str = zb_strdup("hello");
+    CHECK(from_str != NULL && strcmp(from_str, "hello") == 0);
+    free(from_str);
+
+    char *from_view = zb_strdup_view(sv("hello"));
+    CHECK(from_view != NULL && strcmp(from_view, "hello") == 0);
+    free(from_view);
+
+    /* A non-NULL pointer with length 0 yields "". */
+    char *empty = zb_strndup("", 0);
+    CHECK(empty != NULL && empty[0] == '\0');
+    free(empty);
+
+    char *empty_view = zb_strdup_view(sv(""));
+    CHECK(empty_view != NULL && empty_view[0] == '\0');
+    free(empty_view);
+
+    /* A NULL pointer yields NULL, across every variant and length. */
+    CHECK(zb_strndup(NULL, 0) == NULL);
+    CHECK(zb_strndup(NULL, 5) == NULL);
+    CHECK(zb_strdup_view((zerobus_string_view_t){NULL, 0}) == NULL);
+    CHECK(zb_strdup_view((zerobus_string_view_t){NULL, 5}) == NULL);
+    CHECK(zb_strdup(NULL) == NULL);
+}
+
+static void test_secure(void)
+{
+    /* Early-out paths must be safe. */
+    zb_secure_zero(NULL, 8);
+    zb_secure_free(NULL, 0);
+    zb_secure_free_cstr(NULL); /* NULL-safe */
+
+    char *p = zb_strndup("secret", 6);
+    CHECK(p != NULL);
+    if (p != NULL) {
+        zb_secure_zero(p, 6); /* the actual overwrite loop */
+        CHECK(p[0] == '\0');
+        zb_secure_free(p, 6);
+    }
+
+    /* zb_secure_free_cstr zeroes strlen(s) bytes and frees a real copy. */
+    zb_secure_free_cstr(zb_strndup("tmp", 3));
+    CHECK(1);
+}
+
+int main(void)
+{
+    test_view_classification();
+    test_utf8();
+    test_json();
+    test_json_depth();
+    test_table_name();
+    test_url_validate();
+    test_host_labels();
+    test_strdup();
+    test_secure();
+    TEST_MAIN_RETURN();
+}

--- a/purec/tests/src/utils_test.c
+++ b/purec/tests/src/utils_test.c
@@ -12,35 +12,6 @@ static bool utf8_ok(const char *s)
     return is_valid_utf8(s, strlen(s));
 }
 
-static bool json_ok(const char *s)
-{
-    return is_valid_json(s, strlen(s));
-}
-
-/* Wrap "0" in `depth` levels of `open`/`close` and report whether it validates,
- * e.g. nested_ok("[", "]", 3) checks "[[[0]]]". */
-static bool nested_ok(const char *open, const char *close, size_t depth)
-{
-    size_t ol = strlen(open), cl = strlen(close);
-    char *buf = (char *)malloc(depth * ol + 1 + depth * cl);
-    if (buf == NULL) {
-        return false;
-    }
-    char *p = buf;
-    for (size_t i = 0; i < depth; ++i) {
-        memcpy(p, open, ol);
-        p += ol;
-    }
-    *p++ = '0';
-    for (size_t i = 0; i < depth; ++i) {
-        memcpy(p, close, cl);
-        p += cl;
-    }
-    bool ok = is_valid_json(buf, (size_t)(p - buf));
-    free(buf);
-    return ok;
-}
-
 static bool labels_ok(const char *s)
 {
     return host_labels_are_valid(s, strlen(s));
@@ -54,10 +25,6 @@ static void test_view_classification(void)
     CHECK(zb_is_empty((zerobus_string_view_t){"x", 0}));
     CHECK(zb_is_empty((zerobus_string_view_t){NULL, 5})); /* invalid */
     CHECK(!zb_is_empty(sv("x")));
-
-    CHECK(zb_is_valid_json(sv("{\"a\":1}")));
-    CHECK(!zb_is_valid_json(sv("{bad")));
-    CHECK(!zb_is_valid_json((zerobus_string_view_t){NULL, 0}));
 
     CHECK(zb_is_valid_string(sv("hello")));
     CHECK(!zb_is_valid_string((zerobus_string_view_t){NULL, 0}));
@@ -91,97 +58,6 @@ static void test_utf8(void)
     CHECK(!is_valid_utf8("\xE2\x9C\x28", 3));     /* bad later continuation */
 }
 
-static void test_json(void)
-{
-    /* Guard: is_valid_json rejects NULL and zero length up front. */
-    CHECK(!is_valid_json(NULL, 0));
-    CHECK(!is_valid_json("x", 0));
-
-    /* Literals, objects, arrays, whitespace. */
-    CHECK(json_ok("{}"));
-    CHECK(json_ok("[]"));
-    CHECK(json_ok("true"));
-    CHECK(json_ok("false"));
-    CHECK(json_ok("null"));
-    CHECK(json_ok("{\"id\":1,\"message\":\"hello\"}"));
-    CHECK(json_ok("[1, 2, 3, true, false, null]"));
-    CHECK(json_ok("[[1],[2,3],{\"k\":[]}]"));
-    CHECK(json_ok("  \t\n{\"k\": \"v\"}\r ")); /* surrounding whitespace ok */
-
-    /* Numbers. */
-    CHECK(json_ok("0"));
-    CHECK(json_ok("-0"));
-    CHECK(json_ok("123"));
-    CHECK(json_ok("-12.5e+3"));
-    CHECK(json_ok("1E10"));
-    CHECK(json_ok("1.5e-3"));
-    CHECK(!json_ok("01")); /* leading zero */
-    CHECK(!json_ok("1.")); /* fraction without a digit */
-    CHECK(!json_ok("-"));  /* lone minus */
-    CHECK(!json_ok("1e")); /* exponent without a digit */
-    CHECK(!json_ok("+1")); /* leading plus */
-    CHECK(!json_ok(".5")); /* fraction without an integer part */
-
-    /* Strings and escapes. */
-    CHECK(json_ok("\"a \\\"quoted\\\" string\""));
-    CHECK(json_ok("\"\\n\\t\\r\\b\\f\\/\\\\\"")); /* all single escapes */
-    CHECK(json_ok("\"\\u00e9\""));                /* valid \u escape */
-    CHECK(json_ok("\"\\uD800\""));  /* lone surrogate: structural only */
-    CHECK(!json_ok("\"\\x\""));     /* invalid escape */
-    CHECK(!json_ok("\"\\u12\""));   /* \u too short */
-    CHECK(!json_ok("\"\\uzzzz\"")); /* \u bad hex */
-    CHECK(!json_ok("\"\x01\""));    /* unescaped control char */
-    CHECK(!json_ok("\"abc"));       /* unterminated string */
-    CHECK(!json_ok("\"\\"));        /* backslash at end of input */
-    CHECK(!json_ok("\xFF"));        /* non-empty but invalid UTF-8 */
-
-    /* Object member not followed by ',' or '}'. */
-    CHECK(!json_ok("{\"a\":1 2}"));
-
-    /* Arrays. */
-    CHECK(!json_ok("["));       /* unterminated */
-    CHECK(!json_ok("[1"));      /* unterminated after a value */
-    CHECK(!json_ok("[1, 2,]")); /* trailing comma */
-    CHECK(!json_ok("[1 2]"));   /* missing comma */
-
-    /* Objects. */
-    CHECK(!json_ok("{"));          /* unterminated */
-    CHECK(!json_ok("{\"k\"}"));    /* missing colon */
-    CHECK(!json_ok("{\"k\": }"));  /* missing value */
-    CHECK(!json_ok("{\"k\":1"));   /* unterminated after a member */
-    CHECK(!json_ok("{\"k\":1,}")); /* trailing comma */
-    CHECK(!json_ok("{1:2}"));      /* non-string key */
-
-    /* Whole-value framing. */
-    CHECK(!json_ok(""));       /* empty is not a JSON value */
-    CHECK(!json_ok("   "));    /* whitespace only */
-    CHECK(!json_ok("nul"));    /* incomplete literal */
-    CHECK(!json_ok("42 abc")); /* trailing garbage after a value */
-}
-
-static void test_json_depth(void)
-{
-    /* A long run of bare openers must be rejected, not overflow the stack. */
-    size_t runaway = ZB_JSON_MAX_DEPTH * 1000;
-    char *deep = (char *)malloc(runaway);
-    CHECK(deep != NULL);
-    if (deep != NULL) {
-        memset(deep, '[', runaway);
-        CHECK(!is_valid_json(deep, runaway));
-        free(deep);
-    }
-
-    /* Nesting exactly at the cap validates; one level deeper is rejected. */
-    CHECK(nested_ok("[", "]", ZB_JSON_MAX_DEPTH));
-    CHECK(!nested_ok("[", "]", ZB_JSON_MAX_DEPTH + 1));
-    CHECK(nested_ok("{\"a\":", "}", ZB_JSON_MAX_DEPTH));
-    CHECK(!nested_ok("{\"a\":", "}", ZB_JSON_MAX_DEPTH + 1));
-
-    /* Alternating object/array nesting. */
-    CHECK(nested_ok("{\"a\":[", "]}", ZB_JSON_MAX_DEPTH / 2));
-    CHECK(!nested_ok("{\"a\":[", "]}", ZB_JSON_MAX_DEPTH / 2 + 1));
-}
-
 static void test_table_name(void)
 {
     CHECK(zb_table_name_is_valid(sv("catalog.schema.table")));
@@ -198,105 +74,82 @@ static void test_table_name(void)
 
 static void test_url_validate(void)
 {
-    char *host = NULL;
-    bool https = false;
-
-    CHECK_EQ_INT(zb_url_validate("https://ws.zerobus.r.cloud.databricks.com",
-                                 &host, &https),
-                 ZB_URL_OK);
-    CHECK(host != NULL &&
-          strcmp(host, "ws.zerobus.r.cloud.databricks.com") == 0);
-    CHECK(https);
-    free(host);
-    host = NULL;
-
-    /* Port and path are stripped from the returned host. */
+    /* Accepted: bare origins, http or https, with or without a port, and a
+     * single-label host (no workspace-subdomain requirement). */
     CHECK_EQ_INT(
-        zb_url_validate("https://host.example.com:8443/path", &host, &https),
+        zb_url_validate(sv("https://ws.zerobus.r.cloud.databricks.com")),
         ZB_URL_OK);
-    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
-    free(host);
-    host = NULL;
-
-    /* Both out-params are optional. */
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com", NULL, NULL),
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:8443")),
                  ZB_URL_OK);
-
-    /* http is valid syntax; the scheme is reported, not rejected. Requiring
-     * TLS is the caller's policy. */
-    CHECK_EQ_INT(zb_url_validate("http://host.example.com", &host, &https),
-                 ZB_URL_OK);
-    CHECK(!https);
-    free(host);
-    host = NULL;
-
+    CHECK_EQ_INT(zb_url_validate(sv("http://host.example.com")), ZB_URL_OK);
+    CHECK_EQ_INT(zb_url_validate(sv("http://localhost:8080")), ZB_URL_OK);
+    CHECK_EQ_INT(zb_url_validate(sv("https://localhost")), ZB_URL_OK);
     /* A single trailing dot is the DNS root form. */
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com.", &host, &https),
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com.")), ZB_URL_OK);
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:443")),
                  ZB_URL_OK);
-    free(host);
-    host = NULL;
+    /* The scheme is case-insensitive (RFC 3986 §3.1). */
+    CHECK_EQ_INT(zb_url_validate(sv("HTTPS://host.example.com")), ZB_URL_OK);
+    CHECK_EQ_INT(zb_url_validate(sv("HtTp://localhost")), ZB_URL_OK);
 
-    /* No scheme at all. */
-    CHECK_EQ_INT(zb_url_validate("host.example.com", &host, &https),
+    /* No scheme, an unsupported one, a bare truncated scheme, or no input. */
+    CHECK_EQ_INT(zb_url_validate(sv("host.example.com")), ZB_URL_NO_SCHEME);
+    CHECK_EQ_INT(zb_url_validate(sv("ftp://host.example.com")),
                  ZB_URL_NO_SCHEME);
-    CHECK(host == NULL);
-    CHECK_EQ_INT(zb_url_validate("ftp://host.example.com", &host, &https),
+    CHECK_EQ_INT(zb_url_validate(sv("http")), ZB_URL_NO_SCHEME);
+    CHECK_EQ_INT(zb_url_validate((zerobus_string_view_t){NULL, 0}),
                  ZB_URL_NO_SCHEME);
-    CHECK_EQ_INT(zb_url_validate(NULL, &host, &https), ZB_URL_NO_SCHEME);
 
     /* Missing host. */
-    CHECK_EQ_INT(zb_url_validate("https://", &host, &https), ZB_URL_EMPTY_HOST);
-    CHECK_EQ_INT(zb_url_validate("https:///path", &host, &https),
-                 ZB_URL_EMPTY_HOST);
-    CHECK_EQ_INT(zb_url_validate("https://:443", &host, &https),
-                 ZB_URL_EMPTY_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://")), ZB_URL_EMPTY_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https:///path")), ZB_URL_EMPTY_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://:443")), ZB_URL_EMPTY_HOST);
 
-    /* Empty labels are not a valid hostname. */
-    CHECK_EQ_INT(zb_url_validate("https://a..b", &host, &https),
-                 ZB_URL_BAD_HOST);
-    CHECK(host == NULL);
-    CHECK_EQ_INT(zb_url_validate("https://.a", &host, &https), ZB_URL_BAD_HOST);
-    CHECK_EQ_INT(zb_url_validate("https://a..b:443/p", &host, &https),
-                 ZB_URL_BAD_HOST);
+    /* Empty labels are not a valid hostname; a malformed host is reported even
+     * when a path also follows. */
+    CHECK_EQ_INT(zb_url_validate(sv("https://a..b")), ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://.a")), ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://a..b:443/p")), ZB_URL_BAD_HOST);
 
-    /* Userinfo, IPv6 literals, and unsafe host characters are rejected. */
-    CHECK_EQ_INT(
-        zb_url_validate("https://user@host.example.com", &host, &https),
-        ZB_URL_BAD_HOST);
-    CHECK(host == NULL);
-    CHECK_EQ_INT(zb_url_validate("https://[::1]", &host, &https),
+    /* Userinfo, IPv6 literals, and forbidden host characters are rejected. */
+    CHECK_EQ_INT(zb_url_validate(sv("https://user@host.example.com")),
                  ZB_URL_BAD_HOST);
-    CHECK_EQ_INT(zb_url_validate("https://ho st.example.com", &host, &https),
+    /* Userinfo with a password: '@' is caught before the ':' split, so this is
+     * BAD_HOST, not a bogus BAD_PORT. */
+    CHECK_EQ_INT(zb_url_validate(sv("https://user:pass@host.example.com")),
+                 ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://[::1]")), ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://ho st.example.com")),
+                 ZB_URL_BAD_HOST);
+    CHECK_EQ_INT(zb_url_validate(sv("https://ho^st.example.com")),
                  ZB_URL_BAD_HOST);
 
     /* A ":port" must be a number in 1..65535. */
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com:", &host, &https),
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:")),
                  ZB_URL_BAD_PORT);
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com:abc", &host, &https),
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:abc")),
                  ZB_URL_BAD_PORT);
-    CHECK_EQ_INT(
-        zb_url_validate("https://host.example.com:99999", &host, &https),
-        ZB_URL_BAD_PORT);
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com:0", &host, &https),
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:99999")),
                  ZB_URL_BAD_PORT);
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com:443", &host, &https),
-                 ZB_URL_OK);
-    free(host);
-    host = NULL;
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:0")),
+                 ZB_URL_BAD_PORT);
 
-    /* The authority ends at '?' or '#'; the host is extracted and the rest
-     * ignored. */
-    CHECK_EQ_INT(zb_url_validate("https://host.example.com?x=1", &host, &https),
-                 ZB_URL_OK);
-    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
-    free(host);
-    host = NULL;
-    CHECK_EQ_INT(
-        zb_url_validate("https://host.example.com#frag", &host, &https),
-        ZB_URL_OK);
-    CHECK(host != NULL && strcmp(host, "host.example.com") == 0);
-    free(host);
-    host = NULL;
+    /* Only a bare origin is accepted: a path, query, fragment, or even a
+     * trailing '/' is rejected. */
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com/")),
+                 ZB_URL_HAS_PATH);
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com/path")),
+                 ZB_URL_HAS_PATH);
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com:8443/path")),
+                 ZB_URL_HAS_PATH);
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com?x=1")),
+                 ZB_URL_HAS_PATH);
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com#frag")),
+                 ZB_URL_HAS_PATH);
+    /* Backslash is a path delimiter for http/https (WHATWG '\' == '/'), so it
+     * ends the authority like '/'. */
+    CHECK_EQ_INT(zb_url_validate(sv("https://host.example.com\\path")),
+                 ZB_URL_HAS_PATH);
 }
 
 static void test_host_labels(void)
@@ -372,8 +225,6 @@ int main(void)
 {
     test_view_classification();
     test_utf8();
-    test_json();
-    test_json_depth();
     test_table_name();
     test_url_validate();
     test_host_labels();


### PR DESCRIPTION
## What changes are proposed in this pull request?

The initial skeleton of the pure-C Zerobus SDK: a native,
dependency-free C implementation of the ingestion client. Code and build 
only in this first commit:

- Public API in `include/zerobus/`: opaque SDK/stream builders and handles,
  fixed-ABI status codes, and owned structured errors.
- Input validation and error/ownership plumbing in `src/`: UTF-8, JSON,
  table-name and endpoint-URL checks, transactional setters, secure-zeroed
  OAuth credentials.
- Build and tests: CMake, Makefile wrappers, `.clang-format`, offline unit
  tests, and a single-producer example.

## How is this tested?

`make verify` passes end to end: `clang-format`, the `-Wall -Wextra -Werror`
build, and the offline unit tests (4/4) plain and under AddressSanitizer/UBSan
and ThreadSanitizer/UBSan. The tests cover the input validators (UTF-8, JSON,
table name, endpoint URL), error ownership, and the public-API validation and
precondition behavior.

No integration or end-to-end tests yet.