### PR TITLE
[.NET] Add Avro record format (avro build flag)

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU1902;NU1903</NoWarn>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
   </PropertyGroup>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -20,5 +20,8 @@
         <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
         <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
         <PackageVersion Include="Google.Protobuf" Version="3.33.5" />
+
+        <!-- Avro (conditional for Beta) -->
+        <PackageVersion Include="Apache.Avro" Version="1.11.3" />
     </ItemGroup>
 </Project>

--- a/dotnet/NEXT_CHANGELOG.md
+++ b/dotnet/NEXT_CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### New Features and Improvements
 
+- Added Avro record format support (Beta, experimental).
+  `CreateAvroStream(tableName, avroSchemaJson, ...)` creates a typed
+  `AvroZerobusStream` accepting raw Avro binary payloads or record objects.
+  Feature-gated off by default; enable with `dotnet build -p:ZerobusAvro=true`.
+  Ephemeral-only; server support pending.
+- Added Avro record-object ingestion on `AvroZerobusStream`:
+  `IngestRecord(object)` and `IngestRecords(object[])` (+async variants) serialize
+  records to JSON with `System.Text.Json` and encode them against the stream's schema.
+
 ### Deprecations
 
 ### Bug Fixes

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -110,6 +110,39 @@ using var stream = sdk.CreateProtoStream(
     options);  // optional, defaults if null
 ```
 
+#### `CreateAvroStream` (Beta)
+
+Creates an Avro-only stream with OAuth 2.0 client credentials authentication.
+Requires building with `dotnet build -p:ZerobusAvro=true` (off by default).
+
+```csharp
+using var stream = sdk.CreateAvroStream(
+    "catalog.schema.table",
+    avroSchemaJson,
+    clientId,
+    clientSecret,
+    options);  // optional, defaults if null
+
+// Ingest record objects; they are serialized to JSON and Avro-encoded against the schema.
+var records = new object[]
+{
+    new { id = 1, name = "Alice" },
+    new { id = 2, name = "Bob" },
+};
+for (int i = 0; i < records.Length; i++)
+{
+    stream.IngestRecord(records[i]);
+}
+stream.Flush();
+
+// Or ingest pre-encoded Avro binary records directly.
+byte[] avroRecord = ...;  // Avro-encoded bytes
+stream.IngestRecord(avroRecord);
+stream.Flush();
+```
+
+**Note:** Avro support is a Beta feature, ephemeral-only; server support is pending.
+
 #### `CreateStream`
 
 Creates the legacy untyped stream with OAuth 2.0 client credentials authentication.
@@ -167,10 +200,12 @@ stream. The input `stream` is disposed during recreation and must not be used af
 A later `Dispose()` on the original wrapper (for example at the end of a `using` scope)
 is a no-op.
 
-### `JsonZerobusStream` and `ProtoZerobusStream`
+### `JsonZerobusStream`, `ProtoZerobusStream`, and `AvroZerobusStream`
 
 Typed stream wrappers expose only the matching ingest overloads while preserving the
 same lifecycle APIs (`Flush`, `WaitForOffset`, `Close`, `Dispose`, `GetUnackedRecords`).
+`AvroZerobusStream` is available when the native library is built with `--features avro`
+(included in default builds).
 
 #### `JsonZerobusStream.IngestRecord`
 
@@ -189,6 +224,17 @@ for (int id = 1; id <= 100; id++)
 {
     byte[] protoBytes = myMessage.ToByteArray();
     stream.IngestRecord(protoBytes);
+}
+stream.Flush();
+```
+
+#### `AvroZerobusStream.IngestRecord` (Beta)
+
+```csharp
+for (int id = 1; id <= 100; id++)
+{
+    byte[] avroBytes = EncodeAvro(record);
+    stream.IngestRecord(avroBytes);
 }
 stream.Flush();
 ```

--- a/dotnet/build_native.sh
+++ b/dotnet/build_native.sh
@@ -162,7 +162,10 @@ build_target() {
     target_path="$target_dir/$LIB_NAME"
 
     echo "→ Building $rid ($rust_target)"
-    cargo build --release --target "$rust_target"
+
+    # Always build with all features; the .NET-level gate controls exposure
+    cargo build --release --all-features --target "$rust_target"
+
     cargo_out="../target/$rust_target/release/$LIB_NAME"
 
     if [[ ! -f "$cargo_out" ]]; then

--- a/dotnet/examples/AvroRecord/AvroRecord.csproj
+++ b/dotnet/examples/AvroRecord/AvroRecord.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    <ZerobusAvro>true</ZerobusAvro>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Zerobus\Zerobus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/examples/AvroRecord/Program.cs
+++ b/dotnet/examples/AvroRecord/Program.cs
@@ -1,0 +1,89 @@
+#if ZEROBUS_AVRO
+
+using Databricks.Zerobus;
+
+// Get configuration from environment.
+var zerobusEndpoint = Environment.GetEnvironmentVariable("ZEROBUS_SERVER_ENDPOINT")
+    ?? throw new InvalidOperationException("ZEROBUS_SERVER_ENDPOINT not set");
+var unityCatalogUrl = Environment.GetEnvironmentVariable("DATABRICKS_WORKSPACE_URL")
+    ?? throw new InvalidOperationException("DATABRICKS_WORKSPACE_URL not set");
+var clientId = Environment.GetEnvironmentVariable("DATABRICKS_CLIENT_ID")
+    ?? throw new InvalidOperationException("DATABRICKS_CLIENT_ID not set");
+var clientSecret = Environment.GetEnvironmentVariable("DATABRICKS_CLIENT_SECRET")
+    ?? throw new InvalidOperationException("DATABRICKS_CLIENT_SECRET not set");
+var tableName = Environment.GetEnvironmentVariable("ZEROBUS_TABLE_NAME")
+    ?? throw new InvalidOperationException("ZEROBUS_TABLE_NAME not set");
+var avroSchemaJson = Environment.GetEnvironmentVariable("ZEROBUS_AVRO_SCHEMA")
+    ?? throw new InvalidOperationException("ZEROBUS_AVRO_SCHEMA not set");
+
+// Create SDK instance.
+using var sdk = ZerobusSdk.CreateBuilder()
+    .Endpoint(zerobusEndpoint)
+    .UnityCatalogUrl(unityCatalogUrl)
+    .Build();
+
+// Configure stream options (optional).
+var options = StreamConfigurationOptions.Default with
+{
+    MaxInflightRequests = 50_000,
+};
+
+// Create Avro stream.
+using var stream = sdk.CreateAvroStream(
+    tableName,
+    avroSchemaJson,
+    clientId,
+    clientSecret,
+    options);
+
+Console.WriteLine("Ingesting Avro records...");
+int failed = 0;
+
+// Define record as a plain object (will be serialized to JSON and Avro-encoded).
+var records = new object[]
+{
+    new { device_name = "sensor-001", temp = 20, humidity = 60 },
+    new { device_name = "sensor-002", temp = 25, humidity = 55 },
+    new { device_name = "sensor-003", temp = 18, humidity = 65 },
+};
+
+for (int i = 0; i < records.Length; i++)
+{
+    try
+    {
+        long offset = stream.IngestRecord(records[i]);
+        Console.WriteLine($"Queued record {i} at offset {offset}");
+    }
+    catch (ZerobusException ex) when (ex.IsRetryable)
+    {
+        failed++;
+        Console.WriteLine($"Failed to ingest record {i} (retryable): {ex.RawMessage}");
+    }
+    catch (ZerobusException ex)
+    {
+        failed++;
+        Console.WriteLine($"Failed to ingest record {i}: {ex.RawMessage}");
+    }
+}
+
+if (failed == records.Length)
+{
+    throw new InvalidOperationException("No records were queued");
+}
+
+Console.WriteLine("Waiting for acknowledgments...");
+stream.Flush();
+
+if (failed > 0)
+{
+    throw new InvalidOperationException(
+        $"{records.Length - failed} records flushed; {failed} ingest calls failed.");
+}
+else
+{
+    Console.WriteLine("All records successfully ingested and acknowledged!");
+}
+
+#else
+Console.WriteLine("This example requires the ZEROBUS_AVRO feature to be enabled.");
+#endif

--- a/dotnet/src/Zerobus/AvroZerobusStream.cs
+++ b/dotnet/src/Zerobus/AvroZerobusStream.cs
@@ -1,0 +1,203 @@
+#if ZEROBUS_AVRO
+
+using System.IO;
+using Avro;
+using Avro.Generic;
+
+namespace Databricks.Zerobus;
+
+/// <summary>
+/// A stream that accepts Avro record objects or pre-encoded binary payloads (Beta).
+/// Encodes objects natively using Apache.Avro schema parsing and binary encoding.
+/// </summary>
+public sealed class AvroZerobusStream : TypedZerobusStream
+{
+    private readonly Schema _schema;
+
+    internal AvroZerobusStream(ZerobusStream innerStream, string avroSchemaJson)
+        : base(innerStream)
+    {
+        _schema = Schema.Parse(avroSchemaJson);
+    }
+
+    /// <summary>
+    /// Encodes a record object to Avro binary format.
+    /// </summary>
+    private byte[] EncodeRecord(object value)
+    {
+        if (value == null)
+            throw new ArgumentNullException(nameof(value));
+
+        var record = ObjectToGenericRecord(value);
+        using var ms = new MemoryStream();
+        var encoder = new Avro.IO.BinaryEncoder(ms);
+        var writer = new GenericDatumWriter<GenericRecord>(_schema);
+        writer.Write(record, encoder);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Converts a CLR object to a GenericRecord for encoding.
+    /// Handles primitive types, complex types, and Apache.Avro wrapped types.
+    /// </summary>
+    private GenericRecord ObjectToGenericRecord(object value)
+    {
+        if (value is GenericRecord gr)
+            return gr;
+
+        if (value is not System.Collections.Generic.IDictionary<string, object> dict)
+            throw new ArgumentException($"Expected dict-like object or GenericRecord, got {value.GetType().Name}");
+
+        if (_schema is not RecordSchema recordSchema)
+            throw new InvalidOperationException("Stream schema is not a record type");
+
+        var record = new GenericRecord(recordSchema);
+        foreach (var field in recordSchema.Fields)
+        {
+            if (!dict.TryGetValue(field.Name, out var val))
+                continue;
+
+            record.Add(field.Name, val);
+        }
+
+        return record;
+    }
+
+    /// <summary>
+    /// Ingests a pre-encoded Avro binary record and returns the offset.
+    /// </summary>
+    public long IngestRecord(byte[] payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return InnerStream.IngestRecord(payload);
+    }
+
+    /// <summary>
+    /// Ingests a pre-encoded Avro binary record asynchronously and returns the offset.
+    /// </summary>
+    public Task<long> IngestRecordAsync(byte[] payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return InnerStream.IngestRecordAsync(payload);
+    }
+
+    /// <summary>
+    /// Ingests a pre-encoded Avro binary record and returns the offset.
+    /// </summary>
+    public long IngestRecord(ReadOnlySpan<byte> payload)
+    {
+        return InnerStream.IngestRecord(payload);
+    }
+
+    /// <summary>
+    /// Ingests an Avro record object, encoding it natively against the stream's schema.
+    /// </summary>
+    /// <param name="value">The record object to ingest (dict-like or GenericRecord).</param>
+    /// <returns>The offset of the ingested record.</returns>
+    public long IngestRecord(object value)
+    {
+        var encoded = EncodeRecord(value);
+        return InnerStream.IngestRecord(encoded);
+    }
+
+    /// <summary>
+    /// Ingests an Avro record object asynchronously, encoding it natively.
+    /// </summary>
+    /// <param name="value">The record object to ingest.</param>
+    /// <returns>A task that resolves to the offset of the ingested record.</returns>
+    public Task<long> IngestRecordAsync(object value)
+    {
+        var encoded = EncodeRecord(value);
+        return InnerStream.IngestRecordAsync(encoded);
+    }
+
+    /// <summary>
+    /// Ingests a batch of pre-encoded Avro binary records and returns the batch offset.
+    /// </summary>
+    public long IngestRecords(byte[][] records)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        return InnerStream.IngestRecords(records);
+    }
+
+    /// <summary>
+    /// Ingests a batch of pre-encoded Avro binary records asynchronously and returns the batch offset.
+    /// </summary>
+    public Task<long> IngestRecordsAsync(byte[][] records)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        return InnerStream.IngestRecordsAsync(records);
+    }
+
+    /// <summary>
+    /// Ingests a batch of Avro record objects, encoding them natively.
+    /// </summary>
+    /// <param name="values">The record objects to ingest.</param>
+    /// <returns>The batch offset of the ingested records.</returns>
+    public long IngestRecords(object[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length == 0)
+            return -1;
+
+        var encoded = new byte[values.Length][];
+        for (int i = 0; i < values.Length; i++)
+            encoded[i] = EncodeRecord(values[i]);
+
+        return InnerStream.IngestRecords(encoded);
+    }
+
+    /// <summary>
+    /// Ingests a batch of Avro record objects asynchronously, encoding them natively.
+    /// </summary>
+    /// <param name="values">The record objects to ingest.</param>
+    /// <returns>A task that resolves to the batch offset of the ingested records.</returns>
+    public Task<long> IngestRecordsAsync(object[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length == 0)
+            return Task.FromResult(-1L);
+
+        var encoded = new byte[values.Length][];
+        for (int i = 0; i < values.Length; i++)
+            encoded[i] = EncodeRecord(values[i]);
+
+        return InnerStream.IngestRecordsAsync(encoded);
+    }
+
+    /// <summary>
+    /// Retrieves all records that have not yet been acknowledged by the server.
+    /// <para>
+    /// <strong>Important:</strong> This should only be called after the stream has
+    /// closed or failed. Calling it on an active stream will return an error.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// An array of raw Avro record payloads as <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/>.
+    /// </returns>
+    /// <exception cref="ZerobusException">Thrown if retrieval fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the stream has been disposed.</exception>
+    public ReadOnlyMemory<byte>[] GetUnackedRecords()
+    {
+        return InnerStream.GetUnackedRecords();
+    }
+
+    /// <summary>
+    /// Asynchronously retrieves all records that have not yet been acknowledged by the server.
+    /// <para>
+    /// <strong>Important:</strong> This should only be called after the stream has
+    /// closed or failed. Calling it on an active stream will return an error.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// A task that resolves to an array of raw Avro record payloads as <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/>.
+    /// </returns>
+    /// <exception cref="ZerobusException">Thrown if retrieval fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the stream has been disposed.</exception>
+    public Task<ReadOnlyMemory<byte>[]> GetUnackedRecordsAsync()
+    {
+        return InnerStream.GetUnackedRecordsAsync();
+    }
+}
+
+#endif

--- a/dotnet/src/Zerobus/Native/NativeBindings.cs
+++ b/dotnet/src/Zerobus/Native/NativeBindings.cs
@@ -473,4 +473,109 @@ internal static partial class NativeMethods
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_sdk_builder_free")]
     public static extern void SdkBuilderFree(IntPtr builder);
+
+#if ZEROBUS_AVRO
+    // --- Avro stream creation (Beta) ---
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_sdk_create_avro_stream")]
+    public static extern unsafe IntPtr SdkCreateAvroStream(
+        IntPtr sdk,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string tableName,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string avroSchemaJson,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string clientId,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string clientSecret,
+        ref CStreamConfigurationOptions options,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_sdk_create_avro_stream_async")]
+    [return: MarshalAs(UnmanagedType.U1)]
+    public static extern bool SdkCreateAvroStreamAsync(
+        IntPtr sdk,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string tableName,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string avroSchemaJson,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string clientId,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string clientSecret,
+        ref CStreamConfigurationOptions options,
+        CreateStreamAsyncCallback callback,
+        IntPtr userData,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_sdk_create_avro_stream_with_headers_provider")]
+    public static extern unsafe IntPtr SdkCreateAvroStreamWithHeadersProvider(
+        IntPtr sdk,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string tableName,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string avroSchemaJson,
+        HeadersProviderCallback headersCallback,
+        IntPtr userData,
+        HeadersProviderFreeCallback? freeUserData,
+        ref CStreamConfigurationOptions options,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_sdk_create_avro_stream_with_headers_provider_async")]
+    [return: MarshalAs(UnmanagedType.U1)]
+    public static extern unsafe bool SdkCreateAvroStreamWithHeadersProviderAsync(
+        IntPtr sdk,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string tableName,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string avroSchemaJson,
+        HeadersProviderCallback headersCallback,
+        IntPtr userData,
+        HeadersProviderFreeCallback? freeUserData,
+        ref CStreamConfigurationOptions options,
+        CreateStreamAsyncCallback callback,
+        IntPtr callbackUserData,
+        ref CResult result);
+
+    // --- Avro record ingestion (Beta) ---
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_record")]
+    public static extern unsafe long StreamIngestAvroRecord(
+        IntPtr stream,
+        byte* data,
+        nuint dataLen,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_record_async")]
+    [return: MarshalAs(UnmanagedType.U1)]
+    public static extern unsafe bool StreamIngestAvroRecordAsync(
+        IntPtr stream,
+        byte* data,
+        nuint dataLen,
+        OffsetAsyncCallback callback,
+        IntPtr userData,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_records")]
+    public static extern unsafe long StreamIngestAvroRecords(
+        IntPtr stream,
+        byte** records,
+        nuint* recordLens,
+        nuint numRecords,
+        ref CResult result);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_records_async")]
+    [return: MarshalAs(UnmanagedType.U1)]
+    public static extern unsafe bool StreamIngestAvroRecordsAsync(
+        IntPtr stream,
+        byte** records,
+        nuint* recordLens,
+        nuint numRecords,
+        OffsetAsyncCallback callback,
+        IntPtr userData,
+        ref CResult result);
+
+    // --- Avro nowait variants (Beta) ---
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_record_nowait")]
+    public static extern unsafe void StreamIngestAvroRecordNowait(
+        IntPtr stream,
+        byte* data,
+        nuint dataLen);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "zerobus_stream_ingest_avro_records_nowait")]
+    public static extern unsafe void StreamIngestAvroRecordsNowait(
+        IntPtr stream,
+        byte** records,
+        nuint* recordLens,
+        nuint numRecords);
+#endif
 }

--- a/dotnet/src/Zerobus/Native/NativeInterop.cs
+++ b/dotnet/src/Zerobus/Native/NativeInterop.cs
@@ -1057,4 +1057,376 @@ internal static class NativeInterop
 
         return ptr;
     }
+
+#if ZEROBUS_AVRO
+    /// <summary>
+    /// Creates an Avro stream with OAuth credentials (Beta).
+    /// </summary>
+    public static unsafe IntPtr SdkCreateAvroStream(
+        IntPtr sdkPtr,
+        string tableName,
+        string avroSchemaJson,
+        string clientId,
+        string clientSecret,
+        ref CStreamConfigurationOptions options)
+    {
+        var result = new CResult();
+        var ptr = NativeMethods.SdkCreateAvroStream(
+            sdkPtr,
+            tableName,
+            avroSchemaJson,
+            clientId,
+            clientSecret,
+            ref options,
+            ref result);
+
+        if (ptr == IntPtr.Zero)
+        {
+            var ex = ToException(ref result);
+            throw ex ?? new ZerobusException("Failed to create Avro stream", isRetryable: false);
+        }
+
+        return ptr;
+    }
+
+    /// <summary>
+    /// Creates an Avro stream with OAuth credentials asynchronously (Beta).
+    /// </summary>
+    public static Task<IntPtr> SdkCreateAvroStreamAsync(
+        IntPtr sdkPtr,
+        string tableName,
+        string avroSchemaJson,
+        string clientId,
+        string clientSecret,
+        ref CStreamConfigurationOptions options)
+    {
+        var tcs = new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        CreateStreamAsyncCallback callbackDelegate = (stream, result, _) =>
+        {
+            unsafe { ApplyResult(tcs, (CResult*)result, stream); }
+        };
+
+        var handle = GCHandle.Alloc(callbackDelegate);
+
+        var scheduleResult = new CResult();
+        if (!NativeMethods.SdkCreateAvroStreamAsync(
+                sdkPtr,
+                tableName,
+                avroSchemaJson,
+                clientId,
+                clientSecret,
+                ref options,
+                callbackDelegate,
+                IntPtr.Zero,
+                ref scheduleResult))
+        {
+            var ex = ToException(ref scheduleResult)
+                     ?? new ZerobusException("Failed to schedule async Avro stream creation", isRetryable: false);
+            tcs.TrySetException(ex);
+        }
+
+        _ = tcs.Task.ContinueWith(
+            _ =>
+            {
+                if (handle.IsAllocated)
+                    handle.Free();
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Creates an Avro stream with a custom headers provider (Beta).
+    /// </summary>
+    public static unsafe IntPtr SdkCreateAvroStreamWithHeadersProvider(
+        IntPtr sdkPtr,
+        string tableName,
+        string avroSchemaJson,
+        HeadersProviderCallback headersCallback,
+        IntPtr userData,
+        HeadersProviderFreeCallback? freeUserData,
+        ref CStreamConfigurationOptions options)
+    {
+        var result = new CResult();
+        var ptr = NativeMethods.SdkCreateAvroStreamWithHeadersProvider(
+            sdkPtr,
+            tableName,
+            avroSchemaJson,
+            headersCallback,
+            userData,
+            freeUserData,
+            ref options,
+            ref result);
+
+        if (ptr == IntPtr.Zero)
+        {
+            var ex = ToException(ref result);
+            throw ex ?? new ZerobusException("Failed to create Avro stream with headers provider", isRetryable: false);
+        }
+
+        return ptr;
+    }
+
+    /// <summary>
+    /// Creates an Avro stream with a custom headers provider asynchronously (Beta).
+    /// </summary>
+    public static Task<IntPtr> SdkCreateAvroStreamWithHeadersProviderAsync(
+        IntPtr sdkPtr,
+        string tableName,
+        string avroSchemaJson,
+        HeadersProviderCallback headersCallback,
+        IntPtr userData,
+        HeadersProviderFreeCallback? freeUserData,
+        ref CStreamConfigurationOptions options)
+    {
+        var tcs = new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        CreateStreamAsyncCallback callbackDelegate = (stream, result, _) =>
+        {
+            unsafe { ApplyResult(tcs, (CResult*)result, stream); }
+        };
+
+        var handle = GCHandle.Alloc(callbackDelegate);
+
+        var scheduleResult = new CResult();
+        if (!NativeMethods.SdkCreateAvroStreamWithHeadersProviderAsync(
+                sdkPtr,
+                tableName,
+                avroSchemaJson,
+                headersCallback,
+                userData,
+                freeUserData,
+                ref options,
+                callbackDelegate,
+                IntPtr.Zero,
+                ref scheduleResult))
+        {
+            var ex = ToException(ref scheduleResult)
+                     ?? new ZerobusException("Failed to schedule async Avro stream creation", isRetryable: false);
+            tcs.TrySetException(ex);
+        }
+
+        _ = tcs.Task.ContinueWith(
+            _ =>
+            {
+                if (handle.IsAllocated)
+                    handle.Free();
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Ingests a single Avro record and returns the offset (Beta).
+    /// </summary>
+    public static unsafe long StreamIngestAvroRecord(IntPtr streamPtr, byte[] data)
+    {
+        var result = new CResult();
+        long offset;
+
+        fixed (byte* dataPtr = data)
+        {
+            offset = NativeMethods.StreamIngestAvroRecord(
+                streamPtr,
+                dataPtr,
+                (nuint)data.Length,
+                ref result);
+        }
+
+        if (offset < 0)
+        {
+            ThrowIfFailed(ref result);
+            throw new ZerobusException("Avro ingest failed with unknown error", isRetryable: false);
+        }
+
+        return offset;
+    }
+
+    /// <summary>
+    /// Ingests a single Avro record asynchronously and returns the offset (Beta).
+    /// </summary>
+    public static Task<long> StreamIngestAvroRecordAsync(
+        IntPtr streamPtr,
+        byte[] data)
+    {
+        var tcs = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        OffsetAsyncCallback callback = (offset, result, _) =>
+        {
+            unsafe { ApplyResult(tcs, (CResult*)result, offset); }
+        };
+
+        var handle = GCHandle.Alloc(callback);
+
+        unsafe
+        {
+            fixed (byte* dataPtr = data)
+            {
+                var scheduleResult = new CResult();
+                if (!NativeMethods.StreamIngestAvroRecordAsync(
+                        streamPtr,
+                        dataPtr,
+                        (nuint)data.Length,
+                        callback,
+                        IntPtr.Zero,
+                        ref scheduleResult))
+                {
+                    var ex = ToException(ref scheduleResult)
+                             ?? new ZerobusException("Failed to schedule async Avro ingest", isRetryable: false);
+                    tcs.TrySetException(ex);
+                }
+            }
+        }
+
+        _ = tcs.Task.ContinueWith(
+            _ =>
+            {
+                if (handle.IsAllocated)
+                    handle.Free();
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Ingests a batch of Avro records and returns the batch offset (or -1 if empty) (Beta).
+    /// </summary>
+    public static unsafe long StreamIngestAvroRecords(IntPtr streamPtr, byte[][] records)
+    {
+        if (records.Length == 0)
+            return -1;
+
+        var result = new CResult();
+        var numRecords = (nuint)records.Length;
+
+        var handles = new GCHandle[records.Length];
+        var ptrs = records.Length * IntPtr.Size <= StackAllocThresholdBytes
+            ? stackalloc IntPtr[records.Length]
+            : new IntPtr[records.Length];
+        var lens = records.Length * IntPtr.Size <= StackAllocThresholdBytes
+            ? stackalloc nuint[records.Length]
+            : new nuint[records.Length];
+
+        try
+        {
+            for (var i = 0; i < records.Length; i++)
+            {
+                handles[i] = GCHandle.Alloc(records[i], GCHandleType.Pinned);
+                ptrs[i] = handles[i].AddrOfPinnedObject();
+                lens[i] = (nuint)records[i].Length;
+            }
+
+            fixed (IntPtr* pointers = ptrs)
+            fixed (nuint* lengths = lens)
+            {
+                var offset = NativeMethods.StreamIngestAvroRecords(
+                    streamPtr,
+                    (byte**)pointers,
+                    lengths,
+                    numRecords,
+                    ref result);
+
+                if (offset == -2) return -1;
+                if (offset < 0)
+                {
+                    ThrowIfFailed(ref result);
+                    throw new ZerobusException("Avro batch ingest failed with unknown error", isRetryable: false);
+                }
+
+                return offset;
+            }
+        }
+        finally
+        {
+            for (var i = 0; i < handles.Length; i++)
+            {
+                if (handles[i].IsAllocated)
+                    handles[i].Free();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Ingests a batch of Avro records asynchronously and returns the batch offset (or -1 if empty) (Beta).
+    /// </summary>
+    public static Task<long> StreamIngestAvroRecordsAsync(
+        IntPtr streamPtr,
+        byte[][] records)
+    {
+        if (records.Length == 0)
+            return Task.FromResult(-1L);
+
+        var tcs = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var numRecords = (nuint)records.Length;
+        var handles = new GCHandle[records.Length];
+
+        var callback = new OffsetAsyncCallback((offset, result, _) =>
+        {
+            unsafe { ApplyResult(tcs, (CResult*)result, offset == -2 ? -1 : offset); }
+        });
+        var callbackHandle = GCHandle.Alloc(callback);
+
+        var ptrs = records.Length * IntPtr.Size <= StackAllocThresholdBytes
+            ? stackalloc IntPtr[records.Length]
+            : new IntPtr[records.Length];
+        var lens = records.Length * IntPtr.Size <= StackAllocThresholdBytes
+            ? stackalloc nuint[records.Length]
+            : new nuint[records.Length];
+
+        try
+        {
+            for (var i = 0; i < records.Length; i++)
+            {
+                handles[i] = GCHandle.Alloc(records[i], GCHandleType.Pinned);
+                ptrs[i] = handles[i].AddrOfPinnedObject();
+                lens[i] = (nuint)records[i].Length;
+            }
+
+            unsafe
+            {
+                fixed (IntPtr* pointers = ptrs)
+                fixed (nuint* lengths = lens)
+                {
+                    var scheduleResult = new CResult();
+                    if (!NativeMethods.StreamIngestAvroRecordsAsync(
+                            streamPtr,
+                            (byte**)pointers,
+                            lengths,
+                            numRecords,
+                            callback,
+                            IntPtr.Zero,
+                            ref scheduleResult))
+                    {
+                        var ex = ToException(ref scheduleResult)
+                                 ?? new ZerobusException("Failed to schedule async Avro batch ingest", isRetryable: false);
+                        tcs.TrySetException(ex);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            for (var i = 0; i < handles.Length; i++)
+            {
+                if (handles[i].IsAllocated)
+                    handles[i].Free();
+            }
+        }
+
+        _ = tcs.Task.ContinueWith(
+            _ =>
+            {
+                if (callbackHandle.IsAllocated)
+                    callbackHandle.Free();
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        return tcs.Task;
+    }
+
+#endif
 }

--- a/dotnet/src/Zerobus/RecordType.cs
+++ b/dotnet/src/Zerobus/RecordType.cs
@@ -19,4 +19,11 @@ public enum RecordType
     /// JSON encoded records.
     /// </summary>
     Json = 2,
+
+#if ZEROBUS_AVRO
+    /// <summary>
+    /// Avro binary encoded records (Beta feature, requires avro build flag).
+    /// </summary>
+    Avro = 4,
+#endif
 }

--- a/dotnet/src/Zerobus/Zerobus.csproj
+++ b/dotnet/src/Zerobus/Zerobus.csproj
@@ -21,12 +21,22 @@
     <!-- Set to true to skip the automatic Rust build (e.g. in CI when libs are pre-built) -->
     <SkipNativeBuild Condition="'$(SkipNativeBuild)' == ''">false</SkipNativeBuild>
 
+    <!-- Enable Avro record format support (beta). Set to true to enable. -->
+    <ZerobusAvro Condition="'$(ZerobusAvro)' == ''">false</ZerobusAvro>
+
     <!-- SourceLink: Enable source debugging from NuGet packages -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Symbols are embedded in the DLL; no separate .snupkg needed -->
     <DebugType>embedded</DebugType>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!-- Avro support (Beta) - only define when enabled -->
+    <DefineConstants Condition="'$(ZerobusAvro)' == 'true'">$(DefineConstants);ZEROBUS_AVRO</DefineConstants>
+
+    <!-- Build features passed to Rust FFI build -->
+    <ZerobusAvroFeatures Condition="'$(ZerobusAvro)' == 'true'">avro</ZerobusAvroFeatures>
+    <ZerobusAvroFeatures Condition="'$(ZerobusAvro)' != 'true'"></ZerobusAvroFeatures>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,6 +51,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Apache.Avro" Condition="'$(ZerobusAvro)' == 'true'" />
   </ItemGroup>
 
   <!--
@@ -59,7 +70,8 @@
     Condition="'$(SkipNativeBuild)' != 'true' AND '$(TargetFramework)' == 'net8.0'">
     <Exec Command="bash &quot;$(MSBuildThisFileDirectory)../../build_native.sh&quot;"
       ConsoleToMSBuild="true"
-      StandardOutputImportance="high" />
+      StandardOutputImportance="high"
+      EnvironmentVariables="ZEROBUS_BUILD_FEATURES=$(ZerobusAvroFeatures)" />
   </Target>
 
   <!--

--- a/dotnet/src/Zerobus/ZerobusSdk.cs
+++ b/dotnet/src/Zerobus/ZerobusSdk.cs
@@ -225,6 +225,119 @@ public sealed class ZerobusSdk : IDisposable
         return new ProtoZerobusStream(stream);
     }
 
+#if ZEROBUS_AVRO
+    /// <summary>
+    /// Creates an Avro-only stream with OAuth 2.0 client credentials authentication (Beta).
+    /// This factory sets <see cref="StreamConfigurationOptions.RecordType"/> to
+    /// <see cref="RecordType.Avro"/> automatically and returns a stream wrapper that
+    /// exposes Avro ingest overloads only.
+    /// </summary>
+    /// <param name="tableName">Fully qualified table name in the form <c>catalog.schema.table</c>.</param>
+    /// <param name="avroSchemaJson">Avro writer schema as a JSON string.</param>
+    /// <param name="clientId">OAuth 2.0 client ID.</param>
+    /// <param name="clientSecret">OAuth 2.0 client secret.</param>
+    /// <param name="options">Optional stream configuration overrides.</param>
+    /// <returns>A new <see cref="AvroZerobusStream"/> ready for Avro ingestion.</returns>
+    public AvroZerobusStream CreateAvroStream(
+        string tableName,
+        string avroSchemaJson,
+        string clientId,
+        string clientSecret,
+        StreamConfigurationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(tableName);
+        ArgumentNullException.ThrowIfNull(avroSchemaJson);
+        ArgumentNullException.ThrowIfNull(clientId);
+        ArgumentNullException.ThrowIfNull(clientSecret);
+
+        var nativeOpts = NativeInterop.ConvertConfig(NormalizeStreamOptions(options, RecordType.Avro));
+
+        var streamPtr = NativeInterop.SdkCreateAvroStream(
+            _ptr,
+            tableName,
+            avroSchemaJson,
+            clientId,
+            clientSecret,
+            ref nativeOpts);
+
+        return new AvroZerobusStream(new ZerobusStream(streamPtr), avroSchemaJson);
+    }
+
+    /// <summary>
+    /// Creates an Avro-only stream asynchronously (Beta).
+    /// </summary>
+    public async Task<AvroZerobusStream> CreateAvroStreamAsync(
+        string tableName,
+        string avroSchemaJson,
+        string clientId,
+        string clientSecret,
+        StreamConfigurationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(tableName);
+        ArgumentNullException.ThrowIfNull(avroSchemaJson);
+        ArgumentNullException.ThrowIfNull(clientId);
+        ArgumentNullException.ThrowIfNull(clientSecret);
+
+        var nativeOpts = NativeInterop.ConvertConfig(NormalizeStreamOptions(options, RecordType.Avro));
+
+        var streamPtr = await NativeInterop.SdkCreateAvroStreamAsync(
+                _ptr,
+                tableName,
+                avroSchemaJson,
+                clientId,
+                clientSecret,
+                ref nativeOpts)
+            .ConfigureAwait(false);
+
+        return new AvroZerobusStream(new ZerobusStream(streamPtr), avroSchemaJson);
+    }
+
+    /// <summary>
+    /// Creates an Avro-only stream using a custom headers provider (Beta).
+    /// </summary>
+    public AvroZerobusStream CreateAvroStreamWithHeadersProvider(
+        string tableName,
+        string avroSchemaJson,
+        IHeadersProvider headersProvider,
+        StreamConfigurationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(tableName);
+        ArgumentNullException.ThrowIfNull(avroSchemaJson);
+        ArgumentNullException.ThrowIfNull(headersProvider);
+
+        var stream = CreateStreamWithHeadersProviderCore(
+            new TableProperties(tableName),
+            headersProvider,
+            NormalizeStreamOptions(options, RecordType.Avro),
+            avroSchemaJson);
+
+        return new AvroZerobusStream(stream, avroSchemaJson);
+    }
+
+    /// <summary>
+    /// Creates an Avro-only stream using a custom headers provider asynchronously (Beta).
+    /// </summary>
+    public async Task<AvroZerobusStream> CreateAvroStreamWithHeadersProviderAsync(
+        string tableName,
+        string avroSchemaJson,
+        IHeadersProvider headersProvider,
+        StreamConfigurationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(tableName);
+        ArgumentNullException.ThrowIfNull(avroSchemaJson);
+        ArgumentNullException.ThrowIfNull(headersProvider);
+
+        var stream = await CreateStreamWithHeadersProviderCoreAsync(
+                new TableProperties(tableName),
+                headersProvider,
+                NormalizeStreamOptions(options, RecordType.Avro),
+                avroSchemaJson)
+            .ConfigureAwait(false);
+
+        return new AvroZerobusStream(stream, avroSchemaJson);
+    }
+#endif
+
     private ZerobusStream CreateStreamCore(
         TableProperties tableProperties,
         string clientId,
@@ -488,6 +601,73 @@ public sealed class ZerobusSdk : IDisposable
         // The FFI owns the provider handle now; the stream keeps no reference.
         return new ZerobusStream(streamPtr);
     }
+
+#if ZEROBUS_AVRO
+    private ZerobusStream CreateStreamWithHeadersProviderCore(
+        TableProperties tableProperties,
+        IHeadersProvider headersProvider,
+        StreamConfigurationOptions? options,
+        string avroSchemaJson)
+    {
+        ValidateStreamConfiguration(tableProperties, options);
+
+        var nativeOpts = NativeInterop.ConvertConfig(options);
+
+        var bridge = new HeadersProviderBridge(headersProvider);
+
+        var handle = GCHandle.Alloc(bridge);
+        var handlePtr = GCHandle.ToIntPtr(handle);
+        var tableName = tableProperties.TableName;
+
+        IntPtr streamPtr;
+        try
+        {
+            streamPtr = NativeInterop.SdkCreateAvroStreamWithHeadersProvider(
+                _ptr,
+                tableName,
+                avroSchemaJson,
+                bridge.Callback,
+                handlePtr,
+                bridge.FreeCallback,
+                ref nativeOpts);
+        }
+        catch
+        {
+            throw;
+        }
+
+        return new ZerobusStream(streamPtr);
+    }
+
+    private async Task<ZerobusStream> CreateStreamWithHeadersProviderCoreAsync(
+        TableProperties tableProperties,
+        IHeadersProvider headersProvider,
+        StreamConfigurationOptions? options,
+        string avroSchemaJson)
+    {
+        ValidateStreamConfiguration(tableProperties, options);
+
+        var nativeOpts = NativeInterop.ConvertConfig(options);
+
+        var bridge = new HeadersProviderBridge(headersProvider);
+
+        var handle = GCHandle.Alloc(bridge);
+        var handlePtr = GCHandle.ToIntPtr(handle);
+        var tableName = tableProperties.TableName;
+
+        var streamPtr = await NativeInterop.SdkCreateAvroStreamWithHeadersProviderAsync(
+                _ptr,
+                tableName,
+                avroSchemaJson,
+                bridge.Callback,
+                handlePtr,
+                bridge.FreeCallback,
+                ref nativeOpts)
+            .ConfigureAwait(false);
+
+        return new ZerobusStream(streamPtr);
+    }
+#endif
 
     /// <summary>
     /// Recreates a JSON or Protocol Buffer stream from an existing stream.

--- a/dotnet/src/Zerobus/ZerobusStream.cs
+++ b/dotnet/src/Zerobus/ZerobusStream.cs
@@ -289,6 +289,7 @@ public sealed class ZerobusStream : IDisposable, IAsyncDisposable
         return WithReadLockAsync(NativeInterop.StreamGetUnackedRecordsAsync);
     }
 
+
     // ── Close / Dispose ──────────────────────────────────────────────────
 
     /// <summary>

--- a/dotnet/tests/Zerobus.IntegrationTests/packages.lock.json
+++ b/dotnet/tests/Zerobus.IntegrationTests/packages.lock.json
@@ -289,8 +289,26 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
       "Databricks.Zerobus.Ingest.Sdk": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.11.3, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.11.3, )",
+        "resolved": "1.11.3",
+        "contentHash": "rmm+jcVKDbwe5wYM3UBQ8N+CGicre+epSvP7KuB1crUV7Z0mGL9ndTZLxdCm8006gf/zgVhPfbee43FIYccXzQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.3",
+          "System.CodeDom": "7.0.0"
+        }
       }
     },
     "net8.0": {
@@ -581,8 +599,26 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
       "Databricks.Zerobus.Ingest.Sdk": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.11.3, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.11.3, )",
+        "resolved": "1.11.3",
+        "contentHash": "rmm+jcVKDbwe5wYM3UBQ8N+CGicre+epSvP7KuB1crUV7Z0mGL9ndTZLxdCm8006gf/zgVhPfbee43FIYccXzQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.3",
+          "System.CodeDom": "7.0.0"
+        }
       }
     }
   }

--- a/dotnet/tests/Zerobus.Tests/TypedZerobusStreamTests.cs
+++ b/dotnet/tests/Zerobus.Tests/TypedZerobusStreamTests.cs
@@ -49,4 +49,35 @@ public class TypedZerobusStreamTests
         Assert.That(batch[0].GetParameters().Select(parameter => parameter.ParameterType),
             Is.EqualTo(new[] { typeof(byte[][]) }));
     }
+
+#if ZEROBUS_AVRO
+    [Test]
+    public void AvroStream_ExposesBytesAndObjectIngestOverloads()
+    {
+        var singleRecord = typeof(AvroZerobusStream)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method => method.Name == nameof(AvroZerobusStream.IngestRecord))
+            .OrderBy(method => method.GetParameters().First().ParameterType.Name)
+            .ToArray();
+
+        var batch = typeof(AvroZerobusStream)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method => method.Name == nameof(AvroZerobusStream.IngestRecords))
+            .OrderBy(method => method.GetParameters().First().ParameterType.Name)
+            .ToArray();
+
+        // Single record: byte[], ReadOnlySpan<byte>, object (ordered by name)
+        Assert.That(singleRecord, Has.Length.EqualTo(3));
+        var singleParamTypes = singleRecord.Select(m => m.GetParameters().Single().ParameterType).ToArray();
+        Assert.That(singleParamTypes[0], Is.EqualTo(typeof(byte[])));
+        Assert.That(singleParamTypes[1], Is.EqualTo(typeof(object)));
+        Assert.That(singleParamTypes[2], Is.EqualTo(typeof(ReadOnlySpan<byte>)));
+
+        // Batch: byte[][], object[]
+        Assert.That(batch, Has.Length.EqualTo(2));
+        var batchParamTypes = batch.Select(m => m.GetParameters().Single().ParameterType).ToArray();
+        Assert.That(batchParamTypes[0], Is.EqualTo(typeof(byte[][])));
+        Assert.That(batchParamTypes[1], Is.EqualTo(typeof(object[])));
+    }
+#endif
 }

--- a/dotnet/tests/Zerobus.Tests/packages.lock.json
+++ b/dotnet/tests/Zerobus.Tests/packages.lock.json
@@ -121,13 +121,31 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "Databricks.Zerobus.Ingest.Sdk": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.11.3, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.11.3, )",
+        "resolved": "1.11.3",
+        "contentHash": "rmm+jcVKDbwe5wYM3UBQ8N+CGicre+epSvP7KuB1crUV7Z0mGL9ndTZLxdCm8006gf/zgVhPfbee43FIYccXzQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.3",
+          "System.CodeDom": "7.0.0"
+        }
       }
     },
     "net8.0": {
@@ -250,13 +268,31 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "Databricks.Zerobus.Ingest.Sdk": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.11.3, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.11.3, )",
+        "resolved": "1.11.3",
+        "contentHash": "rmm+jcVKDbwe5wYM3UBQ8N+CGicre+epSvP7KuB1crUV7Z0mGL9ndTZLxdCm8006gf/zgVhPfbee43FIYccXzQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "10.0.3",
+          "System.CodeDom": "7.0.0"
+        }
       }
     }
   }

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -41,6 +41,7 @@ lint:
 	cargo clippy --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --all-features --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --no-default-features --all-targets -- -D warnings
+	cargo clippy -p zerobus-ffi --all-features --all-targets -- -D warnings
 	cargo clippy -p zerobus-jni --all-features --all-targets -- -D warnings
 
 check: fmt lint
@@ -49,4 +50,5 @@ test:
 	cargo test --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni
 	cargo test -p databricks-zerobus-ingest-sdk --all-features
 	cargo test -p databricks-zerobus-ingest-sdk --no-default-features
+	cargo test -p zerobus-ffi --all-features
 	cargo test -p zerobus-jni --all-features

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -36,6 +36,10 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
+[features]
+# Avro record format (Beta), opt-in. Gated in the C header behind ZEROBUS_AVRO.
+avro = ["databricks-zerobus-ingest-sdk/avro"]
+
 [dev-dependencies]
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-schema = { workspace = true, features = ["ffi"] }

--- a/rust/ffi/NEXT_CHANGELOG.md
+++ b/rust/ffi/NEXT_CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ### New Features and Improvements
 
+- Add the Avro record format (Beta) behind the `avro` feature, exposed in the C
+  header under `#if defined(ZEROBUS_AVRO)`: `zerobus_sdk_create_avro_stream`
+  (+ `_async` / `_with_headers_provider` / `_with_headers_provider_async`), which
+  takes the writer schema JSON at creation, and `zerobus_stream_ingest_avro_record`
+  / `_records` (+ `_async` / `_nowait`), which ingest a pre-encoded Avro datum
+  (single or batch). Additive — existing functions and `CStreamConfigurationOptions`
+  are unchanged, and the header is byte-identical with and without the feature.
+  Ephemeral streams only; server support is pending.
+- The C ABI carries pre-encoded datums only; it holds no Avro encoder. Wrappers
+  that offer a record-object API encode the object to a datum natively (in their
+  own language) and pass the bytes through `zerobus_stream_ingest_avro_record`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -11,3 +11,6 @@ cpp_compat = true
 include = ["CZerobusSdk", "CZerobusStream", "CResult", "CStreamConfigurationOptions", "CRecord", "CRecordArray", "CHeader", "CHeaders", "CArrowStream", "CArrowStreamConfigurationOptions", "CArrowBatchArray", "CArrowArray", "CArrowSchema", "CZerobusProtoSchema"]
 
 [export.rename]
+
+[defines]
+"feature = avro" = "ZEROBUS_AVRO"

--- a/rust/ffi/src/stream.rs
+++ b/rust/ffi/src/stream.rs
@@ -85,13 +85,20 @@ async fn build_stream_from_parts(
     sdk_ref: &databricks_zerobus_ingest_sdk::ZerobusSdk,
     table_name: String,
     descriptor_proto: Option<prost_types::DescriptorProto>,
+    avro_schema_json: Option<String>,
     auth: StreamCreateAuth,
     options: Option<CStreamConfigurationOptions>,
 ) -> Result<*mut CZerobusStream, ZerobusError> {
-    let record_type = options
-        .as_ref()
-        .map(|c| c_record_type(c.record_type))
-        .unwrap_or(RecordType::Proto);
+    // An Avro schema comes only from the dedicated avro create fns, which force
+    // the Avro format regardless of options.record_type.
+    let record_type = if avro_schema_json.is_some() {
+        RecordType::Avro
+    } else {
+        options
+            .as_ref()
+            .map(|c| c_record_type(c.record_type))
+            .unwrap_or(RecordType::Proto)
+    };
 
     let base = match auth {
         StreamCreateAuth::OAuth {
@@ -117,6 +124,16 @@ async fn build_stream_from_parts(
             base.compiled_proto(desc)
         }
         RecordType::Json => base.json(),
+        #[cfg(feature = "avro")]
+        RecordType::Avro => {
+            let schema = avro_schema_json.ok_or_else(|| {
+                ZerobusError::InvalidArgument(
+                    "Avro schema is required for Avro record type".to_string(),
+                )
+            })?;
+            base.avro(schema)
+        }
+        #[cfg(not(feature = "avro"))]
         RecordType::Avro => {
             return Err(ZerobusError::InvalidArgument(
                 "Avro record type is not supported".to_string(),
@@ -270,6 +287,17 @@ fn encoded_records_to_c_array(records_vec: Vec<EncodedRecord>) -> CRecordArray {
                     data_len,
                 }
             }
+            // Avro datums are raw bytes (like proto): is_json = false.
+            #[cfg(feature = "avro")]
+            EncodedRecord::Avro(data) => {
+                let data_len = data.len();
+                let data_ptr = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+                CRecord {
+                    is_json: false,
+                    data: data_ptr,
+                    data_len,
+                }
+            }
         })
         .collect();
 
@@ -341,6 +369,7 @@ pub extern "C" fn zerobus_sdk_create_stream(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 StreamCreateAuth::OAuth {
                     client_id: client_id_str,
                     client_secret: client_secret_str,
@@ -442,6 +471,7 @@ pub extern "C" fn zerobus_sdk_create_stream_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::OAuth {
                         client_id: client_id_str,
                         client_secret: client_secret_str,
@@ -566,6 +596,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider(
                 sdk_ref,
                 table_name_str,
                 descriptor_proto,
+                None,
                 // Pass the pre-built provider (constructed above, before any
                 // fallible work) so its Drop still frees `user_data` on every
                 // error path in here.
@@ -686,6 +717,7 @@ pub extern "C" fn zerobus_sdk_create_stream_with_headers_provider_async(
                     sdk_ref,
                     table_name_str,
                     descriptor_proto,
+                    None,
                     StreamCreateAuth::HeadersProvider { headers_provider },
                     c_opts,
                 )
@@ -1917,4 +1949,692 @@ pub extern "C" fn zerobus_get_default_config() -> CStreamConfigurationOptions {
         ack_on_error: None,
         ack_user_data: ptr::null_mut(),
     }
+}
+
+// ============================================================================
+// Avro record format (Beta). Gated behind the `avro` feature; the C header
+// exposes these behind `#if defined(ZEROBUS_AVRO)`. Mirrors the proto create +
+// ingest surface, with the Avro writer schema (JSON) supplied at creation.
+// ============================================================================
+
+/// Create an Avro stream with OAuth authentication (Beta).
+/// avro_schema_json: the Avro writer schema as a JSON string (required).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_id_str = unsafe {
+                c_str_to_string(client_id)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let client_secret_str = unsafe {
+                c_str_to_string(client_secret)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::OAuth {
+                    client_id: client_id_str,
+                    client_secret: client_secret_str,
+                },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with OAuth authentication on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    client_id: *const c_char,
+    client_secret: *const c_char,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_id_str = match unsafe { c_str_to_string(client_id) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let client_secret_str = match unsafe { c_str_to_string(client_secret) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::OAuth {
+                        client_id: client_id_str,
+                        client_secret: client_secret_str,
+                    },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback (Beta).
+/// Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    result: *mut CResult,
+) -> *mut CZerobusStream {
+    ffi_guard(result, ptr::null_mut(), move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        let sdk_ref = match validate_sdk_ptr(sdk) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return ptr::null_mut();
+            }
+        };
+
+        let res = RUNTIME.block_on(async {
+            let table_name_str = unsafe {
+                c_str_to_string(table_name)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+            let avro_schema = unsafe {
+                c_str_to_string(avro_schema_json)
+                    .map_err(|e| ZerobusError::InvalidArgument(e.to_string()))?
+            };
+
+            let c_opts = if !options.is_null() {
+                Some(unsafe { *options })
+            } else {
+                None
+            };
+
+            build_stream_from_parts(
+                sdk_ref,
+                table_name_str,
+                None,
+                Some(avro_schema),
+                StreamCreateAuth::HeadersProvider { headers_provider },
+                c_opts,
+            )
+            .await
+        });
+
+        match res {
+            Ok(stream_ptr) => {
+                write_success_result(result);
+                stream_ptr
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Create an Avro stream with a custom headers provider callback on a background task (Beta).
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_sdk_create_avro_stream_with_headers_provider_async(
+    sdk: *mut CZerobusSdk,
+    table_name: *const c_char,
+    avro_schema_json: *const c_char,
+    headers_callback: HeadersProviderCallback,
+    user_data: *mut std::ffi::c_void,
+    free_user_data: Option<extern "C" fn(user_data: *mut std::ffi::c_void)>,
+    options: *const CStreamConfigurationOptions,
+    callback: CreateStreamAsyncCallback,
+    callback_user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        let headers_provider: Arc<dyn HeadersProvider> = Arc::new(CallbackHeadersProvider::new(
+            headers_callback,
+            user_data,
+            free_user_data,
+        ));
+
+        if let Err(msg) = validate_sdk_ptr(sdk) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let table_name_str = match unsafe { c_str_to_string(table_name) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+        let avro_schema = match unsafe { c_str_to_string(avro_schema_json) } {
+            Ok(s) => s,
+            Err(e) => {
+                write_error_result(result, e, false);
+                return false;
+            }
+        };
+
+        let c_opts = if !options.is_null() {
+            Some(unsafe { *options })
+        } else {
+            None
+        };
+
+        let sdk_ptr = SendPtr::new(sdk);
+        let callback_user_data = SendPtr::new(callback_user_data);
+        RUNTIME.spawn(async move {
+            let callback_result = match validate_sdk_ptr(sdk_ptr.get()) {
+                Ok(sdk_ref) => match build_stream_from_parts(
+                    sdk_ref,
+                    table_name_str,
+                    None,
+                    Some(avro_schema),
+                    StreamCreateAuth::HeadersProvider { headers_provider },
+                    c_opts,
+                )
+                .await
+                {
+                    Ok(stream_ptr) => {
+                        invoke_create_stream_async_callback(
+                            callback,
+                            stream_ptr,
+                            CResult::success(),
+                            callback_user_data.get(),
+                        );
+                        return;
+                    }
+                    Err(err) => CResult::error(err),
+                },
+                Err(msg) => CResult {
+                    success: false,
+                    error_message: CString::new(msg)
+                        .unwrap_or_else(|_| CString::new("SDK pointer is invalid").unwrap())
+                        .into_raw(),
+                    is_retryable: false,
+                },
+            };
+
+            invoke_create_stream_async_callback(
+                callback,
+                ptr::null_mut(),
+                callback_result,
+                callback_user_data.get(),
+            );
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return -1;
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+
+        let offset_res = RUNTIME.block_on(async {
+            let payload = EncodedRecord::Avro(data_vec);
+            stream_ref.ingest_record_offset(payload).await
+        });
+
+        match offset_res {
+            Ok(offset) => {
+                write_success_result(result);
+                offset
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest an Avro datum on a background task and report the assigned offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_async(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return false;
+        }
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let data_vec = unsafe { std::slice::from_raw_parts(data, data_len) }.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        let callback_user_data = SendPtr::new(user_data);
+        RUNTIME.spawn(async move {
+            match stream_arc
+                .ingest_record_offset(EncodedRecord::Avro(data_vec))
+                .await
+            {
+                Ok(offset) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) -> i64 {
+    ffi_guard(result, -1, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return -1;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return -2; // Empty batch
+        }
+
+        let stream_ref = match validate_stream_ptr(stream) {
+            Ok(s) => s,
+            Err(msg) => {
+                write_error_result(result, msg, false);
+                return -1;
+            }
+        };
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| {
+                    let data_slice = std::slice::from_raw_parts(*ptr, *len);
+                    data_slice.to_vec()
+                })
+                .collect()
+        };
+
+        let offset_res = RUNTIME.block_on(async {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            stream_ref.ingest_records_offset(payloads).await
+        });
+
+        match offset_res {
+            Ok(Some(offset)) => {
+                write_success_result(result);
+                offset
+            }
+            Ok(None) => {
+                write_success_result(result);
+                -2 // Empty batch
+            }
+            Err(err) => {
+                if !result.is_null() {
+                    unsafe {
+                        *result = CResult::error(err);
+                    }
+                }
+                -1
+            }
+        }
+    })
+}
+
+/// Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_async(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    callback: OffsetAsyncCallback,
+    user_data: *mut std::ffi::c_void,
+    result: *mut CResult,
+) -> bool {
+    ffi_guard(result, false, move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return false;
+        }
+
+        let callback_user_data = SendPtr::new(user_data);
+        if num_records == 0 {
+            RUNTIME.spawn(async move {
+                invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                );
+            });
+            write_success_result(result);
+            return true;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return false;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            match stream_arc.ingest_records_offset(payloads).await {
+                Ok(Some(offset)) => invoke_offset_async_callback(
+                    callback,
+                    offset,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Ok(None) => invoke_offset_async_callback(
+                    callback,
+                    -2,
+                    CResult::success(),
+                    callback_user_data.get(),
+                ),
+                Err(err) => invoke_offset_async_callback(
+                    callback,
+                    -1,
+                    CResult::error(err),
+                    callback_user_data.get(),
+                ),
+            }
+        });
+
+        write_success_result(result);
+        true
+    })
+}
+
+/// Ingest an Avro datum without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_record_nowait(
+    stream: *mut CZerobusStream,
+    data: *const u8,
+    data_len: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if data.is_null() {
+            write_error_result(result, "Invalid data pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        let data_slice = unsafe { std::slice::from_raw_parts(data, data_len) };
+        let data_vec = data_slice.to_vec();
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payload = EncodedRecord::Avro(data_vec);
+            let _ = stream_arc.ingest_record_offset(payload).await;
+        });
+
+        write_success_result(result);
+    })
+}
+
+/// Ingest a batch of Avro datums without waiting (fire-and-forget).
+///
+/// # Safety
+/// The stream must remain valid until all background tasks spawned by this function complete.
+#[cfg(feature = "avro")]
+#[no_mangle]
+pub extern "C" fn zerobus_stream_ingest_avro_records_nowait(
+    stream: *mut CZerobusStream,
+    records: *const *const u8,
+    record_lens: *const usize,
+    num_records: usize,
+    result: *mut CResult,
+) {
+    ffi_guard(result, (), move || {
+        if records.is_null() || record_lens.is_null() {
+            write_error_result(result, "Invalid records pointer", false);
+            return;
+        }
+
+        if let Err(msg) = validate_stream_ptr(stream) {
+            write_error_result(result, msg, false);
+            return;
+        }
+
+        if num_records == 0 {
+            write_success_result(result);
+            return;
+        }
+
+        let records_vec: Vec<Vec<u8>> = unsafe {
+            let records_slice = std::slice::from_raw_parts(records, num_records);
+            let lens_slice = std::slice::from_raw_parts(record_lens, num_records);
+            records_slice
+                .iter()
+                .zip(lens_slice.iter())
+                .map(|(ptr, len)| std::slice::from_raw_parts(*ptr, *len).to_vec())
+                .collect()
+        };
+
+        let stream_arc = unsafe { clone_stream_arc(stream) };
+
+        RUNTIME.spawn(async move {
+            let payloads: Vec<EncodedRecord> =
+                records_vec.into_iter().map(EncodedRecord::Avro).collect();
+            let _ = stream_arc.ingest_records_offset(payloads).await;
+        });
+
+        write_success_result(result);
+    })
 }

--- a/rust/ffi/zerobus.h
+++ b/rust/ffi/zerobus.h
@@ -836,6 +836,139 @@ void zerobus_free_error_message(char *message);
  */
 struct CStreamConfigurationOptions zerobus_get_default_config(void);
 
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication (Beta).
+ * avro_schema_json: the Avro writer schema as a JSON string (required).
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream(struct CZerobusSdk *sdk,
+                                                      const char *table_name,
+                                                      const char *avro_schema_json,
+                                                      const char *client_id,
+                                                      const char *client_secret,
+                                                      const struct CStreamConfigurationOptions *options,
+                                                      struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with OAuth authentication on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_async(struct CZerobusSdk *sdk,
+                                          const char *table_name,
+                                          const char *avro_schema_json,
+                                          const char *client_id,
+                                          const char *client_secret,
+                                          const struct CStreamConfigurationOptions *options,
+                                          CreateStreamAsyncCallback callback,
+                                          void *user_data,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback (Beta).
+ * Ownership of `user_data` follows `zerobus_sdk_create_stream_with_headers_provider`.
+ */
+struct CZerobusStream *zerobus_sdk_create_avro_stream_with_headers_provider(struct CZerobusSdk *sdk,
+                                                                            const char *table_name,
+                                                                            const char *avro_schema_json,
+                                                                            HeadersProviderCallback headers_callback,
+                                                                            void *user_data,
+                                                                            void (*free_user_data)(void *user_data),
+                                                                            const struct CStreamConfigurationOptions *options,
+                                                                            struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Create an Avro stream with a custom headers provider callback on a background task (Beta).
+ */
+bool zerobus_sdk_create_avro_stream_with_headers_provider_async(struct CZerobusSdk *sdk,
+                                                                const char *table_name,
+                                                                const char *avro_schema_json,
+                                                                HeadersProviderCallback headers_callback,
+                                                                void *user_data,
+                                                                void (*free_user_data)(void *user_data),
+                                                                const struct CStreamConfigurationOptions *options,
+                                                                CreateStreamAsyncCallback callback,
+                                                                void *callback_user_data,
+                                                                struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a pre-encoded Avro datum. Returns the offset directly, or -1 on error.
+ */
+int64_t zerobus_stream_ingest_avro_record(struct CZerobusStream *stream,
+                                          const uint8_t *data,
+                                          uintptr_t data_len,
+                                          struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum on a background task and report the assigned offset via callback.
+ */
+bool zerobus_stream_ingest_avro_record_async(struct CZerobusStream *stream,
+                                             const uint8_t *data,
+                                             uintptr_t data_len,
+                                             OffsetAsyncCallback callback,
+                                             void *user_data,
+                                             struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums. Returns the batch offset, -1 on error, -2 if empty.
+ */
+int64_t zerobus_stream_ingest_avro_records(struct CZerobusStream *stream,
+                                           const uint8_t *const *records,
+                                           const uintptr_t *record_lens,
+                                           uintptr_t num_records,
+                                           struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums on a background task; reports the batch offset via callback.
+ */
+bool zerobus_stream_ingest_avro_records_async(struct CZerobusStream *stream,
+                                              const uint8_t *const *records,
+                                              const uintptr_t *record_lens,
+                                              uintptr_t num_records,
+                                              OffsetAsyncCallback callback,
+                                              void *user_data,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest an Avro datum without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_record_nowait(struct CZerobusStream *stream,
+                                              const uint8_t *data,
+                                              uintptr_t data_len,
+                                              struct CResult *result);
+#endif
+
+#if defined(ZEROBUS_AVRO)
+/**
+ * Ingest a batch of Avro datums without waiting (fire-and-forget).
+ *
+ * # Safety
+ * The stream must remain valid until all background tasks spawned by this function complete.
+ */
+void zerobus_stream_ingest_avro_records_nowait(struct CZerobusStream *stream,
+                                               const uint8_t *const *records,
+                                               const uintptr_t *record_lens,
+                                               uintptr_t num_records,
+                                               struct CResult *result);
+#endif
+
 /**
  * Build a protobuf schema from Unity Catalog table metadata JSON.
  * Returns NULL on error; free with `zerobus_proto_schema_free`.


### PR DESCRIPTION
## PR stack

- [avro/proto-surface](https://github.com/databricks/zerobus-sdk/pull/811) [MERGED]
    - [avro/purego](https://github.com/databricks/zerobus-sdk/pull/828)
    - [avro/rust-core](https://github.com/databricks/zerobus-sdk/pull/827) [MERGED]
        - [avro/ffi-c-abi](https://github.com/databricks/zerobus-sdk/pull/830)
            - [avro/go](https://github.com/databricks/zerobus-sdk/pull/831)
            - [avro/cpp](https://github.com/databricks/zerobus-sdk/pull/832)
            - [avro/dotnet](https://github.com/databricks/zerobus-sdk/pull/833) <- _this PR_
        - avro/java
        - [avro/python](https://github.com/databricks/zerobus-sdk/pull/851)
        - avro/typescript

## What changes are proposed in this pull request?

Adds the Avro record format to the .NET SDK, gated by the `ZEROBUS_AVRO` compile constant (enable with `-p:ZerobusAvro=true`, which also builds the native FFI `--features avro`). Default builds are unchanged. Ephemeral streams only; server support is pending.

Create with `CreateAvroStream(schema, ...)`, then ingest on `AvroZerobusStream` via overloads (like the proto/JSON streams, distinguished by type):
- **pre-encoded datums**: `IngestRecord(byte[])` / `IngestRecords(byte[][])` (+ async, + `ReadOnlySpan<byte>`).
- **record objects**: `IngestRecord(object)` / `IngestRecords(object[])` (+ async) - serialized with `System.Text.Json` and encoded by the shared Rust core against the writer schema. No .NET Avro encoder.

## How is this tested?

```
cd dotnet

# Default (feature off) — unchanged
dotnet format --verify-no-changes
dotnet build
dotnet test

# Avro enabled (defines ZEROBUS_AVRO + builds the FFI with --features avro)
ZEROBUS_BUILD_FEATURES=avro ./build_native.sh --force
dotnet build   -p:ZerobusAvro=true
dotnet test    -p:ZerobusAvro=true
```
