### PR TITLE
[CI] Expand Rust lint and test coverage

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -84,4 +84,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Run tests
-        run: cargo test --workspace
+        run: make test

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <!-- SDK Libraries -->
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.111" />
 
         <!-- Testing -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/dotnet/src/Zerobus/packages.lock.json
+++ b/dotnet/src/Zerobus/packages.lock.json
@@ -4,45 +4,45 @@
     "net10.0": {
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
-        "requested": "[10.0.103, )",
-        "resolved": "10.0.103",
-        "contentHash": "qZk7r40ftpZY+/sO019sgWAWfNqC2CLSspDdAxNYCJU/bCi/8jVwvOMjzb/d5gjCRNzQ4OCYgBfhdpQyVwLTyw==",
+        "requested": "[10.0.111, )",
+        "resolved": "10.0.111",
+        "contentHash": "ebijs4AieV43Anczb4JjtazG+bd6RcLl+k324ISeTiZ9lqk3pozbvav+BOt8CJxeRkCAhjjHlYzDQYg+93UIeA==",
         "dependencies": {
-          "Microsoft.Build.Tasks.Git": "10.0.103",
-          "Microsoft.SourceLink.Common": "10.0.103"
+          "Microsoft.Build.Tasks.Git": "10.0.111",
+          "Microsoft.SourceLink.Common": "10.0.111"
         }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
-        "resolved": "10.0.103",
-        "contentHash": "QoiCMcPuxC6eqRQmrmF9zBY96ejIznXtve/lJJbonGD9I5Aygf2AUCOWslGiCEtBbfWRSuUnepBjuuVOdAl5ag=="
+        "resolved": "10.0.111",
+        "contentHash": "IRJmiczCoN50PaT8pCFVGXEN1erN1kqWJaink4zN/2QprrQ/4rFhuhawaOQRoxnXQQw0ZFc+Hd+WuxNwz9RqbQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
-        "resolved": "10.0.103",
-        "contentHash": "cMtGW5/r0ck72Jg2QwZcNTX59z+iB/B1kW84VMa/eX8L19DhHIuIcQjfK0pgLLBxd60Jl0Bj9GUolcM0MnJnZA=="
+        "resolved": "10.0.111",
+        "contentHash": "UMlgtOondQTLESEKkPhF0m/btzzA9bnJnj4S2Tm6mBe+Ls0ZQ5ZPJ9mG3+DoWIVUk7oVPD08uaYtj4rFz/liNg=="
       }
     },
     "net8.0": {
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
-        "requested": "[10.0.103, )",
-        "resolved": "10.0.103",
-        "contentHash": "qZk7r40ftpZY+/sO019sgWAWfNqC2CLSspDdAxNYCJU/bCi/8jVwvOMjzb/d5gjCRNzQ4OCYgBfhdpQyVwLTyw==",
+        "requested": "[10.0.111, )",
+        "resolved": "10.0.111",
+        "contentHash": "ebijs4AieV43Anczb4JjtazG+bd6RcLl+k324ISeTiZ9lqk3pozbvav+BOt8CJxeRkCAhjjHlYzDQYg+93UIeA==",
         "dependencies": {
-          "Microsoft.Build.Tasks.Git": "10.0.103",
-          "Microsoft.SourceLink.Common": "10.0.103"
+          "Microsoft.Build.Tasks.Git": "10.0.111",
+          "Microsoft.SourceLink.Common": "10.0.111"
         }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
-        "resolved": "10.0.103",
-        "contentHash": "QoiCMcPuxC6eqRQmrmF9zBY96ejIznXtve/lJJbonGD9I5Aygf2AUCOWslGiCEtBbfWRSuUnepBjuuVOdAl5ag=="
+        "resolved": "10.0.111",
+        "contentHash": "IRJmiczCoN50PaT8pCFVGXEN1erN1kqWJaink4zN/2QprrQ/4rFhuhawaOQRoxnXQQw0ZFc+Hd+WuxNwz9RqbQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
-        "resolved": "10.0.103",
-        "contentHash": "cMtGW5/r0ck72Jg2QwZcNTX59z+iB/B1kW84VMa/eX8L19DhHIuIcQjfK0pgLLBxd60Jl0Bj9GUolcM0MnJnZA=="
+        "resolved": "10.0.111",
+        "contentHash": "UMlgtOondQTLESEKkPhF0m/btzzA9bnJnj4S2Tm6mBe+Ls0ZQ5ZPJ9mG3+DoWIVUk7oVPD08uaYtj4rFz/liNg=="
       }
     }
   }

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -35,6 +35,8 @@ clean:
 fmt:
 	cargo fmt --all
 
+# Enabling the SDK's optional features on the whole workspace would compile
+# them into FFI too, so the SDK and JNI are checked in their own commands.
 lint:
 	cargo clippy --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni --all-targets -- -D warnings
 	cargo clippy -p databricks-zerobus-ingest-sdk --all-features --all-targets -- -D warnings

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -36,9 +36,15 @@ fmt:
 	cargo fmt --all
 
 lint:
-	cargo clippy --all -- -D warnings
+	cargo clippy --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni --all-targets -- -D warnings
+	cargo clippy -p databricks-zerobus-ingest-sdk --all-features --all-targets -- -D warnings
+	cargo clippy -p databricks-zerobus-ingest-sdk --no-default-features --all-targets -- -D warnings
+	cargo clippy -p zerobus-jni --all-features --all-targets -- -D warnings
 
 check: fmt lint
 
 test:
-	cargo test --workspace
+	cargo test --workspace --exclude databricks-zerobus-ingest-sdk --exclude zerobus-jni
+	cargo test -p databricks-zerobus-ingest-sdk --all-features
+	cargo test -p databricks-zerobus-ingest-sdk --no-default-features
+	cargo test -p zerobus-jni --all-features

--- a/rust/tests/src/mock_grpc.rs
+++ b/rust/tests/src/mock_grpc.rs
@@ -136,6 +136,7 @@ impl MockZerobusServer {
     }
 
     /// Get the number of distinct TCP connections that opened streams.
+    #[allow(dead_code)]
     pub async fn get_connection_count(&self) -> usize {
         self.connection_addresses.lock().await.len()
     }

--- a/rust/tests/src/utils.rs
+++ b/rust/tests/src/utils.rs
@@ -23,7 +23,7 @@ pub async fn advance_tokio_time_near_instant_limit() {
     let mut low = 0_u64;
     let mut high = u64::MAX;
     while low < high {
-        let mid = ((low as u128 + high as u128 + 1) / 2) as u64;
+        let mid = (low as u128 + high as u128).div_ceil(2) as u64;
         if now
             .checked_add(std::time::Duration::from_secs(mid))
             .is_some()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expand Rust CI coverage across workspace targets and optional feature configurations.

The lint target now checks tests, examples, and benches. The Rust SDK is checked separately with all features and with no default features, while JNI feature coverage is isolated. Tests use the same package-specific structure, and the Rust workflow delegates to the Make target so local and CI coverage stay aligned.

The package isolation prevents Cargo feature unification from applying SDK-only optional features to FFI and JNI consumers.

- Fixed the .NET CI dependency audit failure by updating Microsoft.SourceLink.GitHub to 10.0.111.

## How is this tested?

Locally exercised the new lint and test matrix across workspace members, the SDK with all features and no default features, and JNI with all features. All configurations passed.
