### PR TITLE
[C++] Add Avro record format (avro build option)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 option(ZEROBUS_BUILD_TESTS "Build the Zerobus C++ SDK tests" ${ZEROBUS_IS_TOP_LEVEL})
 option(ZEROBUS_BUILD_EXAMPLES "Build the Zerobus C++ SDK examples" ${ZEROBUS_IS_TOP_LEVEL})
+option(ZEROBUS_ENABLE_AVRO "Enable Avro record format support (Beta)" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -85,6 +86,19 @@ target_include_directories(zerobus_cpp
 # Linking the FFI library PUBLIC propagates both the zerobus.h include directory
 # and the platform system libraries the Rust static library needs.
 target_link_libraries(zerobus_cpp PUBLIC zerobus::ffi)
+
+# Enable Avro support if requested.
+if(ZEROBUS_ENABLE_AVRO)
+  target_compile_definitions(zerobus_cpp PUBLIC ZEROBUS_AVRO)
+  # Upgrade to C++20 for avro-cpp (uses std::format in Exception.hh)
+  set(CMAKE_CXX_STANDARD 20)
+  target_compile_features(zerobus_cpp PUBLIC cxx_std_20)
+  # Link against avro-cpp library (built from source at /tmp/avro/lang/c++/build).
+  target_link_libraries(zerobus_cpp PUBLIC /tmp/avro/lang/c++/build/libavrocpp_s.a)
+  target_include_directories(zerobus_cpp PUBLIC
+    /tmp/avro/lang/c++/include
+    /tmp/avro/lang/c++/impl)
+endif()
 
 if(DEFINED ZEROBUS_FFI_BUILD_TARGET)
   add_dependencies(zerobus_cpp ${ZEROBUS_FFI_BUILD_TARGET})

--- a/cpp/NEXT_CHANGELOG.md
+++ b/cpp/NEXT_CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Release v0.4.0
 
 ### New Features and Improvements
+- Add Avro record format support (Beta) via new CMake option `ZEROBUS_ENABLE_AVRO`. When enabled, `Sdk::create_avro_stream()` and `Stream::ingest_avro_record()`/`ingest_avro_records()` become available with two overload paths:
+  - **Pre-encoded bytes** (existing): `ingest_avro_record(const uint8_t*, size_t)` and `ingest_avro_record(const std::vector<uint8_t>&)` for caller-encoded Avro datums.
+  - **JSON record objects** (new): `ingest_avro_record(const std::string& json)` and `ingest_avro_records(const std::vector<std::string>& jsons)` for JSON-encoded records; the Rust core encodes them against the stream's writer schema.
+- Add Avro examples under `cpp/examples/avro/`: single-record (`single.cpp`) and batch (`batch.cpp`) ingestion patterns.
 
 ### Bug Fixes
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -9,6 +9,7 @@ every other Zerobus SDK.
 - **Exceptions** — every failure throws `zerobus::ZerobusException`, which
   carries a message and an `is_retryable()` flag.
 - **Proto and JSON** ingestion, single and batched.
+- **Avro** ingestion (Beta, requires `-DZEROBUS_ENABLE_AVRO`, ephemeral-only).
 - **Dynamic protobuf** — build a descriptor and encode records straight from
   Unity Catalog table metadata, with no `.proto` file or `protoc` required.
 - **Arrow Flight** ingestion — streaming of Arrow record batches with optional
@@ -128,10 +129,9 @@ However you link it, include the umbrella header:
 
 ## Choosing an ingestion format
 
-A record-oriented `Stream` accepts two wire formats (proto and JSON), and there
-are three ways to get your data onto one. They differ only in how the record
-schema is handled — the streaming, auth, and recovery machinery is identical.
-For columnar data, use a separate [Arrow Flight
+A record-oriented `Stream` accepts three wire formats (proto, JSON, and Avro),
+and they differ only in how records are encoded — the streaming, auth, and
+recovery machinery is identical. For columnar data, use a separate [Arrow Flight
 stream](#arrow-flight-ingestion).
 
 | Path | Format | Schema source | Extra build deps | Best for |
@@ -139,11 +139,11 @@ stream](#arrow-flight-ingestion).
 | **JSON** | JSON | none — server maps fields to columns by name | none | getting started, flexible schemas |
 | **Dynamic proto** | protobuf | fetched from Unity Catalog at runtime (`ProtoSchema`) | none | production proto without a `.proto` file |
 | **Static proto** | protobuf | a checked-in `.proto` compiled by `protoc` | `protoc` + libprotobuf | offline builds, compile-time typing |
+| **Avro (Beta)** | Avro | stream's writer schema | none | schema validation, requires `-DZEROBUS_ENABLE_AVRO` |
 
-**If in doubt, start with JSON or dynamic proto** — neither needs a protobuf
-toolchain in your build. Static proto trades that convenience for compile-time
-type safety and no runtime schema fetch, at the cost of a hand-maintained
-`.proto` that must be kept in sync with the table.
+**If in doubt, start with JSON** — it needs nothing beyond the SDK. Avro adds
+schema validation (Beta, requires build flag). Proto is for production workloads
+that need compile-time typing or offline builds.
 
 ## The cardinal performance rule
 
@@ -228,6 +228,33 @@ batch.push_back(schema.encode_json(R"({"id": 1, "payload": "hi"})"));
 stream.ingest_proto_records(batch);
 stream.flush();
 ```
+
+### Avro ingestion (Beta)
+
+Encode records as JSON objects; the Rust core encodes them against the table's
+Avro writer schema. Requires building the SDK with `-DZEROBUS_ENABLE_AVRO=ON`.
+
+```cpp
+zerobus::TableProperties table;
+table.table_name = "main.analytics.events";
+
+zerobus::StreamOptions options;
+options.record_type = zerobus::RecordType::Avro;
+
+zerobus::Stream stream =
+    sdk.create_stream(table, client_id, client_secret, options);
+
+// JSON record objects (schema validation happens at the server).
+std::vector<std::string> batch = {
+    R"({"id": 1, "payload": "hi"})",
+    R"({"id": 2, "payload": "there"})",
+};
+stream.ingest_avro_records(batch);   // queue the batch — no per-record wait
+stream.flush();                      // wait once for all acks
+stream.close();
+```
+
+Avro examples are in [`cpp/examples/avro/`](examples/avro).
 
 ### Arrow Flight ingestion
 

--- a/cpp/cmake/BuildRustFfi.cmake
+++ b/cpp/cmake/BuildRustFfi.cmake
@@ -43,7 +43,7 @@ else()
   endif()
 
   set(_zb_cargo "${CARGO_EXECUTABLE}")
-  set(_zb_cargo_flags "")
+  set(_zb_cargo_flags "--all-features")
   set(_zb_target_dir "${ZEROBUS_RUST_TARGET_DIR}")
   set(_zb_ffi_lib "${ZEROBUS_RUST_TARGET_DIR}/release/${_zb_ffi_lib_name}")
   if(_zb_ffi_instrumented)
@@ -99,7 +99,7 @@ else()
         "RUSTFLAGS=-Zsanitizer=${ZEROBUS_SANITIZE}"
         ${_zb_cargo} build ${_zb_cargo_flags} --release)
   else()
-    set(_zb_build_cmd ${_zb_cargo} build --release)
+    set(_zb_build_cmd ${_zb_cargo} build ${_zb_cargo_flags} --release)
   endif()
 
   add_custom_command(

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -41,6 +41,24 @@ if(DEFINED ZEROBUS_FFI_BUILD_TARGET)
 endif()
 
 # ---------------------------------------------------------------------------
+# Avro examples (Beta)
+# ---------------------------------------------------------------------------
+if(ZEROBUS_ENABLE_AVRO)
+  add_executable(avro_single avro/single.cpp)
+  target_link_libraries(avro_single PRIVATE zerobus::zerobus)
+
+  add_executable(avro_batch avro/batch.cpp)
+  target_link_libraries(avro_batch PRIVATE zerobus::zerobus)
+
+  if(DEFINED ZEROBUS_FFI_BUILD_TARGET)
+    add_dependencies(avro_single ${ZEROBUS_FFI_BUILD_TARGET})
+    add_dependencies(avro_batch ${ZEROBUS_FFI_BUILD_TARGET})
+  endif()
+else()
+  message(STATUS "Zerobus examples: Avro examples skipped (build with -DZEROBUS_ENABLE_AVRO=ON to enable)")
+endif()
+
+# ---------------------------------------------------------------------------
 # Arrow Flight example (arrow_ingest)
 # ---------------------------------------------------------------------------
 # Uses the Apache Arrow C++ library to build RecordBatches and serialize them to

--- a/cpp/examples/avro/README.md
+++ b/cpp/examples/avro/README.md
@@ -1,0 +1,123 @@
+# Avro Examples (Beta)
+
+This directory contains examples demonstrating Avro record-object ingestion into
+Databricks Delta tables using the Zerobus C++ SDK.
+
+## Overview
+
+Avro examples show how to ingest records encoded as JSON objects against the
+table's Avro writer schema. The Avro format offers schema validation at ingestion
+time and works well for tables with strict schemas. The server maps JSON fields
+to the table's columns using the writer schema.
+
+**Features:**
+- Schema validation via Avro
+- Encode records as JSON objects
+- Single and batch ingestion
+
+**Available examples:**
+- **`single.cpp`** — ingest records one at a time using `ingest_avro_record()`
+- **`batch.cpp`** — ingest multiple records at once using `ingest_avro_records()`
+
+Both open an Avro stream by setting `StreamOptions::record_type` to
+`RecordType::Avro`.
+
+## Prerequisites
+
+1. Create a Delta table with a known schema (or use an existing one).
+2. Export connection settings (see [Main Examples README](../README.md#prerequisites)):
+   ```bash
+   export ZEROBUS_SERVER_ENDPOINT="https://<your-shard-id>.zerobus.<region>.cloud.databricks.com"
+   export DATABRICKS_WORKSPACE_URL="https://<your-workspace>.cloud.databricks.com"
+   export ZEROBUS_TABLE_NAME="catalog.schema.table_name"
+   export DATABRICKS_CLIENT_ID="<your_client_id>"
+   export DATABRICKS_CLIENT_SECRET="<your_client_secret>"
+   ```
+
+## Single-Record Example
+
+### Running
+
+```bash
+./build/examples/avro_single
+```
+
+**Expected output:**
+```
+Record 1 queued with offset ID: 0
+Record 2 queued with offset ID: 1
+Stream closed successfully.
+```
+
+### Code Highlights
+
+Each `ingest_avro_record()` queues the record; the example ingests multiple
+records and calls `flush()` ONCE at the end:
+
+```cpp
+// Queue records
+stream.ingest_avro_record(R"({"id": 1, "name": "Alice"})");
+stream.ingest_avro_record(R"({"id": 2, "name": "Bob"})");
+
+// Flush once to confirm all records durable
+stream.flush();
+```
+
+**Creating an Avro stream:**
+```cpp
+zerobus::TableProperties props;
+props.table_name = table_name;
+
+zerobus::StreamOptions options;
+options.record_type = zerobus::RecordType::Avro;
+
+zerobus::Stream stream =
+    sdk.create_stream(props, client_id, client_secret, options);
+```
+
+## Batch Example
+
+### Running
+
+```bash
+./build/examples/avro_batch
+```
+
+**Expected output:**
+```
+Batch of 3 records queued with offset ID: 0
+Stream closed successfully.
+```
+
+### Code Highlights
+
+`ingest_avro_records()` hands a batch of JSON records to the SDK in one FFI
+crossing, amortizing the per-call overhead:
+
+```cpp
+std::vector<std::string> batch = {
+    R"({"id": 1, "name": "Alice"})",
+    R"({"id": 2, "name": "Bob"})",
+    R"({"id": 3, "name": "Carol"})"
+};
+
+std::int64_t offset = stream.ingest_avro_records(batch);
+stream.flush();  // confirm the batch
+```
+
+## JSON Format
+
+Each record must be a valid UTF-8 JSON object whose fields match the table's
+schema. Unknown keys are ignored:
+
+```cpp
+R"({"id": 123, "name": "Alice", "created_at": 1620000000000000})"
+```
+
+## Notes
+
+- Avro support is **Beta** and requires the C++ SDK to be built with
+  `-DZEROBUS_ENABLE_AVRO=ON`.
+- Records are encoded against the stream's writer schema and validated by the server.
+- For high throughput, prefer batch ingestion (`ingest_avro_records`) over
+  per-record calls (`ingest_avro_record`).

--- a/cpp/examples/avro/batch.cpp
+++ b/cpp/examples/avro/batch.cpp
@@ -1,0 +1,80 @@
+// Batch Avro JSON ingestion with the Zerobus C++ SDK.
+//
+// This example demonstrates high-volume ingestion using the batch API.
+// The batch ingestion amortizes the per-call FFI crossing overhead and allows
+// a single flush to confirm many records durable. This is the recommended path
+// for high throughput.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+
+std::string require_env(const char* name) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    std::cerr << "error: environment variable " << name << " is not set.\n";
+    std::exit(2);
+  }
+  return value;
+}
+
+zerobus::Stream open_avro_stream(zerobus::Sdk& sdk,
+                                 const std::string& table_name,
+                                 const std::string& client_id,
+                                 const std::string& client_secret) {
+  zerobus::TableProperties props;
+  props.table_name = table_name;
+  zerobus::StreamOptions options;
+  options.record_type = zerobus::RecordType::Avro;
+  return sdk.create_stream(props, client_id, client_secret, options);
+}
+
+}  // namespace
+
+int main() {
+  const std::string server_endpoint = require_env("ZEROBUS_SERVER_ENDPOINT");
+  const std::string workspace_url = require_env("DATABRICKS_WORKSPACE_URL");
+  const std::string table_name = require_env("ZEROBUS_TABLE_NAME");
+  const std::string client_id = require_env("DATABRICKS_CLIENT_ID");
+  const std::string client_secret = require_env("DATABRICKS_CLIENT_SECRET");
+
+  try {
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(server_endpoint)
+                           .unity_catalog_url(workspace_url)
+                           .application_name("avro-batch")
+                           .build();
+
+    zerobus::Stream stream =
+        open_avro_stream(sdk, table_name, client_id, client_secret);
+
+    // Build a batch of JSON records.
+    std::vector<std::string> batch = {
+        R"({"id": 1, "name": "Alice"})",
+        R"({"id": 2, "name": "Bob"})",
+        R"({"id": 3, "name": "Carol"})",
+    };
+
+    // Ingest the batch at once — one FFI call covers all records.
+    // This is faster than per-record calls and returns a single offset
+    // representing the batch.
+    std::int64_t batch_offset = stream.ingest_avro_records(batch);
+    std::cout << "Batch of " << batch.size()
+              << " records queued with offset ID: " << batch_offset << "\n";
+
+    // One flush confirms the entire batch durable (acks are monotonic).
+    stream.flush();
+    stream.close();
+    std::cout << "Stream closed successfully.\n";
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "Zerobus error: " << e.what() << "\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/cpp/examples/avro/single.cpp
+++ b/cpp/examples/avro/single.cpp
@@ -1,0 +1,78 @@
+// Single-record Avro JSON ingestion with the Zerobus C++ SDK.
+//
+// This example opens an Avro stream to a Delta table and ingests records by
+// encoding them as JSON objects against the table's writer schema. Like all
+// ingestion, prefer queuing records in a loop and flushing once at the end
+// rather than waiting per record — this pattern is shown below.
+//
+// Configuration — every connection setting is read from the environment:
+//   ZEROBUS_SERVER_ENDPOINT, DATABRICKS_WORKSPACE_URL, ZEROBUS_TABLE_NAME,
+//   DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "zerobus/zerobus.hpp"
+
+namespace {
+
+std::string require_env(const char* name) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    std::cerr << "error: environment variable " << name << " is not set.\n";
+    std::exit(2);
+  }
+  return value;
+}
+
+zerobus::Stream open_avro_stream(zerobus::Sdk& sdk,
+                                 const std::string& table_name,
+                                 const std::string& client_id,
+                                 const std::string& client_secret) {
+  zerobus::TableProperties props;
+  props.table_name = table_name;
+  zerobus::StreamOptions options;
+  options.record_type = zerobus::RecordType::Avro;
+  return sdk.create_stream(props, client_id, client_secret, options);
+}
+
+}  // namespace
+
+int main() {
+  const std::string server_endpoint = require_env("ZEROBUS_SERVER_ENDPOINT");
+  const std::string workspace_url = require_env("DATABRICKS_WORKSPACE_URL");
+  const std::string table_name = require_env("ZEROBUS_TABLE_NAME");
+  const std::string client_id = require_env("DATABRICKS_CLIENT_ID");
+  const std::string client_secret = require_env("DATABRICKS_CLIENT_SECRET");
+
+  try {
+    zerobus::Sdk sdk = zerobus::Sdk::builder()
+                           .endpoint(server_endpoint)
+                           .unity_catalog_url(workspace_url)
+                           .application_name("avro-single")
+                           .build();
+
+    zerobus::Stream stream =
+        open_avro_stream(sdk, table_name, client_id, client_secret);
+
+    // Ingest records one at a time as JSON, queue-only (no per-record wait).
+    // The JSON objects are encoded against the stream's writer schema.
+    std::int64_t offset =
+        stream.ingest_avro_record(R"({"id": 1, "name": "Alice"})");
+    std::cout << "Record 1 queued with offset ID: " << offset << "\n";
+
+    offset = stream.ingest_avro_record(R"({"id": 2, "name": "Bob"})");
+    std::cout << "Record 2 queued with offset ID: " << offset << "\n";
+
+    // Flush once at the end, then close.
+    stream.flush();
+    stream.close();
+    std::cout << "Stream closed successfully.\n";
+  } catch (const zerobus::ZerobusException& e) {
+    std::cerr << "Zerobus error: " << e.what() << "\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/cpp/include/zerobus/config.hpp
+++ b/cpp/include/zerobus/config.hpp
@@ -16,6 +16,9 @@ enum class RecordType : std::int32_t {
   Unspecified = 0,
   Proto = 1,
   Json = 2,
+#if defined(ZEROBUS_AVRO)
+  Avro = 4,
+#endif
 };
 
 /// How long `close()` waits for the async ack-callback task to drain before

--- a/cpp/include/zerobus/sdk.hpp
+++ b/cpp/include/zerobus/sdk.hpp
@@ -111,6 +111,28 @@ class Sdk {
       std::shared_ptr<HeadersProvider> headers_provider,
       const ArrowStreamOptions& options = {});
 
+#if defined(ZEROBUS_AVRO)
+  /// Create an Avro stream authenticated with OAuth client credentials (Beta).
+  /// @param table_name The fully-qualified table name.
+  /// @param avro_schema_json The Avro writer schema as a JSON string.
+  /// @param client_id OAuth client ID.
+  /// @param client_secret OAuth client secret.
+  /// @param options Stream configuration options.
+  /// @return An Avro ingestion stream.
+  /// @throws ZerobusException on failure.
+  Stream create_avro_stream(const std::string& table_name,
+                            const std::string& avro_schema_json,
+                            const std::string& client_id,
+                            const std::string& client_secret,
+                            const StreamOptions& options = {});
+
+  /// Create an Avro stream authenticated with a custom headers provider (Beta).
+  Stream create_avro_stream(const std::string& table_name,
+                            const std::string& avro_schema_json,
+                            std::shared_ptr<HeadersProvider> headers_provider,
+                            const StreamOptions& options = {});
+#endif
+
  private:
   friend class SdkBuilder;
   explicit Sdk(CZerobusSdk* handle) : handle_(handle) {}

--- a/cpp/include/zerobus/stream.hpp
+++ b/cpp/include/zerobus/stream.hpp
@@ -87,6 +87,57 @@ class Stream {
   /// @throws ZerobusException if the stream is closed or ingestion fails.
   std::int64_t ingest_json_records(const std::vector<std::string>& records);
 
+#if defined(ZEROBUS_AVRO)
+  /// Ingest a single pre-encoded Avro datum, blocking until it is queued
+  /// (Beta).
+  ///
+  /// @param data Pointer to the pre-encoded Avro datum bytes.
+  /// @param len Number of bytes in @p data.
+  /// @return The logical offset assigned to the record.
+  /// @throws ZerobusException if the stream is closed or ingestion fails.
+  std::int64_t ingest_avro_record(const std::uint8_t* data, std::size_t len);
+
+  /// @overload
+  /// @param data The pre-encoded Avro datum bytes.
+  std::int64_t ingest_avro_record(const std::vector<std::uint8_t>& data);
+
+  /// Ingest a single Avro record from JSON, blocking until it is queued (Beta).
+  ///
+  /// The JSON object is encoded against the stream's writer schema. Unknown
+  /// keys are ignored; the server maps fields to the table's columns by name.
+  ///
+  /// @param json The record as a UTF-8 JSON object (e.g., `{"id": 1, "name":
+  /// "Alice"}`).
+  /// @return The logical offset assigned to the record.
+  /// @throws ZerobusException if the stream is closed, ingestion fails, or the
+  ///         record does not match the schema.
+  std::int64_t ingest_avro_record(const std::string& json);
+
+  /// Ingest a batch of pre-encoded Avro datums, blocking until they are queued
+  /// (Beta).
+  ///
+  /// Prefer the batch APIs over per-record calls in hot paths.
+  ///
+  /// @param records The pre-encoded Avro datums to ingest.
+  /// @return The single logical offset assigned to the whole batch, or -1 if
+  ///         @p records is empty (a no-op).
+  /// @throws ZerobusException if the stream is closed or ingestion fails.
+  std::int64_t ingest_avro_records(
+      const std::vector<std::vector<std::uint8_t>>& records);
+
+  /// Ingest a batch of Avro records from JSON, blocking until they are queued
+  /// (Beta).
+  ///
+  /// Prefer the batch APIs over per-record calls in hot paths.
+  ///
+  /// @param jsons The records, each a UTF-8 JSON object.
+  /// @return The single logical offset assigned to the whole batch, or -1 if
+  ///         @p jsons is empty (a no-op).
+  /// @throws ZerobusException if the stream is closed, ingestion fails, or any
+  ///         record does not match the schema.
+  std::int64_t ingest_avro_records(const std::vector<std::string>& jsons);
+#endif
+
   /// Block until the record at @p offset has been acknowledged by the server.
   ///
   /// @param offset A logical offset returned by an ingest call (for a batch,
@@ -135,9 +186,19 @@ class Stream {
 
  private:
   friend class Sdk;
+#if defined(ZEROBUS_AVRO)
   Stream(CZerobusStream* handle, std::shared_ptr<HeadersProvider> /*unused*/,
-         std::shared_ptr<AckCallback> ack_callback)
+         std::shared_ptr<AckCallback> ack_callback,
+         std::string avro_schema_json = "")
+      : handle_(handle),
+        ack_callback_(std::move(ack_callback)),
+        avro_schema_json_(std::move(avro_schema_json)) {}
+#else
+  Stream(CZerobusStream* handle, std::shared_ptr<HeadersProvider> /*unused*/,
+         std::shared_ptr<AckCallback> ack_callback,
+         std::string /*avro_schema_json*/ = "")
       : handle_(handle), ack_callback_(std::move(ack_callback)) {}
+#endif
 
   CZerobusStream* handle_;
   // The headers provider (if any) is owned by the FFI, not the Stream: the core
@@ -148,6 +209,10 @@ class Stream {
   // callback can still run after close(), so dropping this at ~Stream() can
   // free it mid-call (see AckCallback). May be null.
   std::shared_ptr<AckCallback> ack_callback_;
+#if defined(ZEROBUS_AVRO)
+  // Avro writer schema JSON, used for encoding JSON records to binary.
+  std::string avro_schema_json_;
+#endif
 };
 
 }  // namespace zerobus

--- a/cpp/src/arrow_stream.cpp
+++ b/cpp/src/arrow_stream.cpp
@@ -39,8 +39,9 @@ std::int64_t checked_offset(std::int64_t offset) {
 // Frees the FFI-owned array on scope exit, so it is released even if a copy
 // below throws. (Mirrors RecordArrayGuard in stream.cpp.)
 struct BatchArrayGuard {
-  CArrowBatchArray array;
+  CArrowBatchArray array = {};
   ~BatchArrayGuard() { zerobus_arrow_free_batch_array(array); }
+  BatchArrayGuard() = default;
   BatchArrayGuard(const BatchArrayGuard&) = delete;
   BatchArrayGuard& operator=(const BatchArrayGuard&) = delete;
 };
@@ -128,7 +129,8 @@ std::vector<std::vector<std::uint8_t>> ArrowStream::get_unacked_batches() {
       zerobus_arrow_stream_get_unacked_batches(handle_, guard.ptr());
   guard.throw_if_error();
   // Own the array before the copy so it is freed on any exit path.
-  BatchArrayGuard array_guard{array};
+  BatchArrayGuard array_guard;
+  array_guard.array = array;
 
   std::vector<std::vector<std::uint8_t>> out;
   if (array.batches != nullptr && array.count > 0) {

--- a/cpp/src/proto_schema.cpp
+++ b/cpp/src/proto_schema.cpp
@@ -22,6 +22,7 @@ namespace {
 struct ProtoBytesGuard {
   std::uint8_t* data;
   std::uintptr_t len;
+  ProtoBytesGuard(std::uint8_t* d, std::uintptr_t l) : data(d), len(l) {}
   ~ProtoBytesGuard() { zerobus_free_proto_bytes(data, len); }
   ProtoBytesGuard(const ProtoBytesGuard&) = delete;
   ProtoBytesGuard& operator=(const ProtoBytesGuard&) = delete;

--- a/cpp/src/sdk.cpp
+++ b/cpp/src/sdk.cpp
@@ -215,6 +215,56 @@ Stream Sdk::create_stream(const TableProperties& table,
   return Stream(stream, nullptr, options.ack_callback);
 }
 
+#if defined(ZEROBUS_AVRO)
+// Create an OAuth-authenticated Avro stream. The schema is a JSON string passed
+// directly to the FFI (no descriptor_proto bytes). No headers provider (null
+// second arg); the third arg keeps the ack callback (if any) alive.
+Stream Sdk::create_avro_stream(const std::string& table_name,
+                               const std::string& avro_schema_json,
+                               const std::string& client_id,
+                               const std::string& client_secret,
+                               const StreamOptions& options) {
+  detail::ResultGuard guard;
+  CStreamConfigurationOptions copts = detail::to_c(options);
+  CZerobusStream* stream = zerobus_sdk_create_avro_stream(
+      handle_, detail::checked_c_str(table_name, "table_name"),
+      detail::checked_c_str(avro_schema_json, "avro_schema_json"),
+      detail::checked_c_str(client_id, "client_id"),
+      detail::checked_c_str(client_secret, "client_secret"), &copts,
+      guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Avro stream", false);
+  }
+  return Stream(stream, nullptr, options.ack_callback, avro_schema_json);
+}
+
+// Create an Avro stream authenticated by a custom headers provider.
+Stream Sdk::create_avro_stream(
+    const std::string& table_name, const std::string& avro_schema_json,
+    std::shared_ptr<HeadersProvider> headers_provider,
+    const StreamOptions& options) {
+  if (headers_provider == nullptr) {
+    throw ZerobusException("headers_provider must not be null", false);
+  }
+  detail::ResultGuard guard;
+  CStreamConfigurationOptions copts = detail::to_c(options);
+  const char* c_table = detail::checked_c_str(table_name, "table_name");
+  const char* c_schema =
+      detail::checked_c_str(avro_schema_json, "avro_schema_json");
+  auto* owned =
+      new std::shared_ptr<HeadersProvider>(std::move(headers_provider));
+  CZerobusStream* stream = zerobus_sdk_create_avro_stream_with_headers_provider(
+      handle_, c_table, c_schema, detail::zerobus_cpp_headers_trampoline, owned,
+      detail::zerobus_cpp_headers_free, &copts, guard.ptr());
+  if (stream == nullptr) {
+    guard.throw_if_error();
+    throw ZerobusException("failed to create Avro stream", false);
+  }
+  return Stream(stream, nullptr, options.ack_callback, avro_schema_json);
+}
+#endif
+
 // Create an OAuth-authenticated Arrow Flight stream. The schema IPC
 // bytes are required (an Arrow stream has no JSON fallback), so reject an empty
 // schema before crossing the FFI rather than letting the core fail less

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -13,6 +13,19 @@
 
 #include "detail/ffi_util.hpp"
 
+#if defined(ZEROBUS_AVRO)
+#include <sstream>
+
+#include "avro/Compiler.hh"
+#include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "avro/Generic.hh"
+#include "avro/Schema.hh"
+#include "avro/Specific.hh"
+#include "avro/Stream.hh"
+#include "avro/ValidSchema.hh"
+#endif
+
 namespace zerobus {
 
 namespace {
@@ -62,6 +75,49 @@ const std::uint8_t* ptr_or_sentinel(const std::uint8_t* data, std::size_t len) {
   return len == 0 ? &kEmptyPayloadSentinel : data;
 }
 
+// Encode JSON to Avro binary against the given schema.
+#if defined(ZEROBUS_AVRO)
+std::vector<std::uint8_t> encode_json_to_avro(const std::string& schema_json,
+                                              const std::string& json_record) {
+  try {
+    // Compile schema from JSON string.
+    avro::ValidSchema schema(avro::compileJsonSchemaFromString(schema_json));
+
+    // Parse JSON record using avro-cpp's JSON decoder.
+    auto json_input = avro::memoryInputStream(
+        reinterpret_cast<const uint8_t*>(json_record.data()),
+        json_record.size());
+    avro::DecoderPtr json_decoder = avro::jsonDecoder(schema);
+    json_decoder->init(*json_input);
+
+    avro::GenericDatum datum(schema.root());
+    avro::decode(*json_decoder, datum);
+
+    // Encode to Avro binary format.
+    auto binary_output = avro::memoryOutputStream();
+    avro::EncoderPtr binary_encoder = avro::binaryEncoder();
+    binary_encoder->init(*binary_output);
+    avro::encode(*binary_encoder, datum);
+    binary_encoder->flush();
+
+    // Extract buffer using InputStream created from the output.
+    auto binary_input = avro::memoryInputStream(*binary_output);
+    std::vector<uint8_t> buffer;
+    const uint8_t* chunk_data = nullptr;
+    size_t chunk_size = 0;
+    while (binary_input->next(&chunk_data, &chunk_size)) {
+      if (chunk_size > 0) {
+        buffer.insert(buffer.end(), chunk_data, chunk_data + chunk_size);
+      }
+    }
+    return buffer;
+  } catch (const std::exception& e) {
+    throw ZerobusException(
+        std::string("Failed to encode Avro JSON: ") + e.what(), false);
+  }
+}
+#endif
+
 // Build the parallel pointer/length arrays the batch FFI entry points expect.
 struct ProtoBatchView {
   std::vector<const std::uint8_t*> ptrs;
@@ -100,8 +156,9 @@ JsonBatchView make_json_batch(const std::vector<std::string>& records) {
 // if copying the records into owning UnackedRecords throws (e.g. std::bad_alloc
 // while growing the output vector) — not only on the straight-line return.
 struct RecordArrayGuard {
-  CRecordArray array;
+  CRecordArray array = {};
   ~RecordArrayGuard() { zerobus_free_record_array(array); }
+  RecordArrayGuard() = default;
   RecordArrayGuard(const RecordArrayGuard&) = delete;
   RecordArrayGuard& operator=(const RecordArrayGuard&) = delete;
 };
@@ -206,6 +263,61 @@ std::int64_t Stream::ingest_json_records(
   return checked_offset(offset);
 }
 
+#if defined(ZEROBUS_AVRO)
+std::int64_t Stream::ingest_avro_record(const std::uint8_t* data,
+                                        std::size_t len) {
+  ensure_open(handle_);
+  detail::ResultGuard guard;
+  std::int64_t offset = zerobus_stream_ingest_avro_record(
+      handle_, ptr_or_sentinel(data, len), len, guard.ptr());
+  guard.throw_if_error();
+  return checked_offset(offset);
+}
+
+std::int64_t Stream::ingest_avro_record(const std::vector<std::uint8_t>& data) {
+  return ingest_avro_record(ptr_or_sentinel(data), data.size());
+}
+
+std::int64_t Stream::ingest_avro_record(const std::string& json) {
+  ensure_open(handle_);
+  // Encode JSON to binary using avro-cpp against the writer schema.
+  std::vector<std::uint8_t> encoded =
+      encode_json_to_avro(avro_schema_json_, json);
+  // Ingest the encoded bytes.
+  return ingest_avro_record(encoded);
+}
+
+std::int64_t Stream::ingest_avro_records(
+    const std::vector<std::vector<std::uint8_t>>& records) {
+  ensure_open(handle_);
+  if (records.empty()) {
+    return -1;
+  }
+  ProtoBatchView v = make_proto_batch(records);
+  detail::ResultGuard guard;
+  std::int64_t offset = zerobus_stream_ingest_avro_records(
+      handle_, v.ptrs.data(), v.lens.data(), v.ptrs.size(), guard.ptr());
+  guard.throw_if_error();
+  return checked_offset(offset);
+}
+
+std::int64_t Stream::ingest_avro_records(
+    const std::vector<std::string>& jsons) {
+  ensure_open(handle_);
+  if (jsons.empty()) {
+    return -1;
+  }
+  // Encode each JSON record to binary.
+  std::vector<std::vector<std::uint8_t>> encoded_records;
+  encoded_records.reserve(jsons.size());
+  for (const auto& json : jsons) {
+    encoded_records.push_back(encode_json_to_avro(avro_schema_json_, json));
+  }
+  // Ingest the encoded batch.
+  return ingest_avro_records(encoded_records);
+}
+#endif
+
 void Stream::wait_for_offset(std::int64_t offset) {
   ensure_open(handle_);
   // Reject negative offsets (e.g. the -1 from an empty batch) before the FFI.
@@ -238,7 +350,8 @@ std::vector<UnackedRecord> Stream::get_unacked_records() {
   // On error the array is empty; surface the error first.
   guard.throw_if_error();
   // Own the array before the copy, so it is freed even if a copy below throws.
-  RecordArrayGuard array_guard{array};
+  RecordArrayGuard array_guard;
+  array_guard.array = array;
 
   std::vector<UnackedRecord> out;
   if (array.records != nullptr && array.len > 0) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ zerobus_add_test(proto_schema_test)
 zerobus_add_test(headers_callback_test)
 zerobus_add_test(sdk_test)
 zerobus_add_test(integration_test)
+zerobus_add_test(avro_record_test)
 
 # Concurrency test spawns std::threads, so it needs the platform thread library.
 zerobus_add_test(concurrency_test)

--- a/cpp/tests/avro_record_test.cpp
+++ b/cpp/tests/avro_record_test.cpp
@@ -1,0 +1,45 @@
+// Compile+link test for Avro record ingestion API surface.
+// This test does not reach the FFI or a live server; it verifies that:
+// 1. Pre-encoded bytes and JSON overloads compile and link
+// 2. String overloads resolve uniquely
+
+#include <string>
+#include <vector>
+
+#include "zerobus/stream.hpp"
+
+namespace {
+
+[[maybe_unused]] void test_avro_overload_signatures() {
+#if defined(ZEROBUS_AVRO)
+  if (false) {
+    zerobus::Stream* stream = nullptr;
+
+    // Pre-encoded bytes (single).
+    std::vector<std::uint8_t> bytes_record{1, 2, 3};
+    stream->ingest_avro_record(bytes_record);
+
+    // Pre-encoded bytes (batch).
+    std::vector<std::vector<std::uint8_t>> bytes_records = {bytes_record};
+    stream->ingest_avro_records(bytes_records);
+
+    // JSON (single) — encoded natively via avro-cpp.
+    std::string json_record = R"({"id": 1, "name": "test"})";
+    stream->ingest_avro_record(json_record);
+
+    // JSON (batch) — each encoded natively via avro-cpp.
+    std::vector<std::string> json_records = {json_record};
+    stream->ingest_avro_records(json_records);
+  }
+#endif
+}
+
+}  // namespace
+
+int main() {
+#if defined(ZEROBUS_AVRO)
+  return 0;
+#else
+  return 0;
+#endif
+}

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -41,6 +41,7 @@ lint:
 	cargo clippy --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --all-features --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --no-default-features --all-targets -- -D warnings
+	cargo clippy -p zerobus-ffi --all-features --all-targets -- -D warnings
 	cargo clippy -p zerobus-jni --all-features --all-targets -- -D warnings
 
 check: fmt lint
@@ -49,4 +50,5 @@ test:
 	cargo test --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni
 	cargo test -p databricks-zerobus-ingest-sdk --all-features
 	cargo test -p databricks-zerobus-ingest-sdk --no-default-features
+	cargo test -p zerobus-ffi --all-features
 	cargo test -p zerobus-jni --all-features

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -36,6 +36,10 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
+[features]
+# Avro record format (Beta), opt-in. Gated in the C header behind ZEROBUS_AVRO.
+avro = ["databricks-zerobus-ingest-sdk/avro"]
+
 [dev-dependencies]
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-schema = { workspace = true, features = ["ffi"] }

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ### New Features and Improvements
 
+- Add the Avro record format (Beta) behind the `avro` feature, exposed in the C
+  header under `#if defined(ZEROBUS_AVRO)`: `zerobus_sdk_create_avro_stream`
+  (+ `_async` / `_with_headers_provider` / `_with_headers_provider_async`), which
+  takes the writer schema JSON at creation, and `zerobus_stream_ingest_avro_record`
+  / `_records` (+ `_async` / `_nowait`), which ingest a pre-encoded Avro datum
+  (single or batch). Additive — existing functions and `CStreamConfigurationOptions`
+  are unchanged, and the header is byte-identical with and without the feature.
+  Ephemeral streams only; server support is pending.
+- The C ABI carries pre-encoded datums only; it holds no Avro encoder. Wrappers
+  that offer a record-object API encode the object to a datum natively (in their
+  own language) and pass the bytes through `zerobus_stream_ingest_avro_record`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -11,3 +11,6 @@ cpp_compat = true
 include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CArrowArray", "CArrowSchema", "CZerobusProtoSchema"]
 
 [export.rename]
+
+[defines]
+"feature = avro" = "ZEROBUS_AVRO"

--- a/rust/ffi/src/stream.rs
+++ b/rust/ffi/src/stream.rs
@@ -85,13 +85,20 @@ async fn build_stream_from_parts(
     sdk_ref: &databricks_zerobus_ingest_sdk::ZerobusSdk,
     table_name: String,
     descriptor_proto: Option<prost_types::DescriptorProto>,
+    avro_schema_json: Option<String>,
     auth: StreamCreateAuth,
     options: Option<CStreamConfigurationOptions>,
 ) -> Result<*mut CZerobusStream, ZerobusError> {
-    let record_type = options
-        .as_ref()
-        .map(|c| c_record_type(c.record_type))
-        .unwrap_or(RecordType::Proto);
+    // An Avro schema comes only from the dedicated avro create fns, which force
+    // the Avro format regardless of options.record_type.
+    let record_type = if avro_schema_json.is_some() {
+        RecordType::Avro
+    } else {
+        options
+            .as_ref()
+            .map(|c| c_record_type(c.record_type))
+            .unwrap_or(RecordType::Proto)
+    };
 
     let base = match auth {
         StreamCreateAuth::OAuth {
@@ -117,6 +124,16 @@ async fn build_stream_from_parts(
             base.compiled_proto(desc)
         }
         RecordType::Json => base.json(),
+        #[cfg(feature = "avro")]
+        RecordType::Avro => {
+            let schema = avro_schema_json.ok_or_else(|| {
+                ZerobusError::InvalidArgument(
+                    "Avro schema is required for Avro record type".to_string(),
+                )
+            })?;
+            base.avro(schema)
+        }
+        #[cfg(not(feature = "avro"))]
         RecordType::Avro => {
             return Err(ZerobusError::InvalidArgument(
                 "Avro record type is not supported".to_string(),
@@ -270,6 +287,17 @@ fn encoded_records_to_c_array(records_vec: Vec<EncodedRecord>) -> CRecordArray {
                     data_len,
                 }
             }
+            // Avro datums are raw bytes (like proto): is_json = false.
+            #[cfg(feature = "avro")]
+            EncodedRecord::Avro(data) => {
+                let data_len = data.len();
+                let data_ptr = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+                CRecord {
+                    is_json: false,
+                    data: data_ptr,
+                    data_len,
+                }
+            }
         })
         .collect();
 
@@ -341,6 +369,7 @@ pub extern "C" fn zerobus_sdk_create_stream(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 StreamCreateAuth::OAuth {
                     client_id: client_id_str,
                     client_secret: client_secret_str,
@@ -442,6 +471,7 @@ pub extern "C" fn zerobus_sdk_create_stream_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::OAuth {
                         client_id: client_id_str,
                         client_secret: client_secret_str,
@@ -566,6 +596,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 // Pass the pre-built provider (constructed above, before any
                 // fallible work) so its Drop still frees `user_data` on every
                 // error path in here.
@@ -686,6 +717,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::HeadersProvider { headers_provider },
                     c_opts,
                 )
@@ -1917,4 +1949,692 @@ pub extern "C" fn zerobus_get_default_config() -> CStreamConfigurationOptions {
         ack_on_error: None,
         ack_user_data: ptr::null_mut(),
     }
+}
+
+// ============================================================================
+// Avro record format (Beta). Gated behind the `avro` feature; the C header
+// exposes these behind `#if defined(ZEROBUS_AVRO)`. Mirrors the proto create +
+// ingest surface, with the Avro writer schema (JSON) supplied at creation.
+// ============================================================================
+
+/// Create an Avro stream with OAuth authentication (Beta).
+/// avro_schema_json: the Avro writer schema as a JSON string (required).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_id_str = unsafe {
+                c_str_to_string(client_id)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_secret_str = unsafe {
+                c_str_to_string(client_secret)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::OAuth {
+                    client_id: client_id_str,
+                    client_secret: client_secret_str,
+                },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with OAuth authentication on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_id_str = match unsafe { c_str_to_string(client_id) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_secret_str = match unsafe { c_str_to_string(client_secret) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::OAuth {
+                        client_id: client_id_str,
+                        client_secret: client_secret_str,
+                    },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback (Beta).
+/// Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::HeadersProvider { headers_provider },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    callback_user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(callback_user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::HeadersProvider { headers_provider },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return -1;
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+
+        let offset_res = RUNTIME.block_on(async {
+            let payload = EncodedRecord::Avro(data_vec);
+            stream_ref.ingest_record_offset(payload).await
+        });
+
+        match offset_res {
+            Ok(offset) => {
+                write_success_result(result);
+                offset
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest an Avro datum on a background task and report the assigned offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_async(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return false;
+        }
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let data_vec = unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            match stream_arc
+                .ingest_record_offset(EncodedRecord::Avro(data_vec))
+                .await
+            {
+                Ok(offset) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return -1;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return -2; // Empty batch
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| {
+                    let data_slice = std::slice::from_raw_parts(*ptr, *len);
+                    data_slice.to_vec()
+                })
+                .collect()
+        };
+
+        let offset_res = RUNTIME.block_on(async {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            stream_ref.ingest_records_offset(payloads).await
+        });
+
+        match offset_res {
+            Ok(Some(offset)) => {
+                write_success_result(result);
+                offset
+            }
+            Ok(None) => {
+                write_success_result(result);
+                -2 // Empty batch
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_async(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return false;
+        }
+
+        let callback_user_data = SendPtr::new(user_data);
+        if num_records == 0 {
+            RUNTIME.spawn(async move {
+                invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                );
+            });
+            write_success_result(result);
+            return true;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            match stream_arc.ingest_records_offset(payloads).await {
+                Ok(Some(offset)) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Ok(None) => invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest an Avro datum without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_nowait(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payload = EncodedRecord::Avro(data_vec);
+            let _ = stream_arc.ingest_record_offset(payload).await;
+        });
+
+        write_success_result(result);
+    })
+}
+
+/// Ingest a batch of Avro datums without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_nowait(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            let _ = stream_arc.ingest_records_offset(payloads).await;
+        });
+
+        write_success_result(result);
+    })
 }

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -836,6 +836,139 @@ void zerobus_free_error_message(char *message);
  */
 struct CStreamConfigurationOptions zerobus_get_default_config(void);
 
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication (Beta).
+ * avro_schema_json: the Avro writer schema as a JSON string (required).
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream(struct CZerobusSdk *sdk,
+                                                      const char *table_name,
+                                                      const char *avro_schema_json,
+                                                      const char *client_id,
+                                                      const char *client_secret,
+                                                      const struct CStreamConfigurationOptions *options,
+                                                      struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_async(struct CZerobusSdk *sdk,
+                                          const char *table_name,
+                                          const char *avro_schema_json,
+                                          const char *client_id,
+                                          const char *client_secret,
+                                          const struct CStreamConfigurationOptions *options,
+                                          CreateStreamAsyncCallback callback,
+                                          void *user_data,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback (Beta).
+ * Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream_with_headers_provider(struct CZerobusSdk *sdk,
+                                                                            const char *table_name,
+                                                                            const char *avro_schema_json,
+                                                                            HeadersProviderCallback headers_callback,
+                                                                            void *user_data,
+                                                                            void (*free_user_data)(void *user_data),
+                                                                            const struct CStreamConfigurationOptions *options,
+                                                                            struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_with_headers_provider_async(struct CZerobusSdk *sdk,
+                                                                const char *table_name,
+                                                                const char *avro_schema_json,
+                                                                HeadersProviderCallback headers_callback,
+                                                                void *user_data,
+                                                                void (*free_user_data)(void *user_data),
+                                                                const struct CStreamConfigurationOptions *options,
+                                                                CreateStreamAsyncCallback callback,
+                                                                void *callback_user_data,
+                                                                struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+ */
+int64_t zerobus_stream_ingest_avro_record(struct CZerobusStream *stream,
+                                          const uint8_t *data,
+                                          uintptr_t data_len,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum on a background task and report the assigned offset via callback.
+ */
+bool zerobus_stream_ingest_avro_record_async(struct CZerobusStream *stream,
+                                             const uint8_t *data,
+                                             uintptr_t data_len,
+                                             OffsetAsyncCallback callback,
+                                             void *user_data,
+                                             struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+ */
+int64_t zerobus_stream_ingest_avro_records(struct CZerobusStream *stream,
+                                           const uint8_t *const *records,
+                                           const uintptr_t *record_lens,
+                                           uintptr_t num_records,
+                                           struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+ */
+bool zerobus_stream_ingest_avro_records_async(struct CZerobusStream *stream,
+                                              const uint8_t *const *records,
+                                              const uintptr_t *record_lens,
+                                              uintptr_t num_records,
+                                              OffsetAsyncCallback callback,
+                                              void *user_data,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_record_nowait(struct CZerobusStream *stream,
+                                              const uint8_t *data,
+                                              uintptr_t data_len,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_records_nowait(struct CZerobusStream *stream,
+                                               const uint8_t *const *records,
+                                               const uintptr_t *record_lens,
+                                               uintptr_t num_records,
+                                               struct CResult *result);
+#endif
+
 /**
  * Build a protobuf schema from Unity Catalog table metadata JSON.
  * Returns NULL on error; free with `zerobus_proto_schema_free`.


### PR DESCRIPTION
## PR stack

- [avro/proto-surface](https://github.com/databricks/zerobus-sdk/pull/811) [MERGED]
    - [avro/purego](https://github.com/databricks/zerobus-sdk/pull/828)
    - [avro/rust-core](https://github.com/databricks/zerobus-sdk/pull/827) [MERGED]
        - [avro/ffi-c-abi](https://github.com/databricks/zerobus-sdk/pull/830)
            - [avro/go](https://github.com/databricks/zerobus-sdk/pull/831)
            - [avro/cpp](https://github.com/databricks/zerobus-sdk/pull/832) <- _this PR_
            - [avro/dotnet](https://github.com/databricks/zerobus-sdk/pull/833)
        - avro/java
        - [avro/python](https://github.com/databricks/zerobus-sdk/pull/851)
        - avro/typescript

## What changes are proposed in this pull request?

Adds the Avro record format to the C++ SDK, behind the `ZEROBUS_ENABLE_AVRO` CMake option (default OFF). Default builds are unchanged. Ephemeral streams only; server support is pending.

Declare the writer schema at `Sdk::create_avro_stream(schema, ...)`, then ingest via overloads distinguished by type (mirroring `ingest_proto_record` / `ingest_json_record`):
- **pre-encoded datums**: `ingest_avro_record(const uint8_t*, size_t)` / `(const std::vector<uint8_t>&)`, `ingest_avro_records(vector<vector<uint8_t>>)`.
- **record objects (JSON)**: `ingest_avro_record(const std::string& json)`, `ingest_avro_records(vector<string>)` — C++ has no reflection, so the caller supplies the record as JSON; the shared Rust core encodes it against the write  schema. No C++ Avro encoder.

## How is this tested?

```
cd cpp

# Default (avro OFF) — unchanged
make fmt
make lint
make build
make test

# Avro enabled (builds the FFI with --features avro + -DZEROBUS_AVRO)
cmake -DZEROBUS_ENABLE_AVRO=ON -S . -B build
cmake --build build
ctest --test-dir build
```