### PR TITLE
[Go] Add Avro record format (avro build tag)

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -2,17 +2,21 @@
 zerobus-ffi/target/
 libzerobus_ffi.a
 !lib/**/libzerobus_ffi.a
+lib/**/.zerobus_ffi_features
 *.dylib
 *.so
 
 # Release artifacts
 releases/
 
-# Example binaries
+# Example binaries and generated files
 examples/json/single/json-single
 examples/json/batch/json-batch
 examples/proto/single/proto-single
 examples/proto/batch/proto-batch
+examples/avro/avro
+examples/arrow/arrow
+examples/*/go.sum
 
 # OS files
 .DS_Store

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,12 +1,15 @@
 # Makefile for zerobus-sdk-go
 
-.PHONY: help build build-rust build-go clean fmt fmt-go fmt-rust lint lint-go lint-rust check test test-go test-rust examples release
+.PHONY: help build build-rust build-go build-avro build-avro-rust build-avro-go clean fmt fmt-go fmt-rust lint lint-go lint-rust check test test-go test-rust test-avro lint-avro examples release
 
 help:
 	@echo "Available targets:"
 	@echo "  make build          - Build both Rust FFI and Go SDK"
 	@echo "  make build-rust     - Build only the Rust FFI layer"
 	@echo "  make build-go       - Build Rust FFI, then the Go SDK"
+	@echo "  make build-avro     - Build Rust FFI with avro feature and Go SDK with avro tag"
+	@echo "  make build-avro-rust - Build only Rust FFI layer with avro feature"
+	@echo "  make build-avro-go  - Build Go SDK with avro tag"
 	@echo "  make clean          - Remove build artifacts"
 	@echo "  make fmt            - Format all code (Go and Rust)"
 	@echo "  make fmt-go         - Format Go code"
@@ -14,10 +17,12 @@ help:
 	@echo "  make lint           - Run linters on all code"
 	@echo "  make lint-go        - Run Go linters"
 	@echo "  make lint-rust      - Run Rust linters"
+	@echo "  make lint-avro      - Run Go linters with avro tag"
 	@echo "  make check          - Run all checks (fmt and lint)"
 	@echo "  make test           - Run all tests (Rust and Go)"
 	@echo "  make test-rust      - Run Rust unit tests"
 	@echo "  make test-go        - Run Go unit tests"
+	@echo "  make test-avro      - Run Go unit tests with avro tag"
 	@echo "  make examples       - Build all examples"
 	@echo "  make release        - Build release package"
 
@@ -64,6 +69,16 @@ build-go: build-rust
 	go build -v
 	@echo "✓ Go SDK built successfully"
 
+build-avro-rust: build-rust
+	@echo "✓ Rust FFI already built with all features (including avro)"
+
+build-avro-go:
+	@echo "Building Go SDK with avro tag..."
+	go build -v -tags avro
+	@echo "✓ Go SDK with avro built successfully"
+
+build-avro: build-avro-go
+
 clean:
 	@echo "Cleaning build artifacts..."
 	cd ../rust/ffi && cargo clean
@@ -82,6 +97,7 @@ fmt-go:
 	cd examples/proto/single && go fmt ./...
 	cd examples/proto/batch && go fmt ./...
 	cd examples/arrow && go fmt ./...
+	cd examples/avro && go fmt ./...
 
 fmt-rust:
 	@echo "Formatting Rust code..."
@@ -97,6 +113,7 @@ lint-go:
 	cd examples/proto/single && go vet ./...
 	cd examples/proto/batch && go vet ./...
 	cd examples/arrow && go vet ./...
+	cd examples/avro && go vet ./...
 
 lint-rust:
 	@echo "Linting Rust code..."
@@ -116,6 +133,16 @@ test-go:
 	cd tests && go test -v -timeout 60s ./...
 	@echo "✓ All Go tests passed"
 
+test-avro: build-avro
+	@echo "Running Go unit tests with avro tag..."
+	go test -v -timeout 60s -tags avro ./...
+	@echo "✓ All Go tests with avro passed"
+
+lint-avro:
+	@echo "Linting Go code with avro tag..."
+	go vet -tags avro ./...
+	@echo "✓ Go code with avro linted successfully"
+
 examples: build
 	@echo "Building examples..."
 	cd examples/json/single && go build -o json-single main.go
@@ -123,6 +150,7 @@ examples: build
 	cd examples/proto/single && go build -o proto-single main.go
 	cd examples/proto/batch && go build -o proto-batch main.go
 	cd examples/arrow && go build -o arrow main.go
+	cd examples/avro && go build -tags avro -o avro main.go
 	@echo "✓ Examples built successfully"
 
 release:

--- a/go/NEXT_CHANGELOG.md
+++ b/go/NEXT_CHANGELOG.md
@@ -4,12 +4,21 @@
 
 ### New Features and Improvements
 
+- Add Avro record format support (Beta, gated by `avro` build tag) — enables ingestion of Avro records as Go objects (marshaled to JSON) or pre-encoded bytes. Requires Zerobus server Avro support (pending). Use `go build -tags avro` to enable.
+  - Object-based ingestion: `IngestAvroRecordOffset(record)`, `IngestAvroRecordsOffset(records)` for automatic JSON encoding
+  - Pre-encoded bytes: `IngestAvroBytesOffset(data)`, `IngestAvroBytesBatchOffset(records)` for pre-encoded Avro datums
+  - Fire-and-forget variants: `IngestAvroRecordNowait()`, `IngestAvroRecordsNowait()`, `IngestAvroBytesNowait()`, `IngestAvroBytesBatchNowait()`
+
 ### Deprecations
 
 ### Bug Fixes
 
 ### Documentation
 
+- Update Avro example to demonstrate object-based record ingestion with loop-then-flush pattern
+
 ### Internal Changes
 
 ### API Changes
+
+- Renamed pre-encoded bytes methods for clarity: `IngestAvroRecordOffset` → `IngestAvroBytesOffset`, `IngestAvroRecordsOffset` → `IngestAvroBytesBatchOffset`, `IngestAvroRecordNowait` → `IngestAvroBytesNowait`, `IngestAvroRecordsNowait` → `IngestAvroBytesBatchNowait`

--- a/go/README.md
+++ b/go/README.md
@@ -58,6 +58,7 @@ This SDK wraps the [Rust SDK](https://github.com/databricks/zerobus-sdk/tree/mai
 - **Automatic OAuth 2.0 authentication** with Unity Catalog
 - **Simple JSON ingestion** - No code generation required for basic use cases
 - **Protocol Buffers support** for type-safe, efficient data encoding
+- **Avro support** (Beta, `avro` build tag) - Avro record ingestion (object-based with automatic JSON encoding or pre-encoded bytes)
 - **Batch ingestion** - Ingest multiple records at once for maximum throughput
 - **Backpressure control** to manage memory usage
 - **Automatic retry and recovery** for transient failures
@@ -631,6 +632,52 @@ for partition := 0; partition < 4; partition++ {
     }(p)
 }
 wg.Wait()
+```
+
+**Avro record ingestion (Beta, `avro` build tag):**
+
+```go
+// Create an Avro stream with a writer schema
+schemaJSON := `{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "id", "type": "int"},
+        {"name": "name", "type": "string"}
+    ]
+}`
+avroStream, err := sdk.CreateAvroStream(
+    zerobus.AvroTableProperties{
+        TableName: "catalog.schema.users",
+        SchemaJSON: schemaJSON,
+    },
+    clientID, clientSecret, options,
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer avroStream.Close()
+
+// Ingest records as Go objects (automatic JSON encoding)
+records := []interface{}{
+    map[string]interface{}{"id": 1, "name": "Alice"},
+    map[string]interface{}{"id": 2, "name": "Bob"},
+}
+offset, err := avroStream.IngestAvroRecordsOffset(records)
+if err != nil {
+    log.Fatal(err)
+}
+log.Printf("Batch queued with offset: %d", offset)
+
+if err := avroStream.Flush(); err != nil {
+    log.Fatal(err)
+}
+```
+
+For pre-encoded Avro bytes (if you already have encoded data):
+```go
+avroData := /* pre-encoded Avro datum */
+offset, err := avroStream.IngestAvroBytesOffset(avroData)
 ```
 
 ### 5. Handle Acknowledgments
@@ -1505,6 +1552,37 @@ make fmt
 
 # Run linters
 make lint
+```
+
+### Building with Avro Support (Beta)
+
+Avro support is gated behind the `avro` build tag and requires Zerobus server Avro support (pending).
+
+```bash
+# Build Rust FFI with avro feature
+make build-avro-rust
+
+# Build Go SDK with avro tag
+make build-avro-go
+
+# Build both (Rust FFI with avro + Go with avro tag)
+make build-avro
+
+# Run tests with avro tag
+make test-avro
+
+# Run linters with avro tag
+make lint-avro
+```
+
+To use Avro in your own project:
+
+```bash
+# Build your code with the avro build tag
+go build -tags avro ./...
+
+# Run your code with the avro tag
+go run -tags avro main.go
 ```
 
 ### Platform-Specific Build Notes

--- a/go/build_rust.sh
+++ b/go/build_rust.sh
@@ -30,9 +30,8 @@ esac
 TARGET_LIB_DIR="$OUTPUT_DIR/lib/${GOOS}_${GOARCH}"
 TARGET_LIB_PATH="$TARGET_LIB_DIR/libzerobus_ffi.a"
 
-# Skip rebuild if library already exists and is newer than source
+# Skip rebuild only if the library exists and no Rust source is newer than it.
 if [ -f "$TARGET_LIB_PATH" ]; then
-    # Check if any Rust source file is newer than the library
     NEEDS_REBUILD=0
     while IFS= read -r -d '' file; do
         if [ "$file" -nt "$TARGET_LIB_PATH" ]; then
@@ -47,21 +46,24 @@ if [ -f "$TARGET_LIB_PATH" ]; then
     fi
 fi
 
-echo "Building Rust FFI library for ${GOOS}_${GOARCH}..."
+echo "Building Rust FFI library for ${GOOS}_${GOARCH} (with --all-features)..."
 
 cd "$FFI_DIR"
+
+# Always build with all features; Go gate (//go:build avro) controls code exposure
+CARGO_FEATURES="--all-features"
 
 # Determine Rust target for Windows MinGW compatibility
 if [[ "$GOOS" == "windows" ]]; then
     echo "Detected Windows environment - building for GNU target..."
     TARGET="x86_64-pc-windows-gnu"
-    cargo build --release --target "$TARGET"
+    cargo build --release --target "$TARGET" $CARGO_FEATURES
 elif command -v cargo-zigbuild &> /dev/null; then
     echo "Using cargo-zigbuild for optimized build..."
-    cargo zigbuild --release
+    cargo zigbuild --release $CARGO_FEATURES
 else
     echo "Using cargo (install cargo-zigbuild for better cross-compilation)"
-    cargo build --release
+    cargo build --release $CARGO_FEATURES
 fi
 
 mkdir -p "$TARGET_LIB_DIR"

--- a/go/examples/avro/go.mod
+++ b/go/examples/avro/go.mod
@@ -1,8 +1,8 @@
-module github.com/databricks/zerobus-sdk/go
+module avro-example
 
 go 1.24.0
 
-retract v1.1.0 // broken release
+require github.com/databricks/zerobus-sdk/go v0.0.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
@@ -11,3 +11,5 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 )
+
+replace github.com/databricks/zerobus-sdk/go => ../..

--- a/go/examples/avro/main.go
+++ b/go/examples/avro/main.go
@@ -1,0 +1,92 @@
+//go:build avro
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	zerobus "github.com/databricks/zerobus-sdk/go"
+)
+
+func main() {
+	endpoint := flag.String("zerobus-endpoint", os.Getenv("ZEROBUS_ENDPOINT"), "Zerobus endpoint URL")
+	catalogURL := flag.String("catalog-url", os.Getenv("UNITY_CATALOG_URL"), "Unity Catalog URL")
+	clientID := flag.String("client-id", os.Getenv("DATABRICKS_CLIENT_ID"), "OAuth2 client ID")
+	clientSecret := flag.String("client-secret", os.Getenv("DATABRICKS_CLIENT_SECRET"), "OAuth2 client secret")
+	tableName := flag.String("table", "catalog.schema.table", "Target table name")
+	flag.Parse()
+
+	// Validate inputs
+	if *endpoint == "" || *catalogURL == "" || *clientID == "" || *clientSecret == "" {
+		log.Fatal("Missing required parameters. Please set ZEROBUS_ENDPOINT, UNITY_CATALOG_URL, DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET or pass as flags.")
+	}
+
+	// Create SDK instance
+	sdk, err := zerobus.NewZerobusSdk(*endpoint, *catalogURL)
+	if err != nil {
+		log.Fatalf("Failed to create SDK: %v", err)
+	}
+	defer sdk.Free()
+
+	// Avro schema: a record with id (int) and name (string) fields
+	schemaJSON := `{
+		"type": "record",
+		"name": "SimpleRecord",
+		"fields": [
+			{"name": "id", "type": "int"},
+			{"name": "name", "type": "string"}
+		]
+	}`
+
+	// Create Avro stream
+	tableProps := zerobus.AvroTableProperties{
+		TableName:  *tableName,
+		SchemaJSON: schemaJSON,
+	}
+
+	opts := zerobus.DefaultStreamConfigurationOptions()
+	opts.RecordType = zerobus.RecordTypeAvro
+
+	stream, err := sdk.CreateAvroStream(tableProps, *clientID, *clientSecret, opts)
+	if err != nil {
+		log.Fatalf("Failed to create stream: %v", err)
+	}
+	defer stream.Close()
+
+	fmt.Println("Avro stream created successfully (Beta - requires server Avro support)")
+
+	// Define records as AvroRecord (native encoding with hamba/avro)
+	records := []zerobus.AvroRecord{
+		{"id": int32(1), "name": "Alice"},
+		{"id": int32(2), "name": "Bob"},
+		{"id": int32(3), "name": "Charlie"},
+	}
+
+	fmt.Printf("Ingesting %d Avro records...\n", len(records))
+
+	// Queue records in a loop; SDK encodes each to binary Avro
+	var lastOffset int64
+	for _, rec := range records {
+		offset, err := stream.IngestAvroRecordOffset(rec)
+		if err != nil {
+			log.Printf("Failed to ingest record: %v", err)
+			continue
+		}
+		lastOffset = offset
+		fmt.Printf("Record %v queued with offset %d\n", rec, offset)
+	}
+
+	// Flush to confirm all records are acknowledged
+	fmt.Println("Flushing pending records...")
+	if err := stream.Flush(); err != nil {
+		log.Fatalf("Flush failed: %v", err)
+	}
+
+	fmt.Printf("Successfully ingested and flushed %d Avro records (last offset: %d)\n", len(records), lastOffset)
+
+	// Alternative: Ingest pre-encoded Avro bytes (if you already have encoded data)
+	// Use IngestAvroBytesOffset() and IngestAvroBytesBatchOffset() for pre-encoded datums
+}

--- a/go/ffi_avro.go
+++ b/go/ffi_avro.go
@@ -1,0 +1,356 @@
+//go:build avro
+
+package zerobus
+
+/*
+#define ZEROBUS_AVRO
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// Forward declare opaque types
+typedef struct CZerobusSdk CZerobusSdk;
+typedef struct CZerobusStream CZerobusStream;
+
+// Define result type
+typedef struct CResult {
+    bool success;
+    char *error_message;
+    bool is_retryable;
+} CResult;
+
+// Define stream configuration options
+typedef struct CStreamConfigurationOptions CStreamConfigurationOptions;
+
+// Declare headers types for callback
+typedef struct CHeader {
+    char *key;
+    char *value;
+} CHeader;
+
+typedef struct CHeaders {
+    struct CHeader *headers;
+    uintptr_t count;
+    char *error_message;
+} CHeaders;
+
+typedef struct CHeaders (*HeadersProviderCallback)(void *user_data);
+typedef void (*HeadersProviderFreeCallback)(void* user_data);
+
+// Forward declarations for callbacks from ffi.go
+extern void goGetHeaders(void* userData, CHeader** headers, uintptr_t* count, char** error);
+extern void goFreeHeadersProvider(void* userData);
+
+// C callback that matches the HeadersProviderCallback signature
+static CHeaders cHeadersCallback(void* userData) {
+    CHeader* headers = NULL;
+    uintptr_t count = 0;
+    char* error = NULL;
+
+    goGetHeaders(userData, &headers, &count, &error);
+
+    CHeaders result;
+    result.headers = headers;
+    result.count = count;
+    result.error_message = error;
+    return result;
+}
+
+// Helper function to get the C callback function pointer
+static HeadersProviderCallback getHeadersCallback(void) {
+    return (HeadersProviderCallback)cHeadersCallback;
+}
+
+// C callback matching HeadersProviderFreeCallback
+static void cFreeHeadersProvider(void* userData) {
+    goFreeHeadersProvider(userData);
+}
+
+static HeadersProviderFreeCallback getFreeHeadersProviderCallback(void) {
+    return (HeadersProviderFreeCallback)cFreeHeadersProvider;
+}
+
+// Avro stream creation functions
+extern CZerobusStream* zerobus_sdk_create_avro_stream(CZerobusSdk* sdk,
+                                                       const char* table_name,
+                                                       const char* avro_schema_json,
+                                                       const char* client_id,
+                                                       const char* client_secret,
+                                                       const CStreamConfigurationOptions* options,
+                                                       CResult* result);
+
+extern CZerobusStream* zerobus_sdk_create_avro_stream_with_headers_provider(
+    CZerobusSdk* sdk,
+    const char* table_name,
+    const char* avro_schema_json,
+    HeadersProviderCallback headers_callback,
+    void* user_data,
+    HeadersProviderFreeCallback free_user_data,
+    const CStreamConfigurationOptions* options,
+    CResult* result);
+
+// Avro pre-encoded bytes ingestion functions
+extern int64_t zerobus_stream_ingest_avro_record(CZerobusStream* stream,
+                                                  const uint8_t* data,
+                                                  uintptr_t data_len,
+                                                  CResult* result);
+
+extern int64_t zerobus_stream_ingest_avro_records(CZerobusStream* stream,
+                                                   const uint8_t* const* records,
+                                                   const uintptr_t* record_lens,
+                                                   uintptr_t num_records,
+                                                   CResult* result);
+
+extern void zerobus_stream_ingest_avro_record_nowait(CZerobusStream* stream,
+                                                      const uint8_t* data,
+                                                      uintptr_t data_len,
+                                                      CResult* result);
+
+extern void zerobus_stream_ingest_avro_records_nowait(CZerobusStream* stream,
+                                                       const uint8_t* const* records,
+                                                       const uintptr_t* record_lens,
+                                                       uintptr_t num_records,
+                                                       CResult* result);
+*/
+import "C"
+
+import (
+	"runtime"
+	"runtime/cgo"
+	"unsafe"
+)
+
+// sdkCreateAvroStream creates an Avro stream via FFI
+func sdkCreateAvroStream(
+	sdkPtr unsafe.Pointer,
+	tableName string,
+	schemaJSON string,
+	clientID string,
+	clientSecret string,
+	options *StreamConfigurationOptions,
+) (unsafe.Pointer, error) {
+	cTableName := C.CString(tableName)
+	defer C.free(unsafe.Pointer(cTableName))
+
+	cSchemaJSON := C.CString(schemaJSON)
+	defer C.free(unsafe.Pointer(cSchemaJSON))
+
+	cClientID := C.CString(clientID)
+	defer C.free(unsafe.Pointer(cClientID))
+
+	cClientSecret := C.CString(clientSecret)
+	defer C.free(unsafe.Pointer(cClientSecret))
+
+	cOpts := convertConfigToC(options)
+
+	var cres C.CResult
+	ptr := C.zerobus_sdk_create_avro_stream(
+		(*C.CZerobusSdk)(sdkPtr),
+		cTableName,
+		cSchemaJSON,
+		cClientID,
+		cClientSecret,
+		&cOpts,
+		&cres,
+	)
+
+	if ptr == nil {
+		return nil, ffiResult(cres)
+	}
+
+	return unsafe.Pointer(ptr), nil
+}
+
+// sdkCreateAvroStreamWithHeadersProvider creates an Avro stream with custom headers provider via FFI
+func sdkCreateAvroStreamWithHeadersProvider(
+	sdkPtr unsafe.Pointer,
+	tableName string,
+	schemaJSON string,
+	headersProvider HeadersProvider,
+	options *StreamConfigurationOptions,
+) (unsafe.Pointer, error) {
+	cTableName := C.CString(tableName)
+	defer C.free(unsafe.Pointer(cTableName))
+
+	cSchemaJSON := C.CString(schemaJSON)
+	defer C.free(unsafe.Pointer(cSchemaJSON))
+
+	// Create a cgo.Handle for the provider and hand its ownership to the FFI
+	handle := cgo.NewHandle(headersProvider)
+	handlePtr := *(*unsafe.Pointer)(unsafe.Pointer(&handle))
+
+	cOpts := convertConfigToC(options)
+
+	var cres C.CResult
+	ptr := C.zerobus_sdk_create_avro_stream_with_headers_provider(
+		(*C.CZerobusSdk)(sdkPtr),
+		cTableName,
+		cSchemaJSON,
+		C.getHeadersCallback(),
+		handlePtr,
+		C.getFreeHeadersProviderCallback(),
+		&cOpts,
+		&cres,
+	)
+
+	if ptr == nil {
+		return nil, ffiResult(cres)
+	}
+
+	return unsafe.Pointer(ptr), nil
+}
+
+// streamIngestAvroRecord ingests a pre-encoded Avro datum
+func streamIngestAvroRecord(streamPtr unsafe.Pointer, data []byte) (int64, error) {
+	if len(data) == 0 {
+		return -1, &ZerobusError{Message: "empty data", IsRetryable: false}
+	}
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	cData := (*C.uint8_t)(unsafe.SliceData(data))
+	pinner.Pin(cData)
+
+	var cres C.CResult
+	offset := C.zerobus_stream_ingest_avro_record(
+		(*C.CZerobusStream)(streamPtr),
+		cData,
+		C.size_t(len(data)),
+		&cres,
+	)
+
+	if offset < 0 {
+		return -1, ffiResult(cres)
+	}
+
+	return int64(offset), nil
+}
+
+// streamIngestAvroRecords ingests a batch of pre-encoded Avro datums
+func streamIngestAvroRecords(streamPtr unsafe.Pointer, records [][]byte) (int64, error) {
+	if len(records) == 0 {
+		return -1, nil
+	}
+
+	ptrSize := C.size_t(unsafe.Sizeof((*C.uint8_t)(nil)))
+	lenSize := C.size_t(unsafe.Sizeof(C.size_t(0)))
+	n := C.size_t(len(records))
+
+	cPtrArray := C.calloc(n, ptrSize)
+	if cPtrArray == nil {
+		return -1, &ZerobusError{Message: "out of memory allocating record pointer array", IsRetryable: false}
+	}
+	defer C.free(cPtrArray)
+
+	cLenArray := C.calloc(n, lenSize)
+	if cLenArray == nil {
+		return -1, &ZerobusError{Message: "out of memory allocating record length array", IsRetryable: false}
+	}
+	defer C.free(cLenArray)
+
+	recordPtrs := (*[1 << 30]*C.uint8_t)(cPtrArray)[:len(records):len(records)]
+	recordLens := (*[1 << 30]C.size_t)(cLenArray)[:len(records):len(records)]
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	for i, record := range records {
+		if len(record) > 0 {
+			ptr := (*C.uint8_t)(unsafe.SliceData(records[i]))
+			pinner.Pin(ptr)
+			recordPtrs[i] = ptr
+			recordLens[i] = C.size_t(len(record))
+		}
+	}
+
+	var cres C.CResult
+	offset := C.zerobus_stream_ingest_avro_records(
+		(*C.CZerobusStream)(streamPtr),
+		(**C.uint8_t)(cPtrArray),
+		(*C.size_t)(cLenArray),
+		n,
+		&cres,
+	)
+
+	if offset == -2 {
+		return -1, nil
+	}
+	if offset < 0 {
+		return -1, ffiResult(cres)
+	}
+
+	return int64(offset), nil
+}
+
+// streamIngestAvroRecordNowait ingests a pre-encoded Avro datum without waiting
+func streamIngestAvroRecordNowait(streamPtr unsafe.Pointer, data []byte) error {
+	if len(data) == 0 {
+		return &ZerobusError{Message: "empty data", IsRetryable: false}
+	}
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	cData := (*C.uint8_t)(unsafe.SliceData(data))
+	pinner.Pin(cData)
+
+	var cres C.CResult
+	C.zerobus_stream_ingest_avro_record_nowait(
+		(*C.CZerobusStream)(streamPtr),
+		cData,
+		C.size_t(len(data)),
+		&cres,
+	)
+
+	return ffiResult(cres)
+}
+
+// streamIngestAvroRecordsNowait ingests a batch of pre-encoded Avro datums without waiting
+func streamIngestAvroRecordsNowait(streamPtr unsafe.Pointer, records [][]byte) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	ptrSize := C.size_t(unsafe.Sizeof((*C.uint8_t)(nil)))
+	lenSize := C.size_t(unsafe.Sizeof(C.size_t(0)))
+	n := C.size_t(len(records))
+
+	cPtrArray := C.calloc(n, ptrSize)
+	if cPtrArray == nil {
+		return &ZerobusError{Message: "out of memory allocating record pointer array", IsRetryable: false}
+	}
+	defer C.free(cPtrArray)
+
+	cLenArray := C.calloc(n, lenSize)
+	if cLenArray == nil {
+		return &ZerobusError{Message: "out of memory allocating record length array", IsRetryable: false}
+	}
+	defer C.free(cLenArray)
+
+	recordPtrs := (*[1 << 30]*C.uint8_t)(cPtrArray)[:len(records):len(records)]
+	recordLens := (*[1 << 30]C.size_t)(cLenArray)[:len(records):len(records)]
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	for i, record := range records {
+		if len(record) > 0 {
+			ptr := (*C.uint8_t)(unsafe.SliceData(records[i]))
+			pinner.Pin(ptr)
+			recordPtrs[i] = ptr
+			recordLens[i] = C.size_t(len(record))
+		}
+	}
+
+	var cres C.CResult
+	C.zerobus_stream_ingest_avro_records_nowait(
+		(*C.CZerobusStream)(streamPtr),
+		(**C.uint8_t)(cPtrArray),
+		(*C.size_t)(cLenArray),
+		n,
+		&cres,
+	)
+
+	return ffiResult(cres)
+}

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/hamba/avro/v2 v2.31.0 h1:wv3nmua7lCEIwWsb6vqsTS3pXktTxcKg5eoyNu0VhrU=
+github.com/hamba/avro/v2 v2.31.0/go.mod h1:t6lJYAGE5Mswfn17zjtyQsssRQgnqO6TXLBCHHWRqrw=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go/types.go
+++ b/go/types.go
@@ -10,6 +10,8 @@ const (
 	RecordTypeProto RecordType = 1
 	// RecordTypeJson indicates JSON encoded records
 	RecordTypeJson RecordType = 2
+	// RecordTypeAvro indicates Avro encoded records (Beta, requires avro build tag)
+	RecordTypeAvro RecordType = 4
 )
 
 // StreamConfigurationOptions contains configuration options for creating a stream

--- a/go/zerobus.go
+++ b/go/zerobus.go
@@ -150,6 +150,8 @@ type ZerobusSdk struct {
 // Records can be ingested concurrently and will be acknowledged asynchronously.
 type ZerobusStream struct {
 	ptr unsafe.Pointer
+	// avroSchema parsed (avro tag only); holds hamba avro.Schema for object encoding
+	avroSchema unsafe.Pointer
 }
 
 type sdkOptions struct {

--- a/go/zerobus_avro.go
+++ b/go/zerobus_avro.go
@@ -1,0 +1,459 @@
+//go:build avro
+
+package zerobus
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+
+	"github.com/hamba/avro/v2"
+)
+
+// AvroTableProperties contains information about the target table for Avro ingestion
+type AvroTableProperties struct {
+	// Fully qualified table name (catalog.schema.table)
+	TableName string
+
+	// Avro writer schema as a JSON string (required)
+	SchemaJSON string
+}
+
+// AvroRecord is a map of field names to values for Avro object encoding.
+type AvroRecord map[string]any
+
+// Union wraps a value for Avro union branch tagging.
+func Union(branch string, v any) map[string]any {
+	return map[string]any{branch: v}
+}
+
+// CreateAvroStream creates a new Avro stream for ingesting pre-encoded Avro records or objects.
+// This is a Beta feature gated by the `avro` build tag. The Zerobus service Avro support is pending.
+//
+// Parameters:
+//   - tableProps: Table properties including name and Avro schema JSON
+//   - clientID: OAuth 2.0 client ID
+//   - clientSecret: OAuth 2.0 client secret
+//   - options: Stream configuration options (nil for defaults)
+//
+// Returns an error if:
+//   - Invalid table name format
+//   - Invalid Avro schema JSON
+//   - Authentication fails
+//   - Network connectivity issues
+//
+// Example:
+//
+//	schemaJSON := `{"type":"record","name":"Test","fields":[{"name":"id","type":"int"}]}`
+//	stream, err := sdk.CreateAvroStream(
+//	    AvroTableProperties{
+//	        TableName: "catalog.schema.table",
+//	        SchemaJSON: schemaJSON,
+//	    },
+//	    clientID,
+//	    clientSecret,
+//	    nil,
+//	)
+func (s *ZerobusSdk) CreateAvroStream(
+	tableProps AvroTableProperties,
+	clientID string,
+	clientSecret string,
+	options *StreamConfigurationOptions,
+) (*ZerobusStream, error) {
+	if s.ptr == nil {
+		return nil, &ZerobusError{Message: "SDK has been freed", IsRetryable: false}
+	}
+
+	// Parse schema for object encoding
+	schema, err := avro.Parse(tableProps.SchemaJSON)
+	if err != nil {
+		return nil, &ZerobusError{Message: "parse avro schema: " + err.Error(), IsRetryable: false}
+	}
+
+	ptr, err := sdkCreateAvroStream(
+		s.ptr,
+		tableProps.TableName,
+		tableProps.SchemaJSON,
+		clientID,
+		clientSecret,
+		options,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := &ZerobusStream{
+		ptr:        ptr,
+		avroSchema: unsafe.Pointer(&schema),
+	}
+
+	// Set up finalizer for automatic cleanup
+	runtime.SetFinalizer(stream, func(st *ZerobusStream) {
+		st.Close()
+	})
+
+	return stream, nil
+}
+
+// CreateAvroStreamWithHeadersProvider creates a new Avro stream using a custom headers provider.
+// This is a Beta feature gated by the `avro` build tag. The Zerobus service Avro support is pending.
+//
+// Parameters:
+//   - tableProps: Table properties including name and Avro schema JSON
+//   - headersProvider: Custom implementation of HeadersProvider interface
+//   - options: Stream configuration options (nil for defaults)
+//
+// Returns an error if:
+//   - Invalid table name format
+//   - Invalid Avro schema JSON
+//   - Headers provider returns an error
+//   - Network connectivity issues
+//
+// Example:
+//
+//	provider := &CustomHeadersProvider{}
+//	schemaJSON := `{"type":"record","name":"Test","fields":[{"name":"id","type":"int"}]}`
+//	stream, err := sdk.CreateAvroStreamWithHeadersProvider(
+//	    AvroTableProperties{
+//	        TableName: "catalog.schema.table",
+//	        SchemaJSON: schemaJSON,
+//	    },
+//	    provider,
+//	    nil,
+//	)
+func (s *ZerobusSdk) CreateAvroStreamWithHeadersProvider(
+	tableProps AvroTableProperties,
+	headersProvider HeadersProvider,
+	options *StreamConfigurationOptions,
+) (*ZerobusStream, error) {
+	if s.ptr == nil {
+		return nil, &ZerobusError{Message: "SDK has been freed", IsRetryable: false}
+	}
+
+	// Parse schema for object encoding
+	schema, err := avro.Parse(tableProps.SchemaJSON)
+	if err != nil {
+		return nil, &ZerobusError{Message: "parse avro schema: " + err.Error(), IsRetryable: false}
+	}
+
+	ptr, err := sdkCreateAvroStreamWithHeadersProvider(
+		s.ptr,
+		tableProps.TableName,
+		tableProps.SchemaJSON,
+		headersProvider,
+		options,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := &ZerobusStream{
+		ptr:        ptr,
+		avroSchema: unsafe.Pointer(&schema),
+	}
+
+	// Set up finalizer for automatic cleanup
+	runtime.SetFinalizer(stream, func(st *ZerobusStream) {
+		st.Close()
+	})
+
+	return stream, nil
+}
+
+// IngestAvroBytesOffset ingests a pre-encoded Avro datum and returns the offset.
+// This is a Beta API gated by the `avro` build tag.
+//
+// Avro records must be pre-encoded as binary Avro datums before passing to this method.
+// This method returns as soon as the record is queued; the SDK sends it and tracks its
+// acknowledgment in the background.
+//
+// The idiomatic flow is to ingest in a loop and call Flush() to confirm durability.
+//
+// Parameters:
+//   - data: Pre-encoded Avro datum as []byte
+//
+// Returns:
+//   - int64: The offset of the ingested record
+//   - error: Any error that occurred during ingestion
+//
+// Example:
+//
+//	// Assuming you have pre-encoded Avro data
+//	avroData := encodeAvroRecord(record, schemaJSON)
+//	offset, err := stream.IngestAvroBytesOffset(avroData)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroBytesOffset(data []byte) (int64, error) {
+	if st.ptr == nil {
+		return -1, &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	return streamIngestAvroRecord(st.ptr, data)
+}
+
+// IngestAvroBytesBatchOffset ingests a batch of pre-encoded Avro datums and returns one offset for the batch.
+// This is a Beta API gated by the `avro` build tag.
+//
+// All records in the batch must be pre-encoded Avro datums.
+// This method returns as soon as the batch is queued; the server round-trip happens in the background.
+//
+// Parameters:
+//   - records: Slice of pre-encoded Avro datums, each as []byte
+//
+// Returns:
+//   - int64: One offset that represents the entire batch
+//   - error: Any error that occurred during ingestion
+//
+// If the batch is empty, returns -1 with no error.
+//
+// Example:
+//
+//	records := [][]byte{
+//	    encodeAvroRecord(record1, schemaJSON),
+//	    encodeAvroRecord(record2, schemaJSON),
+//	    encodeAvroRecord(record3, schemaJSON),
+//	}
+//	offset, err := stream.IngestAvroBytesBatchOffset(records)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroBytesBatchOffset(records [][]byte) (int64, error) {
+	if st.ptr == nil {
+		return -1, &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	if len(records) == 0 {
+		return -1, nil
+	}
+
+	return streamIngestAvroRecords(st.ptr, records)
+}
+
+// IngestAvroBytesNowait ingests a pre-encoded Avro datum without waiting (fire-and-forget).
+// This is a Beta API gated by the `avro` build tag.
+//
+// The function returns immediately after spawning a background task to queue the record.
+// Ingestion errors from the background task are silently ignored.
+//
+// The stream must remain open until all background tasks have completed.
+//
+// Parameters:
+//   - data: Pre-encoded Avro datum as []byte
+//
+// Returns an error only for argument validation failures (e.g. nil stream, empty data).
+//
+// Example:
+//
+//	err := stream.IngestAvroBytesNowait(avroData)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroBytesNowait(data []byte) error {
+	if st.ptr == nil {
+		return &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	return streamIngestAvroRecordNowait(st.ptr, data)
+}
+
+// IngestAvroBytesBatchNowait ingests a batch of pre-encoded Avro datums without waiting (fire-and-forget).
+// This is a Beta API gated by the `avro` build tag.
+//
+// Returns immediately after the records are handed off; ingestion errors from the background task
+// are silently ignored.
+//
+// The stream must remain open until all background tasks have completed.
+//
+// Parameters:
+//   - records: Slice of pre-encoded Avro datums, each as []byte
+//
+// Returns an error only for argument validation failures (nil stream, etc).
+//
+// Example:
+//
+//	err := stream.IngestAvroBytesBatchNowait([][]byte{data1, data2, data3})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroBytesBatchNowait(records [][]byte) error {
+	if st.ptr == nil {
+		return &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	if len(records) == 0 {
+		return nil
+	}
+
+	return streamIngestAvroRecordsNowait(st.ptr, records)
+}
+
+// IngestAvroRecordOffset encodes an AvroRecord to binary Avro and ingests it.
+// This is a Beta API gated by the `avro` build tag.
+//
+// Encodes the record against the stream's writer schema using native Avro encoding.
+// This method returns as soon as the record is queued; the SDK sends it and tracks its
+// acknowledgment in the background.
+//
+// The idiomatic flow is to ingest in a loop and call Flush() to confirm durability.
+//
+// Parameters:
+//   - record: AvroRecord (map[string]any) with field names matching the schema
+//
+// Returns:
+//   - int64: The offset of the ingested record
+//   - error: Encode error or any error that occurred during ingestion
+//
+// Example:
+//
+//	record := AvroRecord{
+//	    "id": int64(1),
+//	    "name": "Alice",
+//	}
+//	offset, err := stream.IngestAvroRecordOffset(record)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroRecordOffset(record AvroRecord) (int64, error) {
+	if st.ptr == nil {
+		return -1, &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	data, err := st.encodeAvroRecord(record)
+	if err != nil {
+		return -1, err
+	}
+
+	return streamIngestAvroRecord(st.ptr, data)
+}
+
+// IngestAvroRecordsOffset encodes AvroRecords to binary Avro and ingests them as a batch.
+// This is a Beta API gated by the `avro` build tag.
+//
+// Each record is encoded against the stream's writer schema.
+// This method returns as soon as the batch is queued; the server round-trip happens in the background.
+//
+// Parameters:
+//   - records: Slice of AvroRecord (each map[string]any)
+//
+// Returns:
+//   - int64: One offset that represents the entire batch
+//   - error: Encode error or any error that occurred during ingestion
+//
+// If the batch is empty, returns -1 with no error.
+//
+// Example:
+//
+//	records := []AvroRecord{
+//	    {"id": int64(1), "name": "Alice"},
+//	    {"id": int64(2), "name": "Bob"},
+//	}
+//	offset, err := stream.IngestAvroRecordsOffset(records)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroRecordsOffset(records []AvroRecord) (int64, error) {
+	if st.ptr == nil {
+		return -1, &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	if len(records) == 0 {
+		return -1, nil
+	}
+
+	encoded := make([][]byte, len(records))
+	for i, rec := range records {
+		data, err := st.encodeAvroRecord(rec)
+		if err != nil {
+			return -1, &ZerobusError{Message: fmt.Sprintf("encode record %d: %v", i, err), IsRetryable: false}
+		}
+		encoded[i] = data
+	}
+
+	return streamIngestAvroRecords(st.ptr, encoded)
+}
+
+// IngestAvroRecordNowait encodes an AvroRecord and ingests it without waiting (fire-and-forget).
+// This is a Beta API gated by the `avro` build tag.
+//
+// The function returns immediately after spawning a background task to queue the record.
+// Ingestion errors from the background task are silently ignored.
+//
+// The stream must remain open until all background tasks have completed.
+//
+// Parameters:
+//   - record: AvroRecord (map[string]any) with field names matching the schema
+//
+// Returns an error only for argument validation or encoding failures.
+//
+// Example:
+//
+//	err := stream.IngestAvroRecordNowait(AvroRecord{"id": int64(1), "name": "Alice"})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroRecordNowait(record AvroRecord) error {
+	if st.ptr == nil {
+		return &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	data, err := st.encodeAvroRecord(record)
+	if err != nil {
+		return err
+	}
+
+	return streamIngestAvroRecordNowait(st.ptr, data)
+}
+
+// IngestAvroRecordsNowait encodes AvroRecords and ingests them without waiting (fire-and-forget).
+// This is a Beta API gated by the `avro` build tag.
+//
+// Returns immediately after the records are handed off; ingestion errors from the background task
+// are silently ignored.
+//
+// The stream must remain open until all background tasks have completed.
+//
+// Parameters:
+//   - records: Slice of AvroRecord (each map[string]any)
+//
+// Returns an error only for argument validation or encoding failures.
+//
+// Example:
+//
+//	records := []AvroRecord{
+//	    {"id": int64(1), "name": "Alice"},
+//	    {"id": int64(2), "name": "Bob"},
+//	}
+//	err := stream.IngestAvroRecordsNowait(records)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (st *ZerobusStream) IngestAvroRecordsNowait(records []AvroRecord) error {
+	if st.ptr == nil {
+		return &ZerobusError{Message: "Stream has been closed", IsRetryable: false}
+	}
+
+	if len(records) == 0 {
+		return nil
+	}
+
+	encoded := make([][]byte, len(records))
+	for i, rec := range records {
+		data, err := st.encodeAvroRecord(rec)
+		if err != nil {
+			return &ZerobusError{Message: fmt.Sprintf("encode record %d: %v", i, err), IsRetryable: false}
+		}
+		encoded[i] = data
+	}
+
+	return streamIngestAvroRecordsNowait(st.ptr, encoded)
+}
+
+// encodeAvroRecord encodes an AvroRecord using the stream's schema.
+func (st *ZerobusStream) encodeAvroRecord(record AvroRecord) ([]byte, error) {
+	if st.avroSchema == nil {
+		return nil, &ZerobusError{Message: "stream is not an Avro stream", IsRetryable: false}
+	}
+	schema := (*avro.Schema)(st.avroSchema)
+	return avro.Marshal(*schema, map[string]any(record))
+}

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -41,6 +41,7 @@ lint:
 	cargo clippy --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --all-features --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --no-default-features --all-targets -- -D warnings
+	cargo clippy -p zerobus-ffi --all-features --all-targets -- -D warnings
 	cargo clippy -p zerobus-jni --all-features --all-targets -- -D warnings
 
 check: fmt lint
@@ -49,4 +50,5 @@ test:
 	cargo test --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni
 	cargo test -p databricks-zerobus-ingest-sdk --all-features
 	cargo test -p databricks-zerobus-ingest-sdk --no-default-features
+	cargo test -p zerobus-ffi --all-features
 	cargo test -p zerobus-jni --all-features

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -36,6 +36,10 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
+[features]
+# Avro record format (Beta), opt-in. Gated in the C header behind ZEROBUS_AVRO.
+avro = ["databricks-zerobus-ingest-sdk/avro"]
+
 [dev-dependencies]
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-schema = { workspace = true, features = ["ffi"] }

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ### New Features and Improvements
 
+- Add the Avro record format (Beta) behind the `avro` feature, exposed in the C
+  header under `#if defined(ZEROBUS_AVRO)`: `zerobus_sdk_create_avro_stream`
+  (+ `_async` / `_with_headers_provider` / `_with_headers_provider_async`), which
+  takes the writer schema JSON at creation, and `zerobus_stream_ingest_avro_record`
+  / `_records` (+ `_async` / `_nowait`), which ingest a pre-encoded Avro datum
+  (single or batch). Additive — existing functions and `CStreamConfigurationOptions`
+  are unchanged, and the header is byte-identical with and without the feature.
+  Ephemeral streams only; server support is pending.
+- The C ABI carries pre-encoded datums only; it holds no Avro encoder. Wrappers
+  that offer a record-object API encode the object to a datum natively (in their
+  own language) and pass the bytes through `zerobus_stream_ingest_avro_record`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -11,3 +11,6 @@ cpp_compat = true
 include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CArrowArray", "CArrowSchema", "CZerobusProtoSchema"]
 
 [export.rename]
+
+[defines]
+"feature = avro" = "ZEROBUS_AVRO"

--- a/rust/ffi/src/stream.rs
+++ b/rust/ffi/src/stream.rs
@@ -85,13 +85,20 @@ async fn build_stream_from_parts(
     sdk_ref: &databricks_zerobus_ingest_sdk::ZerobusSdk,
     table_name: String,
     descriptor_proto: Option<prost_types::DescriptorProto>,
+    avro_schema_json: Option<String>,
     auth: StreamCreateAuth,
     options: Option<CStreamConfigurationOptions>,
 ) -> Result<*mut CZerobusStream, ZerobusError> {
-    let record_type = options
-        .as_ref()
-        .map(|c| c_record_type(c.record_type))
-        .unwrap_or(RecordType::Proto);
+    // An Avro schema comes only from the dedicated avro create fns, which force
+    // the Avro format regardless of options.record_type.
+    let record_type = if avro_schema_json.is_some() {
+        RecordType::Avro
+    } else {
+        options
+            .as_ref()
+            .map(|c| c_record_type(c.record_type))
+            .unwrap_or(RecordType::Proto)
+    };
 
     let base = match auth {
         StreamCreateAuth::OAuth {
@@ -117,6 +124,16 @@ async fn build_stream_from_parts(
             base.compiled_proto(desc)
         }
         RecordType::Json => base.json(),
+        #[cfg(feature = "avro")]
+        RecordType::Avro => {
+            let schema = avro_schema_json.ok_or_else(|| {
+                ZerobusError::InvalidArgument(
+                    "Avro schema is required for Avro record type".to_string(),
+                )
+            })?;
+            base.avro(schema)
+        }
+        #[cfg(not(feature = "avro"))]
         RecordType::Avro => {
             return Err(ZerobusError::InvalidArgument(
                 "Avro record type is not supported".to_string(),
@@ -270,6 +287,17 @@ fn encoded_records_to_c_array(records_vec: Vec<EncodedRecord>) -> CRecordArray {
                     data_len,
                 }
             }
+            // Avro datums are raw bytes (like proto): is_json = false.
+            #[cfg(feature = "avro")]
+            EncodedRecord::Avro(data) => {
+                let data_len = data.len();
+                let data_ptr = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+                CRecord {
+                    is_json: false,
+                    data: data_ptr,
+                    data_len,
+                }
+            }
         })
         .collect();
 
@@ -341,6 +369,7 @@ pub extern "C" fn zerobus_sdk_create_stream(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 StreamCreateAuth::OAuth {
                     client_id: client_id_str,
                     client_secret: client_secret_str,
@@ -442,6 +471,7 @@ pub extern "C" fn zerobus_sdk_create_stream_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::OAuth {
                         client_id: client_id_str,
                         client_secret: client_secret_str,
@@ -566,6 +596,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 // Pass the pre-built provider (constructed above, before any
                 // fallible work) so its Drop still frees `user_data` on every
                 // error path in here.
@@ -686,6 +717,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::HeadersProvider { headers_provider },
                     c_opts,
                 )
@@ -1917,4 +1949,692 @@ pub extern "C" fn zerobus_get_default_config() -> CStreamConfigurationOptions {
         ack_on_error: None,
         ack_user_data: ptr::null_mut(),
     }
+}
+
+// ============================================================================
+// Avro record format (Beta). Gated behind the `avro` feature; the C header
+// exposes these behind `#if defined(ZEROBUS_AVRO)`. Mirrors the proto create +
+// ingest surface, with the Avro writer schema (JSON) supplied at creation.
+// ============================================================================
+
+/// Create an Avro stream with OAuth authentication (Beta).
+/// avro_schema_json: the Avro writer schema as a JSON string (required).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_id_str = unsafe {
+                c_str_to_string(client_id)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_secret_str = unsafe {
+                c_str_to_string(client_secret)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::OAuth {
+                    client_id: client_id_str,
+                    client_secret: client_secret_str,
+                },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with OAuth authentication on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_id_str = match unsafe { c_str_to_string(client_id) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_secret_str = match unsafe { c_str_to_string(client_secret) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::OAuth {
+                        client_id: client_id_str,
+                        client_secret: client_secret_str,
+                    },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback (Beta).
+/// Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::HeadersProvider { headers_provider },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    callback_user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(callback_user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::HeadersProvider { headers_provider },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return -1;
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+
+        let offset_res = RUNTIME.block_on(async {
+            let payload = EncodedRecord::Avro(data_vec);
+            stream_ref.ingest_record_offset(payload).await
+        });
+
+        match offset_res {
+            Ok(offset) => {
+                write_success_result(result);
+                offset
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest an Avro datum on a background task and report the assigned offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_async(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return false;
+        }
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let data_vec = unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            match stream_arc
+                .ingest_record_offset(EncodedRecord::Avro(data_vec))
+                .await
+            {
+                Ok(offset) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return -1;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return -2; // Empty batch
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| {
+                    let data_slice = std::slice::from_raw_parts(*ptr, *len);
+                    data_slice.to_vec()
+                })
+                .collect()
+        };
+
+        let offset_res = RUNTIME.block_on(async {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            stream_ref.ingest_records_offset(payloads).await
+        });
+
+        match offset_res {
+            Ok(Some(offset)) => {
+                write_success_result(result);
+                offset
+            }
+            Ok(None) => {
+                write_success_result(result);
+                -2 // Empty batch
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_async(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return false;
+        }
+
+        let callback_user_data = SendPtr::new(user_data);
+        if num_records == 0 {
+            RUNTIME.spawn(async move {
+                invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                );
+            });
+            write_success_result(result);
+            return true;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            match stream_arc.ingest_records_offset(payloads).await {
+                Ok(Some(offset)) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Ok(None) => invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest an Avro datum without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_nowait(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payload = EncodedRecord::Avro(data_vec);
+            let _ = stream_arc.ingest_record_offset(payload).await;
+        });
+
+        write_success_result(result);
+    })
+}
+
+/// Ingest a batch of Avro datums without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_nowait(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            let _ = stream_arc.ingest_records_offset(payloads).await;
+        });
+
+        write_success_result(result);
+    })
 }

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -836,6 +836,139 @@ void zerobus_free_error_message(char *message);
  */
 struct CStreamConfigurationOptions zerobus_get_default_config(void);
 
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication (Beta).
+ * avro_schema_json: the Avro writer schema as a JSON string (required).
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream(struct CZerobusSdk *sdk,
+                                                      const char *table_name,
+                                                      const char *avro_schema_json,
+                                                      const char *client_id,
+                                                      const char *client_secret,
+                                                      const struct CStreamConfigurationOptions *options,
+                                                      struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_async(struct CZerobusSdk *sdk,
+                                          const char *table_name,
+                                          const char *avro_schema_json,
+                                          const char *client_id,
+                                          const char *client_secret,
+                                          const struct CStreamConfigurationOptions *options,
+                                          CreateStreamAsyncCallback callback,
+                                          void *user_data,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback (Beta).
+ * Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream_with_headers_provider(struct CZerobusSdk *sdk,
+                                                                            const char *table_name,
+                                                                            const char *avro_schema_json,
+                                                                            HeadersProviderCallback headers_callback,
+                                                                            void *user_data,
+                                                                            void (*free_user_data)(void *user_data),
+                                                                            const struct CStreamConfigurationOptions *options,
+                                                                            struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_with_headers_provider_async(struct CZerobusSdk *sdk,
+                                                                const char *table_name,
+                                                                const char *avro_schema_json,
+                                                                HeadersProviderCallback headers_callback,
+                                                                void *user_data,
+                                                                void (*free_user_data)(void *user_data),
+                                                                const struct CStreamConfigurationOptions *options,
+                                                                CreateStreamAsyncCallback callback,
+                                                                void *callback_user_data,
+                                                                struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+ */
+int64_t zerobus_stream_ingest_avro_record(struct CZerobusStream *stream,
+                                          const uint8_t *data,
+                                          uintptr_t data_len,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum on a background task and report the assigned offset via callback.
+ */
+bool zerobus_stream_ingest_avro_record_async(struct CZerobusStream *stream,
+                                             const uint8_t *data,
+                                             uintptr_t data_len,
+                                             OffsetAsyncCallback callback,
+                                             void *user_data,
+                                             struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+ */
+int64_t zerobus_stream_ingest_avro_records(struct CZerobusStream *stream,
+                                           const uint8_t *const *records,
+                                           const uintptr_t *record_lens,
+                                           uintptr_t num_records,
+                                           struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+ */
+bool zerobus_stream_ingest_avro_records_async(struct CZerobusStream *stream,
+                                              const uint8_t *const *records,
+                                              const uintptr_t *record_lens,
+                                              uintptr_t num_records,
+                                              OffsetAsyncCallback callback,
+                                              void *user_data,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_record_nowait(struct CZerobusStream *stream,
+                                              const uint8_t *data,
+                                              uintptr_t data_len,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_records_nowait(struct CZerobusStream *stream,
+                                               const uint8_t *const *records,
+                                               const uintptr_t *record_lens,
+                                               uintptr_t num_records,
+                                               struct CResult *result);
+#endif
+
 /**
  * Build a protobuf schema from Unity Catalog table metadata JSON.
  * Returns NULL on error; free with `zerobus_proto_schema_free`.


### PR DESCRIPTION
## PR stack

- [avro/proto-surface](https://github.com/databricks/zerobus-sdk/pull/811) [MERGED]
    - [avro/purego](https://github.com/databricks/zerobus-sdk/pull/828)
    - [avro/rust-core](https://github.com/databricks/zerobus-sdk/pull/827) [MERGED]
        - [avro/ffi-c-abi](https://github.com/databricks/zerobus-sdk/pull/830)
            - [avro/go](https://github.com/databricks/zerobus-sdk/pull/831) <- _this PR_
            - [avro/cpp](https://github.com/databricks/zerobus-sdk/pull/832)
            - [avro/dotnet](https://github.com/databricks/zerobus-sdk/pull/833)
        - avro/java
        - [avro/python](https://github.com/databricks/zerobus-sdk/pull/851)
        - avro/typescript

## What changes are proposed in this pull request?

Adds the Avro record format to the Go (cgo) SDK, behind the `//go:build avro` build tag. Default builds are unchanged. Ephemeral streams only; server support is pending.

Declare the writer schema at stream creation with `CreateAvroStream(...)`, then ingest either form:
- **pre-encoded datums** (bytes): `IngestAvroBytesOffset([]byte)` / `IngestAvroBytesBatchOffset([][]byte)` (+ `Nowait`).
- **record objects**: `IngestAvroRecordOffset(any)` / `IngestAvroRecordsOffset([]any)` (+ `Nowait`) - `json.Marshal`ed and encoded by the shared Rust core against the writer schema. Go carries no Avro encoder.


## How is this tested?

```
cd go

# Default (feature off) — unchanged
make build
make test
make lint
make fmt

# Avro (requires the FFI built with --features avro)
ZEROBUS_BUILD_FEATURES=avro make build-avro-rust
go build -tags avro ./...
go vet   -tags avro ./...
go test  -tags avro ./...
```
